### PR TITLE
[codex] Harden trust workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,4 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run typecheck
-      - run: npm test
       - run: npm run test:coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
       - run: npm ci
+      - run: npm run lint
       - run: npm run typecheck
       - run: npm test
-      - run: npm run lint
+      - run: npm run test:coverage

--- a/docs/CURRENT_CAPABILITIES.md
+++ b/docs/CURRENT_CAPABILITIES.md
@@ -1,0 +1,23 @@
+# Stratum Current Capabilities
+
+## Implemented now
+
+- Cloudflare Worker API using Hono, Artifacts, KV, D1, Queues, and a merge Durable Object binding.
+- User and agent API tokens with hashed storage, plus GitHub OAuth session login plumbing.
+- Project creation/import, workspace fork/commit/delete, change creation, evaluation-gated merge, and provenance records.
+- Per-change evaluator evidence for secret scanning, diff checks, webhook checks, LLM checks when AI is configured, and sandbox checks when Sandboxes are configured.
+- Read-only web UI for projects, files, commit logs, workspaces, changes, evaluator evidence, and merge provenance.
+
+## Not yet production-complete
+
+- Project/workspace identity still lives in KV; D1 stores changes and provenance only.
+- Authorization is owner-based and intentionally minimal; org/team permissions are not wired into project access yet.
+- Git operations still run inside the Worker with in-memory repositories.
+- The merge coordinator serializes merges but is not a full async queue with retries or dead-letter behavior.
+- Sandbox execution depends on Cloudflare Sandboxes access and fails closed when the binding is absent.
+
+## Public-copy gap to revisit before early access
+
+- The product can support evaluated agent changes, but behavioral artifacts beyond evaluator evidence are not built yet.
+- Provenance tracks agent/change/workspace/commit/evaluation score, but not full prompts, model metadata, or reasoning traces.
+- The UI is a functional review surface, not a full GitHub-class code browser or diff viewer.

--- a/migrations/005_eval_run_issues.sql
+++ b/migrations/005_eval_run_issues.sql
@@ -1,0 +1,1 @@
+ALTER TABLE eval_runs ADD COLUMN issues TEXT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,102 @@
       "dependencies": {
         "diff": "^9.0.0",
         "hono": "^4.7.7",
-        "isomorphic-git": "^1.27.1"
+        "isomorphic-git": "^1.27.1",
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@cloudflare/workers-types": "^4.20260101.0",
         "@types/diff": "^7.0.2",
+        "@vitest/coverage-v8": "^3.2.4",
         "typescript": "^5.8.3",
         "vitest": "^3.1.3",
         "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -1259,6 +1346,56 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1285,6 +1422,17 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -1718,6 +1866,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1845,6 +2027,32 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1854,6 +2062,36 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-lock": {
       "version": "1.4.1",
@@ -1874,6 +2112,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/base64-js": {
@@ -1902,6 +2150,19 @@
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/buffer": {
       "version": "6.0.3",
@@ -2017,6 +2278,26 @@
       "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
       "license": "Apache-2.0"
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -2041,6 +2322,21 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -2141,6 +2437,20 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
@@ -2302,6 +2612,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2363,6 +2690,61 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2373,6 +2755,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -2435,6 +2827,13 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2482,6 +2881,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
@@ -2502,6 +2911,13 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/isomorphic-git": {
       "version": "1.37.6",
@@ -2528,6 +2944,100 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -2552,6 +3062,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2560,6 +3077,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2604,6 +3149,22 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -2620,6 +3181,16 @@
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -2657,11 +3228,45 @@
         "wrappy": "1"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -2939,12 +3544,48 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -3024,6 +3665,110 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -3048,6 +3793,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinybench": {
@@ -3350,6 +4110,22 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which-typed-array": {
@@ -3930,6 +4706,104 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -3956,6 +4830,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/youch": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "lint": "biome check src tests",
     "lint:fix": "biome check --write src tests",
@@ -15,12 +16,14 @@
   "dependencies": {
     "diff": "^9.0.0",
     "hono": "^4.7.7",
-    "isomorphic-git": "^1.27.1"
+    "isomorphic-git": "^1.27.1",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@cloudflare/workers-types": "^4.20260101.0",
     "@types/diff": "^7.0.2",
+    "@vitest/coverage-v8": "^3.2.4",
     "typescript": "^5.8.3",
     "vitest": "^3.1.3",
     "wrangler": "^4.0.0"

--- a/src/evaluation/composite-evaluator.ts
+++ b/src/evaluation/composite-evaluator.ts
@@ -13,6 +13,10 @@ export class CompositeEvaluator {
   }
 
   aggregate(results: EvalResult[], policy: EvalPolicy): EvalResult {
+    if (results.length === 0) {
+      return { score: 0, passed: false, reason: "No evaluators ran." };
+    }
+
     const requireAll = policy.requireAll ?? true;
 
     const passed = requireAll ? results.every((r) => r.passed) : results.some((r) => r.passed);

--- a/src/evaluation/composite-evaluator.ts
+++ b/src/evaluation/composite-evaluator.ts
@@ -9,6 +9,10 @@ export class CompositeEvaluator {
 
   async evaluateAndAggregate(diff: string, policy: EvalPolicy): Promise<EvalResult> {
     const results = await this.evaluate(diff, policy);
+    return this.aggregate(results, policy);
+  }
+
+  aggregate(results: EvalResult[], policy: EvalPolicy): EvalResult {
     const requireAll = policy.requireAll ?? true;
 
     const passed = requireAll ? results.every((r) => r.passed) : results.some((r) => r.passed);

--- a/src/evaluation/index.ts
+++ b/src/evaluation/index.ts
@@ -5,3 +5,4 @@ export * from "./composite-evaluator";
 export * from "./policy-loader";
 export * from "./sandbox-evaluator";
 export * from "./llm-evaluator";
+export * from "./secret-scanner";

--- a/src/evaluation/policy-loader.ts
+++ b/src/evaluation/policy-loader.ts
@@ -1,3 +1,4 @@
+import YAML from "yaml";
 import { readFileFromRepo } from "../storage/git-ops";
 import type { EvalPolicy } from "./types";
 
@@ -8,15 +9,30 @@ const DEFAULT_POLICY: EvalPolicy = {
 };
 
 export async function loadPolicy(remote: string, token: string): Promise<EvalPolicy> {
+  const yamlPolicy = await readAndParsePolicy(remote, token, ".stratum/policy.yaml", "yaml");
+  if (yamlPolicy) return yamlPolicy;
+
+  const jsonPolicy = await readAndParsePolicy(remote, token, "stratum.config.json", "json");
+  if (jsonPolicy) return jsonPolicy;
+
+  return DEFAULT_POLICY;
+}
+
+async function readAndParsePolicy(
+  remote: string,
+  token: string,
+  path: string,
+  format: "json" | "yaml",
+): Promise<EvalPolicy | null> {
   try {
-    const content = await readFileFromRepo(remote, token, "stratum.config.json");
-    if (content === null || content === undefined) return DEFAULT_POLICY;
+    const content = await readFileFromRepo(remote, token, path);
+    if (content === null || content === undefined) return null;
 
     let parsed: unknown;
     try {
-      parsed = JSON.parse(content);
+      parsed = format === "json" ? JSON.parse(content) : YAML.parse(content);
     } catch {
-      return DEFAULT_POLICY;
+      return null;
     }
 
     if (
@@ -25,11 +41,11 @@ export async function loadPolicy(remote: string, token: string): Promise<EvalPol
       !("evaluators" in parsed) ||
       !Array.isArray((parsed as Record<string, unknown>).evaluators)
     ) {
-      return DEFAULT_POLICY;
+      return null;
     }
 
     return { ...DEFAULT_POLICY, ...(parsed as Partial<EvalPolicy>) };
   } catch {
-    return DEFAULT_POLICY;
+    return null;
   }
 }

--- a/src/evaluation/secret-scanner.ts
+++ b/src/evaluation/secret-scanner.ts
@@ -1,4 +1,4 @@
-import type { EvalResult } from "./types";
+import type { EvalPolicy, EvalResult, Evaluator } from "./types";
 
 const SECRET_PATTERNS = [
   { name: "AWS Access Key", pattern: /AKIA[0-9A-Z]{16}/ },
@@ -9,8 +9,8 @@ const SECRET_PATTERNS = [
   { name: "Stratum Agent Token", pattern: /stratum_agent_[a-f0-9]{32}/ },
 ];
 
-export class SecretScanEvaluator {
-  async evaluate(diff: string, _policy: unknown): Promise<EvalResult> {
+export class SecretScanEvaluator implements Evaluator {
+  async evaluate(diff: string, _policy: EvalPolicy): Promise<EvalResult> {
     const issues: string[] = [];
 
     const lines = diff.split("\n");

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -9,6 +9,7 @@ declare module "hono" {
   interface ContextVariableMap {
     userId?: string;
     agentId?: string;
+    agentOwnerId?: string;
   }
 }
 
@@ -34,6 +35,7 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
       const agent = await getAgentByToken(c.env.DB, token);
       if (!agent) return c.json({ error: "Invalid token" }, 401);
       c.set("agentId", agent.id);
+      c.set("agentOwnerId", agent.ownerId);
       await next();
       return;
     }

--- a/src/queue/merge-queue.ts
+++ b/src/queue/merge-queue.ts
@@ -31,6 +31,7 @@ export class MergeQueue {
         project.token,
         workspace.remote,
         workspace.token,
+        { strategy: "merge" },
       );
 
       await updateChangeStatus(this.env.DB, changeId, "merged", {

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -109,6 +109,9 @@ app.post("/projects/:name/changes", async (c) => {
             },
           ];
         default:
+          console.warn(
+            `Unknown evaluator type "${(cfg as { type: string }).type}" in policy for project ${projectName}`,
+          );
           return [];
       }
     }),
@@ -139,7 +142,7 @@ app.post("/projects/:name/changes", async (c) => {
             aggregateResult.reason === blockingFailure.result.reason
               ? blockingFailure.result.reason
               : `${blockingFailure.result.reason} ${aggregateResult.reason}`,
-          issues: [...(blockingFailure.result.issues ?? []), ...(aggregateResult.issues ?? [])],
+          issues: aggregateResult.issues,
         };
 
   const newStatus: Change["status"] = evalResult.passed ? "approved" : "open";

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -3,29 +3,47 @@ import {
   CompositeEvaluator,
   DiffEvaluator,
   LLMEvaluator,
+  SandboxEvaluator,
+  SecretScanEvaluator,
   WebhookEvaluator,
   loadPolicy,
 } from "../evaluation";
+import type { EvalPolicy, EvalResult } from "../evaluation/types";
 import type { Evaluator } from "../evaluation/types";
 import { publishEvent } from "../queue/events";
 import { createChange, getChange, listChanges, updateChangeStatus } from "../storage/changes";
+import { listEvalRuns, recordEvalRuns } from "../storage/eval-runs";
 import { getDiffBetweenRepos, mergeWorkspaceIntoProject } from "../storage/git-ops";
 import { recordProvenance } from "../storage/provenance";
 import { getProject, getWorkspace } from "../storage/state";
 import type { Change, Env } from "../types";
-import { badRequest, created, notFound, ok, unauthorized } from "../utils/response";
+import { canReadProject, canWriteProject } from "../utils/authz";
+import { badRequest, created, forbidden, notFound, ok, unauthorized } from "../utils/response";
 
 const app = new Hono<{ Bindings: Env }>();
+
+class UnavailableEvaluator implements Evaluator {
+  constructor(
+    private evaluatorType: string,
+    private reason: string,
+  ) {}
+
+  async evaluate(_diff: string, _policy: EvalPolicy): Promise<EvalResult> {
+    return { score: 0, passed: false, reason: `${this.evaluatorType} unavailable: ${this.reason}` };
+  }
+}
 
 app.post("/projects/:name/changes", async (c) => {
   const userId = c.get("userId");
   const agentId = c.get("agentId");
+  const agentOwnerId = c.get("agentOwnerId");
   if (!userId && !agentId) return unauthorized("Authentication required");
 
   const { name: projectName } = c.req.param();
 
   const project = await getProject(c.env.STATE, projectName);
   if (!project) return notFound("Project", projectName);
+  if (!canWriteProject(project, userId, agentOwnerId)) return forbidden("Project access denied");
 
   const body = await c.req.json<{ workspace?: unknown }>().catch(() => ({ workspace: undefined }));
   if (typeof body.workspace !== "string" || !body.workspace.trim()) {
@@ -61,28 +79,72 @@ app.post("/projects/:name/changes", async (c) => {
     workspace.token,
   );
 
-  const evaluators: Evaluator[] = policy.evaluators.flatMap((cfg) => {
-    switch (cfg.type) {
-      case "diff":
-        return [new DiffEvaluator()];
-      case "webhook":
-        return [new WebhookEvaluator()];
-      case "llm":
-        if (c.env.AI) return [new LLMEvaluator(c.env.AI)];
-        return [];
-      default:
-        return [];
-    }
-  });
+  const evaluators: Array<{ type: string; evaluator: Evaluator }> = [
+    { type: "secret_scan", evaluator: new SecretScanEvaluator() },
+  ];
 
-  const composite = new CompositeEvaluator(
-    evaluators.length > 0 ? evaluators : [new DiffEvaluator()],
+  evaluators.push(
+    ...policy.evaluators.flatMap((cfg): Array<{ type: string; evaluator: Evaluator }> => {
+      switch (cfg.type) {
+        case "diff":
+          return [{ type: "diff", evaluator: new DiffEvaluator() }];
+        case "webhook":
+          return [{ type: "webhook", evaluator: new WebhookEvaluator() }];
+        case "llm":
+          if (c.env.AI) return [{ type: "llm", evaluator: new LLMEvaluator(c.env.AI) }];
+          return [
+            {
+              type: "llm",
+              evaluator: new UnavailableEvaluator("llm", "AI binding is not configured"),
+            },
+          ];
+        case "sandbox":
+          if (c.env.SANDBOX) {
+            return [{ type: "sandbox", evaluator: new SandboxEvaluator(c.env.SANDBOX) }];
+          }
+          return [
+            {
+              type: "sandbox",
+              evaluator: new UnavailableEvaluator("sandbox", "SANDBOX binding is not configured"),
+            },
+          ];
+        default:
+          return [];
+      }
+    }),
   );
-  const evalResult = await composite.evaluateAndAggregate(diff, policy);
+
+  const evalRuns = await Promise.all(
+    evaluators.map(async ({ type, evaluator }) => ({
+      evaluatorType: type,
+      result: await evaluator.evaluate(diff, policy),
+    })),
+  );
+
+  const composite = new CompositeEvaluator(evaluators.map(({ evaluator }) => evaluator));
+  const aggregateResult = composite.aggregate(
+    evalRuns.map(({ result }) => result),
+    policy,
+  );
+  const blockingFailure = evalRuns.find(
+    ({ evaluatorType, result }) => evaluatorType === "secret_scan" && !result.passed,
+  );
+  const evalResult =
+    blockingFailure === undefined
+      ? aggregateResult
+      : {
+          score: Math.min(aggregateResult.score, blockingFailure.result.score),
+          passed: false,
+          reason:
+            aggregateResult.reason === blockingFailure.result.reason
+              ? blockingFailure.result.reason
+              : `${blockingFailure.result.reason} ${aggregateResult.reason}`,
+          issues: [...(blockingFailure.result.issues ?? []), ...(aggregateResult.issues ?? [])],
+        };
 
   const newStatus: Change["status"] = evalResult.passed ? "approved" : "open";
 
-  // TODO: write per-evaluator results to eval_runs table (currently only aggregate stored on changes)
+  await recordEvalRuns(c.env.DB, change.id, evalRuns);
   await updateChangeStatus(c.env.DB, change.id, newStatus, {
     evalScore: evalResult.score,
     evalPassed: evalResult.passed,
@@ -104,14 +166,17 @@ app.post("/projects/:name/changes", async (c) => {
     evalReason: evalResult.reason,
   };
 
-  return created({ change: updatedChange, eval: evalResult });
+  return created({ change: updatedChange, eval: evalResult, evalRuns });
 });
 
 app.get("/projects/:name/changes", async (c) => {
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
   const { name: projectName } = c.req.param();
 
   const project = await getProject(c.env.STATE, projectName);
   if (!project) return notFound("Project", projectName);
+  if (!canReadProject(project, userId, agentOwnerId)) return forbidden("Project access denied");
 
   const statusParam = c.req.query("status");
   const validStatuses: Change["status"][] = ["open", "approved", "merged", "rejected"];
@@ -125,10 +190,16 @@ app.get("/projects/:name/changes", async (c) => {
 });
 
 app.get("/changes/:id", async (c) => {
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
   const { id } = c.req.param();
   const change = await getChange(c.env.DB, id);
   if (!change) return notFound("Change", id);
-  return ok({ change });
+  const project = await getProject(c.env.STATE, change.project);
+  if (!project) return notFound("Project", change.project);
+  if (!canReadProject(project, userId, agentOwnerId)) return forbidden("Project access denied");
+  const evalRuns = await listEvalRuns(c.env.DB, id);
+  return ok({ change, evalRuns });
 });
 
 app.post("/changes/:id/merge", async (c) => {
@@ -137,15 +208,24 @@ app.post("/changes/:id/merge", async (c) => {
 
   const { id } = c.req.param();
   const force = c.req.query("force") === "true";
+  const strategyParam = c.req.query("strategy");
+  const strategy = strategyParam === "squash" ? "squash" : "merge";
+  if (strategyParam !== undefined && strategyParam !== "squash" && strategyParam !== "merge") {
+    return badRequest("strategy must be 'merge' or 'squash'");
+  }
 
   const change = await getChange(c.env.DB, id);
   if (!change) return notFound("Change", id);
+
+  const project = await getProject(c.env.STATE, change.project);
+  if (!project) return notFound("Project", change.project);
+  if (!canWriteProject(project, userId)) return forbidden("Project access denied");
 
   if (change.status !== "approved" && !force) {
     return badRequest("Change must be approved before merging");
   }
 
-  if (c.env.MERGE_QUEUE) {
+  if (c.env.MERGE_QUEUE && strategy === "merge") {
     const doId = c.env.MERGE_QUEUE.idFromName(change.project);
     const stub = c.env.MERGE_QUEUE.get(doId);
     const result = await (
@@ -174,18 +254,22 @@ app.post("/changes/:id/merge", async (c) => {
     });
   }
 
-  const project = await getProject(c.env.STATE, change.project);
-  if (!project) return notFound("Project", change.project);
-
   const workspace = await getWorkspace(c.env.STATE, change.workspace);
   if (!workspace) return notFound("Workspace", change.workspace);
 
-  const commit = await mergeWorkspaceIntoProject(
-    project.remote,
-    project.token,
-    workspace.remote,
-    workspace.token,
-  );
+  let commit: string;
+  try {
+    commit = await mergeWorkspaceIntoProject(
+      project.remote,
+      project.token,
+      workspace.remote,
+      workspace.token,
+      { strategy },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return badRequest(message);
+  }
 
   const mergedAt = new Date().toISOString();
   await updateChangeStatus(c.env.DB, id, "merged", {
@@ -228,6 +312,10 @@ app.post("/changes/:id/reject", async (c) => {
 
   const change = await getChange(c.env.DB, id);
   if (!change) return notFound("Change", id);
+
+  const project = await getProject(c.env.STATE, change.project);
+  if (!project) return notFound("Project", change.project);
+  if (!canWriteProject(project, userId)) return forbidden("Project access denied");
 
   if (change.status === "merged") {
     return badRequest("Cannot reject a merged change");

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -51,7 +51,6 @@ app.post("/", async (c) => {
 app.get("/", async (c) => {
   const userId = c.get("userId");
   const agentOwnerId = c.get("agentOwnerId");
-  if (!userId && !agentOwnerId) return unauthorized("Authentication required");
 
   const projects = filterReadableProjects(await listProjects(c.env.STATE), userId, agentOwnerId);
   return ok({

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -3,7 +3,8 @@ import { getCommitLog, importFromGitHub, initAndPush, listFilesInRepo } from "..
 import { listProvenance } from "../storage/provenance";
 import { getProject, listProjects, setProject } from "../storage/state";
 import type { Env } from "../types";
-import { badRequest, created, notFound, ok, unauthorized } from "../utils/response";
+import { canReadProject, filterReadableProjects } from "../utils/authz";
+import { badRequest, created, forbidden, notFound, ok, unauthorized } from "../utils/response";
 import { isStringRecord, isValidGitHubUrl, isValidSlug } from "../utils/validation";
 
 const DEFAULT_FILES: Record<string, string> = {
@@ -48,7 +49,11 @@ app.post("/", async (c) => {
 });
 
 app.get("/", async (c) => {
-  const projects = await listProjects(c.env.STATE);
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  if (!userId && !agentOwnerId) return unauthorized("Authentication required");
+
+  const projects = filterReadableProjects(await listProjects(c.env.STATE), userId, agentOwnerId);
   return ok({
     projects: projects.map(({ name, remote, createdAt }) => ({ name, remote, createdAt })),
   });
@@ -83,32 +88,38 @@ app.post("/:name/import", async (c) => {
   return created({ name, remote: repo.remote, source: body.url });
 });
 
-// TODO: restrict read-only endpoints to authenticated users or project members
 app.get("/:name/files", async (c) => {
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
   const { name } = c.req.param();
   const project = await getProject(c.env.STATE, name);
   if (!project) return notFound("Project", name);
+  if (!canReadProject(project, userId, agentOwnerId)) return forbidden("Project access denied");
 
   const files = await listFilesInRepo(project.remote, project.token);
   return ok({ project: name, files });
 });
 
-// TODO: restrict read-only endpoints to authenticated users or project members
 app.get("/:name/log", async (c) => {
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
   const { name } = c.req.param();
   const project = await getProject(c.env.STATE, name);
   if (!project) return notFound("Project", name);
+  if (!canReadProject(project, userId, agentOwnerId)) return forbidden("Project access denied");
 
   const depth = Number(c.req.query("depth") ?? 20);
   const log = await getCommitLog(project.remote, project.token, depth);
   return ok({ project: name, log });
 });
 
-// TODO: restrict read-only endpoints to authenticated users or project members
 app.get("/:name/provenance", async (c) => {
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
   const { name } = c.req.param();
   const project = await getProject(c.env.STATE, name);
   if (!project) return notFound("Project", name);
+  if (!canReadProject(project, userId, agentOwnerId)) return forbidden("Project access denied");
 
   const limitParam = c.req.query("limit");
   const limit = limitParam !== undefined ? Number(limitParam) : undefined;

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import { getChange, listChanges } from "../storage/changes";
+import { listEvalRuns } from "../storage/eval-runs";
 import { getCommitLog, listFilesInRepo } from "../storage/git-ops";
+import { getProvenance } from "../storage/provenance";
 import { getProject, listProjects, listWorkspaces } from "../storage/state";
 import type { Env } from "../types";
 import { ChangeDetailPage } from "../ui/pages/change-detail";
@@ -109,7 +111,12 @@ app.get("/changes/:id", async (c) => {
     );
   }
 
-  return c.html(<ChangeDetailPage change={change} />);
+  const [evalRuns, provenance] = await Promise.all([
+    listEvalRuns(c.env.DB, id),
+    getProvenance(c.env.DB, id),
+  ]);
+
+  return c.html(<ChangeDetailPage change={change} evalRuns={evalRuns} provenance={provenance} />);
 });
 
 // GET /ui/projects/:name/workspaces — Workspace list

--- a/src/routes/workspaces.ts
+++ b/src/routes/workspaces.ts
@@ -8,7 +8,8 @@ import {
   setWorkspace,
 } from "../storage/state";
 import type { Env } from "../types";
-import { badRequest, created, notFound, ok, unauthorized } from "../utils/response";
+import { canReadProject, canWriteProject } from "../utils/authz";
+import { badRequest, created, forbidden, notFound, ok, unauthorized } from "../utils/response";
 import { isStringRecord, isValidSlug } from "../utils/validation";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -16,11 +17,13 @@ const app = new Hono<{ Bindings: Env }>();
 app.post("/projects/:name/workspaces", async (c) => {
   const userId = c.get("userId");
   const agentId = c.get("agentId");
+  const agentOwnerId = c.get("agentOwnerId");
   if (!userId && !agentId) return unauthorized("Authentication required");
 
   const { name: projectName } = c.req.param();
   const project = await getProject(c.env.STATE, projectName);
   if (!project) return notFound("Project", projectName);
+  if (!canWriteProject(project, userId, agentOwnerId)) return forbidden("Project access denied");
 
   const body = await c.req.json<{ name?: unknown }>().catch(() => ({ name: undefined }));
   const workspaceName = isValidSlug(body.name) ? body.name : `ws-${Date.now()}`;
@@ -40,9 +43,12 @@ app.post("/projects/:name/workspaces", async (c) => {
 });
 
 app.get("/projects/:name/workspaces", async (c) => {
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
   const { name: projectName } = c.req.param();
   const project = await getProject(c.env.STATE, projectName);
   if (!project) return notFound("Project", projectName);
+  if (!canReadProject(project, userId, agentOwnerId)) return forbidden("Project access denied");
 
   const workspaces = await listWorkspaces(c.env.STATE, projectName);
   return ok({
@@ -54,11 +60,15 @@ app.get("/projects/:name/workspaces", async (c) => {
 app.post("/:name/commit", async (c) => {
   const userId = c.get("userId");
   const agentId = c.get("agentId");
+  const agentOwnerId = c.get("agentOwnerId");
   if (!userId && !agentId) return unauthorized("Authentication required");
 
   const { name: workspaceName } = c.req.param();
   const workspace = await getWorkspace(c.env.STATE, workspaceName);
   if (!workspace) return notFound("Workspace", workspaceName);
+  const project = await getProject(c.env.STATE, workspace.parent);
+  if (!project) return notFound("Project", workspace.parent);
+  if (!canWriteProject(project, userId, agentOwnerId)) return forbidden("Project access denied");
 
   const body = await c.req.json<{ files?: unknown; message?: unknown }>();
   if (!isStringRecord(body.files))
@@ -89,11 +99,15 @@ app.post("/:name/merge", (c) => {
 app.delete("/:name", async (c) => {
   const userId = c.get("userId");
   const agentId = c.get("agentId");
+  const agentOwnerId = c.get("agentOwnerId");
   if (!userId && !agentId) return unauthorized("Authentication required");
 
   const { name: workspaceName } = c.req.param();
   const workspace = await getWorkspace(c.env.STATE, workspaceName);
   if (!workspace) return notFound("Workspace", workspaceName);
+  const project = await getProject(c.env.STATE, workspace.parent);
+  if (!project) return notFound("Project", workspace.parent);
+  if (!canWriteProject(project, userId, agentOwnerId)) return forbidden("Project access denied");
 
   await c.env.ARTIFACTS.delete(workspaceName).catch((err: unknown) => {
     console.warn(`[workspaces] Failed to delete Artifacts repo "${workspaceName}":`, err);

--- a/src/storage/eval-runs.ts
+++ b/src/storage/eval-runs.ts
@@ -1,0 +1,89 @@
+import type { EvalResult } from "../evaluation/types";
+import { newId } from "../utils/ids";
+
+export interface EvalRun {
+  id: string;
+  changeId: string;
+  evaluatorType: string;
+  score: number;
+  passed: boolean;
+  reason: string;
+  issues?: string[];
+  ranAt: string;
+}
+
+interface EvalRunRow {
+  id: string;
+  change_id: string;
+  evaluator_type: string;
+  score: number;
+  passed: number;
+  reason: string;
+  issues: string | null;
+  ran_at: string;
+}
+
+function rowToEvalRun(row: EvalRunRow): EvalRun {
+  const run: EvalRun = {
+    id: row.id,
+    changeId: row.change_id,
+    evaluatorType: row.evaluator_type,
+    score: row.score,
+    passed: row.passed === 1,
+    reason: row.reason,
+    ranAt: row.ran_at,
+  };
+  if (row.issues !== null) run.issues = JSON.parse(row.issues) as string[];
+  return run;
+}
+
+export async function recordEvalRuns(
+  db: D1Database,
+  changeId: string,
+  results: Array<{ evaluatorType: string; result: EvalResult }>,
+): Promise<EvalRun[]> {
+  const runs: EvalRun[] = [];
+
+  for (const { evaluatorType, result } of results) {
+    const id = newId("evl");
+    const ranAt = new Date().toISOString();
+    await db
+      .prepare(
+        "INSERT INTO eval_runs (id, change_id, evaluator_type, score, passed, reason, issues, ran_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      )
+      .bind(
+        id,
+        changeId,
+        evaluatorType,
+        result.score,
+        result.passed ? 1 : 0,
+        result.reason,
+        result.issues !== undefined ? JSON.stringify(result.issues) : null,
+        ranAt,
+      )
+      .run();
+
+    const run: EvalRun = {
+      id,
+      changeId,
+      evaluatorType,
+      score: result.score,
+      passed: result.passed,
+      reason: result.reason,
+      ranAt,
+    };
+    if (result.issues !== undefined) run.issues = result.issues;
+    runs.push(run);
+  }
+
+  return runs;
+}
+
+export async function listEvalRuns(db: D1Database, changeId: string): Promise<EvalRun[]> {
+  const result = await db
+    .prepare("SELECT * FROM eval_runs WHERE change_id = ? ORDER BY ran_at ASC")
+    .bind(changeId)
+    .all<EvalRunRow>();
+
+  return result.results.map(rowToEvalRun);
+}

--- a/src/storage/eval-runs.ts
+++ b/src/storage/eval-runs.ts
@@ -33,7 +33,16 @@ function rowToEvalRun(row: EvalRunRow): EvalRun {
     reason: row.reason,
     ranAt: row.ran_at,
   };
-  if (row.issues !== null) run.issues = JSON.parse(row.issues) as string[];
+  if (row.issues !== null) {
+    try {
+      const parsed = JSON.parse(row.issues);
+      if (Array.isArray(parsed) && parsed.every((item) => typeof item === "string")) {
+        run.issues = parsed as string[];
+      }
+    } catch {
+      // ignore malformed issues
+    }
+  }
   return run;
 }
 
@@ -42,27 +51,16 @@ export async function recordEvalRuns(
   changeId: string,
   results: Array<{ evaluatorType: string; result: EvalResult }>,
 ): Promise<EvalRun[]> {
+  const stmt = db.prepare(
+    "INSERT INTO eval_runs (id, change_id, evaluator_type, score, passed, reason, issues, ran_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+  );
+
   const runs: EvalRun[] = [];
+  const statements: D1PreparedStatement[] = [];
 
   for (const { evaluatorType, result } of results) {
     const id = newId("evl");
     const ranAt = new Date().toISOString();
-    await db
-      .prepare(
-        "INSERT INTO eval_runs (id, change_id, evaluator_type, score, passed, reason, issues, ran_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-      )
-      .bind(
-        id,
-        changeId,
-        evaluatorType,
-        result.score,
-        result.passed ? 1 : 0,
-        result.reason,
-        result.issues !== undefined ? JSON.stringify(result.issues) : null,
-        ranAt,
-      )
-      .run();
-
     const run: EvalRun = {
       id,
       changeId,
@@ -74,8 +72,22 @@ export async function recordEvalRuns(
     };
     if (result.issues !== undefined) run.issues = result.issues;
     runs.push(run);
+
+    statements.push(
+      stmt.bind(
+        id,
+        changeId,
+        evaluatorType,
+        result.score,
+        result.passed ? 1 : 0,
+        result.reason,
+        result.issues !== undefined ? JSON.stringify(result.issues) : null,
+        ranAt,
+      ),
+    );
   }
 
+  await db.batch(statements);
   return runs;
 }
 

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -8,6 +8,20 @@ const DIR = "/";
 
 const SYSTEM_AUTHOR: Author = { name: "Stratum", email: "system@usestratum.dev" };
 
+export type MergeStrategy = "merge" | "squash";
+
+export interface MergeWorkspaceOptions {
+  author?: Author;
+  strategy?: MergeStrategy;
+}
+
+export class MergeConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MergeConflictError";
+  }
+}
+
 /**
  * Artifacts tokens are formatted as `<secret>?expires=<timestamp>`.
  * Only the secret portion is used for HTTP Basic auth.
@@ -92,8 +106,9 @@ export async function mergeWorkspaceIntoProject(
   projectToken: string,
   workspaceRemote: string,
   workspaceToken: string,
-  author: Author = SYSTEM_AUTHOR,
+  options: MergeWorkspaceOptions = {},
 ): Promise<string> {
+  const author = options.author ?? SYSTEM_AUTHOR;
   const { fs, dir } = await cloneRepo(projectRemote, projectToken);
 
   await git.addRemote({ fs, dir, remote: "workspace", url: workspaceRemote });
@@ -114,8 +129,13 @@ export async function mergeWorkspaceIntoProject(
     workspaceSha = await git.resolveRef({ fs, dir, ref: "refs/remotes/workspace/main" });
   }
 
+  if (options.strategy === "squash") {
+    return squashMerge(fs, dir, workspaceSha, projectRemote, projectToken, author);
+  }
+
+  let result: Awaited<ReturnType<typeof git.merge>>;
   try {
-    const result = await git.merge({
+    result = await git.merge({
       fs,
       dir,
       ours: "main",
@@ -123,19 +143,21 @@ export async function mergeWorkspaceIntoProject(
       author,
       message: "Merge workspace into project",
     });
-    await git.push({
-      fs,
-      dir,
-      http,
-      url: projectRemote,
-      ref: "main",
-      onAuth: makeAuth(projectToken),
-    });
-    if (!result.oid) throw new Error("Merge produced no commit OID");
-    return result.oid;
-  } catch {
-    return squashMerge(fs, dir, workspaceSha, projectRemote, projectToken, author);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new MergeConflictError(`Merge failed; workspace may be stale or conflicting: ${message}`);
   }
+
+  await git.push({
+    fs,
+    dir,
+    http,
+    url: projectRemote,
+    ref: "main",
+    onAuth: makeAuth(projectToken),
+  });
+  if (!result.oid) throw new Error("Merge produced no commit OID");
+  return result.oid;
 }
 
 async function squashMerge(
@@ -148,11 +170,13 @@ async function squashMerge(
 ): Promise<string> {
   const workspaceFiles = await listFilesAtCommit(projectFs, workspaceSha);
   const projectFiles = await listFilesAtCommit(projectFs, "main");
+  const workspaceMap = new Map(workspaceFiles);
 
   const changed = workspaceFiles.filter(([path, hash]) => {
     const projectHash = projectFiles.find(([p]) => p === path)?.[1];
     return projectHash !== hash;
   });
+  const deleted = projectFiles.filter(([path]) => !workspaceMap.has(path));
 
   for (const [path] of changed) {
     const content = await readFileAtCommit(projectFs, workspaceSha, path);
@@ -160,10 +184,20 @@ async function squashMerge(
     await git.add({ fs: projectFs, dir: projectDir, filepath: path });
   }
 
+  for (const [path] of deleted) {
+    await projectFs.promises.unlink(`${projectDir}/${path}`);
+    await git.remove({ fs: projectFs, dir: projectDir, filepath: path });
+  }
+
+  const changeCount = changed.length + deleted.length;
+  if (changeCount === 0) {
+    return git.resolveRef({ fs: projectFs, dir: projectDir, ref: "main" });
+  }
+
   const sha = await git.commit({
     fs: projectFs,
     dir: projectDir,
-    message: `Squash merge workspace (${changed.length} file${changed.length === 1 ? "" : "s"} changed)`,
+    message: `Squash merge workspace (${changeCount} file${changeCount === 1 ? "" : "s"} changed)`,
     author,
   });
 
@@ -323,30 +357,39 @@ export async function getDiffBetweenRepos(
     listFilesAtCommit(baseFs, "main"),
   ]);
 
-  const baseMap = new Map(baseFiles);
-  const workspaceMap = new Map(workspaceFiles);
+  const baseContent = new Map<string, string>();
+  const workspaceContent = new Map<string, string>();
 
+  await Promise.all([
+    ...baseFiles.map(async ([path]) => {
+      baseContent.set(path, await readFileAtCommit(baseFs, "main", path));
+    }),
+    ...workspaceFiles.map(async ([path]) => {
+      workspaceContent.set(path, await readFileAtCommit(workspaceFs, "main", path));
+    }),
+  ]);
+
+  return buildUnifiedDiff(baseContent, workspaceContent);
+}
+
+export function buildUnifiedDiff(
+  baseFiles: Map<string, string>,
+  workspaceFiles: Map<string, string>,
+): string {
   const diffParts: string[] = [];
+  const paths = new Set([...baseFiles.keys(), ...workspaceFiles.keys()]);
 
-  for (const [path, oid] of workspaceFiles) {
-    const baseOid = baseMap.get(path);
-    if (baseOid === oid) continue;
+  for (const path of [...paths].sort()) {
+    const oldContent = baseFiles.get(path);
+    const newContent = workspaceFiles.get(path);
+    if (oldContent === newContent) continue;
 
-    const workspaceContent = await readFileAtCommit(workspaceFs, "main", path);
-
-    if (baseOid === undefined) {
-      diffParts.push(newFileDiff(path, workspaceContent));
-    } else {
-      const baseContent = await readFileAtCommit(baseFs, "main", path);
-      const patch = fileUnifiedDiff(path, baseContent, workspaceContent);
-      diffParts.push(patch);
-    }
-  }
-
-  for (const [path] of baseFiles) {
-    if (!workspaceMap.has(path)) {
-      const baseContent = await readFileAtCommit(baseFs, "main", path);
-      diffParts.push(deletedFileDiff(path, baseContent));
+    if (oldContent === undefined && newContent !== undefined) {
+      diffParts.push(newFileDiff(path, newContent));
+    } else if (newContent === undefined && oldContent !== undefined) {
+      diffParts.push(deletedFileDiff(path, oldContent));
+    } else if (oldContent !== undefined && newContent !== undefined) {
+      diffParts.push(fileUnifiedDiff(path, oldContent, newContent));
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,7 @@ export interface ProjectEntry {
   createdAt: string;
   githubUrl?: string;
   ownerId?: string;
+  visibility?: "private" | "public";
 }
 
 export interface WorkspaceEntry {

--- a/src/ui/pages/change-detail.tsx
+++ b/src/ui/pages/change-detail.tsx
@@ -13,6 +13,22 @@ interface ChangeDetailProps {
     createdAt: string;
     mergedAt?: string;
   };
+  evalRuns: Array<{
+    id: string;
+    evaluatorType: string;
+    score: number;
+    passed: boolean;
+    reason: string;
+    issues?: string[];
+    ranAt: string;
+  }>;
+  provenance: {
+    commitSha: string;
+    workspace: string;
+    agentId?: string;
+    evalScore?: number;
+    mergedAt: string;
+  } | null;
 }
 
 function statusBadgeClass(status: string): string {
@@ -30,7 +46,7 @@ function statusBadgeClass(status: string): string {
   }
 }
 
-export const ChangeDetailPage: FC<ChangeDetailProps> = ({ change }) => {
+export const ChangeDetailPage: FC<ChangeDetailProps> = ({ change, evalRuns, provenance }) => {
   return (
     <Layout title={`Change ${change.id}`}>
       <div class="page-header">
@@ -87,6 +103,71 @@ export const ChangeDetailPage: FC<ChangeDetailProps> = ({ change }) => {
           )}
         </dl>
       </div>
+
+      <div class="card">
+        <h2>Evaluator evidence</h2>
+        {evalRuns.length === 0 ? (
+          <div class="empty-state">
+            <p>No evaluator evidence recorded.</p>
+          </div>
+        ) : (
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Evaluator</th>
+                <th>Status</th>
+                <th>Score</th>
+                <th>Reason</th>
+              </tr>
+            </thead>
+            <tbody>
+              {evalRuns.map((run) => (
+                <tr key={run.id}>
+                  <td>{run.evaluatorType}</td>
+                  <td>
+                    {run.passed ? (
+                      <span class="badge badge-approved">passed</span>
+                    ) : (
+                      <span class="badge badge-rejected">failed</span>
+                    )}
+                  </td>
+                  <td>{Math.round(run.score * 100)}%</td>
+                  <td>
+                    {run.reason}
+                    {run.issues !== undefined && run.issues.length > 0 && (
+                      <ul class="issue-list">
+                        {run.issues.map((issue) => (
+                          <li key={issue}>{issue}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {provenance !== null && (
+        <div class="card">
+          <h2>Provenance</h2>
+          <dl class="detail-list">
+            <dt>Commit</dt>
+            <dd class="mono">{provenance.commitSha}</dd>
+            <dt>Workspace</dt>
+            <dd>{provenance.workspace}</dd>
+            {provenance.agentId !== undefined && (
+              <>
+                <dt>Agent</dt>
+                <dd>{provenance.agentId}</dd>
+              </>
+            )}
+            <dt>Merged</dt>
+            <dd>{new Date(provenance.mergedAt).toLocaleString()}</dd>
+          </dl>
+        </div>
+      )}
 
       {(change.status === "approved" || change.status === "open") && (
         <div class="action-row">

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -127,5 +127,7 @@ a:hover { text-decoration: underline; }
 
 .action-row { display: flex; gap: 0.75rem; margin-top: 1rem; }
 
+.issue-list { margin-top: 0.35rem; padding-left: 1rem; color: #fca5a5; }
+
 .mono { font-family: 'JetBrains Mono', monospace; }
 `;

--- a/src/utils/authz.ts
+++ b/src/utils/authz.ts
@@ -1,0 +1,27 @@
+import type { ProjectEntry } from "../types";
+
+export function canReadProject(
+  project: ProjectEntry,
+  userId?: string,
+  agentOwnerId?: string,
+): boolean {
+  if (project.visibility === "public") return true;
+  return canWriteProject(project, userId, agentOwnerId);
+}
+
+export function canWriteProject(
+  project: ProjectEntry,
+  userId?: string,
+  agentOwnerId?: string,
+): boolean {
+  if (!project.ownerId) return false;
+  return project.ownerId === userId || project.ownerId === agentOwnerId;
+}
+
+export function filterReadableProjects(
+  projects: ProjectEntry[],
+  userId?: string,
+  agentOwnerId?: string,
+): ProjectEntry[] {
+  return projects.filter((project) => canReadProject(project, userId, agentOwnerId));
+}

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -20,6 +20,10 @@ export function unauthorized(message: string): Response {
   return error(message, 401);
 }
 
+export function forbidden(message: string): Response {
+  return error(message, 403);
+}
+
 export function internalError(message: string): Response {
   return error(message, 500);
 }

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -24,14 +24,48 @@ vi.mock("../src/storage/state", () => ({
 vi.mock("../src/evaluation", () => ({
   loadPolicy: vi.fn(),
   DiffEvaluator: vi.fn().mockImplementation(() => ({
-    evaluate: vi.fn(),
+    evaluate: vi.fn().mockResolvedValue({
+      score: 1,
+      passed: true,
+      reason: "Diff passed all checks.",
+    }),
   })),
   WebhookEvaluator: vi.fn().mockImplementation(() => ({
-    evaluate: vi.fn(),
+    evaluate: vi.fn().mockResolvedValue({
+      score: 1,
+      passed: true,
+      reason: "Webhook passed.",
+    }),
+  })),
+  SecretScanEvaluator: vi.fn().mockImplementation(() => ({
+    evaluate: vi.fn().mockResolvedValue({
+      score: 1,
+      passed: true,
+      reason: "No secrets detected",
+    }),
+  })),
+  SandboxEvaluator: vi.fn().mockImplementation(() => ({
+    evaluate: vi.fn().mockResolvedValue({
+      score: 1,
+      passed: true,
+      reason: "Sandbox passed.",
+    }),
+  })),
+  LLMEvaluator: vi.fn().mockImplementation(() => ({
+    evaluate: vi.fn().mockResolvedValue({
+      score: 1,
+      passed: true,
+      reason: "LLM passed.",
+    }),
   })),
   CompositeEvaluator: vi.fn().mockImplementation(() => ({
-    evaluateAndAggregate: vi.fn(),
+    aggregate: vi.fn(),
   })),
+}));
+
+vi.mock("../src/storage/eval-runs", () => ({
+  listEvalRuns: vi.fn().mockResolvedValue([]),
+  recordEvalRuns: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("../src/storage/provenance", () => ({
@@ -48,6 +82,14 @@ vi.mock("../src/storage/users", () => ({
       return {
         id: "user_test",
         email: "test@example.com",
+        tokenHash: "hash",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      };
+    }
+    if (token === "stratum_user_othertoken000000000000000") {
+      return {
+        id: "user_other",
+        email: "other@example.com",
         tokenHash: "hash",
         createdAt: "2026-01-01T00:00:00.000Z",
       };
@@ -71,12 +113,14 @@ vi.mock("../src/storage/agents", () => ({
   }),
 }));
 
-import { CompositeEvaluator, loadPolicy } from "../src/evaluation";
+import { CompositeEvaluator, SecretScanEvaluator, loadPolicy } from "../src/evaluation";
 import { createChange, getChange, listChanges, updateChangeStatus } from "../src/storage/changes";
+import { listEvalRuns, recordEvalRuns } from "../src/storage/eval-runs";
 import { getDiffBetweenRepos, mergeWorkspaceIntoProject } from "../src/storage/git-ops";
 import { getProject, getWorkspace } from "../src/storage/state";
 
 const USER_AUTH = { Authorization: "Bearer stratum_user_testtoken00000000000000000" };
+const OTHER_USER_AUTH = { Authorization: "Bearer stratum_user_othertoken000000000000000" };
 const AGENT_AUTH = { Authorization: "Bearer stratum_agent_testtoken0000000000000000" };
 
 function makeApp() {
@@ -116,6 +160,7 @@ const mockProject = {
   remote: "https://artifacts.example.com/repos/my-project",
   token: "tok_project",
   createdAt: "2026-01-01T00:00:00.000Z",
+  ownerId: "user_test",
 };
 
 const mockWorkspace = {
@@ -168,10 +213,11 @@ describe("POST /api/projects/:name/changes", () => {
       "diff --git a/src/index.ts b/src/index.ts\n+new line",
     );
     vi.mocked(updateChangeStatus).mockResolvedValue(undefined);
+    vi.mocked(recordEvalRuns).mockResolvedValue([]);
     vi.mocked(CompositeEvaluator).mockImplementation(
       () =>
         ({
-          evaluateAndAggregate: vi.fn().mockResolvedValue(passingEvalResult),
+          aggregate: vi.fn().mockReturnValue(passingEvalResult),
         }) as unknown as CompositeEvaluator,
     );
   });
@@ -182,7 +228,11 @@ describe("POST /api/projects/:name/changes", () => {
       env,
     );
     expect(res.status).toBe(201);
-    const body = (await res.json()) as { change: Change; eval: typeof passingEvalResult };
+    const body = (await res.json()) as {
+      change: Change;
+      eval: typeof passingEvalResult;
+      evalRuns: unknown[];
+    };
     expect(body.change.status).toBe("approved");
     expect(body.change.evalPassed).toBe(true);
     expect(body.eval.passed).toBe(true);
@@ -191,6 +241,14 @@ describe("POST /api/projects/:name/changes", () => {
       "chg_abc123",
       "approved",
       expect.objectContaining({ evalPassed: true }),
+    );
+    expect(recordEvalRuns).toHaveBeenCalledWith(
+      env.DB,
+      "chg_abc123",
+      expect.arrayContaining([
+        expect.objectContaining({ evaluatorType: "secret_scan" }),
+        expect.objectContaining({ evaluatorType: "diff" }),
+      ]),
     );
   });
 
@@ -210,11 +268,25 @@ describe("POST /api/projects/:name/changes", () => {
     expect(res.status).toBe(401);
   });
 
+  it("returns 403 when caller does not own project", async () => {
+    const res = await app.fetch(
+      request(
+        "POST",
+        "/api/projects/my-project/changes",
+        { workspace: "fix-bug" },
+        OTHER_USER_AUTH,
+      ),
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(createChange).not.toHaveBeenCalled();
+  });
+
   it("returns open status when eval fails", async () => {
     vi.mocked(CompositeEvaluator).mockImplementation(
       () =>
         ({
-          evaluateAndAggregate: vi.fn().mockResolvedValue(failingEvalResult),
+          aggregate: vi.fn().mockReturnValue(failingEvalResult),
         }) as unknown as CompositeEvaluator,
     );
 
@@ -232,6 +304,72 @@ describe("POST /api/projects/:name/changes", () => {
       "chg_abc123",
       "open",
       expect.objectContaining({ evalPassed: false }),
+    );
+  });
+
+  it("keeps secret scan failures blocking even when policy allows any evaluator to pass", async () => {
+    vi.mocked(loadPolicy).mockResolvedValue({
+      evaluators: [{ type: "diff" }],
+      requireAll: false,
+      minScore: 0.7,
+    });
+    vi.mocked(SecretScanEvaluator).mockImplementationOnce(
+      () =>
+        ({
+          evaluate: vi.fn().mockResolvedValue({
+            score: 0,
+            passed: false,
+            reason: "Secret detected: AWS Access Key",
+            issues: ["AWS Access Key: line 4"],
+          }),
+        }) as unknown as SecretScanEvaluator,
+    );
+    vi.mocked(CompositeEvaluator).mockImplementation(
+      () =>
+        ({
+          aggregate: vi.fn().mockReturnValue({
+            score: 1,
+            passed: true,
+            reason: "All evaluators passed.",
+          }),
+        }) as unknown as CompositeEvaluator,
+    );
+
+    const res = await app.fetch(
+      request("POST", "/api/projects/my-project/changes", { workspace: "fix-bug" }, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { change: Change; eval: typeof failingEvalResult };
+    expect(body.change.status).toBe("open");
+    expect(body.eval.passed).toBe(false);
+    expect(body.eval.reason).toContain("Secret detected");
+  });
+
+  it("records unavailable sandbox evaluator when SANDBOX binding is missing", async () => {
+    vi.mocked(loadPolicy).mockResolvedValue({
+      evaluators: [{ type: "sandbox" }],
+      requireAll: true,
+      minScore: 0.7,
+    });
+
+    const res = await app.fetch(
+      request("POST", "/api/projects/my-project/changes", { workspace: "fix-bug" }, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(201);
+    expect(recordEvalRuns).toHaveBeenCalledWith(
+      env.DB,
+      "chg_abc123",
+      expect.arrayContaining([
+        expect.objectContaining({
+          evaluatorType: "sandbox",
+          result: expect.objectContaining({
+            passed: false,
+            reason: expect.stringContaining("SANDBOX binding is not configured"),
+          }),
+        }),
+      ]),
     );
   });
 
@@ -288,7 +426,10 @@ describe("GET /api/projects/:name/changes", () => {
   });
 
   it("lists changes for a project", async () => {
-    const res = await app.fetch(request("GET", "/api/projects/my-project/changes"), env);
+    const res = await app.fetch(
+      request("GET", "/api/projects/my-project/changes", undefined, USER_AUTH),
+      env,
+    );
     expect(res.status).toBe(200);
     const body = (await res.json()) as { project: string; changes: Change[] };
     expect(body.project).toBe("my-project");
@@ -300,7 +441,7 @@ describe("GET /api/projects/:name/changes", () => {
   it("filters by status when ?status= is provided", async () => {
     vi.mocked(listChanges).mockResolvedValue([]);
     const res = await app.fetch(
-      request("GET", "/api/projects/my-project/changes?status=open"),
+      request("GET", "/api/projects/my-project/changes?status=open", undefined, USER_AUTH),
       env,
     );
     expect(res.status).toBe(200);
@@ -309,8 +450,20 @@ describe("GET /api/projects/:name/changes", () => {
 
   it("returns 404 when project not found", async () => {
     vi.mocked(getProject).mockResolvedValue(null);
-    const res = await app.fetch(request("GET", "/api/projects/nope/changes"), env);
+    const res = await app.fetch(
+      request("GET", "/api/projects/nope/changes", undefined, USER_AUTH),
+      env,
+    );
     expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when listing another user's private project changes", async () => {
+    const res = await app.fetch(
+      request("GET", "/api/projects/my-project/changes", undefined, OTHER_USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(listChanges).not.toHaveBeenCalled();
   });
 });
 
@@ -326,17 +479,46 @@ describe("GET /api/changes/:id", () => {
 
   it("returns a single change by id", async () => {
     vi.mocked(getChange).mockResolvedValue(mockChange);
-    const res = await app.fetch(request("GET", "/api/changes/chg_abc123"), env);
+    vi.mocked(getProject).mockResolvedValue(mockProject);
+    vi.mocked(listEvalRuns).mockResolvedValue([
+      {
+        id: "evl_abc123",
+        changeId: "chg_abc123",
+        evaluatorType: "diff",
+        score: 1,
+        passed: true,
+        reason: "ok",
+        ranAt: "2026-01-01T02:01:00.000Z",
+      },
+    ]);
+    const res = await app.fetch(
+      request("GET", "/api/changes/chg_abc123", undefined, USER_AUTH),
+      env,
+    );
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { change: Change };
+    const body = (await res.json()) as { change: Change; evalRuns: unknown[] };
     expect(body.change.id).toBe("chg_abc123");
     expect(body.change.project).toBe("my-project");
+    expect(body.evalRuns).toHaveLength(1);
   });
 
   it("returns 404 when change not found", async () => {
     vi.mocked(getChange).mockResolvedValue(null);
-    const res = await app.fetch(request("GET", "/api/changes/chg_missing"), env);
+    const res = await app.fetch(
+      request("GET", "/api/changes/chg_missing", undefined, USER_AUTH),
+      env,
+    );
     expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when reading another user's private change", async () => {
+    vi.mocked(getChange).mockResolvedValue(mockChange);
+    vi.mocked(getProject).mockResolvedValue(mockProject);
+    const res = await app.fetch(
+      request("GET", "/api/changes/chg_abc123", undefined, OTHER_USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(403);
   });
 });
 
@@ -375,7 +557,13 @@ describe("POST /api/changes/:id/merge", () => {
     expect(body.project).toBe("my-project");
     expect(body.workspace).toBe("fix-bug");
     expect(body.commit).toBe("sha_merged");
-    expect(mergeWorkspaceIntoProject).toHaveBeenCalled();
+    expect(mergeWorkspaceIntoProject).toHaveBeenCalledWith(
+      "https://artifacts.example.com/repos/my-project",
+      "tok_project",
+      "https://artifacts.example.com/repos/fix-bug",
+      "tok_workspace",
+      { strategy: "merge" },
+    );
     expect(updateChangeStatus).toHaveBeenCalledWith(
       env.DB,
       "chg_abc123",
@@ -390,6 +578,18 @@ describe("POST /api/changes/:id/merge", () => {
 
     const res = await app.fetch(request("POST", "/api/changes/chg_abc123/merge"), env);
     expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when merging another user's project", async () => {
+    const approvedChange: Change = { ...mockChange, status: "approved" };
+    vi.mocked(getChange).mockResolvedValue(approvedChange);
+
+    const res = await app.fetch(
+      request("POST", "/api/changes/chg_abc123/merge", undefined, OTHER_USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(mergeWorkspaceIntoProject).not.toHaveBeenCalled();
   });
 
   it("returns 400 when change is not approved", async () => {
@@ -416,6 +616,53 @@ describe("POST /api/changes/:id/merge", () => {
     const body = (await res.json()) as { merged: boolean };
     expect(body.merged).toBe(true);
     expect(mergeWorkspaceIntoProject).toHaveBeenCalled();
+  });
+
+  it("passes explicit squash strategy to merge implementation", async () => {
+    const approvedChange: Change = { ...mockChange, status: "approved" };
+    vi.mocked(getChange).mockResolvedValue(approvedChange);
+
+    const res = await app.fetch(
+      request("POST", "/api/changes/chg_abc123/merge?strategy=squash", undefined, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(mergeWorkspaceIntoProject).toHaveBeenCalledWith(
+      "https://artifacts.example.com/repos/my-project",
+      "tok_project",
+      "https://artifacts.example.com/repos/fix-bug",
+      "tok_workspace",
+      { strategy: "squash" },
+    );
+  });
+
+  it("returns 400 when merge implementation reports a conflict", async () => {
+    const approvedChange: Change = { ...mockChange, status: "approved" };
+    vi.mocked(getChange).mockResolvedValue(approvedChange);
+    vi.mocked(mergeWorkspaceIntoProject).mockRejectedValue(
+      new Error("Merge failed; workspace may be stale or conflicting"),
+    );
+
+    const res = await app.fetch(
+      request("POST", "/api/changes/chg_abc123/merge", undefined, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("stale or conflicting");
+    expect(updateChangeStatus).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown merge strategy", async () => {
+    const approvedChange: Change = { ...mockChange, status: "approved" };
+    vi.mocked(getChange).mockResolvedValue(approvedChange);
+
+    const res = await app.fetch(
+      request("POST", "/api/changes/chg_abc123/merge?strategy=rebase", undefined, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(mergeWorkspaceIntoProject).not.toHaveBeenCalled();
   });
 
   it("returns 404 when change not found", async () => {
@@ -464,6 +711,17 @@ describe("POST /api/changes/:id/reject", () => {
 
     const res = await app.fetch(request("POST", "/api/changes/chg_abc123/reject"), env);
     expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when rejecting another user's project change", async () => {
+    vi.mocked(getChange).mockResolvedValue(mockChange);
+
+    const res = await app.fetch(
+      request("POST", "/api/changes/chg_abc123/reject", undefined, OTHER_USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(updateChangeStatus).not.toHaveBeenCalled();
   });
 
   it("returns 400 when trying to reject a merged change", async () => {

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -684,6 +684,7 @@ describe("POST /api/changes/:id/reject", () => {
     app = makeApp();
     env = makeEnv();
     vi.clearAllMocks();
+    vi.mocked(getProject).mockResolvedValue(mockProject);
     vi.mocked(updateChangeStatus).mockResolvedValue(undefined);
   });
 

--- a/tests/eval-runs.test.ts
+++ b/tests/eval-runs.test.ts
@@ -46,6 +46,13 @@ function makeD1(): D1Database {
 
   return {
     prepare: (sql: string) => makeStmt(sql, []),
+    batch: async (
+      statements: Array<{
+        run: () => Promise<{ success: boolean; meta: Record<string, unknown> }>;
+      }>,
+    ) => {
+      return Promise.all(statements.map((stmt) => stmt.run()));
+    },
   } as unknown as D1Database;
 }
 

--- a/tests/eval-runs.test.ts
+++ b/tests/eval-runs.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { listEvalRuns, recordEvalRuns } from "../src/storage/eval-runs";
+
+interface StoredRow {
+  id: string;
+  change_id: string;
+  evaluator_type: string;
+  score: number;
+  passed: number;
+  reason: string;
+  issues: string | null;
+  ran_at: string;
+}
+
+function makeD1(): D1Database {
+  const rows: StoredRow[] = [];
+
+  function makeStmt(sql: string, bindings: unknown[]) {
+    return {
+      bind: (...args: unknown[]) => makeStmt(sql, args),
+      run: async () => {
+        if (sql.trim().toUpperCase().startsWith("INSERT INTO EVAL_RUNS")) {
+          rows.push({
+            id: bindings[0] as string,
+            change_id: bindings[1] as string,
+            evaluator_type: bindings[2] as string,
+            score: bindings[3] as number,
+            passed: bindings[4] as number,
+            reason: bindings[5] as string,
+            issues: bindings[6] as string | null,
+            ran_at: bindings[7] as string,
+          });
+        }
+        return { success: true, meta: {} };
+      },
+      all: async <T>() => {
+        const changeId = bindings[0] as string;
+        return {
+          results: rows.filter((row) => row.change_id === changeId) as T[],
+          success: true,
+          meta: {},
+        };
+      },
+    };
+  }
+
+  return {
+    prepare: (sql: string) => makeStmt(sql, []),
+  } as unknown as D1Database;
+}
+
+describe("eval run storage", () => {
+  let db: D1Database;
+
+  beforeEach(() => {
+    db = makeD1();
+  });
+
+  it("records and lists per-evaluator results with issues", async () => {
+    await recordEvalRuns(db, "chg_abc123", [
+      {
+        evaluatorType: "secret_scan",
+        result: {
+          score: 0,
+          passed: false,
+          reason: "Secret detected",
+          issues: ["AWS Access Key: line 4"],
+        },
+      },
+      {
+        evaluatorType: "diff",
+        result: { score: 1, passed: true, reason: "Diff passed" },
+      },
+    ]);
+
+    const runs = await listEvalRuns(db, "chg_abc123");
+    expect(runs).toHaveLength(2);
+    expect(runs[0]).toMatchObject({
+      evaluatorType: "secret_scan",
+      passed: false,
+      issues: ["AWS Access Key: line 4"],
+    });
+    expect(runs[1]).toMatchObject({ evaluatorType: "diff", passed: true });
+  });
+});

--- a/tests/evaluation.test.ts
+++ b/tests/evaluation.test.ts
@@ -343,7 +343,9 @@ describe("loadPolicy", () => {
       requireAll: false,
       minScore: 0.5,
     };
-    mockReadFileFromRepo.mockResolvedValue(JSON.stringify(config));
+    mockReadFileFromRepo
+      .mockRejectedValueOnce(new Error("missing yaml"))
+      .mockResolvedValueOnce(JSON.stringify(config));
     const policy = await loadPolicy("https://repo.example.com", "tok");
     expect(policy.requireAll).toBe(false);
     expect(policy.minScore).toBe(0.5);
@@ -352,7 +354,9 @@ describe("loadPolicy", () => {
 
   it("merges parsed config with defaults", async () => {
     const config = { evaluators: [{ type: "diff", maxLines: 100 }] };
-    mockReadFileFromRepo.mockResolvedValue(JSON.stringify(config));
+    mockReadFileFromRepo
+      .mockRejectedValueOnce(new Error("missing yaml"))
+      .mockResolvedValueOnce(JSON.stringify(config));
     const policy = await loadPolicy("https://repo.example.com", "tok");
     expect(policy.requireAll).toBe(true);
     expect(policy.minScore).toBe(0.7);
@@ -360,13 +364,17 @@ describe("loadPolicy", () => {
   });
 
   it("returns DEFAULT_POLICY on invalid JSON", async () => {
-    mockReadFileFromRepo.mockResolvedValue("not { valid json");
+    mockReadFileFromRepo
+      .mockRejectedValueOnce(new Error("missing yaml"))
+      .mockResolvedValueOnce("not { valid json");
     const policy = await loadPolicy("https://repo.example.com", "tok");
     expect(policy.evaluators).toEqual([{ type: "diff" }]);
   });
 
   it("returns DEFAULT_POLICY when evaluators is missing", async () => {
-    mockReadFileFromRepo.mockResolvedValue(JSON.stringify({ minScore: 0.5 }));
+    mockReadFileFromRepo
+      .mockRejectedValueOnce(new Error("missing yaml"))
+      .mockResolvedValueOnce(JSON.stringify({ minScore: 0.5 }));
     const policy = await loadPolicy("https://repo.example.com", "tok");
     expect(policy.evaluators).toEqual([{ type: "diff" }]);
   });
@@ -375,5 +383,28 @@ describe("loadPolicy", () => {
     mockReadFileFromRepo.mockRejectedValue(new Error("Network error"));
     const policy = await loadPolicy("https://repo.example.com", "tok");
     expect(policy.evaluators).toEqual([{ type: "diff" }]);
+  });
+
+  it("parses .stratum/policy.yaml before stratum.config.json", async () => {
+    mockReadFileFromRepo.mockImplementation(async (_remote, _token, path) => {
+      if (path === ".stratum/policy.yaml") {
+        return [
+          "evaluators:",
+          "  - type: diff",
+          "    maxLines: 42",
+          "requireAll: false",
+          "minScore: 0.4",
+        ].join("\n");
+      }
+      return JSON.stringify({
+        evaluators: [{ type: "webhook", url: "https://example.com/eval" }],
+      });
+    });
+
+    const policy = await loadPolicy("https://repo.example.com", "tok");
+    expect(policy.requireAll).toBe(false);
+    expect(policy.minScore).toBe(0.4);
+    expect(policy.evaluators[0]).toMatchObject({ type: "diff", maxLines: 42 });
+    expect(mockReadFileFromRepo).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/git-ops.test.ts
+++ b/tests/git-ops.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractTokenSecret } from "../src/storage/git-ops";
+import { buildUnifiedDiff, extractTokenSecret } from "../src/storage/git-ops";
 import { MemoryFS } from "../src/storage/memory-fs";
 
 describe("extractTokenSecret", () => {
@@ -71,5 +71,38 @@ describe("commitAndPush path construction", () => {
     await fs.promises.writeFile(fullPath, "content");
     const result = await fs.promises.readFile("/repo/src/index.ts", { encoding: "utf8" });
     expect(result).toBe("content");
+  });
+});
+
+describe("buildUnifiedDiff", () => {
+  it("emits a real hunk for a one-line edit in a large file", () => {
+    const base = Array.from({ length: 120 }, (_, i) => `line ${i + 1}`);
+    const changed = [...base];
+    changed[59] = "line 60 changed";
+
+    const diff = buildUnifiedDiff(
+      new Map([["src/large.ts", `${base.join("\n")}\n`]]),
+      new Map([["src/large.ts", `${changed.join("\n")}\n`]]),
+    );
+
+    expect(diff).toContain("diff --git a/src/large.ts b/src/large.ts");
+    expect(diff).toContain("@@");
+    expect(diff).toContain("-line 60");
+    expect(diff).toContain("+line 60 changed");
+    expect(diff).not.toContain("-line 1\n-line 2\n-line 3");
+  });
+
+  it("preserves new-file and deleted-file diffs", () => {
+    const diff = buildUnifiedDiff(
+      new Map([["src/old.ts", "export const old = true;\n"]]),
+      new Map([["src/new.ts", "export const fresh = true;\n"]]),
+    );
+
+    expect(diff).toContain("diff --git a/src/new.ts b/src/new.ts");
+    expect(diff).toContain("new file mode 100644");
+    expect(diff).toContain("+export const fresh = true;");
+    expect(diff).toContain("diff --git a/src/old.ts b/src/old.ts");
+    expect(diff).toContain("deleted file mode 100644");
+    expect(diff).toContain("-export const old = true;");
   });
 });

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -12,12 +12,40 @@ vi.mock("../src/storage/users", () => ({
         createdAt: "2026-01-01T00:00:00.000Z",
       };
     }
+    if (token === "stratum_user_othertoken000000000000000") {
+      return {
+        id: "user_other",
+        email: "other@example.com",
+        tokenHash: "hash",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      };
+    }
     return null;
   }),
 }));
 
 vi.mock("../src/storage/agents", () => ({
-  getAgentByToken: vi.fn(async () => null),
+  getAgentByToken: vi.fn(async (_, token: string) => {
+    if (token === "stratum_agent_testtoken0000000000000000") {
+      return {
+        id: "agent_test",
+        name: "agent",
+        ownerId: "user_test",
+        tokenHash: "hash",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      };
+    }
+    if (token === "stratum_agent_othertoken00000000000000") {
+      return {
+        id: "agent_other",
+        name: "other-agent",
+        ownerId: "user_other",
+        tokenHash: "hash",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      };
+    }
+    return null;
+  }),
 }));
 
 vi.mock("../src/storage/sessions", () => ({
@@ -26,6 +54,11 @@ vi.mock("../src/storage/sessions", () => ({
 }));
 
 const AUTH_HEADERS = { Authorization: "Bearer stratum_user_testtoken00000000000000000" };
+const OTHER_AUTH_HEADERS = { Authorization: "Bearer stratum_user_othertoken000000000000000" };
+const AGENT_AUTH_HEADERS = { Authorization: "Bearer stratum_agent_testtoken0000000000000000" };
+const OTHER_AGENT_AUTH_HEADERS = {
+  Authorization: "Bearer stratum_agent_othertoken00000000000000",
+};
 
 // ─── KV mock ──────────────────────────────────────────────────────────────────
 
@@ -187,7 +220,7 @@ describe("POST /api/projects", () => {
 describe("GET /api/projects", () => {
   it("returns empty list initially", async () => {
     const env = makeEnv();
-    const res = await app.fetch(request("GET", "/api/projects"), env);
+    const res = await app.fetch(request("GET", "/api/projects", undefined, AUTH_HEADERS), env);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { projects: unknown[] };
     expect(body.projects).toEqual([]);
@@ -196,10 +229,28 @@ describe("GET /api/projects", () => {
   it("lists created projects", async () => {
     const env = makeEnv();
     await app.fetch(request("POST", "/api/projects", { name: "proj-a" }, AUTH_HEADERS), env);
-    const res = await app.fetch(request("GET", "/api/projects"), env);
+    const res = await app.fetch(request("GET", "/api/projects", undefined, AUTH_HEADERS), env);
     const body = (await res.json()) as { projects: ProjectEntry[] };
     expect(body.projects).toHaveLength(1);
     expect(body.projects[0]?.name).toBe("proj-a");
+  });
+
+  it("requires auth to list projects", async () => {
+    const env = makeEnv();
+    const res = await app.fetch(request("GET", "/api/projects"), env);
+    expect(res.status).toBe(401);
+  });
+
+  it("does not list private projects for a different user", async () => {
+    const env = makeEnv();
+    await app.fetch(request("POST", "/api/projects", { name: "proj-a" }, AUTH_HEADERS), env);
+    const res = await app.fetch(
+      request("GET", "/api/projects", undefined, OTHER_AUTH_HEADERS),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { projects: ProjectEntry[] };
+    expect(body.projects).toHaveLength(0);
   });
 });
 
@@ -207,7 +258,10 @@ describe("GET /api/projects/:name/files", () => {
   it("returns file list for existing project", async () => {
     const env = makeEnv();
     await app.fetch(request("POST", "/api/projects", { name: "my-project" }, AUTH_HEADERS), env);
-    const res = await app.fetch(request("GET", "/api/projects/my-project/files"), env);
+    const res = await app.fetch(
+      request("GET", "/api/projects/my-project/files", undefined, AUTH_HEADERS),
+      env,
+    );
     expect(res.status).toBe(200);
     const body = (await res.json()) as { files: string[] };
     expect(body.files).toContain("src/index.ts");
@@ -218,13 +272,26 @@ describe("GET /api/projects/:name/files", () => {
     const res = await app.fetch(request("GET", "/api/projects/nope/files"), env);
     expect(res.status).toBe(404);
   });
+
+  it("returns 403 for another user's private project", async () => {
+    const env = makeEnv();
+    await app.fetch(request("POST", "/api/projects", { name: "my-project" }, AUTH_HEADERS), env);
+    const res = await app.fetch(
+      request("GET", "/api/projects/my-project/files", undefined, OTHER_AUTH_HEADERS),
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
 });
 
 describe("GET /api/projects/:name/log", () => {
   it("returns commit log for existing project", async () => {
     const env = makeEnv();
     await app.fetch(request("POST", "/api/projects", { name: "my-project" }, AUTH_HEADERS), env);
-    const res = await app.fetch(request("GET", "/api/projects/my-project/log"), env);
+    const res = await app.fetch(
+      request("GET", "/api/projects/my-project/log", undefined, AUTH_HEADERS),
+      env,
+    );
     expect(res.status).toBe(200);
     const body = (await res.json()) as { log: unknown[] };
     expect(body.log).toHaveLength(1);
@@ -266,6 +333,32 @@ describe("POST /api/workspaces/projects/:name/workspaces", () => {
     const body = (await res.json()) as { workspace: string; parent: string };
     expect(body.workspace).toBe("fix-bug");
     expect(body.parent).toBe("my-project");
+  });
+
+  it("allows an agent owned by the project owner to fork a workspace", async () => {
+    const res = await app.fetch(
+      request(
+        "POST",
+        "/api/workspaces/projects/my-project/workspaces",
+        { name: "agent-workspace" },
+        AGENT_AUTH_HEADERS,
+      ),
+      env,
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("returns 403 for an agent owned by a different user", async () => {
+    const res = await app.fetch(
+      request(
+        "POST",
+        "/api/workspaces/projects/my-project/workspaces",
+        { name: "bad-agent-workspace" },
+        OTHER_AGENT_AUTH_HEADERS,
+      ),
+      env,
+    );
+    expect(res.status).toBe(403);
   });
 
   it("returns 401 when unauthenticated", async () => {

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -235,10 +235,12 @@ describe("GET /api/projects", () => {
     expect(body.projects[0]?.name).toBe("proj-a");
   });
 
-  it("requires auth to list projects", async () => {
+  it("allows unauthenticated users to list public projects", async () => {
     const env = makeEnv();
     const res = await app.fetch(request("GET", "/api/projects"), env);
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { projects: unknown[] };
+    expect(body.projects).toEqual([]);
   });
 
   it("does not list private projects for a different user", async () => {

--- a/tests/secret-scanner.test.ts
+++ b/tests/secret-scanner.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { SecretScanEvaluator } from "../src/evaluation/secret-scanner";
+import type { EvalPolicy } from "../src/evaluation/types";
 
 const evaluator = new SecretScanEvaluator();
+const policy: EvalPolicy = { evaluators: [], requireAll: true, minScore: 0.7 };
 
 function makeDiff(addedLines: string[], removedLines: string[] = []): string {
   const header = [
@@ -17,7 +19,7 @@ function makeDiff(addedLines: string[], removedLines: string[] = []): string {
 describe("SecretScanEvaluator", () => {
   it("passes a clean diff with no secrets", async () => {
     const diff = makeDiff(["const x = 1;", "export default x;"]);
-    const result = await evaluator.evaluate(diff, null);
+    const result = await evaluator.evaluate(diff, policy);
     expect(result.passed).toBe(true);
     expect(result.score).toBe(1);
     expect(result.reason).toBe("No secrets detected");
@@ -26,7 +28,7 @@ describe("SecretScanEvaluator", () => {
 
   it("detects AWS access key in added line", async () => {
     const diff = makeDiff(['const key = "AKIAIOSFODNN7EXAMPLE";']);
-    const result = await evaluator.evaluate(diff, null);
+    const result = await evaluator.evaluate(diff, policy);
     expect(result.passed).toBe(false);
     expect(result.score).toBe(0);
     expect(result.reason).toContain("AWS Access Key");
@@ -36,42 +38,42 @@ describe("SecretScanEvaluator", () => {
 
   it("detects GitHub classic token in added line", async () => {
     const diff = makeDiff([`const token = "ghp_${"a".repeat(36)}";`]);
-    const result = await evaluator.evaluate(diff, null);
+    const result = await evaluator.evaluate(diff, policy);
     expect(result.passed).toBe(false);
     expect(result.reason).toContain("GitHub Token (Classic)");
   });
 
   it("detects GitHub app token in added line", async () => {
     const diff = makeDiff([`const token = "ghs_${"a".repeat(36)}";`]);
-    const result = await evaluator.evaluate(diff, null);
+    const result = await evaluator.evaluate(diff, policy);
     expect(result.passed).toBe(false);
     expect(result.reason).toContain("GitHub App Token");
   });
 
   it("detects GitHub refresh token in added line", async () => {
     const diff = makeDiff([`const token = "ghr_${"a".repeat(76)}";`]);
-    const result = await evaluator.evaluate(diff, null);
+    const result = await evaluator.evaluate(diff, policy);
     expect(result.passed).toBe(false);
     expect(result.reason).toContain("GitHub Refresh Token");
   });
 
   it("detects Stratum user token in added line", async () => {
     const diff = makeDiff([`const token = "stratum_user_${"a".repeat(32)}";`]);
-    const result = await evaluator.evaluate(diff, null);
+    const result = await evaluator.evaluate(diff, policy);
     expect(result.passed).toBe(false);
     expect(result.reason).toContain("Stratum User Token");
   });
 
   it("detects Stratum agent token in added line", async () => {
     const diff = makeDiff([`const token = "stratum_agent_${"a".repeat(32)}";`]);
-    const result = await evaluator.evaluate(diff, null);
+    const result = await evaluator.evaluate(diff, policy);
     expect(result.passed).toBe(false);
     expect(result.reason).toContain("Stratum Agent Token");
   });
 
   it("does not scan removed lines (starting with -)", async () => {
     const diff = makeDiff(["const safe = true;"], ['const key = "AKIAIOSFODNN7EXAMPLE";']);
-    const result = await evaluator.evaluate(diff, null);
+    const result = await evaluator.evaluate(diff, policy);
     expect(result.passed).toBe(true);
   });
 
@@ -82,20 +84,20 @@ describe("SecretScanEvaluator", () => {
       "+++ b/src/index.ts",
       "+const x = 1;",
     ].join("\n");
-    const result = await evaluator.evaluate(diff, null);
+    const result = await evaluator.evaluate(diff, policy);
     expect(result.passed).toBe(true);
   });
 
   it("reports issue with correct line number", async () => {
     const diff = makeDiff(["const safe = true;", 'const key = "AKIAIOSFODNN7EXAMPLE";']);
-    const result = await evaluator.evaluate(diff, null);
+    const result = await evaluator.evaluate(diff, policy);
     expect(result.passed).toBe(false);
     expect(result.issues?.[0]).toMatch(/line \d+/);
   });
 
   it("ignores policy configuration — always runs", async () => {
     const diff = makeDiff(['const key = "AKIAIOSFODNN7EXAMPLE";']);
-    const resultWithNull = await evaluator.evaluate(diff, null);
+    const resultWithNull = await evaluator.evaluate(diff, policy);
     const resultWithPolicy = await evaluator.evaluate(diff, { evaluators: [], requireAll: false });
     expect(resultWithNull.passed).toBe(false);
     expect(resultWithPolicy.passed).toBe(false);

--- a/tests/ui.test.ts
+++ b/tests/ui.test.ts
@@ -1,0 +1,78 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { uiRouter } from "../src/routes/ui";
+import type { Env } from "../src/types";
+
+vi.mock("../src/storage/changes", () => ({
+  getChange: vi.fn().mockResolvedValue({
+    id: "chg_abc123",
+    project: "my-project",
+    workspace: "fix-bug",
+    status: "merged",
+    evalScore: 0.5,
+    evalPassed: false,
+    evalReason: "Secret detected",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    mergedAt: "2026-01-01T01:00:00.000Z",
+  }),
+  listChanges: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../src/storage/eval-runs", () => ({
+  listEvalRuns: vi.fn().mockResolvedValue([
+    {
+      id: "evl_abc123",
+      changeId: "chg_abc123",
+      evaluatorType: "secret_scan",
+      score: 0,
+      passed: false,
+      reason: "Secret detected",
+      issues: ["AWS Access Key: line 4"],
+      ranAt: "2026-01-01T00:01:00.000Z",
+    },
+  ]),
+}));
+
+vi.mock("../src/storage/provenance", () => ({
+  getProvenance: vi.fn().mockResolvedValue({
+    id: "prv_abc123",
+    commitSha: "abc123def456",
+    project: "my-project",
+    workspace: "fix-bug",
+    changeId: "chg_abc123",
+    mergedAt: "2026-01-01T01:00:00.000Z",
+  }),
+}));
+
+vi.mock("../src/storage/state", () => ({
+  getProject: vi.fn().mockResolvedValue(null),
+  listProjects: vi.fn().mockResolvedValue([]),
+  listWorkspaces: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../src/storage/git-ops", () => ({
+  getCommitLog: vi.fn().mockResolvedValue([]),
+  listFilesInRepo: vi.fn().mockResolvedValue([]),
+}));
+
+function makeApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.route("/ui", uiRouter);
+  return app;
+}
+
+describe("UI routes", () => {
+  it("renders evaluator evidence and provenance on change detail", async () => {
+    const res = await makeApp().fetch(
+      new Request("http://localhost/ui/changes/chg_abc123"),
+      {} as Env,
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Evaluator evidence");
+    expect(html).toContain("secret_scan");
+    expect(html).toContain("AWS Access Key: line 4");
+    expect(html).toContain("Provenance");
+    expect(html).toContain("abc123def456");
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements the next trust-floor sprint for Stratum: authorization on project-scoped operations, per-evaluator evidence, safer merge behavior, policy alignment, UI evidence rendering, and reliable quality gates.

## What changed

- Added owner-based project authorization for project, workspace, change, merge, and reject routes, including agent-owner checks.
- Added per-evaluator `eval_runs` persistence and surfaced evaluator evidence through API/UI.
- Made secret scanning always run and always block approval on failure.
- Added `.stratum/policy.yaml` support ahead of `stratum.config.json` fallback.
- Made missing sandbox/LLM bindings explicit evaluator failures instead of silent skips.
- Made merges safer by removing silent squash fallback, adding explicit `?strategy=squash`, and returning clear conflict/stale errors.
- Added coverage tooling, CI coverage step, and a current-capabilities doc.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` — 18 files, 251 tests passing
- `npm run test:coverage` — passing, overall coverage 60.38%

Note: the existing `tests/users.test.ts` intentionally logs a mocked unique-constraint error to stderr while asserting the 500 path; the suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Change evaluations now display detailed per-evaluator evidence, scores, and reasoning in the UI.
  * Project access control with public/private visibility settings and authorization checks.
  * Configurable merge strategies (merge or squash) for integrating workspace changes.
  * Policy configuration files now support YAML format (.stratum/policy.yaml).

* **Bug Fixes**
  * Improved merge conflict error messaging.
  * Fixed file deletion handling in squash merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->