### PR TITLE
fix: remove duplicate version column from migration 011

### DIFF
--- a/migrations/011_import_jobs_version.sql
+++ b/migrations/011_import_jobs_version.sql
@@ -1,7 +1,5 @@
--- Add version column for optimistic locking
--- Prevents race conditions during concurrent import progress updates
-
-ALTER TABLE import_jobs ADD COLUMN version INTEGER NOT NULL DEFAULT 1;
+-- version column was included directly in 010_import_jobs.sql's CREATE TABLE,
+-- so the ALTER TABLE is skipped here to avoid "duplicate column name" on existing DBs.
 
 -- Create index for efficient version-based lookups during updates
 CREATE INDEX IF NOT EXISTS idx_import_jobs_version ON import_jobs(id, version);


### PR DESCRIPTION
## Summary

- `010_import_jobs.sql` already includes `version INTEGER DEFAULT 1` in its `CREATE TABLE`
- `011_import_jobs_version.sql` then tries `ALTER TABLE ADD COLUMN version`, which fails with `duplicate column name: SQLITE_ERROR` on any DB where `010` was already applied (including staging)
- Drop the `ALTER TABLE` from `011` and keep only the `CREATE INDEX IF NOT EXISTS`, which is idempotent and works on both existing and fresh databases

Fixes the staging deploy failure in https://github.com/jlamoreaux/stratum/actions/runs/25530018568/job/74934110048#step:5:356

## Test plan
- [ ] Staging migration applies cleanly (`011` adds the index, skips the column)
- [ ] Fresh DB (e.g. PR preview) runs both `010` and `011` without error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)