### PR TITLE
fix: use root domain for EMAIL_FROM_ADDRESS in preview environments

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -318,7 +318,7 @@ jobs:
           [vars]
           POSTHOG_HOST = "https://app.posthog.com"
           OAUTH_REDIRECT_URI = "https://${{ env.PREVIEW_SUBDOMAIN }}.staging.app.usestratum.dev/auth/github/callback"
-          EMAIL_FROM_ADDRESS = "noreply@staging.app.usestratum.dev"
+          EMAIL_FROM_ADDRESS = "noreply@usestratum.dev"
           PREVIEW_ENV = "pr-${{ env.PR_NUMBER }}"
           EOF
           


### PR DESCRIPTION
## Summary

- Preview environments were setting `EMAIL_FROM_ADDRESS = "noreply@staging.app.usestratum.dev"`
- `staging.app.usestratum.dev` is a wildcard HTTP subdomain — it has no Email Routing outbound record in Cloudflare
- This causes `E_SENDER_DOMAIN_NOT_AVAILABLE` from Cloudflare Email Workers whenever a preview environment tries to send a magic link
- Fix: use `noreply@usestratum.dev` (the zone root, which is configured for Email Workers outbound sending)

## Test plan
- [ ] Trigger signup on a PR preview environment and confirm magic link email sends successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)