### PR TITLE
fix: resolve broken UI routes, dead links, and wrong form actions

### DIFF
--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -4,6 +4,7 @@ import { listEvalRuns } from "../storage/eval-runs";
 import { getCommitLog, listFilesInRepo, readFileFromRepo } from "../storage/git-ops";
 import { getImportProgress } from "../storage/imports";
 import { getProject, getProjectByPath, listProjects, listWorkspaces } from "../storage/state";
+import { getSyncStatus } from "../storage/sync";
 import { getUser } from "../storage/users";
 import type { Env } from "../types";
 import { ChangeDetailPage } from "../ui/pages/change-detail";
@@ -11,6 +12,7 @@ import { ChangesPage } from "../ui/pages/changes";
 import { HomePage } from "../ui/pages/home";
 import { NewProjectPage } from "../ui/pages/new-project";
 import { RepoPage } from "../ui/pages/repo";
+import { SyncPage } from "../ui/pages/sync";
 import { WorkspacesPage } from "../ui/pages/workspaces";
 import { canReadProject, filterReadableProjects } from "../utils/authz";
 import { createLogger } from "../utils/logger";
@@ -408,6 +410,194 @@ app.get("/p/:name/workspaces", async (c) => {
       project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
       workspaces={view}
       user={userResult}
+    />,
+  );
+});
+
+// GET /:namespace/:slug/changes — Changes list (namespace format)
+app.get("/:namespace/:slug/changes", async (c) => {
+  const { namespace, slug } = c.req.param();
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const logger = createLogger({ path: c.req.path, userId });
+
+  if (!isValidNamespace(namespace) || !isValidSlug(slug)) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">Invalid project path.</div>,
+      400,
+    );
+  }
+
+  const [userResult, projectResult] = await Promise.all([
+    getCurrentUser(c, logger),
+    getProjectByPath(c.env.STATE, namespace, slug, logger),
+  ]);
+
+  if (!projectResult.success) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Project '{namespace}/{slug}' not found.
+      </div>,
+      404,
+    );
+  }
+  const project = projectResult.data;
+
+  if (!canReadProject(project, userId, agentOwnerId)) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">Access denied.</div>,
+      403,
+    );
+  }
+
+  const changesResult = await listChanges(c.env.DB, logger, project.name);
+  const changes = changesResult.success
+    ? changesResult.data.map((change) => ({
+        id: change.id,
+        project: change.project,
+        workspace: change.workspace,
+        status: change.status,
+        ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+        ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
+        createdAt: change.createdAt,
+      }))
+    : [];
+
+  return c.html(
+    <ChangesPage
+      project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
+      changes={changes}
+      user={userResult}
+    />,
+  );
+});
+
+// GET /:namespace/:slug/workspaces — Workspaces list (namespace format)
+app.get("/:namespace/:slug/workspaces", async (c) => {
+  const { namespace, slug } = c.req.param();
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const logger = createLogger({ path: c.req.path, userId });
+
+  if (!isValidNamespace(namespace) || !isValidSlug(slug)) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">Invalid project path.</div>,
+      400,
+    );
+  }
+
+  const [userResult, projectResult] = await Promise.all([
+    getCurrentUser(c, logger),
+    getProjectByPath(c.env.STATE, namespace, slug, logger),
+  ]);
+
+  if (!projectResult.success) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Project '{namespace}/{slug}' not found.
+      </div>,
+      404,
+    );
+  }
+  const project = projectResult.data;
+
+  if (!canReadProject(project, userId, agentOwnerId)) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">Access denied.</div>,
+      403,
+    );
+  }
+
+  const workspacesResult = await listWorkspaces(c.env.STATE, project.id, logger);
+  const workspaces = workspacesResult.success
+    ? workspacesResult.data.map((ws) => ({
+        name: ws.name,
+        parent: ws.parent,
+        createdAt: ws.createdAt,
+      }))
+    : [];
+
+  return c.html(
+    <WorkspacesPage
+      project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
+      workspaces={workspaces}
+      user={userResult}
+    />,
+  );
+});
+
+// GET /:namespace/:slug/sync — Sync management page
+app.get("/:namespace/:slug/sync", async (c) => {
+  const { namespace, slug } = c.req.param();
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const logger = createLogger({ path: c.req.path, userId });
+
+  if (!isValidNamespace(namespace) || !isValidSlug(slug)) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">Invalid project path.</div>,
+      400,
+    );
+  }
+
+  if (!userId) {
+    return c.redirect("/auth/email");
+  }
+
+  const [_userResult, projectResult] = await Promise.all([
+    getCurrentUser(c, logger),
+    getProjectByPath(c.env.STATE, namespace, slug, logger),
+  ]);
+
+  if (!projectResult.success) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Project '{namespace}/{slug}' not found.
+      </div>,
+      404,
+    );
+  }
+  const project = projectResult.data;
+
+  if (!canReadProject(project, userId, agentOwnerId)) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">Access denied.</div>,
+      403,
+    );
+  }
+
+  const syncStatusResult = await getSyncStatus(c.env.STATE, namespace, slug, logger);
+  const stored = syncStatusResult.success ? syncStatusResult.data : null;
+  const syncStatus = {
+    namespace,
+    slug,
+    sourceUrl: project.remote || "",
+    sourceBranch: "main",
+    lastSyncStatus: (stored?.lastSyncStatus ?? "idle") as
+      | "success"
+      | "failed"
+      | "in_progress"
+      | "idle",
+    lastSyncedAt: stored?.lastSyncedAt,
+    lastSyncedCommit: stored?.lastSyncedCommit,
+    lastSyncError: stored?.lastSyncError,
+    hasUpdates: stored?.hasUpdates ?? false,
+    commitsBehind: stored?.commitsBehind,
+    latestCommit: stored?.latestCommit,
+    autoSyncEnabled: stored?.autoSyncEnabled ?? false,
+    syncFrequency: stored?.syncFrequency,
+    lastCheckedAt: stored?.lastCheckedAt ?? new Date().toISOString(),
+  };
+
+  return c.html(
+    <SyncPage
+      project={{
+        namespace: project.namespace || namespace,
+        slug: project.slug || slug,
+        name: project.name,
+      }}
+      syncStatus={syncStatus}
+      syncHistory={[]}
     />,
   );
 });

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -451,17 +451,25 @@ app.get("/:namespace/:slug/changes", async (c) => {
   }
 
   const changesResult = await listChanges(c.env.DB, logger, project.name);
-  const changes = changesResult.success
-    ? changesResult.data.map((change) => ({
-        id: change.id,
-        project: change.project,
-        workspace: change.workspace,
-        status: change.status,
-        ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
-        ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
-        createdAt: change.createdAt,
-      }))
-    : [];
+  if (!changesResult.success) {
+    logger.error("Failed to list changes", changesResult.error);
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Error loading changes. Please try again.
+      </div>,
+      500,
+    );
+  }
+
+  const changes = changesResult.data.map((change) => ({
+    id: change.id,
+    project: change.project,
+    workspace: change.workspace,
+    status: change.status,
+    ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+    ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
+    createdAt: change.createdAt,
+  }));
 
   return c.html(
     <ChangesPage
@@ -509,13 +517,21 @@ app.get("/:namespace/:slug/workspaces", async (c) => {
   }
 
   const workspacesResult = await listWorkspaces(c.env.STATE, project.id, logger);
-  const workspaces = workspacesResult.success
-    ? workspacesResult.data.map((ws) => ({
-        name: ws.name,
-        parent: ws.parent,
-        createdAt: ws.createdAt,
-      }))
-    : [];
+  if (!workspacesResult.success) {
+    logger.error("Failed to list workspaces", workspacesResult.error);
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Error loading workspaces. Please try again.
+      </div>,
+      500,
+    );
+  }
+
+  const workspaces = workspacesResult.data.map((ws) => ({
+    name: ws.name,
+    parent: ws.parent,
+    createdAt: ws.createdAt,
+  }));
 
   return c.html(
     <WorkspacesPage

--- a/src/ui/components/conflict-resolution.tsx
+++ b/src/ui/components/conflict-resolution.tsx
@@ -99,9 +99,9 @@ export const ConflictResolution: FC<ConflictResolutionProps> = ({ conflict, onRe
           >
             Accept All Theirs
           </button>
-          <a href="/docs/conflict-resolution" class="btn btn-link" target="_blank" rel="noreferrer">
+          <span class="btn btn-link" style="cursor:default;opacity:0.5">
             📖 Learn More
-          </a>
+          </span>
         </div>
       )}
 

--- a/src/ui/components/import-progress.tsx
+++ b/src/ui/components/import-progress.tsx
@@ -341,20 +341,6 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
               🔄 Retry Import
             </button>
           </form>
-          <a
-            href={"/docs/troubleshooting#import-errors"}
-            class="btn btn-link"
-            target="_blank"
-            rel="noreferrer"
-          >
-            📖 View Documentation
-          </a>
-          <a
-            href={`/support?error=${encodeURIComponent(mainError)}&project=${namespace}/${slug}`}
-            class="btn btn-link"
-          >
-            📧 Contact Support
-          </a>
         </div>
       )}
 

--- a/src/ui/pages/repo.tsx
+++ b/src/ui/pages/repo.tsx
@@ -102,7 +102,7 @@ export const RepoPage: FC<RepoProps> = ({
           {hasSource && canSync && (
             <form
               method="post"
-              action={`/${project.namespace}/${project.slug}/sync`}
+              action={`/api/projects/${project.namespace}/${project.slug}/sync`}
               style={{ display: "inline" }}
             >
               <button

--- a/src/ui/pages/sync.tsx
+++ b/src/ui/pages/sync.tsx
@@ -66,7 +66,7 @@ export const SyncPage: FC<SyncPageProps> = ({ project, syncStatus, syncHistory }
         <div class="page-header">
           <h1>Sync Status</h1>
           <div class="header-actions">
-            <a href={`/p/${project.namespace}/${project.slug}`} class="btn btn-secondary">
+            <a href={`/${project.namespace}/${project.slug}`} class="btn btn-secondary">
               ← Back to Project
             </a>
           </div>


### PR DESCRIPTION
## Summary

- **Missing routes**: `GET /:namespace/:slug/changes`, `/:namespace/:slug/workspaces`, and `/:namespace/:slug/sync` were never registered in the UI router — only the deprecated `/p/:name` variants existed. The "View changes" button on every repo page was a dead link.
- **Wrong sync form action**: The sync button on the repo page posted to `/:namespace/:slug/sync` (a UI path that doesn't exist) instead of `/api/projects/:namespace/:slug/sync`.
- **Broken back link on sync page**: Back button produced `/p/@user/repo` which doesn't match the single-segment `/p/:name` route pattern — always 404'd.
- **Dead doc/support links**: Import error UI linked to `/docs/troubleshooting` and `/support` — neither route exists. Removed both.
- **Dead conflict-resolution doc link**: Replaced broken `/docs/conflict-resolution` anchor with a disabled placeholder.

## Test plan

- [ ] Navigate to a project repo page — "View changes" button loads correctly
- [ ] On a synced project, click "Sync Now" — posts to correct API endpoint
- [ ] Navigate to `/:namespace/:slug/sync` — sync management page renders
- [ ] On the sync page, "Back to Project" returns to `/:namespace/:slug`
- [ ] Trigger an import failure — no broken doc/support links in the error UI
- [ ] `npm run typecheck`, `npm run lint`, `npm test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated project pages for Changes, Workspaces, and Sync management.

* **Improvements**
  * Enhanced import failure UI with categorized error details, troubleshooting tips, and contextual actions.
  * Unified routing/navigation for project and sync pages.
  * Simplified conflict-resolution UI by replacing the external docs link with an inline “Learn More” element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->