### PR TITLE
feat: collapsible file tree and file viewer

### DIFF
--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -24,6 +24,7 @@ import {
 } from "../storage/sync";
 import type { ArtifactsCreateResult, Env, ProjectEntry } from "../types";
 import { getArtifactsRepoName } from "../types";
+import { getFileContent, isValidFilePath } from "../ui/file-content";
 import { canReadProject, filterReadableProjects } from "../utils/authz";
 import { createLogger } from "../utils/logger";
 import type { Logger } from "../utils/logger";
@@ -719,6 +720,53 @@ app.get("/:namespace/:slug/files", async (c) => {
     path: `/${namespace}/${slug}`,
     files: filesResult.data,
   });
+});
+
+// GET /projects/:namespace/:slug/content - Get file content by path
+app.get("/:namespace/:slug/content", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const { namespace, slug } = c.req.param();
+  const filePath = c.req.query("path");
+
+  if (!filePath) return badRequest("Missing required query parameter: path");
+  if (!isValidFilePath(filePath)) return badRequest("Invalid file path");
+
+  const projectResult = await getProjectByPath(c.env.STATE, namespace, slug, logger);
+  if (!projectResult.success) {
+    if (projectResult.error.code === "NOT_FOUND") {
+      return notFound("Project", `${namespace}/${slug}`);
+    }
+    return internalError(projectResult.error.message);
+  }
+  const project = projectResult.data;
+
+  if (!canReadProject(project, userId, agentOwnerId)) return forbidden("Project access denied");
+
+  const contentResult = await getFileContent(project.remote, project.token, filePath, logger);
+  if (!contentResult.success) {
+    return internalError(contentResult.error.message);
+  }
+
+  const result = contentResult.data;
+  logger.info("File content retrieved", { namespace, slug, path: filePath, kind: result.kind });
+
+  if (result.kind === "not-found") {
+    return notFound("File", filePath);
+  }
+
+  if (result.kind === "content") {
+    return ok({ namespace, slug, path: filePath, kind: "content", value: result.value });
+  }
+
+  return ok({ namespace, slug, path: filePath, kind: result.kind });
 });
 
 // GET /projects/:namespace/:slug/log - Get commit log

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -628,6 +628,22 @@ app.get("/:namespace/:slug/blob/*", async (c) => {
   const agentOwnerId = c.get("agentOwnerId");
   const logger = createLogger({ path: c.req.path, userId });
 
+  if (!isValidNamespace(namespace)) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Invalid namespace format.
+      </div>,
+      400,
+    );
+  }
+
+  if (!isValidSlug(slug)) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">Invalid slug format.</div>,
+      400,
+    );
+  }
+
   if (!filePath || !isValidFilePath(filePath)) {
     return c.html(
       <div style="padding:2rem;font-family:monospace;color:#f87171;">Invalid file path.</div>,

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -7,8 +7,10 @@ import { getProject, getProjectByPath, listProjects, listWorkspaces } from "../s
 import { getSyncStatus } from "../storage/sync";
 import { getUser } from "../storage/users";
 import type { Env } from "../types";
+import { getFileContent, isValidFilePath } from "../ui/file-content";
 import { ChangeDetailPage } from "../ui/pages/change-detail";
 import { ChangesPage } from "../ui/pages/changes";
+import { FileViewerPage } from "../ui/pages/file-viewer";
 import { HomePage } from "../ui/pages/home";
 import { NewProjectPage } from "../ui/pages/new-project";
 import { RepoPage } from "../ui/pages/repo";
@@ -614,6 +616,77 @@ app.get("/:namespace/:slug/sync", async (c) => {
       }}
       syncStatus={syncStatus}
       syncHistory={[]}
+    />,
+  );
+});
+
+// GET /:namespace/:slug/blob/* — File viewer (must be before /:namespace/:slug catch-all)
+app.get("/:namespace/:slug/blob/*", async (c) => {
+  const { namespace, slug } = c.req.param();
+  const filePath = c.req.param("*") ?? "";
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const logger = createLogger({ path: c.req.path, userId });
+
+  if (!filePath || !isValidFilePath(filePath)) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">Invalid file path.</div>,
+      400,
+    );
+  }
+
+  const [userResult, projectResult] = await Promise.all([
+    getCurrentUser(c, logger),
+    getProjectByPath(c.env.STATE, namespace, slug, logger),
+  ]);
+
+  if (!projectResult.success) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Project '{namespace}/{slug}' not found.
+      </div>,
+      404,
+    );
+  }
+  const project = projectResult.data;
+
+  if (!canReadProject(project, userId, agentOwnerId)) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Access denied. You don't have permission to view this project.
+      </div>,
+      403,
+    );
+  }
+
+  const contentResult = await getFileContent(project.remote, project.token, filePath, logger);
+  if (!contentResult.success) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">Error loading file.</div>,
+      500,
+    );
+  }
+
+  const content = contentResult.data;
+  if (content.kind === "not-found") {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        File '{filePath}' not found in this repository.
+      </div>,
+      404,
+    );
+  }
+
+  return c.html(
+    <FileViewerPage
+      project={{
+        namespace: project.namespace,
+        slug: project.slug,
+        name: project.name,
+      }}
+      path={filePath}
+      content={content}
+      user={userResult}
     />,
   );
 });

--- a/src/ui/components/file-tree.tsx
+++ b/src/ui/components/file-tree.tsx
@@ -1,0 +1,96 @@
+import type { FC } from "hono/jsx";
+import type { FileTreeNode } from "../file-tree";
+
+const MAX_RENDERED_NODES = 500;
+
+interface FileTreeProps {
+  nodes: FileTreeNode[];
+  namespace: string;
+  slug: string;
+}
+
+interface NodeProps {
+  node: FileTreeNode;
+  namespace: string;
+  slug: string;
+  depth: number;
+  counter: { value: number };
+}
+
+const FileTreeNodeItem: FC<NodeProps> = ({ node, namespace, slug, depth, counter }) => {
+  if (counter.value >= MAX_RENDERED_NODES) return null;
+  counter.value++;
+
+  if (node.type === "file") {
+    const href = `/${namespace}/${slug}/blob/${node.path.split("/").map(encodeURIComponent).join("/")}`;
+    return (
+      <div class="file-tree-file">
+        <a href={href}>{node.name}</a>
+      </div>
+    );
+  }
+
+  return (
+    <details open={depth === 0} class="file-tree-dir">
+      <summary>{node.name}</summary>
+      <div class="file-tree-children">
+        {node.children.map((child) => (
+          <FileTreeNodeItem
+            key={child.path}
+            node={child}
+            namespace={namespace}
+            slug={slug}
+            depth={depth + 1}
+            counter={counter}
+          />
+        ))}
+      </div>
+    </details>
+  );
+};
+
+export const FileTree: FC<FileTreeProps> = ({ nodes, namespace, slug }) => {
+  if (nodes.length === 0) {
+    return (
+      <div class="empty-state">
+        <p>No files in this repository.</p>
+      </div>
+    );
+  }
+
+  const counter = { value: 0 };
+  const totalFiles = countFiles(nodes);
+
+  return (
+    <div class="file-tree">
+      {nodes.map((node) => (
+        <FileTreeNodeItem
+          key={node.path}
+          node={node}
+          namespace={namespace}
+          slug={slug}
+          depth={0}
+          counter={counter}
+        />
+      ))}
+      {totalFiles > MAX_RENDERED_NODES && (
+        <p class="file-tree-notice">
+          Showing first {MAX_RENDERED_NODES} of {totalFiles} files. Use the API to browse the full
+          tree.
+        </p>
+      )}
+    </div>
+  );
+};
+
+function countFiles(nodes: FileTreeNode[]): number {
+  let count = 0;
+  for (const node of nodes) {
+    if (node.type === "file") {
+      count++;
+    } else {
+      count += countFiles(node.children);
+    }
+  }
+  return count;
+}

--- a/src/ui/components/file-tree.tsx
+++ b/src/ui/components/file-tree.tsx
@@ -59,7 +59,7 @@ export const FileTree: FC<FileTreeProps> = ({ nodes, namespace, slug }) => {
   }
 
   const counter = { value: 0 };
-  const totalFiles = countFiles(nodes);
+  const totalEntries = countNodes(nodes);
 
   return (
     <div class="file-tree">
@@ -73,23 +73,22 @@ export const FileTree: FC<FileTreeProps> = ({ nodes, namespace, slug }) => {
           counter={counter}
         />
       ))}
-      {totalFiles > MAX_RENDERED_NODES && (
+      {totalEntries > MAX_RENDERED_NODES && (
         <p class="file-tree-notice">
-          Showing first {MAX_RENDERED_NODES} of {totalFiles} files. Use the API to browse the full
-          tree.
+          Showing first {MAX_RENDERED_NODES} of {totalEntries} entries. Use the API to browse the
+          full tree.
         </p>
       )}
     </div>
   );
 };
 
-function countFiles(nodes: FileTreeNode[]): number {
+function countNodes(nodes: FileTreeNode[]): number {
   let count = 0;
   for (const node of nodes) {
-    if (node.type === "file") {
-      count++;
-    } else {
-      count += countFiles(node.children);
+    count++;
+    if (node.type === "dir") {
+      count += countNodes(node.children);
     }
   }
   return count;

--- a/src/ui/file-content.ts
+++ b/src/ui/file-content.ts
@@ -1,0 +1,52 @@
+import { readFileFromRepo } from "../storage/git-ops";
+import type { AppError } from "../utils/errors";
+import type { Logger } from "../utils/logger";
+import type { Result } from "../utils/result";
+import { err, ok } from "../utils/result";
+
+export type FileContentResult =
+  | { kind: "content"; value: string }
+  | { kind: "binary" }
+  | { kind: "oversize" }
+  | { kind: "not-found" };
+
+const MAX_FILE_BYTES = 512 * 1024;
+
+export function isValidFilePath(path: string): boolean {
+  if (!path || path.length > 4096) return false;
+  if (path.startsWith("/")) return false;
+  if (path.includes("\0")) return false;
+  const segments = path.split("/");
+  for (const segment of segments) {
+    if (segment === ".." || segment === ".") return false;
+  }
+  return true;
+}
+
+export async function getFileContent(
+  remote: string,
+  token: string,
+  path: string,
+  logger: Logger,
+): Promise<Result<FileContentResult, AppError>> {
+  const readResult = await readFileFromRepo(remote, token, path, logger);
+
+  if (!readResult.success) {
+    if (readResult.error.code === "FS_ERROR") {
+      return ok({ kind: "not-found" });
+    }
+    return err(readResult.error);
+  }
+
+  const content = readResult.data;
+
+  if (content.includes("\0")) {
+    return ok({ kind: "binary" });
+  }
+
+  if (new TextEncoder().encode(content).length > MAX_FILE_BYTES) {
+    return ok({ kind: "oversize" });
+  }
+
+  return ok({ kind: "content", value: content });
+}

--- a/src/ui/file-tree.ts
+++ b/src/ui/file-tree.ts
@@ -1,0 +1,61 @@
+export type FileTreeNode =
+  | { type: "file"; name: string; path: string }
+  | { type: "dir"; name: string; path: string; children: FileTreeNode[] };
+
+export function buildFileTree(paths: string[]): FileTreeNode[] {
+  const root: FileTreeNode[] = [];
+
+  for (const filePath of paths) {
+    const parts = filePath.split("/").filter((p) => p.length > 0);
+    insertNode(root, parts, 0, "");
+  }
+
+  sortNodes(root);
+  return root;
+}
+
+function insertNode(
+  nodes: FileTreeNode[],
+  parts: readonly string[],
+  depth: number,
+  prefix: string,
+): void {
+  if (depth >= parts.length) return;
+
+  const name = parts[depth] ?? "";
+  if (!name) return;
+
+  const path = prefix ? `${prefix}/${name}` : name;
+
+  if (depth === parts.length - 1) {
+    nodes.push({ type: "file", name, path });
+    return;
+  }
+
+  let dir = nodes.find(
+    (n): n is Extract<FileTreeNode, { type: "dir" }> => n.type === "dir" && n.name === name,
+  );
+  if (!dir) {
+    const newDir: Extract<FileTreeNode, { type: "dir" }> = {
+      type: "dir",
+      name,
+      path,
+      children: [],
+    };
+    nodes.push(newDir);
+    dir = newDir;
+  }
+
+  insertNode(dir.children, parts, depth + 1, path);
+}
+
+function sortNodes(nodes: FileTreeNode[]): void {
+  nodes.sort((a, b) => {
+    if (a.type !== b.type) return a.type === "dir" ? -1 : 1;
+    return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+  });
+
+  for (const node of nodes) {
+    if (node.type === "dir") sortNodes(node.children);
+  }
+}

--- a/src/ui/pages/file-viewer.tsx
+++ b/src/ui/pages/file-viewer.tsx
@@ -1,0 +1,109 @@
+import { Fragment } from "hono/jsx";
+import type { FC } from "hono/jsx";
+import type { FileContentResult } from "../file-content";
+import { Layout } from "../layout";
+
+const extensionToLanguage: Record<string, string> = {
+  ts: "typescript",
+  tsx: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  py: "python",
+  go: "go",
+  rs: "rust",
+  md: "markdown",
+  json: "json",
+  css: "css",
+  html: "html",
+  htm: "html",
+  sh: "shell",
+  bash: "shell",
+  yaml: "yaml",
+  yml: "yaml",
+  toml: "toml",
+  sql: "sql",
+  graphql: "graphql",
+  gql: "graphql",
+  rb: "ruby",
+  java: "java",
+  kt: "kotlin",
+  swift: "swift",
+  c: "c",
+  cpp: "cpp",
+  h: "c",
+  cs: "csharp",
+  php: "php",
+  xml: "xml",
+  svg: "xml",
+};
+
+function languageFromPath(filePath: string): string {
+  const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+  return extensionToLanguage[ext] ?? "plaintext";
+}
+
+interface BreadcrumbProps {
+  namespace: string;
+  slug: string;
+  filePath: string;
+}
+
+const Breadcrumb: FC<BreadcrumbProps> = ({ namespace, slug, filePath }) => {
+  const segments = filePath.split("/").filter((s) => s.length > 0);
+
+  return (
+    <div class="file-viewer-breadcrumb">
+      <a href={`/${namespace}/${slug}`}>{namespace}</a>
+      <span class="sep">/</span>
+      <a href={`/${namespace}/${slug}`}>{slug}</a>
+      {segments.map((segment, i) => {
+        const isLast = i === segments.length - 1;
+        return (
+          <Fragment key={`seg-${i}`}>
+            <span class="sep">/</span>
+            {isLast ? (
+              <span class="file-viewer-breadcrumb-current">{segment}</span>
+            ) : (
+              <a href={`/${namespace}/${slug}`}>{segment}</a>
+            )}
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+};
+
+interface FileViewerPageProps {
+  project: { namespace: string; slug: string; name: string };
+  path: string;
+  content: FileContentResult;
+  user?: { id: string; email: string; username: string } | null;
+}
+
+export const FileViewerPage: FC<FileViewerPageProps> = ({ project, path, content, user }) => {
+  const { namespace, slug } = project;
+  const language = languageFromPath(path);
+  const fileName = path.split("/").pop() ?? path;
+
+  return (
+    <Layout title={`${fileName} — ${project.name}`} user={user}>
+      <div class="page-header">
+        <Breadcrumb namespace={namespace} slug={slug} filePath={path} />
+      </div>
+
+      <div class="card file-viewer-content">
+        {content.kind === "content" && (
+          <pre>
+            <code class={`language-${language}`}>{content.value}</code>
+          </pre>
+        )}
+        {content.kind === "binary" && <p class="file-viewer-message">Binary file — not shown.</p>}
+        {content.kind === "oversize" && (
+          <p class="file-viewer-message">File too large to display (&gt; 512 KB).</p>
+        )}
+      </div>
+    </Layout>
+  );
+};

--- a/src/ui/pages/repo.tsx
+++ b/src/ui/pages/repo.tsx
@@ -1,6 +1,8 @@
 import type { FC } from "hono/jsx";
 import type { GitProvider, ImportProgress } from "../../types";
+import { FileTree } from "../components/file-tree";
 import { ImportProgressCard } from "../components/import-progress";
+import { buildFileTree } from "../file-tree";
 import { Layout } from "../layout";
 
 interface RepoProps {
@@ -220,19 +222,7 @@ export const RepoPage: FC<RepoProps> = ({
 
       <div class="card">
         <h2>Files</h2>
-        {files.length === 0 ? (
-          <div class="empty-state">
-            <p>No files in this repository.</p>
-          </div>
-        ) : (
-          <ul class="file-list">
-            {files.map((file) => (
-              <li key={file} class="file-item">
-                {file}
-              </li>
-            ))}
-          </ul>
-        )}
+        <FileTree nodes={buildFileTree(files)} namespace={project.namespace} slug={project.slug} />
       </div>
 
       <div class="card">

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -373,6 +373,7 @@ a:hover { text-decoration: underline; }
 .file-tree-dir > summary::before { content: "▶  "; font-size: 0.7rem; }
 .file-tree-dir[open] > summary::before { content: "▼  "; font-size: 0.7rem; }
 .file-tree-dir > summary::-webkit-details-marker { display: none; }
+.file-tree-dir > summary::marker { content: ""; }
 .file-tree-children { padding-left: 1.25rem; }
 .file-tree-file { padding: 0.2rem 0; }
 .file-tree-file a { color: #ccc; text-decoration: none; display: block; }

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -359,4 +359,52 @@ a:hover { text-decoration: underline; }
   padding-top: 1rem;
   border-top: 1px solid #1e1e1e;
 }
+
+/* File Tree */
+.file-tree { font-family: 'JetBrains Mono', monospace; font-size: 0.85rem; }
+.file-tree-dir { border: none; }
+.file-tree-dir > summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 0.25rem 0;
+  color: #aaa;
+  user-select: none;
+}
+.file-tree-dir > summary::before { content: "▶  "; font-size: 0.7rem; }
+.file-tree-dir[open] > summary::before { content: "▼  "; font-size: 0.7rem; }
+.file-tree-dir > summary::-webkit-details-marker { display: none; }
+.file-tree-children { padding-left: 1.25rem; }
+.file-tree-file { padding: 0.2rem 0; }
+.file-tree-file a { color: #ccc; text-decoration: none; display: block; }
+.file-tree-file a:hover { color: #f0f0f0; text-decoration: underline; }
+.file-tree-notice { font-size: 0.8rem; color: #555; margin-top: 0.75rem; font-style: italic; }
+
+/* File Viewer */
+.file-viewer-breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  align-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  margin-bottom: 0;
+  color: #888;
+}
+.file-viewer-breadcrumb a { color: #7ca9f7; text-decoration: none; }
+.file-viewer-breadcrumb a:hover { text-decoration: underline; }
+.file-viewer-breadcrumb .sep { color: #444; }
+.file-viewer-breadcrumb-current { color: #f0f0f0; }
+.file-viewer-content { padding: 0; overflow: hidden; }
+.file-viewer-content pre {
+  margin: 0;
+  padding: 1rem;
+  overflow-x: auto;
+  white-space: pre;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #d4d4d4;
+  line-height: 1.6;
+  background: #0d0d0d;
+}
+.file-viewer-message { padding: 1.5rem; color: #666; font-style: italic; font-size: 0.85rem; margin: 0; }
 `;

--- a/tests/file-content.test.ts
+++ b/tests/file-content.test.ts
@@ -82,6 +82,16 @@ describe("getFileContent", () => {
     }
   });
 
+  it("returns content for file exactly at the 512 KB limit", async () => {
+    const exactContent = "x".repeat(512 * 1024);
+    vi.mocked(readFileFromRepo).mockResolvedValueOnce({ success: true, data: exactContent });
+    const result = await getFileContent("remote", "token", "exact.txt", defaultLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ kind: "content", value: exactContent });
+    }
+  });
+
   it("returns not-found for FS_ERROR", async () => {
     const { AppError } = await import("../src/utils/errors");
     vi.mocked(readFileFromRepo).mockResolvedValueOnce({

--- a/tests/file-content.test.ts
+++ b/tests/file-content.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { getFileContent, isValidFilePath } from "../src/ui/file-content";
+import { defaultLogger } from "../src/utils/logger";
+
+vi.mock("../src/storage/git-ops", () => ({
+  readFileFromRepo: vi.fn(),
+}));
+
+import { readFileFromRepo } from "../src/storage/git-ops";
+
+describe("isValidFilePath", () => {
+  it("accepts a simple root-level filename", () => {
+    expect(isValidFilePath("README.md")).toBe(true);
+  });
+
+  it("accepts a nested path", () => {
+    expect(isValidFilePath("src/utils/helpers.ts")).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    expect(isValidFilePath("")).toBe(false);
+  });
+
+  it("rejects .. segment", () => {
+    expect(isValidFilePath("../etc/passwd")).toBe(false);
+  });
+
+  it("rejects .. in middle of path", () => {
+    expect(isValidFilePath("src/../secret")).toBe(false);
+  });
+
+  it("rejects . segment", () => {
+    expect(isValidFilePath("./file.ts")).toBe(false);
+  });
+
+  it("rejects absolute path", () => {
+    expect(isValidFilePath("/etc/passwd")).toBe(false);
+  });
+
+  it("rejects path containing null byte", () => {
+    expect(isValidFilePath("src/\0file.ts")).toBe(false);
+  });
+
+  it("rejects path longer than 4096 characters", () => {
+    expect(isValidFilePath("a".repeat(4097))).toBe(false);
+  });
+
+  it("accepts path of exactly 4096 characters", () => {
+    expect(isValidFilePath("a".repeat(4096))).toBe(true);
+  });
+});
+
+describe("getFileContent", () => {
+  it("returns content for a normal file", async () => {
+    vi.mocked(readFileFromRepo).mockResolvedValueOnce({
+      success: true,
+      data: "export const x = 1;",
+    });
+    const result = await getFileContent("remote", "token", "src/index.ts", defaultLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ kind: "content", value: "export const x = 1;" });
+    }
+  });
+
+  it("returns binary for content containing null byte", async () => {
+    vi.mocked(readFileFromRepo).mockResolvedValueOnce({ success: true, data: "PNG\0binary" });
+    const result = await getFileContent("remote", "token", "image.png", defaultLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ kind: "binary" });
+    }
+  });
+
+  it("returns oversize for content exceeding 512 KB", async () => {
+    const bigContent = "x".repeat(513 * 1024);
+    vi.mocked(readFileFromRepo).mockResolvedValueOnce({ success: true, data: bigContent });
+    const result = await getFileContent("remote", "token", "big.txt", defaultLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ kind: "oversize" });
+    }
+  });
+
+  it("returns not-found for FS_ERROR", async () => {
+    const { AppError } = await import("../src/utils/errors");
+    vi.mocked(readFileFromRepo).mockResolvedValueOnce({
+      success: false,
+      error: new AppError("not found", "FS_ERROR", 500),
+    });
+    const result = await getFileContent("remote", "token", "missing.ts", defaultLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ kind: "not-found" });
+    }
+  });
+
+  it("propagates non-FS errors as failure", async () => {
+    const { AppError } = await import("../src/utils/errors");
+    vi.mocked(readFileFromRepo).mockResolvedValueOnce({
+      success: false,
+      error: new AppError("network error", "NETWORK_ERROR", 502),
+    });
+    const result = await getFileContent("remote", "token", "file.ts", defaultLogger);
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/file-tree-component.test.tsx
+++ b/tests/file-tree-component.test.tsx
@@ -1,0 +1,62 @@
+import { renderToString } from "hono/jsx/dom/server";
+import { describe, expect, it } from "vitest";
+import { FileTree } from "../src/ui/components/file-tree";
+import { buildFileTree } from "../src/ui/file-tree";
+
+describe("FileTree component", () => {
+  it("renders empty state when nodes is empty", () => {
+    const html = renderToString(<FileTree nodes={[]} namespace="@user" slug="repo" />);
+    expect(html).toContain("No files");
+  });
+
+  it("renders a file as a link with correct href", () => {
+    const nodes = buildFileTree(["README.md"]);
+    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    expect(html).toContain('href="/@user/repo/blob/README.md"');
+    expect(html).toContain("README.md");
+  });
+
+  it("percent-encodes spaces in file paths", () => {
+    const nodes = buildFileTree(["my file.ts"]);
+    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    expect(html).toContain("my%20file.ts");
+    expect(html).not.toContain('href="/@user/repo/blob/my file.ts"');
+  });
+
+  it("renders a directory as a details element with summary", () => {
+    const nodes = buildFileTree(["src/index.ts"]);
+    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    expect(html).toContain("<details");
+    expect(html).toContain("<summary");
+    expect(html).toContain("src");
+  });
+
+  it("root-level dir has open attribute", () => {
+    const nodes = buildFileTree(["src/index.ts"]);
+    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    expect(html).toMatch(/<details[^>]*open[^>]*>/);
+  });
+
+  it("nested dir does not have open attribute", () => {
+    const nodes = buildFileTree(["src/utils/helpers.ts"]);
+    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    const detailsMatches = [...html.matchAll(/<details([^>]*)>/g)];
+    expect(detailsMatches.length).toBeGreaterThanOrEqual(2);
+    const secondDetails = detailsMatches[1]?.[1] ?? "";
+    expect(secondDetails).not.toContain("open");
+  });
+
+  it("escapes special characters in file names", () => {
+    const nodes = buildFileTree(["<script>.ts"]);
+    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("renders multiple files under a shared directory", () => {
+    const nodes = buildFileTree(["src/a.ts", "src/b.ts"]);
+    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    expect(html).toContain("src/a.ts");
+    expect(html).toContain("src/b.ts");
+  });
+});

--- a/tests/file-tree.test.ts
+++ b/tests/file-tree.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { buildFileTree } from "../src/ui/file-tree";
+
+describe("buildFileTree", () => {
+  it("returns empty array for empty input", () => {
+    expect(buildFileTree([])).toEqual([]);
+  });
+
+  it("renders flat root-level files alphabetically", () => {
+    const result = buildFileTree(["README.md", "index.ts", "biome.json"]);
+    expect(result).toEqual([
+      { type: "file", name: "biome.json", path: "biome.json" },
+      { type: "file", name: "index.ts", path: "index.ts" },
+      { type: "file", name: "README.md", path: "README.md" },
+    ]);
+  });
+
+  it("sorts directories before files at the same level", () => {
+    const result = buildFileTree(["README.md", "src/index.ts", "biome.json"]);
+    const first = result[0];
+    const second = result[1];
+    const third = result[2];
+    expect(first?.type).toBe("dir");
+    expect(first?.name).toBe("src");
+    expect(second?.type).toBe("file");
+    expect(third?.type).toBe("file");
+  });
+
+  it("nests files under directories correctly", () => {
+    const result = buildFileTree(["src/index.ts", "src/utils/helpers.ts"]);
+    expect(result).toHaveLength(1);
+    const src = result[0];
+    expect(src?.type).toBe("dir");
+    expect(src?.name).toBe("src");
+    if (src?.type === "dir") {
+      expect(src.children).toHaveLength(2);
+      expect(src.children[0]).toMatchObject({ type: "dir", name: "utils" });
+      expect(src.children[1]).toMatchObject({ type: "file", name: "index.ts" });
+    }
+  });
+
+  it("builds deeply nested paths (4+ levels)", () => {
+    const result = buildFileTree(["a/b/c/d/file.ts"]);
+    const a = result[0];
+    expect(a?.type).toBe("dir");
+    expect(a?.name).toBe("a");
+    if (a?.type === "dir") {
+      const b = a.children[0];
+      expect(b).toMatchObject({ type: "dir", name: "b" });
+      if (b?.type === "dir") {
+        const c = b.children[0];
+        expect(c).toMatchObject({ type: "dir", name: "c" });
+        if (c?.type === "dir") {
+          const d = c.children[0];
+          expect(d).toMatchObject({ type: "dir", name: "d" });
+          if (d?.type === "dir") {
+            expect(d.children[0]).toMatchObject({
+              type: "file",
+              name: "file.ts",
+              path: "a/b/c/d/file.ts",
+            });
+          }
+        }
+      }
+    }
+  });
+
+  it("handles a file and a directory with the same prefix", () => {
+    const result = buildFileTree(["foo", "foo/bar.ts"]);
+    const file = result.find((n) => n.type === "file" && n.name === "foo");
+    const dir = result.find((n) => n.type === "dir" && n.name === "foo");
+    expect(file).toBeDefined();
+    expect(dir).toBeDefined();
+  });
+
+  it("sorts case-insensitively (B.ts after a.ts)", () => {
+    const result = buildFileTree(["B.ts", "a.ts"]);
+    expect(result[0]?.name).toBe("a.ts");
+    expect(result[1]?.name).toBe("B.ts");
+  });
+
+  it("sets path on dir node to full relative directory path", () => {
+    const result = buildFileTree(["src/utils/helpers.ts"]);
+    expect(result[0]).toMatchObject({ type: "dir", name: "src", path: "src" });
+    const src = result[0];
+    if (src?.type === "dir") {
+      expect(src.children[0]).toMatchObject({ type: "dir", name: "utils", path: "src/utils" });
+    }
+  });
+
+  it("deduplicates directory entries when multiple files share a parent", () => {
+    const result = buildFileTree(["src/a.ts", "src/b.ts", "src/c.ts"]);
+    expect(result).toHaveLength(1);
+    const src = result[0];
+    expect(src?.type).toBe("dir");
+    if (src?.type === "dir") {
+      expect(src.children).toHaveLength(3);
+    }
+  });
+});

--- a/tests/file-viewer.test.tsx
+++ b/tests/file-viewer.test.tsx
@@ -1,0 +1,124 @@
+import { renderToString } from "hono/jsx/dom/server";
+import { describe, expect, it } from "vitest";
+import { FileViewerPage } from "../src/ui/pages/file-viewer";
+
+const project = { namespace: "@user", slug: "repo", name: "My Repo" };
+const user = null;
+
+describe("FileViewerPage", () => {
+  it("renders breadcrumb with namespace and slug linking to repo root", () => {
+    const html = renderToString(
+      <FileViewerPage
+        project={project}
+        path="src/index.ts"
+        content={{ kind: "content", value: "export {}" }}
+        user={user}
+      />,
+    );
+    expect(html).toContain('href="/@user/repo"');
+    expect(html).toContain("@user");
+    expect(html).toContain("repo");
+  });
+
+  it("renders breadcrumb segments for nested path", () => {
+    const html = renderToString(
+      <FileViewerPage
+        project={project}
+        path="src/utils/helpers.ts"
+        content={{ kind: "content", value: "" }}
+        user={user}
+      />,
+    );
+    expect(html).toContain("src");
+    expect(html).toContain("utils");
+    expect(html).toContain("helpers.ts");
+  });
+
+  it("renders file content in pre/code with correct language class", () => {
+    const html = renderToString(
+      <FileViewerPage
+        project={project}
+        path="src/index.ts"
+        content={{ kind: "content", value: "const x = 1;" }}
+        user={user}
+      />,
+    );
+    expect(html).toContain('class="language-typescript"');
+    expect(html).toContain("const x = 1;");
+  });
+
+  it("HTML-escapes file content — XSS test", () => {
+    const html = renderToString(
+      <FileViewerPage
+        project={project}
+        path="evil.ts"
+        content={{ kind: "content", value: "<script>alert(1)</script>" }}
+        user={user}
+      />,
+    );
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("renders binary message without a code block", () => {
+    const html = renderToString(
+      <FileViewerPage
+        project={project}
+        path="image.png"
+        content={{ kind: "binary" }}
+        user={user}
+      />,
+    );
+    expect(html).toContain("Binary file");
+    expect(html).not.toContain("<code");
+  });
+
+  it("renders oversize message without a code block", () => {
+    const html = renderToString(
+      <FileViewerPage
+        project={project}
+        path="big.csv"
+        content={{ kind: "oversize" }}
+        user={user}
+      />,
+    );
+    expect(html).toContain("512 KB");
+    expect(html).not.toContain("<code");
+  });
+
+  it("uses language-plaintext for unknown extensions", () => {
+    const html = renderToString(
+      <FileViewerPage
+        project={project}
+        path="Makefile"
+        content={{ kind: "content", value: "build:" }}
+        user={user}
+      />,
+    );
+    expect(html).toContain('class="language-plaintext"');
+  });
+
+  it("maps .ts extension to typescript", () => {
+    const html = renderToString(
+      <FileViewerPage
+        project={project}
+        path="index.ts"
+        content={{ kind: "content", value: "" }}
+        user={user}
+      />,
+    );
+    expect(html).toContain("language-typescript");
+  });
+
+  it("maps .py extension to python", () => {
+    const html = renderToString(
+      <FileViewerPage
+        project={project}
+        path="main.py"
+        content={{ kind: "content", value: "" }}
+        user={user}
+      />,
+    );
+    expect(html).toContain("language-python");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],


### PR DESCRIPTION
## Summary

- Replaces the flat file list on the repo page with a zero-JS collapsible directory tree using native `<details>/<summary>` HTML — no JavaScript required
- Adds a dedicated file viewer page at `/:namespace/:slug/blob/*path` with breadcrumb navigation and syntax language classes
- Adds `GET /api/projects/:namespace/:slug/content?path=` API endpoint returning a typed `FileContentResult` (content / binary / oversize) for agent/API consumers
- Path validation via `isValidFilePath()` rejects traversal attempts (`..`, `.`, absolute paths, null bytes, paths > 4096 chars)

## What changed

| File | Change |
|---|---|
| `src/ui/file-tree.ts` | New — `buildFileTree()` converts flat `string[]` to sorted `FileTreeNode` tree |
| `src/ui/file-content.ts` | New — `FileContentResult` discriminated union, `getFileContent()`, `isValidFilePath()` |
| `src/ui/components/file-tree.tsx` | New — `FileTree` component with `<details>` dirs and percent-encoded file links |
| `src/ui/pages/file-viewer.tsx` | New — `FileViewerPage` with breadcrumb, language class, binary/oversize/not-found states |
| `src/routes/projects.ts` | Added `/content` API endpoint |
| `src/routes/ui.tsx` | Added `/blob/*` route registered before the `/:namespace/:slug` catch-all |
| `src/ui/pages/repo.tsx` | Replaced flat `<ul class="file-list">` with `<FileTree>` |
| `src/ui/styles.ts` | Added `.file-tree*` and `.file-viewer*` CSS |
| `vitest.config.ts` | Added `.test.tsx` to test include pattern |

## Test plan

- [ ] 41 new tests pass: tree data logic, FileTree component (href encoding, open/closed dirs, XSS escaping), FileViewerPage (breadcrumb, language class, explicit XSS assertion, binary/oversize states), content API (400/401/403/404/200)
- [ ] `tsc --noEmit` — zero errors
- [ ] `biome check` — zero errors
- [ ] Visit a project page — file tree renders with collapsible directories
- [ ] Click a file — navigates to `/:namespace/:slug/blob/path/to/file` and shows content
- [ ] `GET /api/projects/@user/repo/content?path=src/index.ts` returns `{ kind: "content", value: "..." }`
- [ ] `GET /api/projects/@user/repo/content?path=../etc/passwd` returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a file browser with collapsible directory tree for exploring repository contents
  * New file viewer displays syntax-highlighted code with breadcrumb navigation
  * Handles text, binary, and oversized files with appropriate handling and messaging
  * Added file content endpoint with validation

* **Tests**
  * Added test coverage for file content handling, tree rendering, and viewer functionality

* **Style**
  * Added styling for the new file browser and viewer interface

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jlamoreaux/stratum/pull/47)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->