### PR TITLE
feat: durable event pipeline + project activity feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ dist/
 coverage/
 .claude/
 .playwright-mcp/
+
+# Local screenshots
+*.png
+!coverage/*.png

--- a/migrations/016_events.sql
+++ b/migrations/016_events.sql
@@ -1,0 +1,23 @@
+-- Durable event outbox: one row per domain event, written before queue delivery.
+-- The queue message carries only the event id; this row is the source of truth.
+-- status: 'pending' until the consumer processes it, then 'processed';
+-- 'failed' once attempts exhaust the retry budget.
+
+CREATE TABLE IF NOT EXISTS events (
+  id TEXT PRIMARY KEY,
+  type TEXT NOT NULL,
+  project TEXT NOT NULL,
+  actor_type TEXT NOT NULL DEFAULT 'system' CHECK(actor_type IN ('user','agent','system')),
+  actor_id TEXT,
+  payload TEXT NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','processed','failed')),
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL,
+  processed_at DATETIME
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_project_created
+  ON events(project, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_events_status_created
+  ON events(status, created_at);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,8 @@ import { githubWebhookRouter } from "./github/webhooks";
 import { analyticsMiddleware } from "./middleware/analytics";
 import { authMiddleware } from "./middleware/auth";
 import { rateLimitMiddleware } from "./middleware/rate-limit";
-import type { StratumEvent } from "./queue/events";
+import { handleEventQueue, sweepStaleEvents } from "./queue/event-consumer";
+import type { EventQueueMessage } from "./queue/events";
 import { handleImportQueue } from "./queue/import-queue";
 import { runTtlSweep } from "./queue/ttl-sweep";
 import { agentsRouter } from "./routes/agents";
@@ -154,8 +155,12 @@ app.onError((err, c) => {
 
 export default {
   fetch: app.fetch,
-  async scheduled(_event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
+  async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
     const logger = createLogger({ component: "scheduled" });
+    if (event.cron === "*/5 * * * *") {
+      ctx.waitUntil(sweepStaleEvents(env, logger));
+      return;
+    }
     ctx.waitUntil(Promise.all([runTtlSweep(env, logger), syncAllProjects(env)]));
   },
   async queue(batch: MessageBatch<unknown>, env: Env): Promise<void> {
@@ -172,15 +177,7 @@ export default {
       });
       await handleImportQueue(batch as MessageBatch<ImportJobMessage | SyncJobMessage>, env);
     } else if (queueName === "stratum-events") {
-      // Handle events queue messages
-      const eventsBatch = batch as MessageBatch<StratumEvent>;
-      for (const msg of eventsBatch.messages) {
-        logger.info("Processing events queue message", {
-          type: msg.body.type,
-          messageId: msg.id,
-        });
-        msg.ack();
-      }
+      await handleEventQueue(batch as MessageBatch<EventQueueMessage>, env);
     } else {
       // Unknown queue - ack all messages to prevent retries
       logger.warn("Unknown queue", { queue: queueName });

--- a/src/queue/event-consumer.ts
+++ b/src/queue/event-consumer.ts
@@ -1,0 +1,158 @@
+import { createPostHogClient } from "../analytics/posthog";
+import {
+  type EventRecord,
+  getEvent,
+  incrementEventAttempts,
+  listStalePendingEvents,
+  markEventFailed,
+  markEventProcessed,
+} from "../storage/events";
+import type { Env, Message, MessageBatch } from "../types";
+import type { Logger } from "../utils/logger";
+import { createLogger } from "../utils/logger";
+import type { EventQueueMessage } from "./events";
+
+/** Attempts after which a pending event is abandoned and marked failed. */
+export const MAX_EVENT_ATTEMPTS = 5;
+
+/** Pending events older than this are re-enqueued by the sweep cron. */
+const STALE_EVENT_MS = 5 * 60 * 1000;
+
+export interface EventHandler {
+  /** Stable name used in logs. */
+  name: string;
+  handle(env: Env, event: EventRecord, logger: Logger): Promise<void>;
+}
+
+const analyticsHandler: EventHandler = {
+  name: "analytics",
+  async handle(env, event) {
+    const posthog = createPostHogClient(env);
+    await posthog.capture({
+      event: `stratum.${event.type}`,
+      distinctId: event.actorId ?? "system",
+      properties: { project: event.project, actorType: event.actorType },
+    });
+  },
+};
+
+/**
+ * Ordered handler registry. Later features (webhook notifications, issue
+ * auto-close) append here; every handler runs for every event and decides
+ * internally whether the event type concerns it.
+ */
+const handlers: EventHandler[] = [analyticsHandler];
+
+async function processEvent(env: Env, event: EventRecord, logger: Logger): Promise<void> {
+  for (const handler of handlers) {
+    await handler.handle(env, event, logger);
+  }
+}
+
+async function consumeOne(
+  env: Env,
+  msg: Message<EventQueueMessage>,
+  logger: Logger,
+): Promise<void> {
+  const eventId = msg.body?.eventId;
+  if (typeof eventId !== "string" || !eventId) {
+    logger.warn("Event queue message without eventId; dropping", { messageId: msg.id });
+    msg.ack();
+    return;
+  }
+
+  const eventResult = await getEvent(env.DB, logger, eventId);
+  if (!eventResult.success) {
+    if (eventResult.error.code === "NOT_FOUND") {
+      logger.warn("Event row missing for queue message; dropping", { eventId });
+      msg.ack();
+    } else {
+      // Transient D1 error — let the queue redeliver.
+      msg.retry();
+    }
+    return;
+  }
+  const event = eventResult.data;
+
+  if (event.status !== "pending") {
+    msg.ack();
+    return;
+  }
+
+  await incrementEventAttempts(env.DB, logger, eventId);
+
+  try {
+    await processEvent(env, event, logger);
+  } catch (error) {
+    const attempts = event.attempts + 1;
+    logger.error(
+      "Event handler failed",
+      error instanceof Error ? error : new Error(String(error)),
+      { eventId, eventType: event.type, attempts },
+    );
+    if (attempts >= MAX_EVENT_ATTEMPTS) {
+      await markEventFailed(env.DB, logger, eventId);
+      msg.ack();
+    } else {
+      msg.retry();
+    }
+    return;
+  }
+
+  await markEventProcessed(env.DB, logger, eventId);
+  msg.ack();
+}
+
+export async function handleEventQueue(
+  batch: MessageBatch<EventQueueMessage>,
+  env: Env,
+): Promise<void> {
+  const logger = createLogger({ component: "EventConsumer" });
+  for (const msg of batch.messages) {
+    await consumeOne(env, msg, logger);
+  }
+}
+
+/**
+ * Re-enqueue pending events whose queue message was lost, and abandon events
+ * that exhausted their attempt budget. Runs on the frequent cron.
+ */
+export async function sweepStaleEvents(env: Env, logger: Logger): Promise<void> {
+  const staleResult = await listStalePendingEvents(env.DB, logger, { olderThanMs: STALE_EVENT_MS });
+  if (!staleResult.success) return;
+  const stale = staleResult.data;
+  if (stale.length === 0) return;
+
+  logger.info("Sweeping stale pending events", { count: stale.length });
+
+  for (const event of stale) {
+    if (event.attempts >= MAX_EVENT_ATTEMPTS) {
+      await markEventFailed(env.DB, logger, event.id);
+      continue;
+    }
+    if (!env.EVENTS_QUEUE) {
+      // No queue bound (local dev): process inline so events still complete.
+      await incrementEventAttempts(env.DB, logger, event.id);
+      try {
+        await processEvent(env, event, logger);
+        await markEventProcessed(env.DB, logger, event.id);
+      } catch (error) {
+        logger.error(
+          "Inline event processing failed during sweep",
+          error instanceof Error ? error : new Error(String(error)),
+          { eventId: event.id, eventType: event.type },
+        );
+      }
+      continue;
+    }
+    try {
+      const message: EventQueueMessage = { eventId: event.id };
+      await env.EVENTS_QUEUE.send(message);
+    } catch (error) {
+      logger.warn("Failed to re-enqueue stale event", {
+        eventId: event.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}

--- a/src/queue/events.ts
+++ b/src/queue/events.ts
@@ -1,38 +1,77 @@
+import { type EventActorType, insertEvent } from "../storage/events";
 import type { Queue } from "../types";
+import type { Logger } from "../utils/logger";
 import { createLogger } from "../utils/logger";
 
 export type StratumEvent =
-  | { type: "change.created"; changeId: string; project: string; workspace: string }
-  | { type: "change.evaluated"; changeId: string; score: number; passed: boolean }
-  | { type: "change.merged"; changeId: string; project: string; commit: string }
-  | { type: "change.rejected"; changeId: string; project: string };
+  | { type: "change.created"; project: string; changeId: string; workspace: string }
+  | { type: "change.evaluated"; project: string; changeId: string; score: number; passed: boolean }
+  | { type: "change.merged"; project: string; changeId: string; commit: string }
+  | { type: "change.rejected"; project: string; changeId: string }
+  | { type: "project.created"; project: string }
+  | { type: "project.imported"; project: string; sourceUrl: string }
+  // workspace.deleted is deliberately absent: the delete path only knows the
+  // project ID, and events are scoped by project name. It lands with the
+  // project-identity unification work.
+  | { type: "workspace.created"; project: string; workspace: string }
+  | { type: "sync.completed"; project: string; commit?: string };
 
-const logger = createLogger({ component: "Events" });
+export interface EventActor {
+  type: EventActorType;
+  id?: string;
+}
 
-export async function publishEvent(
+/** Message delivered on the stratum-events queue. The outbox row is the source of truth. */
+export interface EventQueueMessage {
+  eventId: string;
+}
+
+const fallbackLogger = createLogger({ component: "Events" });
+
+/**
+ * Durably record a domain event (outbox row in D1), then nudge the queue consumer.
+ *
+ * The queue send is best-effort: if it fails or no queue is bound, the sweep cron
+ * re-enqueues pending rows. Never throws — event emission must not break the
+ * primary request path.
+ */
+export async function emitEvent(
+  db: D1Database,
   queue: Queue | undefined | null,
   event: StratumEvent,
+  actor: EventActor,
+  logger: Logger = fallbackLogger,
 ): Promise<void> {
-  if (!queue) {
-    logger.debug("Event not published - no queue configured", { eventType: event.type });
+  const { type, project, ...payload } = event;
+
+  const insertResult = await insertEvent(db, logger, {
+    type,
+    project,
+    actorType: actor.type,
+    ...(actor.id !== undefined ? { actorId: actor.id } : {}),
+    payload,
+  });
+  if (!insertResult.success) {
+    // Already logged by insertEvent; nothing durable to deliver, so stop here.
     return;
   }
 
-  logger.debug("Publishing event", {
-    eventType: event.type,
-    changeId: "changeId" in event ? event.changeId : undefined,
-  });
+  if (!queue) {
+    logger.debug("No events queue bound; event waits for sweep", {
+      eventId: insertResult.data.id,
+      eventType: type,
+    });
+    return;
+  }
 
   try {
-    await queue.send(event);
-    logger.info("Event published successfully", {
-      eventType: event.type,
-      changeId: "changeId" in event ? event.changeId : undefined,
+    const message: EventQueueMessage = { eventId: insertResult.data.id };
+    await queue.send(message);
+  } catch (error) {
+    logger.warn("Event queue send failed; sweep will re-enqueue", {
+      eventId: insertResult.data.id,
+      eventType: type,
+      error: error instanceof Error ? error.message : String(error),
     });
-  } catch (err) {
-    logger.error("Failed to publish event", err instanceof Error ? err : new Error(String(err)), {
-      eventType: event.type,
-    });
-    throw err;
   }
 }

--- a/src/queue/import-queue.ts
+++ b/src/queue/import-queue.ts
@@ -27,6 +27,7 @@ import type { Message, MessageBatch } from "../types";
 import { getArtifactsRepoName } from "../types";
 import { escapeHtml } from "../utils/html";
 import { type Logger, createLogger } from "../utils/logger";
+import { emitEvent } from "./events";
 
 const logger = createLogger({ component: "ImportQueue" });
 
@@ -324,6 +325,18 @@ async function processImportJob(
       logger,
     );
 
+    await emitEvent(
+      env.DB,
+      env.EVENTS_QUEUE,
+      {
+        type: "project.imported",
+        project: updatedProject.name,
+        sourceUrl: msg.body.sourceUrl ?? githubUrl,
+      },
+      { type: "system" },
+      logger,
+    );
+
     logger.info("Import completed successfully", { importId, namespace, slug, duration });
     msg.ack();
   } catch (error) {
@@ -541,6 +554,18 @@ async function processSyncJob(
     await writeSnapshotFromRepo(
       env.STATE,
       { remote: updatedProject.remote, token: updatedProject.token, namespace, slug },
+      logger,
+    );
+
+    await emitEvent(
+      env.DB,
+      env.EVENTS_QUEUE,
+      {
+        type: "sync.completed",
+        project: updatedProject.name,
+        ...(latestCommitSha !== undefined ? { commit: latestCommitSha } : {}),
+      },
+      { type: "system" },
       logger,
     );
 

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -10,7 +10,7 @@ import {
 } from "../evaluation";
 import type { EvalPolicy, EvalResult } from "../evaluation/types";
 import type { Evaluator } from "../evaluation/types";
-import { publishEvent } from "../queue/events";
+import { type EventActor, emitEvent } from "../queue/events";
 import { createChange, getChange, listChanges, updateChangeStatus } from "../storage/changes";
 import { listEvalRuns, recordEvalRuns } from "../storage/eval-runs";
 import {
@@ -113,12 +113,22 @@ app.post("/projects/:name/changes", async (c) => {
   }
   const change = changeResult.data;
 
-  await publishEvent(c.env.EVENTS_QUEUE, {
-    type: "change.created",
-    changeId: change.id,
-    project: projectName,
-    workspace: body.workspace,
-  });
+  const actor: EventActor = agentId
+    ? { type: "agent", id: agentId }
+    : { type: "user", ...(userId !== undefined ? { id: userId } : {}) };
+
+  await emitEvent(
+    c.env.DB,
+    c.env.EVENTS_QUEUE,
+    {
+      type: "change.created",
+      project: projectName,
+      changeId: change.id,
+      workspace: body.workspace,
+    },
+    actor,
+    logger,
+  );
 
   const policy = await loadPolicy(project.remote, project.token, logger);
 
@@ -226,12 +236,19 @@ app.post("/projects/:name/changes", async (c) => {
     return badRequest(updateResult.error.message);
   }
 
-  await publishEvent(c.env.EVENTS_QUEUE, {
-    type: "change.evaluated",
-    changeId: change.id,
-    score: evalResult.score,
-    passed: evalResult.passed,
-  });
+  await emitEvent(
+    c.env.DB,
+    c.env.EVENTS_QUEUE,
+    {
+      type: "change.evaluated",
+      project: projectName,
+      changeId: change.id,
+      score: evalResult.score,
+      passed: evalResult.passed,
+    },
+    { type: "system" },
+    logger,
+  );
 
   const updatedChange: Change = {
     ...change,
@@ -404,12 +421,13 @@ app.post("/changes/:id/merge", async (c) => {
       return badRequest(result.error ?? "Merge failed");
     }
 
-    await publishEvent(c.env.EVENTS_QUEUE, {
-      type: "change.merged",
-      changeId: id,
-      project: change.project,
-      commit: result.commit ?? "",
-    });
+    await emitEvent(
+      c.env.DB,
+      c.env.EVENTS_QUEUE,
+      { type: "change.merged", project: change.project, changeId: id, commit: result.commit ?? "" },
+      { type: "user", id: userId },
+      logger,
+    );
 
     logger.info("Change merged via queue", {
       changeId: id,
@@ -504,12 +522,13 @@ app.post("/changes/:id/merge", async (c) => {
     // Don't fail the request if provenance recording fails
   }
 
-  await publishEvent(c.env.EVENTS_QUEUE, {
-    type: "change.merged",
-    changeId: id,
-    project: change.project,
-    commit,
-  });
+  await emitEvent(
+    c.env.DB,
+    c.env.EVENTS_QUEUE,
+    { type: "change.merged", project: change.project, changeId: id, commit },
+    { type: "user", id: userId },
+    logger,
+  );
 
   logger.info("Change merged", {
     changeId: id,
@@ -575,11 +594,13 @@ app.post("/changes/:id/reject", async (c) => {
     return badRequest(updateResult.error.message);
   }
 
-  await publishEvent(c.env.EVENTS_QUEUE, {
-    type: "change.rejected",
-    changeId: id,
-    project: change.project,
-  });
+  await emitEvent(
+    c.env.DB,
+    c.env.EVENTS_QUEUE,
+    { type: "change.rejected", project: change.project, changeId: id },
+    { type: "user", id: userId },
+    logger,
+  );
 
   logger.info("Change rejected", { changeId: id, project: change.project });
   return ok({ rejected: true, changeId: id });

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 import { importRateLimitMiddleware, releaseImportLock } from "../middleware/rate-limit";
+import { emitEvent } from "../queue/events";
+import { listProjectEvents } from "../storage/events";
 import { getCommitLog, importFromGitHub, initAndPush, listFilesInRepo } from "../storage/git-ops";
 import { buildAuthConfig } from "../storage/git-providers";
 import {
@@ -203,6 +205,14 @@ app.post("/", async (c) => {
     slug,
     visibility,
   });
+
+  await emitEvent(
+    c.env.DB,
+    c.env.EVENTS_QUEUE,
+    { type: "project.created", project: project.name },
+    { type: "user", id: userId },
+    logger,
+  );
 
   return created({
     id: projectId,
@@ -943,6 +953,58 @@ app.get("/:namespace/:slug/provenance", async (c) => {
     slug,
     path: `/${namespace}/${slug}`,
     records: recordsResult.data,
+  });
+});
+
+// GET /projects/:namespace/:slug/activity - Project activity feed (domain events)
+app.get("/:namespace/:slug/activity", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const { namespace, slug } = c.req.param();
+
+  const projectResult = await getProjectByPath(c.env.STATE, namespace, slug, logger);
+  if (!projectResult.success) {
+    if (projectResult.error.code === "NOT_FOUND") {
+      return notFound("Project", `${namespace}/${slug}`);
+    }
+    logger.error("Failed to get project", projectResult.error);
+    return internalError(projectResult.error.message);
+  }
+  const project = projectResult.data;
+
+  if (!canReadProject(project, userId, agentOwnerId))
+    return notFound("Project", `${project.namespace}/${project.slug}`);
+
+  const limitParam = c.req.query("limit");
+  const parsedLimit = limitParam !== undefined ? Number(limitParam) : Number.NaN;
+  const limit = Number.isInteger(parsedLimit) && parsedLimit > 0 ? Math.min(parsedLimit, 200) : 50;
+
+  const eventsResult = await listProjectEvents(c.env.DB, logger, project.name, limit);
+  if (!eventsResult.success) {
+    logger.error("Failed to list project events", eventsResult.error);
+    return internalError(eventsResult.error.message);
+  }
+
+  logger.info("Activity listed", { namespace, slug, count: eventsResult.data.length });
+  return ok({
+    namespace,
+    slug,
+    path: `/${namespace}/${slug}`,
+    events: eventsResult.data.map((event) => ({
+      id: event.id,
+      type: event.type,
+      actorType: event.actorType,
+      ...(event.actorId !== undefined ? { actorId: event.actorId } : {}),
+      payload: event.payload,
+      createdAt: event.createdAt,
+    })),
   });
 });
 

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { getChange, listChanges } from "../storage/changes";
 import { listEvalRuns } from "../storage/eval-runs";
+import { listProjectEvents } from "../storage/events";
 import { getCommitLog, listFilesInRepo, readFileFromRepo } from "../storage/git-ops";
 import { getImportProgress } from "../storage/imports";
 import { readRepoSnapshot } from "../storage/repo-snapshot";
@@ -9,6 +10,7 @@ import { getProjectSourceUrl, getSyncStatus } from "../storage/sync";
 import { getUser } from "../storage/users";
 import type { Env } from "../types";
 import { getFileContent, isValidFilePath } from "../ui/file-content";
+import { ActivityPage } from "../ui/pages/activity";
 import { ChangeDetailPage } from "../ui/pages/change-detail";
 import { ChangesPage } from "../ui/pages/changes";
 import { FileViewerPage } from "../ui/pages/file-viewer";
@@ -522,6 +524,64 @@ app.get("/:namespace/:slug/changes", async (c) => {
     <ChangesPage
       project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
       changes={changes}
+      user={userResult}
+    />,
+  );
+});
+
+// GET /:namespace/:slug/activity — Project activity feed
+app.get("/:namespace/:slug/activity", async (c) => {
+  const { namespace, slug } = c.req.param();
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const logger = createLogger({ path: c.req.path, userId });
+
+  if (!isValidNamespace(namespace) || !isValidSlug(slug)) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">Invalid project path.</div>,
+      400,
+    );
+  }
+
+  const [userResult, projectResult] = await Promise.all([
+    getCurrentUser(c, logger),
+    getProjectByPath(c.env.STATE, namespace, slug, logger),
+  ]);
+
+  if (!projectResult.success) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Project '{namespace}/{slug}' not found.
+      </div>,
+      404,
+    );
+  }
+  const project = projectResult.data;
+
+  if (!canReadProject(project, userId, agentOwnerId)) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Project '{namespace}/{slug}' not found.
+      </div>,
+      404,
+    );
+  }
+
+  const eventsResult = await listProjectEvents(c.env.DB, logger, project.name);
+  if (!eventsResult.success) {
+    logger.error("Failed to list project events", eventsResult.error);
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Error loading activity. Please try again.
+      </div>,
+      500,
+    );
+  }
+
+  return c.html(
+    <ActivityPage
+      project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
+      events={eventsResult.data}
       user={userResult}
     />,
   );

--- a/src/routes/workspaces.ts
+++ b/src/routes/workspaces.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { type EventActor, emitEvent } from "../queue/events";
 import { cloneRepo, commitAndPush } from "../storage/git-ops";
 import {
   deleteWorkspace,
@@ -72,6 +73,18 @@ app.post("/:namespace/:slug/workspaces", async (c) => {
   }
 
   logger.info("Workspace created", { workspaceName, namespace, slug, projectId: project.id });
+
+  const actor: EventActor = agentId
+    ? { type: "agent", id: agentId }
+    : { type: "user", ...(userId !== undefined ? { id: userId } : {}) };
+  await emitEvent(
+    c.env.DB,
+    c.env.EVENTS_QUEUE,
+    { type: "workspace.created", project: project.name, workspace: workspaceName },
+    actor,
+    logger,
+  );
+
   return created({
     workspace: workspaceName,
     remote: forked.remote,

--- a/src/storage/events.ts
+++ b/src/storage/events.ts
@@ -1,0 +1,251 @@
+import { AppError, NotFoundError } from "../utils/errors";
+import { newId } from "../utils/ids";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+
+export type EventActorType = "user" | "agent" | "system";
+export type EventStatus = "pending" | "processed" | "failed";
+
+export interface EventRecord {
+  id: string;
+  type: string;
+  project: string;
+  actorType: EventActorType;
+  actorId?: string;
+  payload: Record<string, unknown>;
+  status: EventStatus;
+  attempts: number;
+  createdAt: string;
+  processedAt?: string;
+}
+
+interface EventRow {
+  id: string;
+  type: string;
+  project: string;
+  actor_type: string;
+  actor_id: string | null;
+  payload: string;
+  status: string;
+  attempts: number;
+  created_at: string;
+  processed_at: string | null;
+}
+
+function rowToEvent(row: EventRow, logger: Logger): EventRecord {
+  let payload: Record<string, unknown> = {};
+  try {
+    const parsed: unknown = JSON.parse(row.payload);
+    if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      payload = parsed as Record<string, unknown>;
+    }
+  } catch {
+    logger.warn("Event payload is not valid JSON", { eventId: row.id });
+  }
+
+  const event: EventRecord = {
+    id: row.id,
+    type: row.type,
+    project: row.project,
+    actorType: row.actor_type as EventActorType,
+    payload,
+    status: row.status as EventStatus,
+    attempts: row.attempts,
+    createdAt: row.created_at,
+  };
+  if (row.actor_id !== null) event.actorId = row.actor_id;
+  if (row.processed_at !== null) event.processedAt = row.processed_at;
+  return event;
+}
+
+function toAppError(error: unknown, operation: string, context: Record<string, unknown>) {
+  return error instanceof AppError
+    ? error
+    : new AppError(
+        error instanceof Error ? error.message : `Failed in ${operation}`,
+        "DATABASE_ERROR",
+        500,
+        { operation, ...context },
+      );
+}
+
+export async function insertEvent(
+  db: D1Database,
+  logger: Logger,
+  opts: {
+    type: string;
+    project: string;
+    actorType: EventActorType;
+    actorId?: string;
+    payload: Record<string, unknown>;
+  },
+): Promise<Result<EventRecord, AppError>> {
+  const id = newId("evt");
+  const createdAt = new Date().toISOString();
+
+  try {
+    await db
+      .prepare(
+        "INSERT INTO events (id, type, project, actor_type, actor_id, payload, status, attempts, created_at) VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?)",
+      )
+      .bind(
+        id,
+        opts.type,
+        opts.project,
+        opts.actorType,
+        opts.actorId ?? null,
+        JSON.stringify(opts.payload),
+        createdAt,
+      )
+      .run();
+
+    const event: EventRecord = {
+      id,
+      type: opts.type,
+      project: opts.project,
+      actorType: opts.actorType,
+      payload: opts.payload,
+      status: "pending",
+      attempts: 0,
+      createdAt,
+    };
+    if (opts.actorId !== undefined) event.actorId = opts.actorId;
+
+    logger.debug("Event inserted", { eventId: id, eventType: opts.type, project: opts.project });
+    return ok(event);
+  } catch (error) {
+    const appError = toAppError(error, "insertEvent", { eventType: opts.type });
+    logger.error("Failed to insert event", appError, { eventType: opts.type });
+    return err(appError);
+  }
+}
+
+export async function getEvent(
+  db: D1Database,
+  logger: Logger,
+  id: string,
+): Promise<Result<EventRecord, NotFoundError | AppError>> {
+  try {
+    const row = await db.prepare("SELECT * FROM events WHERE id = ?").bind(id).first<EventRow>();
+    if (!row) {
+      logger.debug("Event not found", { eventId: id });
+      return err(new NotFoundError("Event", id));
+    }
+    return ok(rowToEvent(row, logger));
+  } catch (error) {
+    const appError = toAppError(error, "getEvent", { eventId: id });
+    logger.error("Failed to get event", appError, { eventId: id });
+    return err(appError);
+  }
+}
+
+export async function listProjectEvents(
+  db: D1Database,
+  logger: Logger,
+  project: string,
+  limit = 50,
+): Promise<Result<EventRecord[], AppError>> {
+  try {
+    const result = await db
+      .prepare("SELECT * FROM events WHERE project = ? ORDER BY created_at DESC LIMIT ?")
+      .bind(project, limit)
+      .all<EventRow>();
+    return ok(result.results.map((row) => rowToEvent(row, logger)));
+  } catch (error) {
+    const appError = toAppError(error, "listProjectEvents", { project });
+    logger.error("Failed to list project events", appError, { project });
+    return err(appError);
+  }
+}
+
+export async function listRecentEvents(
+  db: D1Database,
+  logger: Logger,
+  limit = 50,
+): Promise<Result<EventRecord[], AppError>> {
+  try {
+    const result = await db
+      .prepare("SELECT * FROM events ORDER BY created_at DESC LIMIT ?")
+      .bind(limit)
+      .all<EventRow>();
+    return ok(result.results.map((row) => rowToEvent(row, logger)));
+  } catch (error) {
+    const appError = toAppError(error, "listRecentEvents", {});
+    logger.error("Failed to list recent events", appError);
+    return err(appError);
+  }
+}
+
+export async function markEventProcessed(
+  db: D1Database,
+  logger: Logger,
+  id: string,
+): Promise<Result<void, AppError>> {
+  try {
+    await db
+      .prepare("UPDATE events SET status = 'processed', processed_at = ? WHERE id = ?")
+      .bind(new Date().toISOString(), id)
+      .run();
+    logger.debug("Event marked processed", { eventId: id });
+    return ok(undefined);
+  } catch (error) {
+    const appError = toAppError(error, "markEventProcessed", { eventId: id });
+    logger.error("Failed to mark event processed", appError, { eventId: id });
+    return err(appError);
+  }
+}
+
+export async function markEventFailed(
+  db: D1Database,
+  logger: Logger,
+  id: string,
+): Promise<Result<void, AppError>> {
+  try {
+    await db
+      .prepare("UPDATE events SET status = 'failed', processed_at = ? WHERE id = ?")
+      .bind(new Date().toISOString(), id)
+      .run();
+    logger.warn("Event marked failed", { eventId: id });
+    return ok(undefined);
+  } catch (error) {
+    const appError = toAppError(error, "markEventFailed", { eventId: id });
+    logger.error("Failed to mark event failed", appError, { eventId: id });
+    return err(appError);
+  }
+}
+
+export async function incrementEventAttempts(
+  db: D1Database,
+  logger: Logger,
+  id: string,
+): Promise<Result<void, AppError>> {
+  try {
+    await db.prepare("UPDATE events SET attempts = attempts + 1 WHERE id = ?").bind(id).run();
+    return ok(undefined);
+  } catch (error) {
+    const appError = toAppError(error, "incrementEventAttempts", { eventId: id });
+    logger.error("Failed to increment event attempts", appError, { eventId: id });
+    return err(appError);
+  }
+}
+
+export async function listStalePendingEvents(
+  db: D1Database,
+  logger: Logger,
+  opts: { olderThanMs: number; limit?: number },
+): Promise<Result<EventRecord[], AppError>> {
+  const cutoff = new Date(Date.now() - opts.olderThanMs).toISOString();
+  try {
+    const result = await db
+      .prepare(
+        "SELECT * FROM events WHERE status = 'pending' AND created_at < ? ORDER BY created_at ASC LIMIT ?",
+      )
+      .bind(cutoff, opts.limit ?? 100)
+      .all<EventRow>();
+    return ok(result.results.map((row) => rowToEvent(row, logger)));
+  } catch (error) {
+    const appError = toAppError(error, "listStalePendingEvents", {});
+    logger.error("Failed to list stale pending events", appError);
+    return err(appError);
+  }
+}

--- a/src/ui/pages/activity.tsx
+++ b/src/ui/pages/activity.tsx
@@ -1,0 +1,108 @@
+import type { FC } from "hono/jsx";
+import type { EventRecord } from "../../storage/events";
+import { Layout } from "../layout";
+
+interface ActivityProps {
+  project: {
+    name: string;
+    namespace: string;
+    slug: string;
+  };
+  events: EventRecord[];
+  user?: { id: string; email: string; username: string } | null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/** Outcome-oriented one-liner for an event, e.g. "Change chg_1 evaluated → 0.91 passed". */
+export function describeEvent(event: EventRecord): string {
+  const { payload } = event;
+  const changeId = asString(payload.changeId);
+  const workspace = asString(payload.workspace);
+  const commit = asString(payload.commit);
+
+  switch (event.type) {
+    case "project.created":
+      return "Project created";
+    case "project.imported": {
+      const source = asString(payload.sourceUrl);
+      return source ? `Imported from ${source.replace(/^https?:\/\//, "")}` : "Project imported";
+    }
+    case "workspace.created":
+      return workspace ? `Workspace ${workspace} created` : "Workspace created";
+    case "change.created":
+      return `Change ${changeId ?? "?"} opened${workspace ? ` from ${workspace}` : ""}`;
+    case "change.evaluated": {
+      const score = typeof payload.score === "number" ? payload.score.toFixed(2) : "?";
+      const verdict = payload.passed === true ? "passed" : "failed";
+      return `Change ${changeId ?? "?"} evaluated → ${score} ${verdict}`;
+    }
+    case "change.merged":
+      return `Change ${changeId ?? "?"} merged${commit ? ` → ${commit.slice(0, 7)}` : ""}`;
+    case "change.rejected":
+      return `Change ${changeId ?? "?"} rejected`;
+    case "sync.completed":
+      return `Synced from upstream${commit ? ` → ${commit.slice(0, 7)}` : ""}`;
+    default:
+      return event.type;
+  }
+}
+
+/** Coarse relative timestamp ("3h ago"); falls back to the date for older events. */
+export function relativeTime(iso: string, now: Date = new Date()): string {
+  const then = new Date(iso);
+  const diffMs = now.getTime() - then.getTime();
+  if (Number.isNaN(diffMs) || diffMs < 0) return then.toLocaleDateString();
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return then.toLocaleDateString();
+}
+
+function changeLink(event: EventRecord): string | undefined {
+  const changeId = asString(event.payload.changeId);
+  return changeId ? `/changes/${changeId}` : undefined;
+}
+
+export const ActivityPage: FC<ActivityProps> = ({ project, events, user }) => {
+  return (
+    <Layout title={`Activity — ${project.name}`} user={user}>
+      <div class="page-header">
+        <h1>Activity</h1>
+        <a class="btn" href={`/${project.namespace}/${project.slug}`}>
+          Back to repo
+        </a>
+      </div>
+
+      {events.length === 0 ? (
+        <div class="empty-state">
+          <p>No activity yet. Create a workspace or open a change to get started.</p>
+        </div>
+      ) : (
+        <ul class="activity-list">
+          {events.map((event) => {
+            const link = changeLink(event);
+            const description = describeEvent(event);
+            return (
+              <li key={event.id} class="activity-item">
+                <span class={`activity-actor activity-actor-${event.actorType}`}>
+                  {event.actorType}
+                </span>
+                <span class="activity-description">
+                  {link ? <a href={link}>{description}</a> : description}
+                </span>
+                <span class="activity-time">{relativeTime(event.createdAt)}</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Layout>
+  );
+};

--- a/src/ui/pages/repo.tsx
+++ b/src/ui/pages/repo.tsx
@@ -193,6 +193,9 @@ export const RepoPage: FC<RepoProps> = ({
               </button>
             </form>
           )}
+          <a class="btn" href={`/${project.namespace}/${project.slug}/activity`}>
+            Activity
+          </a>
           <a class="btn btn-primary" href={`/${project.namespace}/${project.slug}/changes`}>
             View changes
           </a>

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -444,6 +444,32 @@ a:hover { text-decoration: underline; }
 .file-tree-toggle-btn { background: none; border: none; color: #666; font-size: 0.75rem; cursor: pointer; padding: 0; font-family: inherit; }
 .file-tree-toggle-btn:hover { color: #aaa; }
 
+/* Activity Feed */
+.activity-list { list-style: none; padding: 0; margin: 0; }
+.activity-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid #222;
+  font-size: 0.9rem;
+}
+.activity-actor {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+.activity-actor-user { background: #1e3a5f; color: #7cb7ff; }
+.activity-actor-agent { background: #3b2a5f; color: #c4a7ff; }
+.activity-actor-system { background: #2a2a2a; color: #888; }
+.activity-description { flex: 1; color: #ccc; }
+.activity-description a { color: #7cb7ff; text-decoration: none; }
+.activity-description a:hover { text-decoration: underline; }
+.activity-time { color: #555; font-size: 0.8rem; flex-shrink: 0; }
+
 /* File Viewer */
 .file-viewer-breadcrumb {
   display: flex;

--- a/tests/activity-page.test.tsx
+++ b/tests/activity-page.test.tsx
@@ -1,0 +1,138 @@
+/** @jsxImportSource hono/jsx */
+import { renderToString } from "hono/jsx/dom/server";
+import { describe, expect, it } from "vitest";
+import type { EventRecord } from "../src/storage/events";
+import { ActivityPage, describeEvent, relativeTime } from "../src/ui/pages/activity";
+
+function makeEvent(overrides: Partial<EventRecord>): EventRecord {
+  return {
+    id: "evt_1",
+    type: "change.created",
+    project: "my-project",
+    actorType: "user",
+    payload: {},
+    status: "processed",
+    attempts: 1,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+const project = { name: "my-project", namespace: "@user", slug: "my-project" };
+
+describe("describeEvent", () => {
+  it("describes change lifecycle events", () => {
+    expect(
+      describeEvent(
+        makeEvent({ type: "change.created", payload: { changeId: "chg_1", workspace: "ws-1" } }),
+      ),
+    ).toBe("Change chg_1 opened from ws-1");
+    expect(
+      describeEvent(
+        makeEvent({
+          type: "change.evaluated",
+          payload: { changeId: "chg_1", score: 0.91, passed: true },
+        }),
+      ),
+    ).toBe("Change chg_1 evaluated → 0.91 passed");
+    expect(
+      describeEvent(
+        makeEvent({
+          type: "change.merged",
+          payload: { changeId: "chg_1", commit: "abcdef1234567" },
+        }),
+      ),
+    ).toBe("Change chg_1 merged → abcdef1");
+    expect(
+      describeEvent(makeEvent({ type: "change.rejected", payload: { changeId: "chg_1" } })),
+    ).toBe("Change chg_1 rejected");
+  });
+
+  it("describes project and workspace events", () => {
+    expect(describeEvent(makeEvent({ type: "project.created" }))).toBe("Project created");
+    expect(
+      describeEvent(
+        makeEvent({ type: "project.imported", payload: { sourceUrl: "https://github.com/a/b" } }),
+      ),
+    ).toBe("Imported from github.com/a/b");
+    expect(
+      describeEvent(makeEvent({ type: "workspace.created", payload: { workspace: "ws-1" } })),
+    ).toBe("Workspace ws-1 created");
+    expect(
+      describeEvent(makeEvent({ type: "sync.completed", payload: { commit: "abcdef1234567" } })),
+    ).toBe("Synced from upstream → abcdef1");
+  });
+
+  it("falls back to the raw type for unknown events", () => {
+    expect(describeEvent(makeEvent({ type: "something.else" }))).toBe("something.else");
+  });
+
+  it("tolerates missing payload fields", () => {
+    expect(describeEvent(makeEvent({ type: "change.merged", payload: {} }))).toBe(
+      "Change ? merged",
+    );
+    expect(describeEvent(makeEvent({ type: "sync.completed", payload: {} }))).toBe(
+      "Synced from upstream",
+    );
+  });
+});
+
+describe("relativeTime", () => {
+  const now = new Date("2026-06-11T12:00:00Z");
+
+  it("renders coarse relative times", () => {
+    expect(relativeTime("2026-06-11T11:59:40Z", now)).toBe("just now");
+    expect(relativeTime("2026-06-11T11:30:00Z", now)).toBe("30m ago");
+    expect(relativeTime("2026-06-11T07:00:00Z", now)).toBe("5h ago");
+    expect(relativeTime("2026-06-08T12:00:00Z", now)).toBe("3d ago");
+  });
+
+  it("falls back to a date for old or invalid timestamps", () => {
+    expect(relativeTime("2025-01-01T00:00:00Z", now)).toBe(
+      new Date("2025-01-01T00:00:00Z").toLocaleDateString(),
+    );
+    expect(relativeTime("not-a-date", now)).toBe(new Date("not-a-date").toLocaleDateString());
+  });
+});
+
+describe("ActivityPage", () => {
+  it("renders an empty state when there are no events", () => {
+    const html = renderToString(<ActivityPage project={project} events={[]} user={null} />);
+    expect(html).toContain("No activity yet");
+  });
+
+  it("renders event lines with actor badges and links changes", () => {
+    const events = [
+      makeEvent({
+        id: "evt_1",
+        type: "change.merged",
+        actorType: "user",
+        payload: { changeId: "chg_42", commit: "abcdef1234" },
+      }),
+      makeEvent({
+        id: "evt_2",
+        type: "workspace.created",
+        actorType: "agent",
+        payload: { workspace: "ws-9" },
+      }),
+    ];
+    const html = renderToString(<ActivityPage project={project} events={events} user={null} />);
+
+    expect(html).toContain("activity-actor-user");
+    expect(html).toContain("activity-actor-agent");
+    expect(html).toContain("Change chg_42 merged → abcdef1");
+    expect(html).toContain('href="/changes/chg_42"');
+    expect(html).toContain("Workspace ws-9 created");
+  });
+
+  it("escapes untrusted payload content", () => {
+    const events = [
+      makeEvent({
+        type: "workspace.created",
+        payload: { workspace: '<script>alert("xss")</script>' },
+      }),
+    ];
+    const html = renderToString(<ActivityPage project={project} events={events} user={null} />);
+    expect(html).not.toContain("<script>alert");
+  });
+});

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -104,7 +104,7 @@ vi.mock("../src/storage/provenance", () => ({
 }));
 
 vi.mock("../src/queue/events", () => ({
-  publishEvent: vi.fn().mockResolvedValue(undefined),
+  emitEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../src/storage/users", () => ({

--- a/tests/event-pipeline.test.ts
+++ b/tests/event-pipeline.test.ts
@@ -1,0 +1,281 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MAX_EVENT_ATTEMPTS,
+  handleEventQueue,
+  sweepStaleEvents,
+} from "../src/queue/event-consumer";
+import { emitEvent } from "../src/queue/events";
+import type { Env, Message, MessageBatch, Queue } from "../src/types";
+import type { Logger } from "../src/utils/logger";
+import { makeEventsD1 } from "./helpers/events-d1";
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+function makeQueue(): { queue: Queue; sent: unknown[] } {
+  const sent: unknown[] = [];
+  const queue = {
+    send: vi.fn(async (msg: unknown) => {
+      sent.push(msg);
+    }),
+  } as unknown as Queue;
+  return { queue, sent };
+}
+
+function makeMessage(body: unknown): Message<{ eventId: string }> & {
+  acked: boolean;
+  retried: boolean;
+} {
+  const msg = {
+    id: "msg_1",
+    timestamp: new Date(),
+    body: body as { eventId: string },
+    acked: false,
+    retried: false,
+    ack() {
+      this.acked = true;
+    },
+    retry() {
+      this.retried = true;
+    },
+  };
+  return msg as unknown as Message<{ eventId: string }> & { acked: boolean; retried: boolean };
+}
+
+function makeEnv(db: D1Database, queue?: Queue): Env {
+  return {
+    DB: db,
+    ...(queue ? { EVENTS_QUEUE: queue } : {}),
+  } as unknown as Env;
+}
+
+describe("emitEvent", () => {
+  it("writes an outbox row and sends the event id to the queue", async () => {
+    const { db, rows } = makeEventsD1();
+    const { queue, sent } = makeQueue();
+
+    await emitEvent(
+      db,
+      queue,
+      { type: "change.merged", project: "p", changeId: "chg_1", commit: "abc" },
+      { type: "user", id: "user_1" },
+      mockLogger,
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.type).toBe("change.merged");
+    expect(rows[0]?.actor_type).toBe("user");
+    expect(JSON.parse(rows[0]?.payload ?? "{}")).toEqual({ changeId: "chg_1", commit: "abc" });
+    expect(sent).toEqual([{ eventId: rows[0]?.id }]);
+  });
+
+  it("still writes the outbox row when the queue send fails", async () => {
+    const { db, rows } = makeEventsD1();
+    const queue = {
+      send: vi.fn().mockRejectedValue(new Error("queue down")),
+    } as unknown as Queue;
+
+    await expect(
+      emitEvent(
+        db,
+        queue,
+        { type: "project.created", project: "p" },
+        { type: "user", id: "u1" },
+        mockLogger,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.status).toBe("pending");
+  });
+
+  it("writes the outbox row when no queue is bound", async () => {
+    const { db, rows } = makeEventsD1();
+
+    await emitEvent(
+      db,
+      null,
+      { type: "workspace.created", project: "p", workspace: "ws" },
+      { type: "agent", id: "agent_1" },
+      mockLogger,
+    );
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it("never throws when the database is unavailable", async () => {
+    const badDb = {
+      prepare: () => {
+        throw new Error("D1 unavailable");
+      },
+    } as unknown as D1Database;
+    const { queue, sent } = makeQueue();
+
+    await expect(
+      emitEvent(
+        badDb,
+        queue,
+        { type: "project.created", project: "p" },
+        { type: "system" },
+        mockLogger,
+      ),
+    ).resolves.toBeUndefined();
+    expect(sent).toHaveLength(0);
+  });
+});
+
+describe("handleEventQueue", () => {
+  let db: D1Database;
+  let rows: ReturnType<typeof makeEventsD1>["rows"];
+
+  beforeEach(() => {
+    ({ db, rows } = makeEventsD1());
+  });
+
+  async function seedEvent(): Promise<string> {
+    await emitEvent(
+      db,
+      null,
+      { type: "change.created", project: "p", changeId: "chg_1", workspace: "ws" },
+      { type: "user", id: "u1" },
+      mockLogger,
+    );
+    const id = rows[0]?.id;
+    if (!id) throw new Error("seed failed");
+    return id;
+  }
+
+  it("processes a pending event and acks", async () => {
+    const eventId = await seedEvent();
+    const msg = makeMessage({ eventId });
+    const batch = { queue: "stratum-events", messages: [msg] } as unknown as MessageBatch<{
+      eventId: string;
+    }>;
+
+    await handleEventQueue(batch, makeEnv(db));
+
+    expect(msg.acked).toBe(true);
+    expect(msg.retried).toBe(false);
+    expect(rows[0]?.status).toBe("processed");
+    expect(rows[0]?.attempts).toBe(1);
+  });
+
+  it("acks and skips an already-processed event", async () => {
+    const eventId = await seedEvent();
+    const row = rows[0];
+    if (row) row.status = "processed";
+    const msg = makeMessage({ eventId });
+    const batch = { queue: "stratum-events", messages: [msg] } as unknown as MessageBatch<{
+      eventId: string;
+    }>;
+
+    await handleEventQueue(batch, makeEnv(db));
+
+    expect(msg.acked).toBe(true);
+    expect(rows[0]?.attempts).toBe(0);
+  });
+
+  it("acks a message whose event row is missing", async () => {
+    const msg = makeMessage({ eventId: "evt_gone" });
+    const batch = { queue: "stratum-events", messages: [msg] } as unknown as MessageBatch<{
+      eventId: string;
+    }>;
+
+    await handleEventQueue(batch, makeEnv(db));
+    expect(msg.acked).toBe(true);
+  });
+
+  it("acks a malformed message without an eventId", async () => {
+    const msg = makeMessage({});
+    const batch = { queue: "stratum-events", messages: [msg] } as unknown as MessageBatch<{
+      eventId: string;
+    }>;
+
+    await handleEventQueue(batch, makeEnv(db));
+    expect(msg.acked).toBe(true);
+  });
+});
+
+describe("sweepStaleEvents", () => {
+  it("re-enqueues stale pending events", async () => {
+    const { db, rows } = makeEventsD1();
+    const { queue, sent } = makeQueue();
+    await emitEvent(
+      db,
+      null,
+      { type: "project.created", project: "p" },
+      { type: "system" },
+      mockLogger,
+    );
+    const row = rows[0];
+    if (row) row.created_at = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+
+    await sweepStaleEvents(makeEnv(db, queue), mockLogger);
+
+    expect(sent).toEqual([{ eventId: row?.id }]);
+    expect(row?.status).toBe("pending");
+  });
+
+  it("fails out events that exhausted their attempts", async () => {
+    const { db, rows } = makeEventsD1();
+    const { queue, sent } = makeQueue();
+    await emitEvent(
+      db,
+      null,
+      { type: "project.created", project: "p" },
+      { type: "system" },
+      mockLogger,
+    );
+    const row = rows[0];
+    if (row) {
+      row.created_at = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+      row.attempts = MAX_EVENT_ATTEMPTS;
+    }
+
+    await sweepStaleEvents(makeEnv(db, queue), mockLogger);
+
+    expect(sent).toHaveLength(0);
+    expect(row?.status).toBe("failed");
+  });
+
+  it("processes inline when no queue is bound", async () => {
+    const { db, rows } = makeEventsD1();
+    await emitEvent(
+      db,
+      null,
+      { type: "project.created", project: "p" },
+      { type: "system" },
+      mockLogger,
+    );
+    const row = rows[0];
+    if (row) row.created_at = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+
+    await sweepStaleEvents(makeEnv(db), mockLogger);
+
+    expect(row?.status).toBe("processed");
+  });
+
+  it("ignores fresh pending events", async () => {
+    const { db, rows } = makeEventsD1();
+    const { queue, sent } = makeQueue();
+    await emitEvent(
+      db,
+      null,
+      { type: "project.created", project: "p" },
+      { type: "system" },
+      mockLogger,
+    );
+
+    await sweepStaleEvents(makeEnv(db, queue), mockLogger);
+
+    expect(sent).toHaveLength(0);
+    expect(rows[0]?.status).toBe("pending");
+  });
+});

--- a/tests/events-storage.test.ts
+++ b/tests/events-storage.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getEvent,
+  incrementEventAttempts,
+  insertEvent,
+  listProjectEvents,
+  listRecentEvents,
+  listStalePendingEvents,
+  markEventFailed,
+  markEventProcessed,
+} from "../src/storage/events";
+import type { Logger } from "../src/utils/logger";
+import { type EventRow, makeEventsD1 } from "./helpers/events-d1";
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+describe("events storage", () => {
+  let db: D1Database;
+  let rows: EventRow[];
+
+  beforeEach(() => {
+    ({ db, rows } = makeEventsD1());
+  });
+
+  it("inserts an event as pending with payload", async () => {
+    const result = await insertEvent(db, mockLogger, {
+      type: "change.merged",
+      project: "my-project",
+      actorType: "user",
+      actorId: "user_1",
+      payload: { changeId: "chg_1", commit: "abc123" },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.status).toBe("pending");
+    expect(result.data.attempts).toBe(0);
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0]?.payload ?? "{}")).toEqual({ changeId: "chg_1", commit: "abc123" });
+  });
+
+  it("round-trips an event through getEvent", async () => {
+    const inserted = await insertEvent(db, mockLogger, {
+      type: "workspace.created",
+      project: "p",
+      actorType: "agent",
+      actorId: "agent_1",
+      payload: { workspace: "ws-1" },
+    });
+    expect(inserted.success).toBe(true);
+    if (!inserted.success) return;
+
+    const fetched = await getEvent(db, mockLogger, inserted.data.id);
+    expect(fetched.success).toBe(true);
+    if (!fetched.success) return;
+    expect(fetched.data.type).toBe("workspace.created");
+    expect(fetched.data.actorType).toBe("agent");
+    expect(fetched.data.actorId).toBe("agent_1");
+    expect(fetched.data.payload).toEqual({ workspace: "ws-1" });
+  });
+
+  it("returns NOT_FOUND for a missing event", async () => {
+    const result = await getEvent(db, mockLogger, "evt_missing");
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("lists events scoped by project, newest first", async () => {
+    await insertEvent(db, mockLogger, {
+      type: "project.created",
+      project: "alpha",
+      actorType: "user",
+      payload: {},
+    });
+    await insertEvent(db, mockLogger, {
+      type: "project.created",
+      project: "beta",
+      actorType: "user",
+      payload: {},
+    });
+
+    const result = await listProjectEvents(db, mockLogger, "alpha");
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]?.project).toBe("alpha");
+  });
+
+  it("lists recent events across projects", async () => {
+    await insertEvent(db, mockLogger, {
+      type: "project.created",
+      project: "alpha",
+      actorType: "user",
+      payload: {},
+    });
+    await insertEvent(db, mockLogger, {
+      type: "project.created",
+      project: "beta",
+      actorType: "user",
+      payload: {},
+    });
+
+    const result = await listRecentEvents(db, mockLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toHaveLength(2);
+  });
+
+  it("marks events processed and failed, increments attempts", async () => {
+    const inserted = await insertEvent(db, mockLogger, {
+      type: "change.created",
+      project: "p",
+      actorType: "system",
+      payload: {},
+    });
+    expect(inserted.success).toBe(true);
+    if (!inserted.success) return;
+    const id = inserted.data.id;
+
+    await incrementEventAttempts(db, mockLogger, id);
+    await markEventProcessed(db, mockLogger, id);
+    expect(rows[0]?.status).toBe("processed");
+    expect(rows[0]?.attempts).toBe(1);
+    expect(rows[0]?.processed_at).toBeTruthy();
+
+    await markEventFailed(db, mockLogger, id);
+    expect(rows[0]?.status).toBe("failed");
+  });
+
+  it("finds stale pending events older than the cutoff", async () => {
+    const inserted = await insertEvent(db, mockLogger, {
+      type: "change.created",
+      project: "p",
+      actorType: "system",
+      payload: {},
+    });
+    expect(inserted.success).toBe(true);
+    if (!inserted.success) return;
+
+    // Fresh event: not stale.
+    const fresh = await listStalePendingEvents(db, mockLogger, { olderThanMs: 5 * 60 * 1000 });
+    expect(fresh.success).toBe(true);
+    if (!fresh.success) return;
+    expect(fresh.data).toHaveLength(0);
+
+    // Backdate the row: now stale.
+    const row = rows[0];
+    if (row) row.created_at = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const stale = await listStalePendingEvents(db, mockLogger, { olderThanMs: 5 * 60 * 1000 });
+    expect(stale.success).toBe(true);
+    if (!stale.success) return;
+    expect(stale.data).toHaveLength(1);
+
+    // Processed rows are never stale.
+    if (row) row.status = "processed";
+    const afterProcess = await listStalePendingEvents(db, mockLogger, {
+      olderThanMs: 5 * 60 * 1000,
+    });
+    expect(afterProcess.success).toBe(true);
+    if (!afterProcess.success) return;
+    expect(afterProcess.data).toHaveLength(0);
+  });
+
+  it("tolerates malformed payload JSON", async () => {
+    rows.push({
+      id: "evt_bad",
+      type: "change.created",
+      project: "p",
+      actor_type: "system",
+      actor_id: null,
+      payload: "not-json{",
+      status: "pending",
+      attempts: 0,
+      created_at: new Date().toISOString(),
+      processed_at: null,
+    });
+
+    const result = await getEvent(db, mockLogger, "evt_bad");
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.payload).toEqual({});
+  });
+});

--- a/tests/helpers/events-d1.ts
+++ b/tests/helpers/events-d1.ts
@@ -1,0 +1,81 @@
+export interface EventRow {
+  id: string;
+  type: string;
+  project: string;
+  actor_type: string;
+  actor_id: string | null;
+  payload: string;
+  status: string;
+  attempts: number;
+  created_at: string;
+  processed_at: string | null;
+}
+
+/** Minimal stateful D1 stub understanding the queries events storage issues. */
+export function makeEventsD1(): { db: D1Database; rows: EventRow[] } {
+  const rows: EventRow[] = [];
+
+  function makeStmt(sql: string, bindings: unknown[]) {
+    const upper = sql.trim().toUpperCase();
+    return {
+      bind: (...args: unknown[]) => makeStmt(sql, args),
+      run: async () => {
+        if (upper.startsWith("INSERT INTO EVENTS")) {
+          rows.push({
+            id: bindings[0] as string,
+            type: bindings[1] as string,
+            project: bindings[2] as string,
+            actor_type: bindings[3] as string,
+            actor_id: bindings[4] as string | null,
+            payload: bindings[5] as string,
+            status: "pending",
+            attempts: 0,
+            created_at: bindings[6] as string,
+            processed_at: null,
+          });
+        } else if (upper.includes("SET STATUS = 'PROCESSED'")) {
+          const row = rows.find((r) => r.id === bindings[1]);
+          if (row) {
+            row.status = "processed";
+            row.processed_at = bindings[0] as string;
+          }
+        } else if (upper.includes("SET STATUS = 'FAILED'")) {
+          const row = rows.find((r) => r.id === bindings[1]);
+          if (row) {
+            row.status = "failed";
+            row.processed_at = bindings[0] as string;
+          }
+        } else if (upper.includes("SET ATTEMPTS = ATTEMPTS + 1")) {
+          const row = rows.find((r) => r.id === bindings[0]);
+          if (row) row.attempts += 1;
+        }
+        return { success: true, meta: {} };
+      },
+      first: async <T>() => {
+        return (rows.find((r) => r.id === bindings[0]) ?? null) as T | null;
+      },
+      all: async <T>() => {
+        let results: EventRow[];
+        if (upper.includes("WHERE PROJECT = ?")) {
+          results = rows
+            .filter((r) => r.project === bindings[0])
+            .sort((a, b) => b.created_at.localeCompare(a.created_at))
+            .slice(0, bindings[1] as number);
+        } else if (upper.includes("WHERE STATUS = 'PENDING' AND CREATED_AT < ?")) {
+          results = rows
+            .filter((r) => r.status === "pending" && r.created_at < (bindings[0] as string))
+            .sort((a, b) => a.created_at.localeCompare(b.created_at))
+            .slice(0, bindings[1] as number);
+        } else {
+          results = [...rows]
+            .sort((a, b) => b.created_at.localeCompare(a.created_at))
+            .slice(0, bindings[0] as number);
+        }
+        return { results: results as T[], success: true, meta: {} };
+      },
+    };
+  }
+
+  const db = { prepare: (sql: string) => makeStmt(sql, []) } as unknown as D1Database;
+  return { db, rows };
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -55,8 +55,10 @@ max_batch_size = 1  # Process imports one at a time for resource management
 max_retries = 3     # Retry failed imports up to 3 times
 retry_delay = 30    # Wait 30 seconds between retries
 
+# "0 6 * * *"   — daily housekeeping: workspace TTL sweep + auto-sync
+# "*/5 * * * *" — event outbox sweep: re-enqueue stale pending events
 [triggers]
-crons = ["0 6 * * *"]
+crons = ["0 6 * * *", "*/5 * * * *"]
 
 [vars]
 POSTHOG_HOST = "https://app.posthog.com"


### PR DESCRIPTION
## Summary

Implements master-plan Phase 2.4 (event-driven pipeline foundation) and Phase 3.6 (activity feed):

- **Durable outbox**: every domain event is written to a D1 `events` table before queue delivery; the queue message carries only the event id, so events survive queue loss.
- **Real consumer**: the `stratum-events` consumer (previously a no-op ack) loads the row, runs an ordered handler registry (analytics today; webhook notifications and issue auto-close plug in next), and marks rows processed, with retry and max-attempts fail-out.
- **Sweep cron** (`*/5 * * * *`): re-enqueues pending events older than 5 minutes; fails out events that exhausted attempts. Daily cron behavior unchanged (dispatched by cron pattern).
- **Wider emission coverage**: project.created, project.imported, workspace.created, sync.completed — plus the existing change lifecycle, now consistently scoped by project name. Emission never breaks the primary request path.
- **Activity feed**: `/:namespace/:slug/activity` (UI) and `GET /api/projects/:namespace/:slug/activity` (JSON), outcome-oriented one-liners with actor badges.

## Testing

- 29 new tests: outbox storage, emit/consume/sweep semantics, activity rendering (incl. XSS escaping)
- Full suite: 621 passing; lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)