### PR TITLE
feat: issue tracker with merge auto-close (Phase 3.5)

### DIFF
--- a/migrations/018_issues.sql
+++ b/migrations/018_issues.sql
@@ -1,0 +1,29 @@
+-- Lightweight issue tracker. Issues are scoped by project name (the same key
+-- the changes and events tables use) and numbered per project. An issue
+-- optionally links to a Change; when that Change merges, the issue closes
+-- automatically via the event pipeline.
+
+CREATE TABLE IF NOT EXISTS issues (
+  id TEXT PRIMARY KEY,
+  project TEXT NOT NULL,
+  number INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  body TEXT,
+  status TEXT NOT NULL DEFAULT 'open' CHECK(status IN ('open','closed')),
+  author_type TEXT NOT NULL CHECK(author_type IN ('user','agent')),
+  author_id TEXT NOT NULL,
+  linked_change_id TEXT,
+  closed_at DATETIME,
+  closed_by TEXT,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_issues_project_number
+  ON issues(project, number);
+
+CREATE INDEX IF NOT EXISTS idx_issues_project_status
+  ON issues(project, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_issues_linked_change
+  ON issues(linked_change_id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { bulkImportRouter } from "./routes/bulk-import";
 import { changesRouter } from "./routes/changes";
 import { emailAuthRouter } from "./routes/email-auth";
 import { healthRouter } from "./routes/health";
+import { issuesRouter } from "./routes/issues";
 import { loginRouter } from "./routes/login";
 import { metricsRouter } from "./routes/metrics";
 import { orgsRouter } from "./routes/orgs";
@@ -134,6 +135,7 @@ app.route("/auth/signup", signupRouter);
 app.route("/auth/sessions", sessionRouter);
 app.route("/", uiRouter); // Mount UI at root
 app.route("/api/projects", webhooksRouter);
+app.route("/api/projects", issuesRouter);
 app.route("/api/projects", projectsRouter);
 app.route("/api/workspaces", workspacesRouter);
 app.route("/api/users", usersRouter);

--- a/src/queue/event-consumer.ts
+++ b/src/queue/event-consumer.ts
@@ -11,6 +11,7 @@ import type { Env, Message, MessageBatch } from "../types";
 import type { Logger } from "../utils/logger";
 import { createLogger } from "../utils/logger";
 import type { EventQueueMessage } from "./events";
+import { autoCloseLinkedIssues } from "./issue-autoclose";
 import { deliverEventToWebhooks } from "./webhook-delivery";
 
 /** Attempts after which a pending event is abandoned and marked failed. */
@@ -44,12 +45,19 @@ const webhookHandler: EventHandler = {
   },
 };
 
+const issueAutoCloseHandler: EventHandler = {
+  name: "issue-autoclose",
+  async handle(env, event, logger) {
+    await autoCloseLinkedIssues(env, event, logger);
+  },
+};
+
 /**
- * Ordered handler registry. Later features (issue auto-close) append here;
- * every handler runs for every event and decides internally whether the
- * event type concerns it.
+ * Ordered handler registry. Every handler runs for every event and decides
+ * internally whether the event type concerns it. Issue auto-close runs
+ * before webhooks so receivers observe a consistent issue state.
  */
-const handlers: EventHandler[] = [analyticsHandler, webhookHandler];
+const handlers: EventHandler[] = [analyticsHandler, issueAutoCloseHandler, webhookHandler];
 
 async function processEvent(env: Env, event: EventRecord, logger: Logger): Promise<void> {
   for (const handler of handlers) {

--- a/src/queue/events.ts
+++ b/src/queue/events.ts
@@ -14,7 +14,15 @@ export type StratumEvent =
   // project ID, and events are scoped by project name. It lands with the
   // project-identity unification work.
   | { type: "workspace.created"; project: string; workspace: string }
-  | { type: "sync.completed"; project: string; commit?: string };
+  | { type: "sync.completed"; project: string; commit?: string }
+  | { type: "issue.opened"; project: string; issueNumber: number; title: string }
+  | {
+      type: "issue.closed";
+      project: string;
+      issueNumber: number;
+      title: string;
+      changeId?: string;
+    };
 
 export interface EventActor {
   type: EventActorType;

--- a/src/queue/issue-autoclose.ts
+++ b/src/queue/issue-autoclose.ts
@@ -1,0 +1,54 @@
+import type { EventRecord } from "../storage/events";
+import { closeIssue, listOpenIssuesByChange } from "../storage/issues";
+import type { Env } from "../types";
+import type { Logger } from "../utils/logger";
+import { emitEvent } from "./events";
+
+/**
+ * When a Change merges, close every open issue linked to it and emit
+ * issue.closed events. Per-issue failures are logged and skipped — a close
+ * failure must not retry the whole merged event (other handlers already ran).
+ */
+export async function autoCloseLinkedIssues(
+  env: Env,
+  event: EventRecord,
+  logger: Logger,
+): Promise<void> {
+  if (event.type !== "change.merged") return;
+
+  const changeId = event.payload.changeId;
+  if (typeof changeId !== "string" || !changeId) return;
+
+  const issuesResult = await listOpenIssuesByChange(env.DB, logger, changeId);
+  if (!issuesResult.success) return;
+
+  for (const issue of issuesResult.data) {
+    const closeResult = await closeIssue(env.DB, logger, issue.project, issue.number, "system");
+    if (!closeResult.success) {
+      logger.warn("Failed to auto-close linked issue", {
+        project: issue.project,
+        issueNumber: issue.number,
+        changeId,
+      });
+      continue;
+    }
+    logger.info("Issue auto-closed by merged change", {
+      project: issue.project,
+      issueNumber: issue.number,
+      changeId,
+    });
+    await emitEvent(
+      env.DB,
+      env.EVENTS_QUEUE ?? null,
+      {
+        type: "issue.closed",
+        project: issue.project,
+        issueNumber: issue.number,
+        title: issue.title,
+        changeId,
+      },
+      { type: "system" },
+      logger,
+    );
+  }
+}

--- a/src/routes/issues.ts
+++ b/src/routes/issues.ts
@@ -1,0 +1,353 @@
+import { Hono } from "hono";
+import { type EventActor, emitEvent } from "../queue/events";
+import { getChange } from "../storage/changes";
+import {
+  type IssueStatus,
+  createIssue,
+  getIssueByNumber,
+  listIssues,
+  updateIssue,
+} from "../storage/issues";
+import { getProjectByPath } from "../storage/state";
+import type { Env, ProjectEntry } from "../types";
+import { canReadProject, canWriteProject } from "../utils/authz";
+import { createLogger } from "../utils/logger";
+import type { Logger } from "../utils/logger";
+import {
+  badRequest,
+  created,
+  forbidden,
+  internalError,
+  notFound,
+  ok,
+  unauthorized,
+} from "../utils/response";
+
+const app = new Hono<{ Bindings: Env }>();
+
+const MAX_TITLE_LENGTH = 200;
+const MAX_BODY_LENGTH = 20_000;
+
+interface RouteContext {
+  env: Env;
+  get(key: "userId" | "agentId" | "agentOwnerId"): string | undefined;
+  req: { param(key: string): string };
+}
+
+async function loadProject(
+  c: RouteContext,
+  logger: Logger,
+): Promise<{ project: ProjectEntry } | { response: Response }> {
+  const namespace = c.req.param("namespace");
+  const slug = c.req.param("slug");
+
+  const projectResult = await getProjectByPath(c.env.STATE, namespace, slug, logger);
+  if (!projectResult.success) {
+    if (projectResult.error.code === "NOT_FOUND") {
+      return { response: notFound("Project", `${namespace}/${slug}`) };
+    }
+    logger.error("Failed to get project", projectResult.error);
+    return { response: internalError(projectResult.error.message) };
+  }
+  return { project: projectResult.data };
+}
+
+function parseIssueNumber(raw: string): number | null {
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+// POST /api/projects/:namespace/:slug/issues — Open an issue
+app.post("/:namespace/:slug/issues", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const userId = c.get("userId");
+  const agentId = c.get("agentId");
+  const agentOwnerId = c.get("agentOwnerId");
+  if (!userId && !agentId) return unauthorized("Authentication required");
+
+  const result = await loadProject(c, logger);
+  if ("response" in result) return result.response;
+  const { project } = result;
+
+  // Anyone who can read the project can open issues against it.
+  if (!canReadProject(project, userId, agentOwnerId)) {
+    return notFound("Project", `${project.namespace}/${project.slug}`);
+  }
+
+  let body: { title?: unknown; body?: unknown; linkedChangeId?: unknown };
+  const contentType = c.req.header("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    body = await c.req.json<typeof body>().catch(() => ({}));
+  } else {
+    const form = await c.req.parseBody();
+    body = { title: form.title, body: form.body, linkedChangeId: form.linkedChangeId };
+  }
+
+  if (typeof body.title !== "string" || !body.title.trim()) {
+    return badRequest("title is required");
+  }
+  const title = body.title.trim().slice(0, MAX_TITLE_LENGTH);
+  const issueBody =
+    typeof body.body === "string" && body.body.trim()
+      ? body.body.trim().slice(0, MAX_BODY_LENGTH)
+      : undefined;
+
+  let linkedChangeId: string | undefined;
+  if (typeof body.linkedChangeId === "string" && body.linkedChangeId.trim()) {
+    const changeResult = await getChange(c.env.DB, logger, body.linkedChangeId.trim());
+    if (!changeResult.success || changeResult.data.project !== project.name) {
+      return badRequest("linkedChangeId does not reference a change in this project");
+    }
+    linkedChangeId = changeResult.data.id;
+  }
+
+  const issueResult = await createIssue(c.env.DB, logger, {
+    project: project.name,
+    title,
+    ...(issueBody !== undefined ? { body: issueBody } : {}),
+    authorType: agentId ? "agent" : "user",
+    authorId: agentId ?? userId ?? "unknown",
+    ...(linkedChangeId !== undefined ? { linkedChangeId } : {}),
+  });
+  if (!issueResult.success) {
+    return internalError(issueResult.error.message);
+  }
+  const issue = issueResult.data;
+
+  const actor: EventActor = agentId
+    ? { type: "agent", id: agentId }
+    : { type: "user", ...(userId !== undefined ? { id: userId } : {}) };
+  await emitEvent(
+    c.env.DB,
+    c.env.EVENTS_QUEUE,
+    { type: "issue.opened", project: project.name, issueNumber: issue.number, title: issue.title },
+    actor,
+    logger,
+  );
+
+  if (!contentType.includes("application/json")) {
+    return c.redirect(`/${project.namespace}/${project.slug}/issues/${issue.number}`, 302);
+  }
+  return created({ issue });
+});
+
+// GET /api/projects/:namespace/:slug/issues — List issues
+app.get("/:namespace/:slug/issues", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+
+  const result = await loadProject(c, logger);
+  if ("response" in result) return result.response;
+  const { project } = result;
+
+  if (!canReadProject(project, userId, agentOwnerId)) {
+    return notFound("Project", `${project.namespace}/${project.slug}`);
+  }
+
+  const statusParam = c.req.query("status");
+  const status: IssueStatus | undefined =
+    statusParam === "open" || statusParam === "closed" ? statusParam : undefined;
+
+  const issuesResult = await listIssues(c.env.DB, logger, project.name, status);
+  if (!issuesResult.success) {
+    return internalError(issuesResult.error.message);
+  }
+
+  return ok({ issues: issuesResult.data });
+});
+
+// GET /api/projects/:namespace/:slug/issues/:number — Issue detail
+app.get("/:namespace/:slug/issues/:number", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+
+  const result = await loadProject(c, logger);
+  if ("response" in result) return result.response;
+  const { project } = result;
+
+  if (!canReadProject(project, userId, agentOwnerId)) {
+    return notFound("Project", `${project.namespace}/${project.slug}`);
+  }
+
+  const number = parseIssueNumber(c.req.param("number"));
+  if (number === null) return badRequest("Invalid issue number");
+
+  const issueResult = await getIssueByNumber(c.env.DB, logger, project.name, number);
+  if (!issueResult.success) {
+    if (issueResult.error.code === "NOT_FOUND") return notFound("Issue", `#${number}`);
+    return internalError(issueResult.error.message);
+  }
+
+  return ok({ issue: issueResult.data });
+});
+
+// PATCH /api/projects/:namespace/:slug/issues/:number — Edit / close / reopen
+app.patch("/:namespace/:slug/issues/:number", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const userId = c.get("userId");
+  if (!userId) return unauthorized("Only authenticated users can edit issues");
+
+  const result = await loadProject(c, logger);
+  if ("response" in result) return result.response;
+  const { project } = result;
+
+  // Editing and closing issues requires write access to the project.
+  if (!canWriteProject(project, userId)) return forbidden("Project access denied");
+
+  const number = parseIssueNumber(c.req.param("number"));
+  if (number === null) return badRequest("Invalid issue number");
+
+  const body = await c.req
+    .json<{ title?: unknown; body?: unknown; status?: unknown; linkedChangeId?: unknown }>()
+    .catch(() => ({}) as Record<string, unknown>);
+
+  const updates: {
+    title?: string;
+    body?: string;
+    status?: IssueStatus;
+    linkedChangeId?: string | null;
+    actorId: string;
+  } = { actorId: userId };
+
+  if (body.title !== undefined) {
+    if (typeof body.title !== "string" || !body.title.trim()) {
+      return badRequest("title must be a non-empty string");
+    }
+    updates.title = body.title.trim().slice(0, MAX_TITLE_LENGTH);
+  }
+  if (body.body !== undefined) {
+    if (typeof body.body !== "string") return badRequest("body must be a string");
+    updates.body = body.body.trim().slice(0, MAX_BODY_LENGTH);
+  }
+  if (body.status !== undefined) {
+    if (body.status !== "open" && body.status !== "closed") {
+      return badRequest("status must be 'open' or 'closed'");
+    }
+    updates.status = body.status;
+  }
+  if (body.linkedChangeId !== undefined) {
+    if (body.linkedChangeId === null || body.linkedChangeId === "") {
+      updates.linkedChangeId = null;
+    } else if (typeof body.linkedChangeId === "string") {
+      const changeResult = await getChange(c.env.DB, logger, body.linkedChangeId);
+      if (!changeResult.success || changeResult.data.project !== project.name) {
+        return badRequest("linkedChangeId does not reference a change in this project");
+      }
+      updates.linkedChangeId = changeResult.data.id;
+    } else {
+      return badRequest("linkedChangeId must be a string or null");
+    }
+  }
+
+  const before = await getIssueByNumber(c.env.DB, logger, project.name, number);
+  if (!before.success) {
+    if (before.error.code === "NOT_FOUND") return notFound("Issue", `#${number}`);
+    return internalError(before.error.message);
+  }
+
+  const updateResult = await updateIssue(c.env.DB, logger, project.name, number, updates);
+  if (!updateResult.success) {
+    if (updateResult.error.code === "NOT_FOUND") return notFound("Issue", `#${number}`);
+    return internalError(updateResult.error.message);
+  }
+  const issue = updateResult.data;
+
+  if (updates.status === "closed" && before.data.status === "open") {
+    await emitEvent(
+      c.env.DB,
+      c.env.EVENTS_QUEUE,
+      {
+        type: "issue.closed",
+        project: project.name,
+        issueNumber: issue.number,
+        title: issue.title,
+      },
+      { type: "user", id: userId },
+      logger,
+    );
+  }
+
+  return ok({ issue });
+});
+
+// POST /api/projects/:namespace/:slug/issues/:number/close — Form-friendly close
+app.post("/:namespace/:slug/issues/:number/close", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const userId = c.get("userId");
+  if (!userId) return unauthorized("Only authenticated users can close issues");
+
+  const result = await loadProject(c, logger);
+  if ("response" in result) return result.response;
+  const { project } = result;
+
+  if (!canWriteProject(project, userId)) return forbidden("Project access denied");
+
+  const number = parseIssueNumber(c.req.param("number"));
+  if (number === null) return badRequest("Invalid issue number");
+
+  const before = await getIssueByNumber(c.env.DB, logger, project.name, number);
+  if (!before.success) {
+    if (before.error.code === "NOT_FOUND") return notFound("Issue", `#${number}`);
+    return internalError(before.error.message);
+  }
+
+  const newStatus: IssueStatus = before.data.status === "open" ? "closed" : "open";
+  const updateResult = await updateIssue(c.env.DB, logger, project.name, number, {
+    status: newStatus,
+    actorId: userId,
+  });
+  if (!updateResult.success) {
+    return internalError(updateResult.error.message);
+  }
+
+  if (newStatus === "closed") {
+    await emitEvent(
+      c.env.DB,
+      c.env.EVENTS_QUEUE,
+      {
+        type: "issue.closed",
+        project: project.name,
+        issueNumber: number,
+        title: updateResult.data.title,
+      },
+      { type: "user", id: userId },
+      logger,
+    );
+  }
+
+  return c.redirect(`/${project.namespace}/${project.slug}/issues/${number}`, 302);
+});
+
+export { app as issuesRouter };

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -4,18 +4,20 @@ import { listEvalRuns } from "../storage/eval-runs";
 import { listProjectEvents } from "../storage/events";
 import { getCommitLog, listFilesInRepo, readFileFromRepo } from "../storage/git-ops";
 import { getImportProgress } from "../storage/imports";
+import { getIssueByNumber, listIssues } from "../storage/issues";
 import { readRepoSnapshot } from "../storage/repo-snapshot";
 import { getProject, getProjectByPath, listProjects, listWorkspaces } from "../storage/state";
 import { getProjectSourceUrl, getSyncStatus } from "../storage/sync";
 import { getUser } from "../storage/users";
 import { listDeliveries, listWebhooks } from "../storage/webhooks";
-import type { Env } from "../types";
+import type { Env, ProjectEntry } from "../types";
 import { getFileContent, isValidFilePath } from "../ui/file-content";
 import { ActivityPage } from "../ui/pages/activity";
 import { ChangeDetailPage } from "../ui/pages/change-detail";
 import { ChangesPage } from "../ui/pages/changes";
 import { FileViewerPage } from "../ui/pages/file-viewer";
 import { HomePage } from "../ui/pages/home";
+import { IssueDetailPage, IssuesPage, NewIssuePage } from "../ui/pages/issues";
 import { NewProjectPage } from "../ui/pages/new-project";
 import { RepoPage } from "../ui/pages/repo";
 import { SyncPage } from "../ui/pages/sync";
@@ -588,6 +590,126 @@ app.get("/:namespace/:slug/activity", async (c) => {
       project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
       events={eventsResult.data}
       user={userResult}
+    />,
+  );
+});
+
+// Shared loader for issue pages: validates path, loads user + project, checks read access.
+async function loadIssuePageContext(c: {
+  env: Env;
+  get(key: "userId" | "agentOwnerId"): string | undefined;
+  req: { param(key: string): string; path: string; query(key: string): string | undefined };
+}): Promise<
+  | {
+      project: ProjectEntry;
+      user: { id: string; email: string; username: string } | null;
+      userId: string | undefined;
+      logger: ReturnType<typeof createLogger>;
+    }
+  | { errorStatus: 400 | 404 }
+> {
+  const namespace = c.req.param("namespace");
+  const slug = c.req.param("slug");
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const logger = createLogger({ path: c.req.path, userId });
+
+  if (!isValidNamespace(namespace) || !isValidSlug(slug)) return { errorStatus: 400 };
+
+  const [user, projectResult] = await Promise.all([
+    getCurrentUser(c, logger),
+    getProjectByPath(c.env.STATE, namespace, slug, logger),
+  ]);
+  if (!projectResult.success) return { errorStatus: 404 };
+  const project = projectResult.data;
+  if (!canReadProject(project, userId, agentOwnerId)) return { errorStatus: 404 };
+
+  return { project, user, userId, logger };
+}
+
+const issuePageError = (status: 400 | 404 | 500) => (
+  <div style="padding:2rem;font-family:monospace;color:#f87171;">
+    {status === 400 ? "Invalid project path." : status === 404 ? "Not found." : "Server error."}
+  </div>
+);
+
+// GET /:namespace/:slug/issues — Issues list
+app.get("/:namespace/:slug/issues", async (c) => {
+  const ctx = await loadIssuePageContext(c);
+  if ("errorStatus" in ctx) return c.html(issuePageError(ctx.errorStatus), ctx.errorStatus);
+  const { project, user, userId, logger } = ctx;
+
+  const statusParam = c.req.query("status");
+  const filter: "open" | "closed" | "all" =
+    statusParam === "closed" ? "closed" : statusParam === "all" ? "all" : "open";
+
+  const issuesResult = await listIssues(
+    c.env.DB,
+    logger,
+    project.name,
+    filter === "all" ? undefined : filter,
+  );
+  if (!issuesResult.success) {
+    logger.error("Failed to list issues", issuesResult.error);
+    return c.html(issuePageError(500), 500);
+  }
+
+  return c.html(
+    <IssuesPage
+      project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
+      issues={issuesResult.data}
+      filter={filter}
+      canWrite={canWriteProject(project, userId)}
+      user={user}
+    />,
+  );
+});
+
+// GET /:namespace/:slug/issues/new — New issue form (writers only)
+app.get("/:namespace/:slug/issues/new", async (c) => {
+  const ctx = await loadIssuePageContext(c);
+  if ("errorStatus" in ctx) return c.html(issuePageError(ctx.errorStatus), ctx.errorStatus);
+  const { project, user, userId } = ctx;
+
+  if (!canWriteProject(project, userId)) {
+    return c.html(issuePageError(404), 404);
+  }
+
+  return c.html(
+    <NewIssuePage
+      project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
+      user={user}
+    />,
+  );
+});
+
+// GET /:namespace/:slug/issues/:number — Issue detail
+app.get("/:namespace/:slug/issues/:number", async (c) => {
+  const ctx = await loadIssuePageContext(c);
+  if ("errorStatus" in ctx) return c.html(issuePageError(ctx.errorStatus), ctx.errorStatus);
+  const { project, user, userId, logger } = ctx;
+
+  const number = Number(c.req.param("number"));
+  if (!Number.isInteger(number) || number <= 0) {
+    return c.html(issuePageError(400), 400);
+  }
+
+  const issueResult = await getIssueByNumber(c.env.DB, logger, project.name, number);
+  if (!issueResult.success) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Issue #{number} not found.
+      </div>,
+      404,
+    );
+  }
+
+  return c.html(
+    <IssueDetailPage
+      project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
+      issue={issueResult.data}
+      canWrite={canWriteProject(project, userId)}
+      user={user}
     />,
   );
 });

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -27,6 +27,8 @@ const SUBSCRIBABLE_EVENTS = [
   "project.imported",
   "workspace.created",
   "sync.completed",
+  "issue.opened",
+  "issue.closed",
 ];
 
 interface ProjectAccess {

--- a/src/storage/issues.ts
+++ b/src/storage/issues.ts
@@ -1,0 +1,260 @@
+import { AppError, NotFoundError } from "../utils/errors";
+import { newId } from "../utils/ids";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+
+export type IssueStatus = "open" | "closed";
+
+export interface Issue {
+  id: string;
+  project: string;
+  number: number;
+  title: string;
+  body?: string;
+  status: IssueStatus;
+  authorType: "user" | "agent";
+  authorId: string;
+  linkedChangeId?: string;
+  closedAt?: string;
+  closedBy?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface IssueRow {
+  id: string;
+  project: string;
+  number: number;
+  title: string;
+  body: string | null;
+  status: string;
+  author_type: string;
+  author_id: string;
+  linked_change_id: string | null;
+  closed_at: string | null;
+  closed_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToIssue(row: IssueRow): Issue {
+  const issue: Issue = {
+    id: row.id,
+    project: row.project,
+    number: row.number,
+    title: row.title,
+    status: row.status as IssueStatus,
+    authorType: row.author_type as Issue["authorType"],
+    authorId: row.author_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+  if (row.body !== null) issue.body = row.body;
+  if (row.linked_change_id !== null) issue.linkedChangeId = row.linked_change_id;
+  if (row.closed_at !== null) issue.closedAt = row.closed_at;
+  if (row.closed_by !== null) issue.closedBy = row.closed_by;
+  return issue;
+}
+
+function toAppError(error: unknown, operation: string, context: Record<string, unknown>) {
+  return error instanceof AppError
+    ? error
+    : new AppError(
+        error instanceof Error ? error.message : `Failed in ${operation}`,
+        "DATABASE_ERROR",
+        500,
+        { operation, ...context },
+      );
+}
+
+export async function createIssue(
+  db: D1Database,
+  logger: Logger,
+  opts: {
+    project: string;
+    title: string;
+    body?: string;
+    authorType: "user" | "agent";
+    authorId: string;
+    linkedChangeId?: string;
+  },
+): Promise<Result<Issue, AppError>> {
+  const id = newId("iss");
+  const now = new Date().toISOString();
+
+  try {
+    // The per-project number is assigned inside the INSERT so concurrent
+    // creates cannot race: SQLite executes the scalar subquery and the
+    // insert as one serialized statement.
+    const row = await db
+      .prepare(
+        `INSERT INTO issues (id, project, number, title, body, status, author_type, author_id, linked_change_id, created_at, updated_at)
+         VALUES (?1, ?2, (SELECT COALESCE(MAX(number), 0) + 1 FROM issues WHERE project = ?2), ?3, ?4, 'open', ?5, ?6, ?7, ?8, ?8)
+         RETURNING *`,
+      )
+      .bind(
+        id,
+        opts.project,
+        opts.title,
+        opts.body ?? null,
+        opts.authorType,
+        opts.authorId,
+        opts.linkedChangeId ?? null,
+        now,
+      )
+      .first<IssueRow>();
+
+    if (!row) {
+      return err(
+        new AppError("Issue insert returned no row", "DATABASE_ERROR", 500, {
+          operation: "createIssue",
+        }),
+      );
+    }
+
+    logger.info("Issue created", { issueId: id, project: opts.project, number: row.number });
+    return ok(rowToIssue(row));
+  } catch (error) {
+    const appError = toAppError(error, "createIssue", { project: opts.project });
+    logger.error("Failed to create issue", appError, { project: opts.project });
+    return err(appError);
+  }
+}
+
+export async function getIssueByNumber(
+  db: D1Database,
+  logger: Logger,
+  project: string,
+  number: number,
+): Promise<Result<Issue, NotFoundError | AppError>> {
+  try {
+    const row = await db
+      .prepare("SELECT * FROM issues WHERE project = ? AND number = ?")
+      .bind(project, number)
+      .first<IssueRow>();
+    if (!row) {
+      logger.debug("Issue not found", { project, number });
+      return err(new NotFoundError("Issue", `${project}#${number}`));
+    }
+    return ok(rowToIssue(row));
+  } catch (error) {
+    const appError = toAppError(error, "getIssueByNumber", { project, number });
+    logger.error("Failed to get issue", appError, { project, number });
+    return err(appError);
+  }
+}
+
+export async function listIssues(
+  db: D1Database,
+  logger: Logger,
+  project: string,
+  status?: IssueStatus,
+): Promise<Result<Issue[], AppError>> {
+  try {
+    const result = status
+      ? await db
+          .prepare("SELECT * FROM issues WHERE project = ? AND status = ? ORDER BY number DESC")
+          .bind(project, status)
+          .all<IssueRow>()
+      : await db
+          .prepare("SELECT * FROM issues WHERE project = ? ORDER BY number DESC")
+          .bind(project)
+          .all<IssueRow>();
+    return ok(result.results.map(rowToIssue));
+  } catch (error) {
+    const appError = toAppError(error, "listIssues", { project });
+    logger.error("Failed to list issues", appError, { project });
+    return err(appError);
+  }
+}
+
+export async function updateIssue(
+  db: D1Database,
+  logger: Logger,
+  project: string,
+  number: number,
+  opts: {
+    title?: string;
+    body?: string;
+    status?: IssueStatus;
+    linkedChangeId?: string | null;
+    actorId: string;
+  },
+): Promise<Result<Issue, NotFoundError | AppError>> {
+  try {
+    const existing = await getIssueByNumber(db, logger, project, number);
+    if (!existing.success) return existing;
+
+    const now = new Date().toISOString();
+    const assignments = ["updated_at = ?"];
+    const bindings: unknown[] = [now];
+
+    if (opts.title !== undefined) {
+      assignments.push("title = ?");
+      bindings.push(opts.title);
+    }
+    if (opts.body !== undefined) {
+      assignments.push("body = ?");
+      bindings.push(opts.body);
+    }
+    if (opts.linkedChangeId !== undefined) {
+      assignments.push("linked_change_id = ?");
+      bindings.push(opts.linkedChangeId);
+    }
+    if (opts.status !== undefined && opts.status !== existing.data.status) {
+      assignments.push("status = ?");
+      bindings.push(opts.status);
+      if (opts.status === "closed") {
+        assignments.push("closed_at = ?", "closed_by = ?");
+        bindings.push(now, opts.actorId);
+      } else {
+        assignments.push("closed_at = NULL", "closed_by = NULL");
+      }
+    }
+
+    bindings.push(project, number);
+    await db
+      .prepare(`UPDATE issues SET ${assignments.join(", ")} WHERE project = ? AND number = ?`)
+      .bind(...bindings)
+      .run();
+
+    const updated = await getIssueByNumber(db, logger, project, number);
+    if (!updated.success) return updated;
+    logger.info("Issue updated", { project, number });
+    return updated;
+  } catch (error) {
+    const appError = toAppError(error, "updateIssue", { project, number });
+    logger.error("Failed to update issue", appError, { project, number });
+    return err(appError);
+  }
+}
+
+/** Open issues linked to a change — used by the merge auto-close handler. */
+export async function listOpenIssuesByChange(
+  db: D1Database,
+  logger: Logger,
+  changeId: string,
+): Promise<Result<Issue[], AppError>> {
+  try {
+    const result = await db
+      .prepare("SELECT * FROM issues WHERE linked_change_id = ? AND status = 'open'")
+      .bind(changeId)
+      .all<IssueRow>();
+    return ok(result.results.map(rowToIssue));
+  } catch (error) {
+    const appError = toAppError(error, "listOpenIssuesByChange", { changeId });
+    logger.error("Failed to list issues by change", appError, { changeId });
+    return err(appError);
+  }
+}
+
+/** Close an issue on behalf of the system (merge auto-close). */
+export async function closeIssue(
+  db: D1Database,
+  logger: Logger,
+  project: string,
+  number: number,
+  closedBy: string,
+): Promise<Result<Issue, NotFoundError | AppError>> {
+  return updateIssue(db, logger, project, number, { status: "closed", actorId: closedBy });
+}

--- a/src/ui/pages/activity.tsx
+++ b/src/ui/pages/activity.tsx
@@ -45,6 +45,15 @@ export function describeEvent(event: EventRecord): string {
       return `Change ${changeId ?? "?"} rejected`;
     case "sync.completed":
       return `Synced from upstream${commit ? ` → ${commit.slice(0, 7)}` : ""}`;
+    case "issue.opened": {
+      const number = typeof payload.issueNumber === "number" ? payload.issueNumber : "?";
+      const title = asString(payload.title);
+      return `Issue #${number} opened${title ? `: ${title}` : ""}`;
+    }
+    case "issue.closed": {
+      const number = typeof payload.issueNumber === "number" ? payload.issueNumber : "?";
+      return `Issue #${number} closed${changeId ? ` by ${changeId}` : ""}`;
+    }
     default:
       return event.type;
   }

--- a/src/ui/pages/issues.tsx
+++ b/src/ui/pages/issues.tsx
@@ -1,0 +1,170 @@
+import type { FC } from "hono/jsx";
+import type { Issue } from "../../storage/issues";
+import { Layout } from "../layout";
+
+interface ProjectRef {
+  name: string;
+  namespace: string;
+  slug: string;
+}
+
+interface IssuesPageProps {
+  project: ProjectRef;
+  issues: Issue[];
+  filter: "open" | "closed" | "all";
+  canWrite: boolean;
+  user?: { id: string; email: string; username: string } | null;
+}
+
+const statusBadge = (status: Issue["status"]) =>
+  status === "open" ? "badge badge-open" : "badge badge-merged";
+
+export const IssuesPage: FC<IssuesPageProps> = ({ project, issues, filter, canWrite, user }) => {
+  const base = `/${project.namespace}/${project.slug}/issues`;
+  return (
+    <Layout title={`Issues — ${project.name}`} user={user}>
+      <div class="page-header">
+        <h1>Issues</h1>
+        <div class="page-header-actions">
+          {canWrite && (
+            <a class="btn btn-primary" href={`${base}/new`}>
+              New issue
+            </a>
+          )}
+          <a class="btn" href={`/${project.namespace}/${project.slug}`}>
+            Back to repo
+          </a>
+        </div>
+      </div>
+
+      <div class="issues-filter">
+        <a href={base} class={filter === "open" ? "issues-filter-active" : ""}>
+          Open
+        </a>
+        <a href={`${base}?status=closed`} class={filter === "closed" ? "issues-filter-active" : ""}>
+          Closed
+        </a>
+        <a href={`${base}?status=all`} class={filter === "all" ? "issues-filter-active" : ""}>
+          All
+        </a>
+      </div>
+
+      {issues.length === 0 ? (
+        <div class="empty-state">
+          <p>No {filter === "all" ? "" : `${filter} `}issues.</p>
+        </div>
+      ) : (
+        <ul class="issues-list">
+          {issues.map((issue) => (
+            <li key={issue.id} class="issues-item">
+              <span class={statusBadge(issue.status)}>{issue.status}</span>
+              <a href={`${base}/${issue.number}`} class="issues-title">
+                #{issue.number} {issue.title}
+              </a>
+              {issue.linkedChangeId && (
+                <a href={`/changes/${issue.linkedChangeId}`} class="issues-linked-change">
+                  {issue.linkedChangeId}
+                </a>
+              )}
+              <span class="issues-meta">
+                opened {new Date(issue.createdAt).toLocaleDateString()} by {issue.authorType}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Layout>
+  );
+};
+
+interface IssueDetailPageProps {
+  project: ProjectRef;
+  issue: Issue;
+  canWrite: boolean;
+  user?: { id: string; email: string; username: string } | null;
+}
+
+export const IssueDetailPage: FC<IssueDetailPageProps> = ({ project, issue, canWrite, user }) => {
+  const base = `/${project.namespace}/${project.slug}/issues`;
+  const apiBase = `/api/projects/${project.namespace}/${project.slug}/issues`;
+  return (
+    <Layout title={`#${issue.number} ${issue.title} — ${project.name}`} user={user}>
+      <div class="page-header">
+        <h1>
+          #{issue.number} {issue.title}
+        </h1>
+        <a class="btn" href={base}>
+          Back to issues
+        </a>
+      </div>
+
+      <div class="issue-status-row">
+        <span class={statusBadge(issue.status)}>{issue.status}</span>
+        <span class="issues-meta">
+          opened {new Date(issue.createdAt).toLocaleString()} by {issue.authorType}
+          {issue.closedAt ? ` · closed ${new Date(issue.closedAt).toLocaleString()}` : ""}
+          {issue.closedBy === "system" ? " (auto-closed by merged change)" : ""}
+        </span>
+        {canWrite && (
+          <form method="post" action={`${apiBase}/${issue.number}/close`}>
+            <button type="submit" class="btn btn-small">
+              {issue.status === "open" ? "Close issue" : "Reopen issue"}
+            </button>
+          </form>
+        )}
+      </div>
+
+      {issue.linkedChangeId && (
+        <div class="card" style={{ marginTop: "1rem" }}>
+          <p style={{ margin: 0 }}>
+            Linked change: <a href={`/changes/${issue.linkedChangeId}`}>{issue.linkedChangeId}</a>
+            {issue.status === "open" ? " — this issue closes automatically when it merges." : ""}
+          </p>
+        </div>
+      )}
+
+      <div class="card issue-body">
+        {issue.body ? <pre class="issue-body-text">{issue.body}</pre> : <p>No description.</p>}
+      </div>
+    </Layout>
+  );
+};
+
+interface NewIssuePageProps {
+  project: ProjectRef;
+  user?: { id: string; email: string; username: string } | null;
+}
+
+export const NewIssuePage: FC<NewIssuePageProps> = ({ project, user }) => {
+  const apiBase = `/api/projects/${project.namespace}/${project.slug}/issues`;
+  return (
+    <Layout title={`New issue — ${project.name}`} user={user}>
+      <div class="page-header">
+        <h1>New issue</h1>
+        <a class="btn" href={`/${project.namespace}/${project.slug}/issues`}>
+          Cancel
+        </a>
+      </div>
+
+      <div class="card">
+        <form method="post" action={apiBase} class="issue-form">
+          <label>
+            Title
+            <input type="text" name="title" maxlength={200} required />
+          </label>
+          <label>
+            Description
+            <textarea name="body" rows={8} />
+          </label>
+          <label>
+            Linked change ID (optional — issue closes when it merges)
+            <input type="text" name="linkedChangeId" placeholder="chg_…" />
+          </label>
+          <button type="submit" class="btn btn-primary">
+            Open issue
+          </button>
+        </form>
+      </div>
+    </Layout>
+  );
+};

--- a/src/ui/pages/repo.tsx
+++ b/src/ui/pages/repo.tsx
@@ -195,6 +195,9 @@ export const RepoPage: FC<RepoProps> = ({
               </button>
             </form>
           )}
+          <a class="btn" href={`/${project.namespace}/${project.slug}/issues`}>
+            Issues
+          </a>
           <a class="btn" href={`/${project.namespace}/${project.slug}/activity`}>
             Activity
           </a>

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -493,6 +493,36 @@ a:hover { text-decoration: underline; }
 .btn-small { font-size: 0.75rem; padding: 0.25rem 0.6rem; }
 .btn-danger { color: #f87171; border-color: #5f1e1e; }
 
+/* Issues */
+.page-header-actions { display: flex; gap: 0.5rem; }
+.issues-filter { display: flex; gap: 1rem; margin-bottom: 1rem; font-size: 0.9rem; }
+.issues-filter a { color: #777; text-decoration: none; }
+.issues-filter a:hover { color: #ccc; }
+.issues-filter-active { color: #f0f0f0 !important; font-weight: 600; }
+.issues-list { list-style: none; padding: 0; margin: 0; }
+.issues-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid #222;
+  font-size: 0.9rem;
+  flex-wrap: wrap;
+}
+.issues-title { color: #e8e8e8; text-decoration: none; flex: 1; min-width: 200px; }
+.issues-title:hover { color: #7cb7ff; }
+.issues-linked-change { font-family: 'JetBrains Mono', monospace; font-size: 0.75rem; color: #c4a7ff; }
+.issues-meta { color: #555; font-size: 0.8rem; }
+.issue-status-row { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
+.issue-body { margin-top: 1rem; }
+.issue-body-text { white-space: pre-wrap; word-break: break-word; font-family: inherit; margin: 0; }
+.issue-form { display: flex; flex-direction: column; gap: 0.75rem; max-width: 560px; }
+.issue-form label { display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.85rem; color: #aaa; }
+.issue-form input, .issue-form textarea {
+  background: #111; border: 1px solid #333; color: #eee;
+  padding: 0.5rem; border-radius: 4px; font-family: inherit;
+}
+
 /* File Viewer */
 .file-viewer-breadcrumb {
   display: flex;

--- a/tests/helpers/issues-d1.ts
+++ b/tests/helpers/issues-d1.ts
@@ -1,0 +1,145 @@
+export interface IssueTableRow {
+  id: string;
+  project: string;
+  number: number;
+  title: string;
+  body: string | null;
+  status: string;
+  author_type: string;
+  author_id: string;
+  linked_change_id: string | null;
+  closed_at: string | null;
+  closed_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface OutboxRow {
+  id: string;
+  type: string;
+  project: string;
+  payload: string;
+}
+
+/**
+ * Stateful D1 stub for the issues table, plus a minimal events-outbox sink so
+ * the auto-close handler's emitEvent calls can be observed.
+ */
+export function makeIssuesD1(): {
+  db: D1Database;
+  issues: IssueTableRow[];
+  emittedEvents: OutboxRow[];
+} {
+  const issues: IssueTableRow[] = [];
+  const emittedEvents: OutboxRow[] = [];
+
+  function applyUpdate(sql: string, bindings: unknown[]) {
+    // UPDATE issues SET <assignments> WHERE project = ? AND number = ?
+    const project = bindings[bindings.length - 2] as string;
+    const number = bindings[bindings.length - 1] as number;
+    const row = issues.find((r) => r.project === project && r.number === number);
+    if (!row) return;
+
+    const assignmentsPart = sql.slice(sql.indexOf("SET") + 3, sql.indexOf("WHERE"));
+    const assignments = assignmentsPart.split(",").map((a) => a.trim());
+    let bindIndex = 0;
+    for (const assignment of assignments) {
+      const [columnRaw, valueRaw] = assignment.split("=").map((part) => part.trim());
+      if (!columnRaw || valueRaw === undefined) continue;
+      const value = valueRaw === "NULL" ? null : (bindings[bindIndex++] as never);
+      switch (columnRaw) {
+        case "updated_at":
+          row.updated_at = value as unknown as string;
+          break;
+        case "title":
+          row.title = value as unknown as string;
+          break;
+        case "body":
+          row.body = value;
+          break;
+        case "status":
+          row.status = value as unknown as string;
+          break;
+        case "linked_change_id":
+          row.linked_change_id = value;
+          break;
+        case "closed_at":
+          row.closed_at = value;
+          break;
+        case "closed_by":
+          row.closed_by = value;
+          break;
+      }
+    }
+  }
+
+  function makeStmt(sql: string, bindings: unknown[]) {
+    const upper = sql.trim().toUpperCase().replace(/\s+/g, " ");
+    return {
+      bind: (...args: unknown[]) => makeStmt(sql, args),
+      run: async () => {
+        if (upper.startsWith("UPDATE ISSUES SET")) {
+          applyUpdate(sql.replace(/\s+/g, " "), bindings);
+        } else if (upper.startsWith("INSERT INTO EVENTS")) {
+          emittedEvents.push({
+            id: bindings[0] as string,
+            type: bindings[1] as string,
+            project: bindings[2] as string,
+            payload: bindings[5] as string,
+          });
+        }
+        return { success: true, meta: {} };
+      },
+      first: async <T>() => {
+        if (upper.startsWith("INSERT INTO ISSUES")) {
+          // VALUES (?1, ?2, (SELECT COALESCE(MAX(number),0)+1 ...), ?3..?8) RETURNING *
+          const project = bindings[1] as string;
+          const number =
+            issues
+              .filter((r) => r.project === project)
+              .reduce((max, r) => Math.max(max, r.number), 0) + 1;
+          const row: IssueTableRow = {
+            id: bindings[0] as string,
+            project,
+            number,
+            title: bindings[2] as string,
+            body: bindings[3] as string | null,
+            status: "open",
+            author_type: bindings[4] as string,
+            author_id: bindings[5] as string,
+            linked_change_id: bindings[6] as string | null,
+            closed_at: null,
+            closed_by: null,
+            created_at: bindings[7] as string,
+            updated_at: bindings[7] as string,
+          };
+          issues.push(row);
+          return row as T;
+        }
+        if (upper.includes("FROM ISSUES WHERE PROJECT = ? AND NUMBER = ?")) {
+          return (issues.find((r) => r.project === bindings[0] && r.number === bindings[1]) ??
+            null) as T | null;
+        }
+        return null;
+      },
+      all: async <T>() => {
+        let results: IssueTableRow[] = [];
+        if (upper.includes("WHERE LINKED_CHANGE_ID = ? AND STATUS = 'OPEN'")) {
+          results = issues.filter((r) => r.linked_change_id === bindings[0] && r.status === "open");
+        } else if (upper.includes("WHERE PROJECT = ? AND STATUS = ?")) {
+          results = issues
+            .filter((r) => r.project === bindings[0] && r.status === bindings[1])
+            .sort((a, b) => b.number - a.number);
+        } else if (upper.includes("FROM ISSUES WHERE PROJECT = ?")) {
+          results = issues
+            .filter((r) => r.project === bindings[0])
+            .sort((a, b) => b.number - a.number);
+        }
+        return { results: results as T[], success: true, meta: {} };
+      },
+    };
+  }
+
+  const db = { prepare: (sql: string) => makeStmt(sql, []) } as unknown as D1Database;
+  return { db, issues, emittedEvents };
+}

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+import { autoCloseLinkedIssues } from "../src/queue/issue-autoclose";
+import type { EventRecord } from "../src/storage/events";
+import {
+  closeIssue,
+  createIssue,
+  getIssueByNumber,
+  listIssues,
+  listOpenIssuesByChange,
+  updateIssue,
+} from "../src/storage/issues";
+import type { Env } from "../src/types";
+import type { Logger } from "../src/utils/logger";
+import { makeIssuesD1 } from "./helpers/issues-d1";
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+async function seedIssue(
+  db: D1Database,
+  overrides: Partial<Parameters<typeof createIssue>[2]> = {},
+) {
+  const result = await createIssue(db, mockLogger, {
+    project: "my-project",
+    title: "Something is broken",
+    authorType: "user",
+    authorId: "user_1",
+    ...overrides,
+  });
+  if (!result.success) throw new Error("seed failed");
+  return result.data;
+}
+
+describe("issue storage", () => {
+  it("assigns sequential per-project numbers", async () => {
+    const { db } = makeIssuesD1();
+    const first = await seedIssue(db);
+    const second = await seedIssue(db);
+    const otherProject = await seedIssue(db, { project: "other" });
+
+    expect(first.number).toBe(1);
+    expect(second.number).toBe(2);
+    expect(otherProject.number).toBe(1);
+  });
+
+  it("round-trips issues through getIssueByNumber", async () => {
+    const { db } = makeIssuesD1();
+    await seedIssue(db, { body: "Details here", linkedChangeId: "chg_1" });
+
+    const fetched = await getIssueByNumber(db, mockLogger, "my-project", 1);
+    expect(fetched.success).toBe(true);
+    if (!fetched.success) return;
+    expect(fetched.data.title).toBe("Something is broken");
+    expect(fetched.data.body).toBe("Details here");
+    expect(fetched.data.linkedChangeId).toBe("chg_1");
+    expect(fetched.data.status).toBe("open");
+  });
+
+  it("returns NOT_FOUND for missing issues", async () => {
+    const { db } = makeIssuesD1();
+    const result = await getIssueByNumber(db, mockLogger, "my-project", 99);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("filters issue lists by status", async () => {
+    const { db } = makeIssuesD1();
+    await seedIssue(db);
+    await seedIssue(db, { title: "Second" });
+    await closeIssue(db, mockLogger, "my-project", 1, "user_1");
+
+    const open = await listIssues(db, mockLogger, "my-project", "open");
+    const closed = await listIssues(db, mockLogger, "my-project", "closed");
+    const all = await listIssues(db, mockLogger, "my-project");
+
+    expect(open.success && open.data.map((i) => i.number)).toEqual([2]);
+    expect(closed.success && closed.data.map((i) => i.number)).toEqual([1]);
+    expect(all.success && all.data).toHaveLength(2);
+  });
+
+  it("closing sets closed_at/closed_by; reopening clears them", async () => {
+    const { db } = makeIssuesD1();
+    await seedIssue(db);
+
+    const closed = await updateIssue(db, mockLogger, "my-project", 1, {
+      status: "closed",
+      actorId: "user_9",
+    });
+    expect(closed.success).toBe(true);
+    if (!closed.success) return;
+    expect(closed.data.status).toBe("closed");
+    expect(closed.data.closedBy).toBe("user_9");
+    expect(closed.data.closedAt).toBeTruthy();
+
+    const reopened = await updateIssue(db, mockLogger, "my-project", 1, {
+      status: "open",
+      actorId: "user_9",
+    });
+    expect(reopened.success).toBe(true);
+    if (!reopened.success) return;
+    expect(reopened.data.status).toBe("open");
+    expect(reopened.data.closedAt).toBeUndefined();
+    expect(reopened.data.closedBy).toBeUndefined();
+  });
+
+  it("updates title, body, and linked change", async () => {
+    const { db } = makeIssuesD1();
+    await seedIssue(db);
+
+    const updated = await updateIssue(db, mockLogger, "my-project", 1, {
+      title: "New title",
+      body: "New body",
+      linkedChangeId: "chg_42",
+      actorId: "user_1",
+    });
+    expect(updated.success).toBe(true);
+    if (!updated.success) return;
+    expect(updated.data.title).toBe("New title");
+    expect(updated.data.body).toBe("New body");
+    expect(updated.data.linkedChangeId).toBe("chg_42");
+  });
+
+  it("finds open issues by linked change", async () => {
+    const { db } = makeIssuesD1();
+    await seedIssue(db, { linkedChangeId: "chg_1" });
+    await seedIssue(db, { title: "Other", linkedChangeId: "chg_2" });
+    await seedIssue(db, { title: "Closed one", linkedChangeId: "chg_1" });
+    await closeIssue(db, mockLogger, "my-project", 3, "user_1");
+
+    const result = await listOpenIssuesByChange(db, mockLogger, "chg_1");
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.map((i) => i.number)).toEqual([1]);
+  });
+});
+
+describe("autoCloseLinkedIssues", () => {
+  function makeMergedEvent(changeId: string): EventRecord {
+    return {
+      id: "evt_1",
+      type: "change.merged",
+      project: "my-project",
+      actorType: "user",
+      payload: { changeId, commit: "abc" },
+      status: "pending",
+      attempts: 0,
+      createdAt: new Date().toISOString(),
+    };
+  }
+
+  it("closes open linked issues and emits issue.closed", async () => {
+    const { db, issues, emittedEvents } = makeIssuesD1();
+    await seedIssue(db, { linkedChangeId: "chg_1" });
+    await seedIssue(db, { title: "Unrelated", linkedChangeId: "chg_other" });
+    const env = { DB: db } as unknown as Env;
+
+    await autoCloseLinkedIssues(env, makeMergedEvent("chg_1"), mockLogger);
+
+    expect(issues[0]?.status).toBe("closed");
+    expect(issues[0]?.closed_by).toBe("system");
+    expect(issues[1]?.status).toBe("open");
+
+    const closedEvents = emittedEvents.filter((e) => e.type === "issue.closed");
+    expect(closedEvents).toHaveLength(1);
+    expect(JSON.parse(closedEvents[0]?.payload ?? "{}")).toMatchObject({
+      issueNumber: 1,
+      changeId: "chg_1",
+    });
+  });
+
+  it("ignores events that are not change.merged", async () => {
+    const { db, issues } = makeIssuesD1();
+    await seedIssue(db, { linkedChangeId: "chg_1" });
+    const env = { DB: db } as unknown as Env;
+
+    await autoCloseLinkedIssues(
+      env,
+      { ...makeMergedEvent("chg_1"), type: "change.created" },
+      mockLogger,
+    );
+
+    expect(issues[0]?.status).toBe("open");
+  });
+
+  it("ignores merged events without a changeId payload", async () => {
+    const { db, issues } = makeIssuesD1();
+    await seedIssue(db, { linkedChangeId: "chg_1" });
+    const env = { DB: db } as unknown as Env;
+
+    const event = makeMergedEvent("chg_1");
+    event.payload = {};
+    await autoCloseLinkedIssues(env, event, mockLogger);
+
+    expect(issues[0]?.status).toBe("open");
+  });
+
+  it("does nothing when no issues link to the change", async () => {
+    const { db, emittedEvents } = makeIssuesD1();
+    const env = { DB: db } as unknown as Env;
+
+    await expect(
+      autoCloseLinkedIssues(env, makeMergedEvent("chg_nope"), mockLogger),
+    ).resolves.toBeUndefined();
+    expect(emittedEvents).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements master-plan Phase 3.5 on top of the event pipeline:

- **Issues per project**: D1-backed, sequential per-project numbers assigned atomically inside the INSERT (scalar subquery — no read-then-write race).
- **Change linking + auto-close**: an issue can link to a Change; the event consumer's `issue-autoclose` handler closes linked open issues when `change.merged` processes, emitting `issue.closed` (visible in activity feed, deliverable via webhooks). Per-issue close failures are logged and skipped so a failure can't re-deliver the merged event to other handlers.
- **API**: `POST/GET /api/projects/:ns/:slug/issues`, `GET/PATCH …/issues/:number`, form-friendly `POST …/issues/:number/close` toggle. Readers can open issues; writers can edit/close.
- **UI**: `/:namespace/:slug/issues` (open/closed/all filter), issue detail with linked-change card and close/reopen, new-issue form, repo-page nav link.
- `issue.opened`/`issue.closed` added to the event union, activity feed descriptions, and webhook-subscribable events.

## Testing

- 11 new tests: per-project numbering, round-trips, status filters, close/reopen semantics, linked-change lookup, auto-close handler (closes linked, ignores unrelated/malformed, emits issue.closed)
- Full suite: 646 passing; lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)