### PR TITLE
feat: branch protection (Phase 3.8) + MergeQueue contract fix

### DIFF
--- a/src/evaluation/policy-loader.ts
+++ b/src/evaluation/policy-loader.ts
@@ -1,7 +1,7 @@
 import YAML from "yaml";
 import { readFileFromRepo } from "../storage/git-ops";
 import type { Logger } from "../utils/logger";
-import type { EvalPolicy } from "./types";
+import type { EvalPolicy, MergePolicy } from "./types";
 
 const DEFAULT_POLICY: EvalPolicy = {
   evaluators: [{ type: "diff" }],
@@ -59,8 +59,41 @@ async function readAndParsePolicy(
       return null;
     }
 
-    return { ...DEFAULT_POLICY, ...(parsed as Partial<EvalPolicy>) };
+    const policy = { ...DEFAULT_POLICY, ...(parsed as Partial<EvalPolicy>) };
+    const merge = sanitizeMergePolicy((parsed as Record<string, unknown>).merge);
+    if (merge) {
+      policy.merge = merge;
+    } else {
+      delete policy.merge;
+    }
+    return policy;
   } catch {
     return null;
   }
+}
+
+/** Keep only well-typed merge-protection fields from user-supplied config. */
+function sanitizeMergePolicy(raw: unknown): MergePolicy | null {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+  const source = raw as Record<string, unknown>;
+  const merge: MergePolicy = {};
+
+  if (
+    typeof source.requiredApprovals === "number" &&
+    Number.isInteger(source.requiredApprovals) &&
+    source.requiredApprovals >= 0
+  ) {
+    merge.requiredApprovals = source.requiredApprovals;
+  }
+  if (
+    Array.isArray(source.requiredEvaluators) &&
+    source.requiredEvaluators.every((entry) => typeof entry === "string")
+  ) {
+    merge.requiredEvaluators = source.requiredEvaluators;
+  }
+  if (typeof source.allowForce === "boolean") {
+    merge.allowForce = source.allowForce;
+  }
+
+  return Object.keys(merge).length > 0 ? merge : null;
 }

--- a/src/evaluation/types.ts
+++ b/src/evaluation/types.ts
@@ -17,6 +17,20 @@ export interface EvalPolicy {
   evaluators: EvaluatorConfig[];
   requireAll?: boolean;
   minScore?: number;
+  merge?: MergePolicy;
+}
+
+/**
+ * Branch-protection rules enforced at the merge step.
+ * Configured under `merge:` in .stratum/policy.yaml.
+ */
+export interface MergePolicy {
+  /** Human approvals required before a change can merge. Default 0. */
+  requiredApprovals?: number;
+  /** Evaluator types whose latest run must have passed (e.g. ["secret_scan", "diff"]). */
+  requiredEvaluators?: string[];
+  /** When false, the ?force=true override is rejected. Default true. */
+  allowForce?: boolean;
 }
 
 export type EvaluatorConfig =

--- a/src/merge/protection.ts
+++ b/src/merge/protection.ts
@@ -1,0 +1,75 @@
+import type { EvalPolicy } from "../evaluation/types";
+import { countApprovals } from "../storage/change-reviews";
+import { listEvalRuns } from "../storage/eval-runs";
+import type { Change } from "../types";
+import { AppError } from "../utils/errors";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+
+export interface ProtectionVerdict {
+  allowed: boolean;
+  /** Human-readable reasons the merge is blocked. Empty when allowed. */
+  reasons: string[];
+}
+
+/**
+ * Evaluate the policy's merge-protection rules against a change.
+ *
+ * Required evaluators check the LATEST run per evaluator type — an earlier
+ * failed run that was superseded by a passing re-run does not block.
+ */
+export async function checkMergeProtection(
+  db: D1Database,
+  logger: Logger,
+  change: Change,
+  policy: EvalPolicy,
+): Promise<Result<ProtectionVerdict, AppError>> {
+  const merge = policy.merge;
+  if (!merge) return ok({ allowed: true, reasons: [] });
+
+  const reasons: string[] = [];
+
+  if (merge.requiredEvaluators && merge.requiredEvaluators.length > 0) {
+    const runsResult = await listEvalRuns(db, logger, change.id);
+    if (!runsResult.success) {
+      return err(
+        runsResult.error instanceof AppError
+          ? runsResult.error
+          : new AppError(runsResult.error.message, "DATABASE_ERROR", 500),
+      );
+    }
+
+    const latestByType = new Map<string, { passed: boolean; ranAt: string }>();
+    for (const run of runsResult.data) {
+      const current = latestByType.get(run.evaluatorType);
+      if (!current || run.ranAt >= current.ranAt) {
+        latestByType.set(run.evaluatorType, { passed: run.passed, ranAt: run.ranAt });
+      }
+    }
+
+    for (const required of merge.requiredEvaluators) {
+      const latest = latestByType.get(required);
+      if (!latest) {
+        reasons.push(`Required evaluator '${required}' has not run`);
+      } else if (!latest.passed) {
+        reasons.push(`Required evaluator '${required}' failed`);
+      }
+    }
+  }
+
+  const requiredApprovals = merge.requiredApprovals ?? 0;
+  if (requiredApprovals > 0) {
+    const approvalsResult = await countApprovals(db, logger, change.id);
+    if (!approvalsResult.success) return err(approvalsResult.error);
+    if (approvalsResult.data < requiredApprovals) {
+      reasons.push(
+        `Requires ${requiredApprovals} approval${requiredApprovals === 1 ? "" : "s"}, has ${approvalsResult.data}`,
+      );
+    }
+  }
+
+  if (reasons.length > 0) {
+    logger.info("Merge blocked by branch protection", { changeId: change.id, reasons });
+  }
+  return ok({ allowed: reasons.length === 0, reasons });
+}

--- a/src/queue/merge-queue.ts
+++ b/src/queue/merge-queue.ts
@@ -3,11 +3,16 @@ import { mergeWorkspaceIntoProject } from "../storage/git-ops";
 import { recordProvenance } from "../storage/provenance";
 import { getProject, getWorkspace } from "../storage/state";
 import type { Env } from "../types";
-import type { AppError } from "../utils/errors";
 import { type Logger, createLogger } from "../utils/logger";
-import { type Result, err, ok } from "../utils/result";
 
 const MERGEABLE_STATUSES = new Set(["approved", "accepted", "promoted"]);
+
+/** Plain, RPC-serializable outcome of a merge attempt. */
+export interface MergeOutcome {
+  success: boolean;
+  commit?: string;
+  error?: string;
+}
 
 export class MergeQueue {
   env: Env;
@@ -18,31 +23,28 @@ export class MergeQueue {
     this.env = env;
   }
 
-  async merge(
-    changeId: string,
-    logger?: Logger,
-  ): Promise<Result<{ success: boolean; commit?: string; error?: string }, AppError>> {
+  async merge(changeId: string, logger?: Logger): Promise<MergeOutcome> {
     const log = logger ?? createLogger({ changeId });
     const changeResult = await getChange(this.env.DB, log, changeId);
     if (!changeResult.success) {
-      return err(changeResult.error);
+      return { success: false, error: changeResult.error.message };
     }
 
     const change = changeResult.data;
     if (!MERGEABLE_STATUSES.has(change.status)) {
-      return ok({ success: false, error: "Change not found or not ready to merge" });
+      return { success: false, error: "Change not found or not ready to merge" };
     }
 
     try {
       const projectResult = await getProject(this.env.STATE, change.project, log);
       if (!projectResult.success) {
-        return err(projectResult.error);
+        return { success: false, error: projectResult.error.message };
       }
       const project = projectResult.data;
 
       const workspaceResult = await getWorkspace(this.env.STATE, project.id, change.workspace, log);
       if (!workspaceResult.success) {
-        return err(workspaceResult.error);
+        return { success: false, error: workspaceResult.error.message };
       }
       const workspace = workspaceResult.data;
 
@@ -56,7 +58,7 @@ export class MergeQueue {
       );
 
       if (!commitResult.success) {
-        return err(commitResult.error);
+        return { success: false, error: commitResult.error.message };
       }
       const commit = commitResult.data;
 
@@ -68,7 +70,7 @@ export class MergeQueue {
       });
 
       if (!updateResult.success) {
-        return err(updateResult.error);
+        return { success: false, error: updateResult.error.message };
       }
 
       await recordProvenance(this.env.DB, log, {
@@ -80,10 +82,10 @@ export class MergeQueue {
         ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
       });
 
-      return ok({ success: true, commit });
+      return { success: true, commit };
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
-      return ok({ success: false, error });
+      return { success: false, error };
     }
   }
 }

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -10,7 +10,9 @@ import {
 } from "../evaluation";
 import type { EvalPolicy, EvalResult } from "../evaluation/types";
 import type { Evaluator } from "../evaluation/types";
+import { checkMergeProtection } from "../merge/protection";
 import { type EventActor, emitEvent } from "../queue/events";
+import type { MergeOutcome } from "../queue/merge-queue";
 import { createChange, getChange, listChanges, updateChangeStatus } from "../storage/changes";
 import { listEvalRuns, recordEvalRuns } from "../storage/eval-runs";
 import {
@@ -404,17 +406,40 @@ app.post("/changes/:id/merge", async (c) => {
 
   if (!canWriteProject(project, userId)) return forbidden("Project access denied");
 
+  // Branch protection: the policy's merge rules gate every merge path.
+  const mergePolicy = await loadPolicy(project.remote, project.token, logger);
+  const forceAllowed = mergePolicy.merge?.allowForce !== false;
+  if (force && !forceAllowed) {
+    return badRequest("Force merge is disabled by this project's policy");
+  }
+
   if (!MERGEABLE_STATUSES.includes(change.status) && !force) {
     return badRequest("Change must be approved, accepted, or promoted before merging");
+  }
+
+  if (!force) {
+    const protectionResult = await checkMergeProtection(c.env.DB, logger, change, mergePolicy);
+    if (!protectionResult.success) {
+      logger.error("Failed to evaluate merge protection", protectionResult.error);
+      return badRequest(protectionResult.error.message);
+    }
+    if (!protectionResult.data.allowed) {
+      return c.json(
+        {
+          error: "Merge blocked by branch protection",
+          code: "PROTECTION_BLOCKED",
+          reasons: protectionResult.data.reasons,
+        },
+        403,
+      );
+    }
   }
 
   if (c.env.MERGE_QUEUE && strategy === "merge") {
     const doId = c.env.MERGE_QUEUE.idFromName(change.project);
     const stub = c.env.MERGE_QUEUE.get(doId);
     const result = await (
-      stub as unknown as {
-        merge(changeId: string): Promise<{ success: boolean; commit?: string; error?: string }>;
-      }
+      stub as unknown as { merge(changeId: string): Promise<MergeOutcome> }
     ).merge(id);
 
     if (!result.success) {

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -806,6 +806,8 @@ describe("POST /api/changes/:id/merge", () => {
       success: true,
       data: undefined,
     });
+    // Default policy: no branch-protection rules.
+    vi.mocked(loadPolicy).mockResolvedValue({ evaluators: [], requireAll: true, minScore: 0.7 });
   });
 
   it("merges an approved change and returns merged=true", async () => {
@@ -996,6 +998,97 @@ describe("POST /api/changes/:id/merge", () => {
       env,
     );
     expect(res.status).toBe(404);
+  });
+
+  it("blocks merge with 403 when required evaluators are missing", async () => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: { ...mockChange, status: "accepted" },
+    });
+    vi.mocked(loadPolicy).mockResolvedValue({
+      evaluators: [],
+      merge: { requiredEvaluators: ["secret_scan"] },
+    });
+    vi.mocked(listEvalRuns).mockResolvedValue({ success: true, data: [] });
+
+    const res = await app.fetch(
+      request("POST", `/api/changes/${mockChange.id}/merge`, undefined, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string; reasons: string[] };
+    expect(body.code).toBe("PROTECTION_BLOCKED");
+    expect(body.reasons[0]).toContain("secret_scan");
+  });
+
+  it("merges when required evaluators have passing latest runs", async () => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: { ...mockChange, status: "accepted" },
+    });
+    vi.mocked(loadPolicy).mockResolvedValue({
+      evaluators: [],
+      merge: { requiredEvaluators: ["secret_scan"] },
+    });
+    vi.mocked(listEvalRuns).mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: "run_1",
+          changeId: mockChange.id,
+          evaluatorType: "secret_scan",
+          score: 1,
+          passed: true,
+          reason: "ok",
+          ranAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const res = await app.fetch(
+      request("POST", `/api/changes/${mockChange.id}/merge`, undefined, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { merged: boolean };
+    expect(body.merged).toBe(true);
+  });
+
+  it("rejects ?force=true when the policy disables force merges", async () => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: { ...mockChange, status: "open" },
+    });
+    vi.mocked(loadPolicy).mockResolvedValue({
+      evaluators: [],
+      merge: { allowForce: false },
+    });
+
+    const res = await app.fetch(
+      request("POST", `/api/changes/${mockChange.id}/merge?force=true`, undefined, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("Force merge is disabled");
+  });
+
+  it("force merge bypasses protection rules when force is allowed", async () => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: { ...mockChange, status: "open" },
+    });
+    vi.mocked(loadPolicy).mockResolvedValue({
+      evaluators: [],
+      merge: { requiredEvaluators: ["secret_scan"] },
+    });
+    vi.mocked(listEvalRuns).mockResolvedValue({ success: true, data: [] });
+
+    const res = await app.fetch(
+      request("POST", `/api/changes/${mockChange.id}/merge?force=true`, undefined, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(200);
   });
 });
 

--- a/tests/merge-protection.test.ts
+++ b/tests/merge-protection.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loadPolicy } from "../src/evaluation/policy-loader";
+import type { EvalPolicy } from "../src/evaluation/types";
+import { checkMergeProtection } from "../src/merge/protection";
+import { readFileFromRepo } from "../src/storage/git-ops";
+import type { Change } from "../src/types";
+import type { Logger } from "../src/utils/logger";
+
+vi.mock("../src/storage/git-ops", () => ({
+  readFileFromRepo: vi.fn(),
+}));
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+const change: Change = {
+  id: "chg_1",
+  project: "my-project",
+  workspace: "ws-1",
+  status: "accepted",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+interface EvalRunRow {
+  id: string;
+  change_id: string;
+  evaluator_type: string;
+  score: number;
+  passed: number;
+  reason: string;
+  issues: string | null;
+  ran_at: string;
+}
+
+/** Stub D1 answering the eval_runs and change_reviews queries protection issues. */
+function makeProtectionD1(opts: { runs?: EvalRunRow[]; approvals?: number }): D1Database {
+  function makeStmt(sql: string, bindings: unknown[]) {
+    const upper = sql.trim().toUpperCase();
+    return {
+      bind: (...args: unknown[]) => makeStmt(sql, args),
+      first: async <T>() => {
+        if (upper.includes("COUNT(*)")) return { approvals: opts.approvals ?? 0 } as T;
+        return null;
+      },
+      all: async <T>() => {
+        const results = (opts.runs ?? []).filter((r) => r.change_id === bindings[0]);
+        return { results: results as T[], success: true, meta: {} };
+      },
+    };
+  }
+  return { prepare: (sql: string) => makeStmt(sql, []) } as unknown as D1Database;
+}
+
+function makeRun(overrides: Partial<EvalRunRow>): EvalRunRow {
+  return {
+    id: "run_1",
+    change_id: "chg_1",
+    evaluator_type: "diff",
+    score: 1,
+    passed: 1,
+    reason: "ok",
+    issues: null,
+    ran_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("checkMergeProtection", () => {
+  it("allows merges when the policy has no merge rules", async () => {
+    const db = makeProtectionD1({});
+    const policy: EvalPolicy = { evaluators: [] };
+
+    const result = await checkMergeProtection(db, mockLogger, change, policy);
+    expect(result.success && result.data.allowed).toBe(true);
+  });
+
+  it("blocks when a required evaluator has not run", async () => {
+    const db = makeProtectionD1({ runs: [] });
+    const policy: EvalPolicy = { evaluators: [], merge: { requiredEvaluators: ["secret_scan"] } };
+
+    const result = await checkMergeProtection(db, mockLogger, change, policy);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.allowed).toBe(false);
+    expect(result.data.reasons[0]).toContain("'secret_scan' has not run");
+  });
+
+  it("blocks when the latest run of a required evaluator failed", async () => {
+    const db = makeProtectionD1({
+      runs: [
+        makeRun({ id: "run_1", evaluator_type: "diff", passed: 1, ran_at: "2026-01-01T00:00:00Z" }),
+        makeRun({ id: "run_2", evaluator_type: "diff", passed: 0, ran_at: "2026-01-02T00:00:00Z" }),
+      ],
+    });
+    const policy: EvalPolicy = { evaluators: [], merge: { requiredEvaluators: ["diff"] } };
+
+    const result = await checkMergeProtection(db, mockLogger, change, policy);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.allowed).toBe(false);
+    expect(result.data.reasons[0]).toContain("'diff' failed");
+  });
+
+  it("uses the latest run per evaluator: a passing re-run unblocks", async () => {
+    const db = makeProtectionD1({
+      runs: [
+        makeRun({ id: "run_1", evaluator_type: "diff", passed: 0, ran_at: "2026-01-01T00:00:00Z" }),
+        makeRun({ id: "run_2", evaluator_type: "diff", passed: 1, ran_at: "2026-01-02T00:00:00Z" }),
+      ],
+    });
+    const policy: EvalPolicy = { evaluators: [], merge: { requiredEvaluators: ["diff"] } };
+
+    const result = await checkMergeProtection(db, mockLogger, change, policy);
+    expect(result.success && result.data.allowed).toBe(true);
+  });
+
+  it("blocks when approvals are below the required count", async () => {
+    const db = makeProtectionD1({ approvals: 1 });
+    const policy: EvalPolicy = { evaluators: [], merge: { requiredApprovals: 2 } };
+
+    const result = await checkMergeProtection(db, mockLogger, change, policy);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.allowed).toBe(false);
+    expect(result.data.reasons[0]).toBe("Requires 2 approvals, has 1");
+  });
+
+  it("allows when approvals meet the required count", async () => {
+    const db = makeProtectionD1({ approvals: 2 });
+    const policy: EvalPolicy = { evaluators: [], merge: { requiredApprovals: 2 } };
+
+    const result = await checkMergeProtection(db, mockLogger, change, policy);
+    expect(result.success && result.data.allowed).toBe(true);
+  });
+
+  it("collects every blocking reason", async () => {
+    const db = makeProtectionD1({ runs: [], approvals: 0 });
+    const policy: EvalPolicy = {
+      evaluators: [],
+      merge: { requiredApprovals: 1, requiredEvaluators: ["secret_scan", "diff"] },
+    };
+
+    const result = await checkMergeProtection(db, mockLogger, change, policy);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.reasons).toHaveLength(3);
+  });
+});
+
+describe("policy loader merge rules", () => {
+  beforeEach(() => {
+    vi.mocked(readFileFromRepo).mockReset();
+  });
+
+  it("parses well-formed merge protection from policy.yaml", async () => {
+    vi.mocked(readFileFromRepo).mockResolvedValueOnce({
+      success: true,
+      data: [
+        "evaluators:",
+        "  - type: diff",
+        "merge:",
+        "  requiredApprovals: 2",
+        "  requiredEvaluators: [secret_scan, diff]",
+        "  allowForce: false",
+      ].join("\n"),
+    });
+
+    const policy = await loadPolicy("remote", "token", mockLogger);
+    expect(policy.merge).toEqual({
+      requiredApprovals: 2,
+      requiredEvaluators: ["secret_scan", "diff"],
+      allowForce: false,
+    });
+  });
+
+  it("drops malformed merge fields", async () => {
+    vi.mocked(readFileFromRepo).mockResolvedValueOnce({
+      success: true,
+      data: [
+        "evaluators:",
+        "  - type: diff",
+        "merge:",
+        "  requiredApprovals: -3",
+        "  requiredEvaluators: [1, 2]",
+        "  allowForce: maybe",
+      ].join("\n"),
+    });
+
+    const policy = await loadPolicy("remote", "token", mockLogger);
+    expect(policy.merge).toBeUndefined();
+  });
+
+  it("returns the default policy without merge rules when no config exists", async () => {
+    vi.mocked(readFileFromRepo).mockResolvedValue({
+      success: false,
+      error: new Error("not found") as never,
+    });
+
+    const policy = await loadPolicy("remote", "token", mockLogger);
+    expect(policy.merge).toBeUndefined();
+    expect(policy.evaluators).toEqual([{ type: "diff" }]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements master-plan Phase 3.8 — required evaluators, required human approvals, and force-merge control, enforced at the merge step:

- **Policy schema**: `.stratum/policy.yaml` gains a `merge:` section — `requiredApprovals` (human approvals from #59), `requiredEvaluators` (evaluator types whose **latest** run must pass — a passing re-run unblocks), `allowForce` (when false, `?force=true` is rejected outright). User-supplied config is sanitized at load: malformed fields are dropped, never trusted.
- **Enforcement**: `checkMergeProtection` runs on every non-force merge (both the Durable Object path and the in-route fallback share the single route-level gate); blocked merges return **403 `PROTECTION_BLOCKED`** with the full list of blocking reasons.
- **Bug fix**: `MergeQueue.merge()` returned a `Result`-wrapped object while the route read `.commit`/`.error` off the wrapper — DO-path merge **failures were reported as success** and the merge commit sha was always dropped. The DO now returns a plain RPC-serializable `MergeOutcome`.

## Testing

- 10 new protection tests (missing/failed/superseded evaluator runs, approval counting, multi-reason collection, YAML parsing + malformed-field sanitization) and 4 new merge-route tests (403 with reasons, pass-through, force-disabled rejection, force bypass)
- Full suite: 664 passing; lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)