### PR TITLE
fix: replace delete operator in policy loader (lint)

### DIFF
--- a/src/evaluation/policy-loader.ts
+++ b/src/evaluation/policy-loader.ts
@@ -59,14 +59,12 @@ async function readAndParsePolicy(
       return null;
     }
 
-    const policy = { ...DEFAULT_POLICY, ...(parsed as Partial<EvalPolicy>) };
     const merge = sanitizeMergePolicy((parsed as Record<string, unknown>).merge);
-    if (merge) {
-      policy.merge = merge;
-    } else {
-      delete policy.merge;
-    }
-    return policy;
+    const { merge: _unsanitized, ...policy } = {
+      ...DEFAULT_POLICY,
+      ...(parsed as Partial<EvalPolicy>),
+    };
+    return merge ? { ...policy, merge } : policy;
   } catch {
     return null;
   }


### PR DESCRIPTION
Hotfix for the Biome `noDelete` violation that landed in #61 and turned main's Lint check red. Replaces the `delete policy.merge` with a destructure-rest so unsanitized merge config is still stripped.

Full suite green locally (664 tests), lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)