### PR TITLE
feat: per-change cost tracking (Phase 2.9)

### DIFF
--- a/migrations/021_cost_records.sql
+++ b/migrations/021_cost_records.sql
@@ -1,0 +1,18 @@
+-- Per-change resource cost samples: estimated LLM tokens, sandbox runtime,
+-- and git/Artifacts operations. Aggregated for display on the change page.
+
+CREATE TABLE IF NOT EXISTS cost_records (
+  id TEXT PRIMARY KEY,
+  project TEXT NOT NULL,
+  change_id TEXT,
+  workspace TEXT,
+  kind TEXT NOT NULL CHECK(kind IN ('llm_tokens','sandbox_ms','git_ops')),
+  quantity REAL NOT NULL,
+  estimated INTEGER NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_costs_change ON cost_records(change_id);
+
+CREATE INDEX IF NOT EXISTS idx_costs_project
+  ON cost_records(project, created_at DESC);

--- a/src/evaluation/llm-evaluator.ts
+++ b/src/evaluation/llm-evaluator.ts
@@ -50,6 +50,7 @@ export class LLMEvaluator implements Evaluator {
         },
       ];
 
+      const promptChars = messages.reduce((sum, m) => sum + m.content.length, 0);
       const raw = await this.ai.run(model, { messages });
 
       if (raw instanceof ReadableStream) {
@@ -62,6 +63,11 @@ export class LLMEvaluator implements Evaluator {
       }
 
       const responseText = raw.response;
+      // Workers AI does not report token usage; ~4 chars/token is the standard estimate.
+      const estimatedTokens = Math.ceil((promptChars + (responseText?.length ?? 0)) / 4);
+      const costs: EvalResult["costs"] = [
+        { kind: "llm_tokens", quantity: estimatedTokens, estimated: true },
+      ];
 
       let parsed: { score: unknown; passed: unknown; reason: unknown; issues?: unknown };
       try {
@@ -78,6 +84,7 @@ export class LLMEvaluator implements Evaluator {
           score: fallbackScore,
           passed: false,
           reason: responseText?.slice(0, 200) ?? "No response",
+          costs,
         });
       }
 
@@ -92,6 +99,7 @@ export class LLMEvaluator implements Evaluator {
           score: fallbackScore,
           passed: false,
           reason: responseText?.slice(0, 200) ?? "No response",
+          costs,
         });
       }
 
@@ -109,6 +117,7 @@ export class LLMEvaluator implements Evaluator {
         passed,
         reason: parsed.reason,
         ...(issues !== undefined ? { issues } : {}),
+        costs,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/evaluation/sandbox-evaluator.ts
+++ b/src/evaluation/sandbox-evaluator.ts
@@ -95,8 +95,10 @@ export class SandboxEvaluator implements Evaluator {
       }
       logger.debug("Files written to sandbox", { fileCount: files.size });
 
+      const runStartedAt = Date.now();
       const result = await sb.run(command, { timeout: timeoutMs });
-      logger.debug("Sandbox command completed", { exitCode: result.exitCode });
+      const sandboxMs = Date.now() - runStartedAt;
+      logger.debug("Sandbox command completed", { exitCode: result.exitCode, sandboxMs });
 
       let score: number;
       if (result.exitCode === 0) {
@@ -110,7 +112,7 @@ export class SandboxEvaluator implements Evaluator {
       const reason = (result.stdout + result.stderr).slice(0, 500).trim();
 
       logger.info("Sandbox evaluation complete", { score, passed });
-      return ok({ score, passed, reason });
+      return ok({ score, passed, reason, costs: [{ kind: "sandbox_ms", quantity: sandboxMs }] });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger.error(

--- a/src/evaluation/types.ts
+++ b/src/evaluation/types.ts
@@ -7,6 +7,8 @@ export interface EvalResult {
   passed: boolean;
   reason: string;
   issues?: string[];
+  /** Resource usage the evaluator incurred, recorded for cost tracking. */
+  costs?: Array<{ kind: "llm_tokens" | "sandbox_ms"; quantity: number; estimated?: boolean }>;
 }
 
 export interface Evaluator {

--- a/src/merge/post-merge.ts
+++ b/src/merge/post-merge.ts
@@ -1,6 +1,7 @@
 import type { EvalPolicy } from "../evaluation/types";
 import { emitEvent } from "../queue/events";
 import { updateChangeStatus } from "../storage/changes";
+import { recordCosts } from "../storage/costs";
 import { getCommitParent, readRepoFiles, revertToCommit } from "../storage/git-ops";
 import type { Env, ProjectEntry } from "../types";
 import type { Logger } from "../utils/logger";
@@ -55,9 +56,14 @@ export async function runPostMergeCheck(
       for (const [path, content] of filesResult.data) {
         await sandbox.writeFile(path, content);
       }
+      const runStartedAt = Date.now();
       const run = await sandbox.run(command, {
         timeout: merge?.postMergeTimeoutMs ?? DEFAULT_POST_MERGE_TIMEOUT_MS,
       });
+      await recordCosts(env.DB, logger, { project: project.name, changeId: opts.changeId }, [
+        { kind: "sandbox_ms", quantity: Date.now() - runStartedAt },
+        { kind: "git_ops", quantity: 1 },
+      ]);
       if (run.exitCode === 0) {
         logger.info("Post-merge check passed", { changeId: opts.changeId });
         return { status: "passed" };

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -15,6 +15,7 @@ import { checkMergeProtection } from "../merge/protection";
 import { type EventActor, emitEvent } from "../queue/events";
 import type { MergeOutcome } from "../queue/merge-queue";
 import { createChange, getChange, listChanges, updateChangeStatus } from "../storage/changes";
+import { type CostSample, getChangeCostSummary, recordCosts } from "../storage/costs";
 import { listEvalRuns, recordEvalRuns } from "../storage/eval-runs";
 import {
   MergeConflictError,
@@ -251,6 +252,18 @@ app.post("/projects/:name/changes", async (c) => {
     return badRequest(recordResult.error.message);
   }
 
+  // Best-effort cost tracking: the diff clones both repos, evaluators self-report.
+  const createCostSamples: CostSample[] = [
+    { kind: "git_ops", quantity: 2 },
+    ...evalRuns.flatMap(({ result }) => result.costs ?? []),
+  ];
+  await recordCosts(
+    c.env.DB,
+    logger,
+    { project: projectName, changeId: change.id, workspace: body.workspace },
+    createCostSamples,
+  );
+
   const updateResult = await updateChangeStatus(c.env.DB, logger, change.id, newStatus, {
     evalScore: evalResult.score,
     evalPassed: evalResult.passed,
@@ -384,8 +397,14 @@ app.get("/changes/:id", async (c) => {
     return badRequest(evalRunsResult.error.message);
   }
 
+  const costsResult = await getChangeCostSummary(c.env.DB, logger, id);
+
   logger.info("Change retrieved", { changeId: id });
-  return ok({ change, evalRuns: evalRunsResult.data });
+  return ok({
+    change,
+    evalRuns: evalRunsResult.data,
+    costs: costsResult.success ? costsResult.data : [],
+  });
 });
 
 app.post("/changes/:id/merge", async (c) => {
@@ -582,6 +601,13 @@ app.post("/changes/:id/merge", async (c) => {
     logger.error("Failed to update change status to merged", updateResult.error);
     return badRequest(updateResult.error.message);
   }
+
+  await recordCosts(
+    c.env.DB,
+    logger,
+    { project: change.project, changeId: id, workspace: change.workspace },
+    [{ kind: "git_ops", quantity: 2 }],
+  );
 
   const provenanceResult = await recordProvenance(c.env.DB, logger, {
     commitSha: commit,
@@ -827,6 +853,17 @@ app.post("/changes/:id/evaluate", async (c) => {
     logger.error("Failed to record eval runs", recordResult.error);
     return badRequest(recordResult.error.message);
   }
+
+  const evaluateCostSamples: CostSample[] = [
+    { kind: "git_ops", quantity: 2 },
+    ...evalRuns.flatMap(({ result }) => result.costs ?? []),
+  ];
+  await recordCosts(
+    c.env.DB,
+    logger,
+    { project: change.project, changeId: id, workspace: change.workspace },
+    evaluateCostSamples,
+  );
 
   const updateResult = await updateChangeStatus(
     c.env.DB,

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { listComments, listReviews } from "../storage/change-reviews";
 import { getChange, listChanges } from "../storage/changes";
+import { getChangeCostSummary } from "../storage/costs";
 import { listEvalRuns } from "../storage/eval-runs";
 import { listProjectEvents } from "../storage/events";
 import { getCommitLog, listFilesInRepo, readFileFromRepo } from "../storage/git-ops";
@@ -370,10 +371,11 @@ app.get("/changes/:id", async (c) => {
     );
   }
 
-  const [evalRunsResult, commentsResult, reviewsResult] = await Promise.all([
+  const [evalRunsResult, commentsResult, reviewsResult, costsResult] = await Promise.all([
     listEvalRuns(c.env.DB, logger, change.id),
     listComments(c.env.DB, logger, change.id),
     listReviews(c.env.DB, logger, change.id),
+    getChangeCostSummary(c.env.DB, logger, change.id),
   ]);
   if (!evalRunsResult.success) {
     logger.error("Failed to list eval runs", evalRunsResult.error);
@@ -407,6 +409,7 @@ app.get("/changes/:id", async (c) => {
       provenance={null}
       comments={commentsResult.success ? commentsResult.data : []}
       reviews={reviewsResult.success ? reviewsResult.data : []}
+      costs={costsResult.success ? costsResult.data : []}
       canReview={!!userResult && canWriteProject(projectResult.data, userId)}
       user={userResult}
     />,

--- a/src/storage/costs.ts
+++ b/src/storage/costs.ts
@@ -1,0 +1,145 @@
+import { AppError } from "../utils/errors";
+import { newId } from "../utils/ids";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+
+export type CostKind = "llm_tokens" | "sandbox_ms" | "git_ops";
+
+export interface CostSample {
+  kind: CostKind;
+  quantity: number;
+  /** True when the quantity is an estimate (e.g. character-based token counts). */
+  estimated?: boolean;
+}
+
+export interface CostSummaryEntry {
+  kind: CostKind;
+  total: number;
+  estimated: boolean;
+}
+
+interface SummaryRow {
+  kind: string;
+  total: number;
+  any_estimated: number;
+}
+
+/**
+ * Record cost samples for a change. Best-effort: failures are logged and
+ * reported, but callers treat cost recording as non-blocking.
+ */
+export async function recordCosts(
+  db: D1Database,
+  logger: Logger,
+  opts: { project: string; changeId?: string; workspace?: string },
+  samples: CostSample[],
+): Promise<Result<void, AppError>> {
+  if (samples.length === 0) return ok(undefined);
+  const createdAt = new Date().toISOString();
+
+  try {
+    const stmt = db.prepare(
+      "INSERT INTO cost_records (id, project, change_id, workspace, kind, quantity, estimated, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    );
+    await db.batch(
+      samples.map((sample) =>
+        stmt.bind(
+          newId("cost"),
+          opts.project,
+          opts.changeId ?? null,
+          opts.workspace ?? null,
+          sample.kind,
+          sample.quantity,
+          sample.estimated ? 1 : 0,
+          createdAt,
+        ),
+      ),
+    );
+    logger.debug("Cost samples recorded", {
+      project: opts.project,
+      changeId: opts.changeId,
+      count: samples.length,
+    });
+    return ok(undefined);
+  } catch (error) {
+    const appError =
+      error instanceof AppError
+        ? error
+        : new AppError(
+            error instanceof Error ? error.message : "Failed to record costs",
+            "DATABASE_ERROR",
+            500,
+            { operation: "recordCosts", project: opts.project },
+          );
+    logger.error("Failed to record cost samples", appError, { project: opts.project });
+    return err(appError);
+  }
+}
+
+export async function getChangeCostSummary(
+  db: D1Database,
+  logger: Logger,
+  changeId: string,
+): Promise<Result<CostSummaryEntry[], AppError>> {
+  try {
+    const result = await db
+      .prepare(
+        "SELECT kind, SUM(quantity) AS total, MAX(estimated) AS any_estimated FROM cost_records WHERE change_id = ? GROUP BY kind",
+      )
+      .bind(changeId)
+      .all<SummaryRow>();
+    return ok(
+      result.results.map((row) => ({
+        kind: row.kind as CostKind,
+        total: row.total,
+        estimated: row.any_estimated === 1,
+      })),
+    );
+  } catch (error) {
+    const appError =
+      error instanceof AppError
+        ? error
+        : new AppError(
+            error instanceof Error ? error.message : "Failed to summarize costs",
+            "DATABASE_ERROR",
+            500,
+            { operation: "getChangeCostSummary", changeId },
+          );
+    logger.error("Failed to get change cost summary", appError, { changeId });
+    return err(appError);
+  }
+}
+
+export async function getProjectCostSummary(
+  db: D1Database,
+  logger: Logger,
+  project: string,
+): Promise<Result<CostSummaryEntry[], AppError>> {
+  try {
+    const result = await db
+      .prepare(
+        "SELECT kind, SUM(quantity) AS total, MAX(estimated) AS any_estimated FROM cost_records WHERE project = ? GROUP BY kind",
+      )
+      .bind(project)
+      .all<SummaryRow>();
+    return ok(
+      result.results.map((row) => ({
+        kind: row.kind as CostKind,
+        total: row.total,
+        estimated: row.any_estimated === 1,
+      })),
+    );
+  } catch (error) {
+    const appError =
+      error instanceof AppError
+        ? error
+        : new AppError(
+            error instanceof Error ? error.message : "Failed to summarize costs",
+            "DATABASE_ERROR",
+            500,
+            { operation: "getProjectCostSummary", project },
+          );
+    logger.error("Failed to get project cost summary", appError, { project });
+    return err(appError);
+  }
+}

--- a/src/ui/pages/change-detail.tsx
+++ b/src/ui/pages/change-detail.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "hono/jsx";
 import type { ChangeComment, ChangeReview } from "../../storage/change-reviews";
+import type { CostSummaryEntry } from "../../storage/costs";
 import { Layout } from "../layout";
 
 interface ChangeDetailProps {
@@ -33,6 +34,7 @@ interface ChangeDetailProps {
   } | null;
   comments?: ChangeComment[];
   reviews?: ChangeReview[];
+  costs?: CostSummaryEntry[];
   /** Whether the current user may submit review verdicts. */
   canReview?: boolean;
   user?: { id: string; email: string; username: string } | null;
@@ -61,12 +63,27 @@ function statusBadgeClass(status: string): string {
 
 const REVIEWABLE_STATUSES = ["open", "needs_changes", "accepted", "approved"];
 
+function describeCost(entry: CostSummaryEntry): string {
+  const prefix = entry.estimated ? "~" : "";
+  switch (entry.kind) {
+    case "llm_tokens":
+      return `${prefix}${Math.round(entry.total).toLocaleString()} LLM tokens`;
+    case "sandbox_ms":
+      return `${prefix}${(entry.total / 1000).toFixed(1)}s sandbox time`;
+    case "git_ops":
+      return `${prefix}${Math.round(entry.total)} git operations`;
+    default:
+      return `${prefix}${entry.total} ${entry.kind}`;
+  }
+}
+
 export const ChangeDetailPage: FC<ChangeDetailProps> = ({
   change,
   evalRuns,
   provenance,
   comments = [],
   reviews = [],
+  costs = [],
   canReview = false,
   user,
 }) => {
@@ -222,6 +239,17 @@ export const ChangeDetailPage: FC<ChangeDetailProps> = ({
             <dt>Merged</dt>
             <dd>{new Date(provenance.mergedAt).toLocaleString()}</dd>
           </dl>
+        </div>
+      )}
+
+      {costs.length > 0 && (
+        <div class="card">
+          <h2>Resource usage</h2>
+          <ul class="cost-list">
+            {costs.map((entry) => (
+              <li key={entry.kind}>{describeCost(entry)}</li>
+            ))}
+          </ul>
         </div>
       )}
 

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -523,6 +523,10 @@ a:hover { text-decoration: underline; }
   padding: 0.5rem; border-radius: 4px; font-family: inherit;
 }
 
+/* Costs */
+.cost-list { list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #ccc; }
+.cost-list li { padding: 0.2rem 0; }
+
 /* Change reviews and comments */
 .review-empty { color: #666; font-size: 0.85rem; }
 .review-list, .comment-list { list-style: none; padding: 0; margin: 0; }

--- a/tests/costs.test.ts
+++ b/tests/costs.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+import { LLMEvaluator } from "../src/evaluation/llm-evaluator";
+import { SandboxEvaluator } from "../src/evaluation/sandbox-evaluator";
+import type { EvalPolicy } from "../src/evaluation/types";
+import { getChangeCostSummary, recordCosts } from "../src/storage/costs";
+import type { AiBinding, SandboxBinding } from "../src/types";
+import type { Logger } from "../src/utils/logger";
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+interface CostRow {
+  id: string;
+  project: string;
+  change_id: string | null;
+  workspace: string | null;
+  kind: string;
+  quantity: number;
+  estimated: number;
+  created_at: string;
+}
+
+function makeCostsD1(): { db: D1Database; rows: CostRow[] } {
+  const rows: CostRow[] = [];
+
+  function makeStmt(sql: string, bindings: unknown[]) {
+    const upper = sql.trim().toUpperCase();
+    const stmt = {
+      bind: (...args: unknown[]) => makeStmt(sql, args),
+      run: async () => {
+        if (upper.startsWith("INSERT INTO COST_RECORDS")) {
+          rows.push({
+            id: bindings[0] as string,
+            project: bindings[1] as string,
+            change_id: bindings[2] as string | null,
+            workspace: bindings[3] as string | null,
+            kind: bindings[4] as string,
+            quantity: bindings[5] as number,
+            estimated: bindings[6] as number,
+            created_at: bindings[7] as string,
+          });
+        }
+        return { success: true, meta: {} };
+      },
+      all: async <T>() => {
+        const scoped = rows.filter((r) => r.change_id === bindings[0]);
+        const byKind = new Map<string, { total: number; any_estimated: number }>();
+        for (const row of scoped) {
+          const entry = byKind.get(row.kind) ?? { total: 0, any_estimated: 0 };
+          entry.total += row.quantity;
+          entry.any_estimated = Math.max(entry.any_estimated, row.estimated);
+          byKind.set(row.kind, entry);
+        }
+        const results = [...byKind.entries()].map(([kind, entry]) => ({ kind, ...entry }));
+        return { results: results as T[], success: true, meta: {} };
+      },
+    };
+    return stmt;
+  }
+
+  const db = {
+    prepare: (sql: string) => makeStmt(sql, []),
+    batch: async (statements: Array<{ run(): Promise<unknown> }>) =>
+      Promise.all(statements.map((stmt) => stmt.run())),
+  } as unknown as D1Database;
+  return { db, rows };
+}
+
+describe("cost storage", () => {
+  it("records samples and aggregates per change by kind", async () => {
+    const { db } = makeCostsD1();
+    await recordCosts(db, mockLogger, { project: "p", changeId: "chg_1", workspace: "ws" }, [
+      { kind: "git_ops", quantity: 2 },
+      { kind: "llm_tokens", quantity: 1200, estimated: true },
+      { kind: "sandbox_ms", quantity: 4500 },
+    ]);
+    await recordCosts(db, mockLogger, { project: "p", changeId: "chg_1" }, [
+      { kind: "git_ops", quantity: 1 },
+    ]);
+    await recordCosts(db, mockLogger, { project: "p", changeId: "chg_other" }, [
+      { kind: "git_ops", quantity: 9 },
+    ]);
+
+    const summary = await getChangeCostSummary(db, mockLogger, "chg_1");
+    expect(summary.success).toBe(true);
+    if (!summary.success) return;
+    const byKind = Object.fromEntries(summary.data.map((e) => [e.kind, e]));
+    expect(byKind.git_ops?.total).toBe(3);
+    expect(byKind.llm_tokens?.total).toBe(1200);
+    expect(byKind.llm_tokens?.estimated).toBe(true);
+    expect(byKind.sandbox_ms?.total).toBe(4500);
+    expect(byKind.sandbox_ms?.estimated).toBe(false);
+  });
+
+  it("is a no-op for an empty sample list", async () => {
+    const { db, rows } = makeCostsD1();
+    const result = await recordCosts(db, mockLogger, { project: "p" }, []);
+    expect(result.success).toBe(true);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("returns an error result when the database fails, without throwing", async () => {
+    const badDb = {
+      prepare: () => {
+        throw new Error("D1 down");
+      },
+    } as unknown as D1Database;
+    const result = await recordCosts(badDb, mockLogger, { project: "p" }, [
+      { kind: "git_ops", quantity: 1 },
+    ]);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("evaluator cost reporting", () => {
+  it("LLM evaluator reports estimated token usage", async () => {
+    const ai: AiBinding = {
+      run: vi.fn().mockResolvedValue({
+        response: JSON.stringify({ score: 0.9, passed: true, reason: "looks good" }),
+      }),
+    };
+    const policy: EvalPolicy = { evaluators: [{ type: "llm" }] };
+
+    const result = await new LLMEvaluator(ai).evaluate("diff content", policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.costs).toHaveLength(1);
+    const cost = result.data.costs?.[0];
+    expect(cost?.kind).toBe("llm_tokens");
+    expect(cost?.estimated).toBe(true);
+    expect(cost?.quantity).toBeGreaterThan(0);
+  });
+
+  it("LLM evaluator reports tokens even when the response fails to parse", async () => {
+    const ai: AiBinding = {
+      run: vi.fn().mockResolvedValue({ response: "not json at all" }),
+    };
+    const policy: EvalPolicy = { evaluators: [{ type: "llm" }] };
+
+    const result = await new LLMEvaluator(ai).evaluate("diff", policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.costs?.[0]?.kind).toBe("llm_tokens");
+  });
+
+  it("sandbox evaluator reports run duration", async () => {
+    const sandbox: SandboxBinding = {
+      create: vi.fn().mockResolvedValue({
+        writeFile: vi.fn(),
+        run: vi.fn().mockResolvedValue({ exitCode: 0, stdout: "ok", stderr: "" }),
+        destroy: vi.fn(),
+      }),
+    };
+    const policy: EvalPolicy = { evaluators: [{ type: "sandbox", command: "npm test" }] };
+
+    const result = await new SandboxEvaluator(sandbox).evaluate("diff", policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.costs?.[0]?.kind).toBe("sandbox_ms");
+    expect(result.data.costs?.[0]?.quantity).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements master-plan Phase 2.9:

- **`cost_records` table**: per-change samples of `llm_tokens` (estimated — Workers AI reports no usage, so ~4 chars/token, flagged `estimated`), `sandbox_ms` (measured), and `git_ops` (clone counts at known-cost call sites: evaluation diff, merge, post-merge check).
- **Evaluator self-reporting**: `EvalResult` gains an optional `costs` array; the LLM evaluator reports token estimates on every AI-call path (including parse fallbacks), the sandbox evaluator reports run duration.
- **Recording**: change creation, re-evaluation, merge, and the post-merge smoke check record samples — best-effort, never blocking the request.
- **Display**: `GET /api/changes/:id` includes the aggregated summary; the change page renders a Resource usage card (`~12,400 LLM tokens · 4.5s sandbox time · 5 git operations`).

## Testing

- 6 new tests: aggregation by kind across multiple recordings, empty-sample no-op, DB-failure containment, LLM token reporting (success + parse-fallback paths), sandbox duration reporting
- Full suite: 679 passing; lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Resource usage tracking now monitors LLM token consumption, sandbox execution time, and operation counts across all changes
  * Resource usage metrics are displayed in change details for cost visibility

* **Tests**
  * Added comprehensive test suite for cost tracking and aggregation

* **Chores**
  * Database schema migration for cost records storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->