### PR TITLE
feat: org-owned projects + org/team permissions (Phase 3.1)

### DIFF
--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -104,7 +104,8 @@ app.post("/projects/:name/changes", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canWriteProject(project, userId, agentOwnerId)) return forbidden("Project access denied");
+  if (!(await canWriteProject(c.env.DB, project, userId, agentOwnerId)))
+    return forbidden("Project access denied");
 
   const body = await c.req.json<{ workspace?: unknown }>().catch(() => ({ workspace: undefined }));
   if (typeof body.workspace !== "string" || !body.workspace.trim()) {
@@ -328,7 +329,7 @@ app.get("/projects/:name/changes", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId))
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId)))
     return notFound("Project", `${project.namespace}/${project.slug}`);
 
   const statusParam = c.req.query("status");
@@ -388,7 +389,7 @@ app.get("/changes/:id", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId))
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId)))
     return notFound("Project", `${project.namespace}/${project.slug}`);
 
   const evalRunsResult = await listEvalRuns(c.env.DB, logger, id);
@@ -446,7 +447,8 @@ app.post("/changes/:id/merge", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canWriteProject(project, userId)) return forbidden("Project access denied");
+  if (!(await canWriteProject(c.env.DB, project, userId)))
+    return forbidden("Project access denied");
 
   // Branch protection: the policy's merge rules gate every merge path.
   const mergePolicy = await loadPolicy(project.remote, project.token, logger);
@@ -687,7 +689,8 @@ app.post("/changes/:id/reject", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canWriteProject(project, userId)) return forbidden("Project access denied");
+  if (!(await canWriteProject(c.env.DB, project, userId)))
+    return forbidden("Project access denied");
 
   if (change.status === "merged") {
     return badRequest("Cannot reject a merged change");
@@ -748,7 +751,8 @@ app.post("/changes/:id/evaluate", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canWriteProject(project, userId)) return forbidden("Project access denied");
+  if (!(await canWriteProject(c.env.DB, project, userId)))
+    return forbidden("Project access denied");
 
   if (change.status === "merged" || change.status === "rejected" || change.status === "promoted") {
     return badRequest(`Cannot re-evaluate a ${change.status} change`);
@@ -926,7 +930,8 @@ app.post("/changes/:id/github-pr", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canWriteProject(project, userId)) return forbidden("Project access denied");
+  if (!(await canWriteProject(c.env.DB, project, userId)))
+    return forbidden("Project access denied");
   if (!project?.githubUrl) return badRequest("Project is not connected to GitHub");
 
   const repo = parseGitHubRepo(project.githubUrl);

--- a/src/routes/issues.ts
+++ b/src/routes/issues.ts
@@ -76,7 +76,7 @@ app.post("/:namespace/:slug/issues", async (c) => {
   const { project } = result;
 
   // Anyone who can read the project can open issues against it.
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     return notFound("Project", `${project.namespace}/${project.slug}`);
   }
 
@@ -153,7 +153,7 @@ app.get("/:namespace/:slug/issues", async (c) => {
   if ("response" in result) return result.response;
   const { project } = result;
 
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     return notFound("Project", `${project.namespace}/${project.slug}`);
   }
 
@@ -185,7 +185,7 @@ app.get("/:namespace/:slug/issues/:number", async (c) => {
   if ("response" in result) return result.response;
   const { project } = result;
 
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     return notFound("Project", `${project.namespace}/${project.slug}`);
   }
 
@@ -218,7 +218,8 @@ app.patch("/:namespace/:slug/issues/:number", async (c) => {
   const { project } = result;
 
   // Editing and closing issues requires write access to the project.
-  if (!canWriteProject(project, userId)) return forbidden("Project access denied");
+  if (!(await canWriteProject(c.env.DB, project, userId)))
+    return forbidden("Project access denied");
 
   const number = parseIssueNumber(c.req.param("number"));
   if (number === null) return badRequest("Invalid issue number");
@@ -312,7 +313,8 @@ app.post("/:namespace/:slug/issues/:number/close", async (c) => {
   if ("response" in result) return result.response;
   const { project } = result;
 
-  if (!canWriteProject(project, userId)) return forbidden("Project access denied");
+  if (!(await canWriteProject(c.env.DB, project, userId)))
+    return forbidden("Project access denied");
 
   const number = parseIssueNumber(c.req.param("number"));
   if (number === null) return badRequest("Invalid issue number");

--- a/src/routes/orgs.ts
+++ b/src/routes/orgs.ts
@@ -15,6 +15,7 @@ import {
   listTeams,
   removeTeamMember,
 } from "../storage/teams";
+import { getUserByUsername } from "../storage/users";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
 import { badRequest, created, notFound, ok } from "../utils/response";
@@ -37,6 +38,13 @@ app.post("/", async (c) => {
   }
   if (!isValidSlug(body.slug)) {
     return badRequest("slug must be a 1-64 char alphanumeric slug");
+  }
+
+  // Org projects live under the @slug namespace; a slug that matches an
+  // existing username would collide with that user's namespace.
+  const existingUser = await getUserByUsername(c.env.DB, body.slug, logger);
+  if (existingUser.success) {
+    return badRequest("slug is already taken by a user namespace");
   }
 
   const orgResult = await createOrg(c.env.DB, logger, userId, body.name, body.slug);

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -13,6 +13,7 @@ import {
   recoverStalledImport,
   updateImportStatus,
 } from "../storage/imports";
+import { getOrgAccessLevel, getOrgBySlug } from "../storage/orgs";
 import { listProvenance } from "../storage/provenance";
 import { writeSnapshotFromRepo } from "../storage/repo-snapshot";
 import { getProjectByPath, listProjectsByNamespace, setProject } from "../storage/state";
@@ -86,18 +87,39 @@ app.post("/", async (c) => {
   const username = c.get("username");
   if (!userId || !username) return unauthorized("Authentication required");
 
-  let body: { name?: unknown; files?: unknown; visibility?: unknown; seed?: unknown };
+  let body: {
+    name?: unknown;
+    files?: unknown;
+    visibility?: unknown;
+    seed?: unknown;
+    org?: unknown;
+  };
   const contentType = c.req.header("content-type") ?? "";
   if (contentType.includes("application/json")) {
     body = await c.req.json<typeof body>();
   } else {
     const form = await c.req.parseBody();
-    body = { name: form.name, visibility: form.visibility, seed: form.seed };
+    body = { name: form.name, visibility: form.visibility, seed: form.seed, org: form.org };
   }
 
   if (!isValidSlug(body.name)) return badRequest("name must be a 1-64 char alphanumeric slug");
 
-  const namespace = getUserNamespace(username);
+  // Optional org ownership: the project lives under the org's namespace and
+  // access follows org/team membership instead of personal ownership.
+  let owner: { id: string; type: "user" | "org" } = { id: userId, type: "user" };
+  let namespace = getUserNamespace(username);
+  if (body.org !== undefined && body.org !== "") {
+    if (typeof body.org !== "string") return badRequest("org must be a string slug");
+    const orgResult = await getOrgBySlug(c.env.DB, logger, body.org);
+    if (!orgResult.success) return notFound("Organization", body.org);
+    const org = orgResult.data;
+    const accessLevel = await getOrgAccessLevel(c.env.DB, logger, org.id, userId);
+    if (accessLevel !== "write" && accessLevel !== "admin") {
+      return forbidden("Creating projects in this organization requires write access");
+    }
+    owner = { id: org.id, type: "org" };
+    namespace = `@${org.slug}`;
+  }
 
   // Validate namespace format
   if (!isValidNamespace(namespace)) {
@@ -185,8 +207,8 @@ app.post("/", async (c) => {
     name: String(body.name),
     slug,
     namespace,
-    ownerId: userId,
-    ownerType: "user",
+    ownerId: owner.id,
+    ownerType: owner.type,
     remote: repo.remote,
     token: repo.token,
     createdAt: new Date().toISOString(),
@@ -251,7 +273,12 @@ app.get("/", async (c) => {
     return internalError(projectsResult.error.message);
   }
 
-  const projects = filterReadableProjects(projectsResult.data, userId, agentOwnerId);
+  const projects = await filterReadableProjects(
+    c.env.DB,
+    projectsResult.data,
+    userId,
+    agentOwnerId,
+  );
   logger.info("Projects listed", { count: projects.length });
 
   return ok({
@@ -291,7 +318,7 @@ app.get("/:namespace/:slug", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId))
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId)))
     return notFound("Project", `${project.namespace}/${project.slug}`);
 
   logger.info("Project retrieved", { namespace, slug });
@@ -793,7 +820,7 @@ app.get("/:namespace/:slug/files", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId))
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId)))
     return notFound("Project", `${project.namespace}/${project.slug}`);
 
   const filesResult = await listFilesInRepo(project.remote, project.token, logger);
@@ -837,7 +864,7 @@ app.get("/:namespace/:slug/content", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId))
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId)))
     return notFound("Project", `${project.namespace}/${project.slug}`);
 
   const contentResult = await getFileContent(project.remote, project.token, filePath, logger);
@@ -882,7 +909,7 @@ app.get("/:namespace/:slug/log", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId))
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId)))
     return notFound("Project", `${project.namespace}/${project.slug}`);
 
   const depth = Number(c.req.query("depth") ?? 20);
@@ -929,7 +956,7 @@ app.get("/:namespace/:slug/provenance", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId))
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId)))
     return notFound("Project", `${project.namespace}/${project.slug}`);
 
   const limitParam = c.req.query("limit");
@@ -979,7 +1006,7 @@ app.get("/:namespace/:slug/activity", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId))
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId)))
     return notFound("Project", `${project.namespace}/${project.slug}`);
 
   const limitParam = c.req.query("limit");
@@ -1027,7 +1054,7 @@ app.get("/:namespace/:slug/import/status", async (c) => {
     return notFound("Project", `${namespace}/${slug}`);
   }
 
-  if (!canReadProject(projectResult.data, userId, agentOwnerId))
+  if (!(await canReadProject(c.env.DB, projectResult.data, userId, agentOwnerId)))
     return notFound("Project", `${namespace}/${slug}`);
 
   const progressResult = await getImportProgress(c.env.DB, namespace, slug, logger);
@@ -1096,7 +1123,7 @@ app.get("/:namespace/:slug/import/stream", async (c) => {
 
   const userId = c.get("userId");
   const agentOwnerId = c.get("agentOwnerId");
-  if (!canReadProject(projectResult.data, userId, agentOwnerId))
+  if (!(await canReadProject(c.env.DB, projectResult.data, userId, agentOwnerId)))
     return notFound("Project", `${namespace}/${slug}`);
 
   // Set up SSE response
@@ -1531,7 +1558,7 @@ app.get("/:namespace/:slug/sync/status", async (c) => {
 
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId))
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId)))
     return notFound("Project", `${namespace}/${slug}`);
 
   // Get detailed sync status

--- a/src/routes/reviews.ts
+++ b/src/routes/reviews.ts
@@ -76,7 +76,7 @@ app.post("/changes/:id/comments", async (c) => {
   if ("response" in loaded) return loaded.response;
   const { change, project } = loaded;
 
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     return notFound("Change", change.id);
   }
 
@@ -136,7 +136,7 @@ app.get("/changes/:id/comments", async (c) => {
   if ("response" in loaded) return loaded.response;
   const { change, project } = loaded;
 
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     return notFound("Change", change.id);
   }
 
@@ -164,7 +164,8 @@ app.post("/changes/:id/reviews", async (c) => {
   if ("response" in loaded) return loaded.response;
   const { change, project } = loaded;
 
-  if (!canWriteProject(project, userId)) return forbidden("Project access denied");
+  if (!(await canWriteProject(c.env.DB, project, userId)))
+    return forbidden("Project access denied");
 
   if (!REVIEWABLE_STATUSES.includes(change.status)) {
     return badRequest(`Cannot review a ${change.status} change`);
@@ -238,7 +239,7 @@ app.get("/changes/:id/reviews", async (c) => {
   if ("response" in loaded) return loaded.response;
   const { change, project } = loaded;
 
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     return notFound("Change", change.id);
   }
 

--- a/src/routes/sync-management.ts
+++ b/src/routes/sync-management.ts
@@ -11,6 +11,7 @@ import {
   updateProjectAfterSync,
 } from "../storage/sync";
 import type { Env } from "../types";
+import { canWriteProject } from "../utils/authz";
 import { createLogger } from "../utils/logger";
 import { notFound, ok } from "../utils/response";
 
@@ -20,45 +21,19 @@ const app = new Hono<{ Bindings: Env }>();
 app.use("*", authMiddleware);
 
 /**
- * Determines whether the caller is authorized to access the project identified by `namespace/slug`.
- *
- * Currently authorization succeeds only when the project exists and its `namespace` equals the requested `namespace`; storage failures or missing projects result in `false`.
- *
- * @param _userId - The authenticated user's ID (currently unused; reserved for future permission checks)
- * @returns `true` if access is allowed, `false` otherwise.
+ * Whether the caller may manage sync for `namespace/slug`. Sync mutates the
+ * project, so this requires write access (owner, or org write/admin).
  */
 async function verifyProjectAccess(
   env: Env,
   namespace: string,
   slug: string,
-  _userId: string,
+  userId: string,
   logger: ReturnType<typeof createLogger>,
 ): Promise<boolean> {
-  // Get project to verify ownership
-  const projectResult = await getProject(env.STATE, `${namespace}/${slug}`, logger);
-
-  if (!projectResult.success) {
-    return false;
-  }
-
-  const project = projectResult.data;
-
-  // Check if user owns the project or has access
-  // For now, we check if the namespace matches the user's namespace
-  // TODO: Add proper organization/team access control
-  // IMPORTANT: This is a placeholder implementation. In production, you must:
-  // 1. Check project.ownerId against the authenticated userId
-  // 2. Check project.members array for userId
-  // 3. Implement organization/team-based permissions
-  // 4. Add role-based access control (owner, admin, member, etc.)
-  // The current implementation only validates the project exists and namespace matches.
-  if (project.namespace === namespace) {
-    // Additional check: verify the user is the owner
-    // This is a simplified check - in production you'd check project.members or project.ownerId
-    return true;
-  }
-
-  return false;
+  const projectResult = await getProjectByPath(env.STATE, namespace, slug, logger);
+  if (!projectResult.success) return false;
+  return canWriteProject(env.DB, projectResult.data, userId);
 }
 
 /**

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -72,7 +72,12 @@ app.get("/", async (c) => {
   }
 
   const user = userResult;
-  const projects = filterReadableProjects(allProjectsResult.data, userId, agentOwnerId);
+  const projects = await filterReadableProjects(
+    c.env.DB,
+    allProjectsResult.data,
+    userId,
+    agentOwnerId,
+  );
   const view = projects.map((p) => ({
     name: p.name,
     namespace: p.namespace,
@@ -130,7 +135,7 @@ app.get("/p/:name", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     logger.warn("Project not found or access denied", { name, userId });
     return c.html(
       <div style="padding:2rem;font-family:monospace;color:#f87171;">
@@ -288,7 +293,7 @@ app.get("/p/:name/changes", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     logger.warn("Project not found or access denied", { name, userId });
     return c.html(
       <div style="padding:2rem;font-family:monospace;color:#f87171;">
@@ -363,7 +368,7 @@ app.get("/changes/:id", async (c) => {
     );
   }
 
-  if (!canReadProject(projectResult.data, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, projectResult.data, userId, agentOwnerId))) {
     logger.warn("Change not found or access denied", { id, userId });
     return c.html(
       <div style="padding:2rem;font-family:monospace;color:#f87171;">Not found.</div>,
@@ -410,7 +415,7 @@ app.get("/changes/:id", async (c) => {
       comments={commentsResult.success ? commentsResult.data : []}
       reviews={reviewsResult.success ? reviewsResult.data : []}
       costs={costsResult.success ? costsResult.data : []}
-      canReview={!!userResult && canWriteProject(projectResult.data, userId)}
+      canReview={!!userResult && (await canWriteProject(c.env.DB, projectResult.data, userId))}
       user={userResult}
     />,
   );
@@ -442,7 +447,7 @@ app.get("/p/:name/workspaces", async (c) => {
     );
   }
 
-  if (!canReadProject(projectResult.data, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, projectResult.data, userId, agentOwnerId))) {
     logger.warn("Project not found or access denied", { name, userId });
     return c.html(
       <div style="padding:2rem;font-family:monospace;color:#f87171;">Not found.</div>,
@@ -508,7 +513,7 @@ app.get("/:namespace/:slug/changes", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     return c.html(
       <div style="padding:2rem;font-family:monospace;color:#f87171;">
         Project '{namespace}/{slug}' not found.
@@ -576,7 +581,7 @@ app.get("/:namespace/:slug/activity", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     return c.html(
       <div style="padding:2rem;font-family:monospace;color:#f87171;">
         Project '{namespace}/{slug}' not found.
@@ -633,7 +638,7 @@ async function loadIssuePageContext(c: {
   ]);
   if (!projectResult.success) return { errorStatus: 404 };
   const project = projectResult.data;
-  if (!canReadProject(project, userId, agentOwnerId)) return { errorStatus: 404 };
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) return { errorStatus: 404 };
 
   return { project, user, userId, logger };
 }
@@ -670,7 +675,7 @@ app.get("/:namespace/:slug/issues", async (c) => {
       project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
       issues={issuesResult.data}
       filter={filter}
-      canWrite={canWriteProject(project, userId)}
+      canWrite={await canWriteProject(c.env.DB, project, userId)}
       user={user}
     />,
   );
@@ -682,7 +687,7 @@ app.get("/:namespace/:slug/issues/new", async (c) => {
   if ("errorStatus" in ctx) return c.html(issuePageError(ctx.errorStatus), ctx.errorStatus);
   const { project, user, userId } = ctx;
 
-  if (!canWriteProject(project, userId)) {
+  if (!(await canWriteProject(c.env.DB, project, userId))) {
     return c.html(issuePageError(404), 404);
   }
 
@@ -719,7 +724,7 @@ app.get("/:namespace/:slug/issues/:number", async (c) => {
     <IssueDetailPage
       project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
       issue={issueResult.data}
-      canWrite={canWriteProject(project, userId)}
+      canWrite={await canWriteProject(c.env.DB, project, userId)}
       user={user}
     />,
   );
@@ -754,7 +759,7 @@ app.get("/:namespace/:slug/webhooks", async (c) => {
   const project = projectResult.data;
 
   // Webhook URLs and secrets are sensitive: writers only.
-  if (!canWriteProject(project, userId)) {
+  if (!(await canWriteProject(c.env.DB, project, userId))) {
     return c.html(
       <div style="padding:2rem;font-family:monospace;color:#f87171;">
         Project '{namespace}/{slug}' not found.
@@ -820,7 +825,7 @@ app.get("/:namespace/:slug/workspaces", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     return c.html(
       <div style="padding:2rem;font-family:monospace;color:#f87171;">
         Project '{namespace}/{slug}' not found.
@@ -888,7 +893,7 @@ app.get("/:namespace/:slug/sync", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     return c.html(
       <div style="padding:2rem;font-family:monospace;color:#f87171;">
         Project '{namespace}/{slug}' not found.
@@ -979,7 +984,7 @@ app.get("/:namespace/:slug/blob/*", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     return c.html(
       <div style="padding:2rem;font-family:monospace;color:#f87171;">
         Project '{namespace}/{slug}' not found.
@@ -1070,7 +1075,7 @@ app.get("/:namespace/:slug", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId)) {
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     logger.warn("Project not found or access denied", { namespace, slug, userId });
     return c.html(
       <div style="padding:2rem;font-family:monospace;color:#f87171;">

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -63,7 +63,7 @@ async function requireProjectAdmin(
   const project = projectResult.data;
 
   // Webhook URLs and secrets are sensitive: writers only, even for reads.
-  if (!canWriteProject(project, userId)) {
+  if (!(await canWriteProject(c.env.DB, project, userId))) {
     return { response: forbidden("Project access denied") };
   }
 

--- a/src/routes/workspaces.ts
+++ b/src/routes/workspaces.ts
@@ -43,7 +43,8 @@ app.post("/:namespace/:slug/workspaces", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canWriteProject(project, userId, agentOwnerId)) return forbidden("Project access denied");
+  if (!(await canWriteProject(c.env.DB, project, userId, agentOwnerId)))
+    return forbidden("Project access denied");
 
   const body = await c.req.json<{ name?: unknown }>().catch(() => ({ name: undefined }));
   const workspaceName = isValidSlug(body.name) ? body.name : `ws-${Date.now()}`;
@@ -117,7 +118,7 @@ app.get("/:namespace/:slug/workspaces", async (c) => {
   }
   const project = projectResult.data;
 
-  if (!canReadProject(project, userId, agentOwnerId))
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId)))
     return notFound("Project", `${project.namespace}/${project.slug}`);
 
   const workspacesResult = await listWorkspaces(c.env.STATE, project.id, logger);

--- a/src/storage/orgs.ts
+++ b/src/storage/orgs.ts
@@ -224,6 +224,56 @@ export async function isOrgMember(
   }
 }
 
+export type OrgAccessLevel = "none" | "read" | "write" | "admin";
+
+interface AccessRow {
+  org_role: string;
+  team_level: number | null;
+}
+
+/**
+ * A user's effective access to an org's projects:
+ * - org owner/admin → admin
+ * - member of a team with write/admin permissions → write
+ * - plain org member → read
+ * - not a member → none
+ *
+ * Team permissions are org-wide (no per-project team grants yet).
+ * Fails closed: database errors report "none".
+ */
+export async function getOrgAccessLevel(
+  db: D1Database,
+  logger: Logger,
+  orgId: string,
+  userId: string,
+): Promise<OrgAccessLevel> {
+  try {
+    const row = await db
+      .prepare(
+        `SELECT om.role AS org_role,
+                MAX(CASE t.permissions WHEN 'admin' THEN 3 WHEN 'write' THEN 2 WHEN 'read' THEN 1 ELSE 0 END) AS team_level
+         FROM org_members om
+         LEFT JOIN team_members tm ON tm.user_id = om.user_id
+         LEFT JOIN teams t ON t.id = tm.team_id AND t.org_id = om.org_id
+         WHERE om.org_id = ? AND om.user_id = ?
+         GROUP BY om.role`,
+      )
+      .bind(orgId, userId)
+      .first<AccessRow>();
+
+    if (!row) return "none";
+    if (row.org_role === "owner" || row.org_role === "admin") return "admin";
+    if ((row.team_level ?? 0) >= 2) return "write";
+    return "read";
+  } catch (error) {
+    logger.error("Failed to resolve org access level", error instanceof Error ? error : undefined, {
+      orgId,
+      userId,
+    });
+    return "none";
+  }
+}
+
 export async function isOrgAdmin(
   db: D1Database,
   logger: Logger,

--- a/src/utils/authz.ts
+++ b/src/utils/authz.ts
@@ -1,32 +1,96 @@
+import { type OrgAccessLevel, getOrgAccessLevel } from "../storage/orgs";
 import type { ProjectEntry } from "../types";
+import { createLogger } from "./logger";
 
-export function canReadProject(
-  project: ProjectEntry,
-  userId?: string,
-  agentOwnerId?: string,
-): boolean {
-  // Incomplete imports are only visible to the owner — the repo has no content yet.
-  // importCompleted is absent on legacy projects; treat absence as completed.
-  if (project.importCompleted === false) {
-    return canWriteProject(project, userId, agentOwnerId);
-  }
-  if (project.visibility === "public") return true;
-  return canWriteProject(project, userId, agentOwnerId);
-}
+const logger = createLogger({ component: "Authz" });
 
-export function canWriteProject(
-  project: ProjectEntry,
-  userId?: string,
-  agentOwnerId?: string,
-): boolean {
+/** Direct ownership: the project belongs to this user (or this agent's owner). */
+function isDirectOwner(project: ProjectEntry, userId?: string, agentOwnerId?: string): boolean {
   if (!project.ownerId) return false;
   return project.ownerId === userId || project.ownerId === agentOwnerId;
 }
 
-export function filterReadableProjects(
+function levelAllowsWrite(level: OrgAccessLevel): boolean {
+  return level === "write" || level === "admin";
+}
+
+/**
+ * Whether the caller may read the project. Org-owned projects grant read to
+ * every org member; agents inherit their owning user's access.
+ */
+export async function canReadProject(
+  db: D1Database,
+  project: ProjectEntry,
+  userId?: string,
+  agentOwnerId?: string,
+): Promise<boolean> {
+  // Incomplete imports are only visible to writers — the repo has no content yet.
+  // importCompleted is absent on legacy projects; treat absence as completed.
+  if (project.importCompleted === false) {
+    return canWriteProject(db, project, userId, agentOwnerId);
+  }
+  if (project.visibility === "public") return true;
+  if (isDirectOwner(project, userId, agentOwnerId)) return true;
+
+  if (project.ownerType === "org") {
+    const actor = userId ?? agentOwnerId;
+    if (!actor) return false;
+    return (await getOrgAccessLevel(db, logger, project.ownerId, actor)) !== "none";
+  }
+  return false;
+}
+
+/**
+ * Whether the caller may write to the project. For org-owned projects, write
+ * requires org owner/admin role or membership in a team with write/admin
+ * permissions.
+ */
+export async function canWriteProject(
+  db: D1Database,
+  project: ProjectEntry,
+  userId?: string,
+  agentOwnerId?: string,
+): Promise<boolean> {
+  if (isDirectOwner(project, userId, agentOwnerId)) return true;
+
+  if (project.ownerType === "org") {
+    const actor = userId ?? agentOwnerId;
+    if (!actor) return false;
+    return levelAllowsWrite(await getOrgAccessLevel(db, logger, project.ownerId, actor));
+  }
+  return false;
+}
+
+/**
+ * Filter a project list down to what the caller may read. Org access is
+ * resolved once per distinct org, not once per project.
+ */
+export async function filterReadableProjects(
+  db: D1Database,
   projects: ProjectEntry[],
   userId?: string,
   agentOwnerId?: string,
-): ProjectEntry[] {
-  return projects.filter((project) => canReadProject(project, userId, agentOwnerId));
+): Promise<ProjectEntry[]> {
+  const actor = userId ?? agentOwnerId;
+  const orgLevels = new Map<string, OrgAccessLevel>();
+
+  const orgIds = new Set(projects.filter((p) => p.ownerType === "org").map((p) => p.ownerId));
+  if (actor) {
+    for (const orgId of orgIds) {
+      orgLevels.set(orgId, await getOrgAccessLevel(db, logger, orgId, actor));
+    }
+  }
+  const orgLevel = (orgId: string): OrgAccessLevel => orgLevels.get(orgId) ?? "none";
+
+  return projects.filter((project) => {
+    if (project.importCompleted === false) {
+      // Same write-only rule as canReadProject for incomplete imports.
+      if (isDirectOwner(project, userId, agentOwnerId)) return true;
+      return project.ownerType === "org" && levelAllowsWrite(orgLevel(project.ownerId));
+    }
+    if (project.visibility === "public") return true;
+    if (isDirectOwner(project, userId, agentOwnerId)) return true;
+    if (project.ownerType === "org") return orgLevel(project.ownerId) !== "none";
+    return false;
+  });
 }

--- a/tests/org-access-level.test.ts
+++ b/tests/org-access-level.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { getOrgAccessLevel } from "../src/storage/orgs";
+import type { Logger } from "../src/utils/logger";
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+function makeDb(row: { org_role: string; team_level: number | null } | null): D1Database {
+  return {
+    prepare: () => ({
+      bind: () => ({
+        first: async () => row,
+      }),
+    }),
+  } as unknown as D1Database;
+}
+
+describe("getOrgAccessLevel", () => {
+  it("returns none for non-members", async () => {
+    expect(await getOrgAccessLevel(makeDb(null), mockLogger, "org_1", "user_1")).toBe("none");
+  });
+
+  it("returns admin for org owners and admins", async () => {
+    expect(
+      await getOrgAccessLevel(
+        makeDb({ org_role: "owner", team_level: null }),
+        mockLogger,
+        "o",
+        "u",
+      ),
+    ).toBe("admin");
+    expect(
+      await getOrgAccessLevel(makeDb({ org_role: "admin", team_level: 0 }), mockLogger, "o", "u"),
+    ).toBe("admin");
+  });
+
+  it("returns write for members of write/admin teams", async () => {
+    expect(
+      await getOrgAccessLevel(makeDb({ org_role: "member", team_level: 2 }), mockLogger, "o", "u"),
+    ).toBe("write");
+    expect(
+      await getOrgAccessLevel(makeDb({ org_role: "member", team_level: 3 }), mockLogger, "o", "u"),
+    ).toBe("write");
+  });
+
+  it("returns read for plain members and read-team members", async () => {
+    expect(
+      await getOrgAccessLevel(
+        makeDb({ org_role: "member", team_level: null }),
+        mockLogger,
+        "o",
+        "u",
+      ),
+    ).toBe("read");
+    expect(
+      await getOrgAccessLevel(makeDb({ org_role: "member", team_level: 1 }), mockLogger, "o", "u"),
+    ).toBe("read");
+  });
+
+  it("fails closed on database errors", async () => {
+    const badDb = {
+      prepare: () => {
+        throw new Error("D1 down");
+      },
+    } as unknown as D1Database;
+    expect(await getOrgAccessLevel(badDb, mockLogger, "o", "u")).toBe("none");
+  });
+});

--- a/tests/org-authz.test.ts
+++ b/tests/org-authz.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getOrgAccessLevel } from "../src/storage/orgs";
+import type { ProjectEntry } from "../src/types";
+import { canReadProject, canWriteProject, filterReadableProjects } from "../src/utils/authz";
+import type { Logger } from "../src/utils/logger";
+
+vi.mock("../src/storage/orgs", () => ({
+  getOrgAccessLevel: vi.fn(),
+}));
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+const db = {} as D1Database;
+
+function makeProject(overrides: Partial<ProjectEntry>): ProjectEntry {
+  return {
+    id: "proj_1",
+    name: "p",
+    slug: "p",
+    namespace: "@owner",
+    ownerId: "user_owner",
+    ownerType: "user",
+    remote: "remote",
+    token: "token",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    visibility: "private",
+    ...overrides,
+  };
+}
+
+const orgProject = makeProject({ namespace: "@acme", ownerId: "org_1", ownerType: "org" });
+
+describe("org project authorization", () => {
+  beforeEach(() => {
+    vi.mocked(getOrgAccessLevel).mockReset();
+  });
+
+  it("keeps user-owned semantics without touching the database", async () => {
+    const project = makeProject({});
+    expect(await canWriteProject(db, project, "user_owner")).toBe(true);
+    expect(await canWriteProject(db, project, "user_other")).toBe(false);
+    expect(await canReadProject(db, project, "user_other")).toBe(false);
+    expect(await canReadProject(db, makeProject({ visibility: "public" }), undefined)).toBe(true);
+    expect(getOrgAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it("grants read to any org member and denies non-members", async () => {
+    vi.mocked(getOrgAccessLevel).mockResolvedValueOnce("read");
+    expect(await canReadProject(db, orgProject, "user_member")).toBe(true);
+
+    vi.mocked(getOrgAccessLevel).mockResolvedValueOnce("none");
+    expect(await canReadProject(db, orgProject, "user_stranger")).toBe(false);
+  });
+
+  it("requires write/admin level for org project writes", async () => {
+    vi.mocked(getOrgAccessLevel).mockResolvedValueOnce("read");
+    expect(await canWriteProject(db, orgProject, "user_member")).toBe(false);
+
+    vi.mocked(getOrgAccessLevel).mockResolvedValueOnce("write");
+    expect(await canWriteProject(db, orgProject, "user_team_writer")).toBe(true);
+
+    vi.mocked(getOrgAccessLevel).mockResolvedValueOnce("admin");
+    expect(await canWriteProject(db, orgProject, "user_admin")).toBe(true);
+  });
+
+  it("agents inherit their owning user's org access", async () => {
+    vi.mocked(getOrgAccessLevel).mockResolvedValueOnce("write");
+    expect(await canWriteProject(db, orgProject, undefined, "user_agent_owner")).toBe(true);
+    expect(getOrgAccessLevel).toHaveBeenCalledWith(
+      db,
+      expect.any(Object),
+      "org_1",
+      "user_agent_owner",
+    );
+  });
+
+  it("denies anonymous callers on private org projects", async () => {
+    expect(await canReadProject(db, orgProject, undefined)).toBe(false);
+    expect(getOrgAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it("filterReadableProjects resolves each org once", async () => {
+    vi.mocked(getOrgAccessLevel).mockResolvedValue("read");
+    const projects = [
+      makeProject({ id: "1", ownerId: "user_me" }),
+      makeProject({ id: "2", ownerId: "org_1", ownerType: "org" }),
+      makeProject({ id: "3", ownerId: "org_1", ownerType: "org" }),
+      makeProject({ id: "4", ownerId: "org_2", ownerType: "org" }),
+      makeProject({ id: "5", ownerId: "user_other" }),
+    ];
+
+    const readable = await filterReadableProjects(db, projects, "user_me");
+    expect(readable.map((p) => p.id)).toEqual(["1", "2", "3", "4"]);
+    // org_1 and org_2 — one lookup each despite three org projects.
+    expect(getOrgAccessLevel).toHaveBeenCalledTimes(2);
+  });
+
+  it("filterReadableProjects hides incomplete org imports from read-level members", async () => {
+    vi.mocked(getOrgAccessLevel).mockResolvedValue("read");
+    const incomplete = makeProject({
+      id: "imp",
+      ownerId: "org_1",
+      ownerType: "org",
+      importCompleted: false,
+    });
+
+    const readable = await filterReadableProjects(db, [incomplete], "user_member");
+    expect(readable).toHaveLength(0);
+
+    vi.mocked(getOrgAccessLevel).mockResolvedValue("write");
+    const writable = await filterReadableProjects(db, [incomplete], "user_writer");
+    expect(writable).toHaveLength(1);
+  });
+});

--- a/tests/orgs.test.ts
+++ b/tests/orgs.test.ts
@@ -7,6 +7,11 @@ import { NotFoundError } from "../src/utils/errors";
 
 vi.mock("../src/storage/users", () => ({
   getUserByToken: vi.fn(),
+  // Default: no username collides with the org slug.
+  getUserByUsername: vi.fn().mockResolvedValue({
+    success: false,
+    error: new Error("not found"),
+  }),
 }));
 
 vi.mock("../src/storage/agents", () => ({


### PR DESCRIPTION
## Summary

Implements master-plan Phase 3.1 — orgs/teams existed as tables and CRUD but were never wired into project access:

- **`getOrgAccessLevel`** (one JOIN query, fails closed): org owner/admin → `admin`; member of a write/admin team → `write`; plain member → `read`; else `none`. Team permissions are org-wide (per-project team grants are future work).
- **Async authz**: `canReadProject`/`canWriteProject`/`filterReadableProjects` now take the DB and resolve org membership for org-owned projects; agents inherit their owning user's access; user-owned projects keep the zero-query fast path. All 46 call sites across 7 route files swept — list filtering resolves each distinct org once, not once per project.
- **Org-owned project creation**: `POST /api/projects` accepts `org: <slug>`; requires org write access; the project lands under the `@org-slug` namespace with `ownerType: org`. Org creation now rejects slugs that collide with existing usernames so namespaces stay unambiguous.
- **Security fix**: `sync-management`'s `verifyProjectAccess` accepted *any* authenticated user (namespace-match only, flagged TODO). It now requires real write access.

## Testing

- 12 new tests: access-level mapping (owner/admin/team-write/member/non-member/DB-failure), org read/write authz, agent inheritance, anonymous denial, per-org batch filtering, incomplete-import visibility rules
- Full suite: 691 passing; lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Organizations can now own and manage projects
  * Added validation to prevent organization names conflicting with existing user names

* **Bug Fixes**
  * Enhanced authorization enforcement across project access controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->