### PR TITLE
feat: syntax highlighting + diff viewer + status polling (Phase 2.8)

### DIFF
--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -4,15 +4,23 @@ import { getChange, listChanges } from "../storage/changes";
 import { getChangeCostSummary } from "../storage/costs";
 import { listEvalRuns } from "../storage/eval-runs";
 import { listProjectEvents } from "../storage/events";
+import { getDiffBetweenRepos } from "../storage/git-ops";
 import { getCommitLog, listFilesInRepo, readFileFromRepo } from "../storage/git-ops";
 import { getImportProgress } from "../storage/imports";
 import { getIssueByNumber, listIssues } from "../storage/issues";
 import { readRepoSnapshot } from "../storage/repo-snapshot";
-import { getProject, getProjectByPath, listProjects, listWorkspaces } from "../storage/state";
+import {
+  getProject,
+  getProjectByPath,
+  getWorkspace,
+  listProjects,
+  listWorkspaces,
+} from "../storage/state";
 import { getProjectSourceUrl, getSyncStatus } from "../storage/sync";
 import { getUser } from "../storage/users";
 import { listDeliveries, listWebhooks } from "../storage/webhooks";
 import type { Env, ProjectEntry } from "../types";
+import { parseUnifiedDiff } from "../ui/components/diff-view";
 import { getFileContent, isValidFilePath } from "../ui/file-content";
 import { ActivityPage } from "../ui/pages/activity";
 import { ChangeDetailPage } from "../ui/pages/change-detail";
@@ -382,6 +390,33 @@ app.get("/changes/:id", async (c) => {
     listReviews(c.env.DB, logger, change.id),
     getChangeCostSummary(c.env.DB, logger, change.id),
   ]);
+
+  // The diff is only renderable while the workspace still exists and the
+  // change is still in review; failures degrade to "no diff section".
+  let diffFiles: ReturnType<typeof parseUnifiedDiff> | null = null;
+  const DIFFABLE_STATUSES = ["open", "needs_changes", "accepted", "approved"];
+  if (DIFFABLE_STATUSES.includes(change.status)) {
+    const workspaceResult = await getWorkspace(
+      c.env.STATE,
+      projectResult.data.id,
+      change.workspace,
+      logger,
+    );
+    if (workspaceResult.success) {
+      const diffResult = await getDiffBetweenRepos(
+        projectResult.data.remote,
+        projectResult.data.token,
+        workspaceResult.data.remote,
+        workspaceResult.data.token,
+        logger,
+      );
+      if (diffResult.success) {
+        diffFiles = parseUnifiedDiff(diffResult.data);
+      } else {
+        logger.warn("Failed to load change diff", { changeId: change.id });
+      }
+    }
+  }
   if (!evalRunsResult.success) {
     logger.error("Failed to list eval runs", evalRunsResult.error);
   }
@@ -415,6 +450,7 @@ app.get("/changes/:id", async (c) => {
       comments={commentsResult.success ? commentsResult.data : []}
       reviews={reviewsResult.success ? reviewsResult.data : []}
       costs={costsResult.success ? costsResult.data : []}
+      diff={diffFiles}
       canReview={!!userResult && (await canWriteProject(c.env.DB, projectResult.data, userId))}
       user={userResult}
     />,

--- a/src/ui/components/diff-view.tsx
+++ b/src/ui/components/diff-view.tsx
@@ -1,0 +1,87 @@
+import type { FC } from "hono/jsx";
+
+export interface DiffFile {
+  path: string;
+  additions: number;
+  deletions: number;
+  lines: Array<{ kind: "add" | "del" | "context" | "hunk"; text: string }>;
+}
+
+/**
+ * Parse a unified diff into per-file sections for rendering.
+ * Tolerant of partial input: unrecognized lines render as context.
+ */
+export function parseUnifiedDiff(diff: string): DiffFile[] {
+  const files: DiffFile[] = [];
+  let current: DiffFile | null = null;
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("--- ")) {
+      continue;
+    }
+    if (line.startsWith("+++ ")) {
+      const rawPath = line.slice(4).trim();
+      const path = rawPath.startsWith("b/") ? rawPath.slice(2) : rawPath;
+      current = { path, additions: 0, deletions: 0, lines: [] };
+      files.push(current);
+      continue;
+    }
+    if (line.startsWith("Index:") || line.startsWith("diff ") || line.startsWith("index ")) {
+      continue;
+    }
+    if (line.startsWith("===")) {
+      continue;
+    }
+    if (!current) continue;
+
+    if (line.startsWith("@@")) {
+      current.lines.push({ kind: "hunk", text: line });
+    } else if (line.startsWith("+")) {
+      current.additions += 1;
+      current.lines.push({ kind: "add", text: line });
+    } else if (line.startsWith("-")) {
+      current.deletions += 1;
+      current.lines.push({ kind: "del", text: line });
+    } else {
+      current.lines.push({ kind: "context", text: line });
+    }
+  }
+
+  return files;
+}
+
+const lineClass: Record<DiffFile["lines"][number]["kind"], string> = {
+  add: "diff-line diff-add",
+  del: "diff-line diff-del",
+  context: "diff-line",
+  hunk: "diff-line diff-hunk",
+};
+
+export const DiffView: FC<{ files: DiffFile[] }> = ({ files }) => {
+  if (files.length === 0) {
+    return <p class="diff-empty">No changes between the workspace and the project.</p>;
+  }
+  return (
+    <div class="diff-view">
+      {files.map((file) => (
+        <details class="diff-file" key={file.path} open={files.length <= 5}>
+          <summary class="diff-file-header">
+            <span class="diff-file-path">{file.path}</span>
+            <span class="diff-file-stats">
+              <span class="diff-stat-add">+{file.additions}</span>{" "}
+              <span class="diff-stat-del">−{file.deletions}</span>
+            </span>
+          </summary>
+          <pre class="diff-file-body">
+            {file.lines.map((line, index) => (
+              <span class={lineClass[line.kind]} key={index}>
+                {line.text}
+                {"\n"}
+              </span>
+            ))}
+          </pre>
+        </details>
+      ))}
+    </div>
+  );
+};

--- a/src/ui/highlight.ts
+++ b/src/ui/highlight.ts
@@ -1,0 +1,521 @@
+/**
+ * Compact server-side syntax highlighter.
+ *
+ * Deliberately dependency-free: highlight.js's type definitions reference
+ * lib="dom", which corrupts the Workers global type scope, and full grammar
+ * engines are oversized for Workers bundles. This lexer covers the token
+ * classes that matter for readability — comments, strings, numbers, and
+ * keywords — and escapes everything it emits.
+ */
+
+interface LanguageConfig {
+  lineComment?: string;
+  blockComment?: [string, string];
+  /** Extra string delimiters beyond ' and " (e.g. backtick). */
+  extraStringDelimiters?: string[];
+  keywords: ReadonlySet<string>;
+}
+
+const C_LIKE_KEYWORDS = [
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "default",
+  "do",
+  "else",
+  "enum",
+  "extends",
+  "finally",
+  "for",
+  "if",
+  "implements",
+  "import",
+  "interface",
+  "new",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "static",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "try",
+  "void",
+  "while",
+];
+
+const JS_KEYWORDS = new Set([
+  ...C_LIKE_KEYWORDS,
+  "as",
+  "async",
+  "await",
+  "declare",
+  "delete",
+  "export",
+  "from",
+  "function",
+  "in",
+  "instanceof",
+  "let",
+  "namespace",
+  "of",
+  "readonly",
+  "satisfies",
+  "type",
+  "typeof",
+  "var",
+  "yield",
+  "true",
+  "false",
+  "null",
+  "undefined",
+]);
+
+const PYTHON_KEYWORDS = new Set([
+  "and",
+  "as",
+  "assert",
+  "async",
+  "await",
+  "break",
+  "class",
+  "continue",
+  "def",
+  "del",
+  "elif",
+  "else",
+  "except",
+  "finally",
+  "for",
+  "from",
+  "global",
+  "if",
+  "import",
+  "in",
+  "is",
+  "lambda",
+  "nonlocal",
+  "not",
+  "or",
+  "pass",
+  "raise",
+  "return",
+  "try",
+  "while",
+  "with",
+  "yield",
+  "True",
+  "False",
+  "None",
+  "self",
+]);
+
+const GO_KEYWORDS = new Set([
+  "break",
+  "case",
+  "chan",
+  "const",
+  "continue",
+  "default",
+  "defer",
+  "else",
+  "fallthrough",
+  "for",
+  "func",
+  "go",
+  "goto",
+  "if",
+  "import",
+  "interface",
+  "map",
+  "package",
+  "range",
+  "return",
+  "select",
+  "struct",
+  "switch",
+  "type",
+  "var",
+  "true",
+  "false",
+  "nil",
+]);
+
+const RUST_KEYWORDS = new Set([
+  "as",
+  "async",
+  "await",
+  "break",
+  "const",
+  "continue",
+  "crate",
+  "dyn",
+  "else",
+  "enum",
+  "extern",
+  "fn",
+  "for",
+  "if",
+  "impl",
+  "in",
+  "let",
+  "loop",
+  "match",
+  "mod",
+  "move",
+  "mut",
+  "pub",
+  "ref",
+  "return",
+  "self",
+  "static",
+  "struct",
+  "trait",
+  "type",
+  "unsafe",
+  "use",
+  "where",
+  "while",
+  "true",
+  "false",
+]);
+
+const JAVA_KEYWORDS = new Set([
+  ...C_LIKE_KEYWORDS,
+  "abstract",
+  "boolean",
+  "byte",
+  "char",
+  "double",
+  "final",
+  "float",
+  "int",
+  "long",
+  "package",
+  "short",
+  "synchronized",
+  "throws",
+  "transient",
+  "volatile",
+  "true",
+  "false",
+  "null",
+]);
+
+const C_KEYWORDS = new Set([
+  ...C_LIKE_KEYWORDS,
+  "auto",
+  "char",
+  "double",
+  "extern",
+  "float",
+  "goto",
+  "inline",
+  "int",
+  "long",
+  "register",
+  "short",
+  "signed",
+  "sizeof",
+  "struct",
+  "typedef",
+  "union",
+  "unsigned",
+  "volatile",
+  "namespace",
+  "template",
+  "typename",
+  "using",
+  "virtual",
+  "nullptr",
+  "true",
+  "false",
+]);
+
+const RUBY_KEYWORDS = new Set([
+  "alias",
+  "and",
+  "begin",
+  "break",
+  "case",
+  "class",
+  "def",
+  "do",
+  "else",
+  "elsif",
+  "end",
+  "ensure",
+  "false",
+  "if",
+  "in",
+  "module",
+  "next",
+  "nil",
+  "not",
+  "or",
+  "raise",
+  "require",
+  "rescue",
+  "retry",
+  "return",
+  "self",
+  "super",
+  "then",
+  "true",
+  "unless",
+  "until",
+  "when",
+  "while",
+  "yield",
+]);
+
+const SQL_KEYWORDS = new Set(
+  [
+    "select",
+    "from",
+    "where",
+    "insert",
+    "into",
+    "values",
+    "update",
+    "set",
+    "delete",
+    "create",
+    "table",
+    "index",
+    "drop",
+    "alter",
+    "add",
+    "column",
+    "primary",
+    "key",
+    "foreign",
+    "references",
+    "not",
+    "null",
+    "unique",
+    "default",
+    "join",
+    "left",
+    "right",
+    "inner",
+    "outer",
+    "on",
+    "group",
+    "by",
+    "order",
+    "having",
+    "limit",
+    "offset",
+    "and",
+    "or",
+    "in",
+    "exists",
+    "between",
+    "like",
+    "as",
+    "distinct",
+    "union",
+    "all",
+    "case",
+    "when",
+    "then",
+    "else",
+    "end",
+    "check",
+    "constraint",
+    "if",
+  ].flatMap((kw) => [kw, kw.toUpperCase()]),
+);
+
+const SHELL_KEYWORDS = new Set([
+  "if",
+  "then",
+  "else",
+  "elif",
+  "fi",
+  "for",
+  "in",
+  "do",
+  "done",
+  "while",
+  "case",
+  "esac",
+  "function",
+  "return",
+  "local",
+  "export",
+  "set",
+  "echo",
+  "exit",
+  "shift",
+  "source",
+]);
+
+const LANGUAGES: Record<string, LanguageConfig> = {
+  javascript: {
+    lineComment: "//",
+    blockComment: ["/*", "*/"],
+    extraStringDelimiters: ["`"],
+    keywords: JS_KEYWORDS,
+  },
+  typescript: {
+    lineComment: "//",
+    blockComment: ["/*", "*/"],
+    extraStringDelimiters: ["`"],
+    keywords: JS_KEYWORDS,
+  },
+  python: { lineComment: "#", keywords: PYTHON_KEYWORDS },
+  go: {
+    lineComment: "//",
+    blockComment: ["/*", "*/"],
+    extraStringDelimiters: ["`"],
+    keywords: GO_KEYWORDS,
+  },
+  rust: { lineComment: "//", blockComment: ["/*", "*/"], keywords: RUST_KEYWORDS },
+  java: { lineComment: "//", blockComment: ["/*", "*/"], keywords: JAVA_KEYWORDS },
+  kotlin: { lineComment: "//", blockComment: ["/*", "*/"], keywords: JAVA_KEYWORDS },
+  swift: { lineComment: "//", blockComment: ["/*", "*/"], keywords: JS_KEYWORDS },
+  c: { lineComment: "//", blockComment: ["/*", "*/"], keywords: C_KEYWORDS },
+  cpp: { lineComment: "//", blockComment: ["/*", "*/"], keywords: C_KEYWORDS },
+  csharp: { lineComment: "//", blockComment: ["/*", "*/"], keywords: JAVA_KEYWORDS },
+  php: { lineComment: "//", blockComment: ["/*", "*/"], keywords: JS_KEYWORDS },
+  ruby: { lineComment: "#", keywords: RUBY_KEYWORDS },
+  shell: { lineComment: "#", keywords: SHELL_KEYWORDS },
+  sql: { lineComment: "--", blockComment: ["/*", "*/"], keywords: SQL_KEYWORDS },
+  yaml: { lineComment: "#", keywords: new Set(["true", "false", "null"]) },
+  toml: { lineComment: "#", keywords: new Set(["true", "false"]) },
+  json: { keywords: new Set(["true", "false", "null"]) },
+  css: { blockComment: ["/*", "*/"], keywords: new Set() },
+  graphql: {
+    lineComment: "#",
+    keywords: new Set([
+      "query",
+      "mutation",
+      "type",
+      "input",
+      "enum",
+      "interface",
+      "fragment",
+      "on",
+      "schema",
+    ]),
+  },
+};
+
+/** Files above this size render unhighlighted to bound CPU per request. */
+const MAX_HIGHLIGHT_BYTES = 256 * 1024;
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function span(cls: string, text: string): string {
+  return `<span class="tok-${cls}">${escapeHtml(text)}</span>`;
+}
+
+const WORD_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+const NUMBER_RE = /^(?:0[xXbBoO][0-9a-fA-F_]+|\d[\d_]*(?:\.[\d_]+)?(?:[eE][+-]?\d+)?)/;
+
+/**
+ * Highlight source code into HTML. Returns null when the language is not
+ * supported or the input is too large — callers fall back to plain text.
+ * All emitted text is HTML-escaped.
+ */
+export function highlightCode(code: string, language: string): string | null {
+  const config = LANGUAGES[language];
+  if (!config) return null;
+  if (code.length > MAX_HIGHLIGHT_BYTES) return null;
+
+  const stringDelimiters = new Set(['"', "'", ...(config.extraStringDelimiters ?? [])]);
+  const out: string[] = [];
+  let plain = "";
+  let i = 0;
+
+  const flushPlain = () => {
+    if (plain) {
+      out.push(escapeHtml(plain));
+      plain = "";
+    }
+  };
+
+  while (i < code.length) {
+    const rest = code.slice(i);
+
+    if (config.blockComment && rest.startsWith(config.blockComment[0])) {
+      const end = code.indexOf(config.blockComment[1], i + config.blockComment[0].length);
+      const stop = end === -1 ? code.length : end + config.blockComment[1].length;
+      flushPlain();
+      out.push(span("comment", code.slice(i, stop)));
+      i = stop;
+      continue;
+    }
+
+    if (config.lineComment && rest.startsWith(config.lineComment)) {
+      const end = code.indexOf("\n", i);
+      const stop = end === -1 ? code.length : end;
+      flushPlain();
+      out.push(span("comment", code.slice(i, stop)));
+      i = stop;
+      continue;
+    }
+
+    const char = code[i] as string;
+    if (stringDelimiters.has(char)) {
+      let j = i + 1;
+      while (j < code.length) {
+        if (code[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (code[j] === char) {
+          j += 1;
+          break;
+        }
+        // Unterminated single-line strings stop at the newline (except template literals).
+        if (code[j] === "\n" && char !== "`") break;
+        j += 1;
+      }
+      flushPlain();
+      out.push(span("string", code.slice(i, Math.min(j, code.length))));
+      i = Math.min(j, code.length);
+      continue;
+    }
+
+    const numberMatch = NUMBER_RE.exec(rest);
+    if (numberMatch && !/[A-Za-z0-9_$]/.test(code[i - 1] ?? "")) {
+      flushPlain();
+      out.push(span("number", numberMatch[0]));
+      i += numberMatch[0].length;
+      continue;
+    }
+
+    const wordMatch = WORD_RE.exec(rest);
+    if (wordMatch) {
+      const word = wordMatch[0];
+      if (config.keywords.has(word)) {
+        flushPlain();
+        out.push(span("keyword", word));
+      } else {
+        plain += word;
+      }
+      i += word.length;
+      continue;
+    }
+
+    plain += char;
+    i += 1;
+  }
+
+  flushPlain();
+  return out.join("");
+}

--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -3,15 +3,20 @@ import type { FC } from "hono/jsx";
 interface LayoutProps {
   title: string;
   user?: { id: string; email: string; username: string } | null | undefined;
+  /** Auto-reload the page every N seconds (status polling without client JS). */
+  refreshSeconds?: number;
   children?: unknown;
 }
 
-export const Layout: FC<LayoutProps> = ({ title, user, children }) => {
+export const Layout: FC<LayoutProps> = ({ title, user, refreshSeconds, children }) => {
   return (
     <html lang="en">
       <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        {refreshSeconds !== undefined && (
+          <meta http-equiv="refresh" content={String(refreshSeconds)} />
+        )}
         <title>{title} — Stratum</title>
         <link rel="stylesheet" href="/ui.css" />
       </head>

--- a/src/ui/pages/change-detail.tsx
+++ b/src/ui/pages/change-detail.tsx
@@ -1,6 +1,7 @@
 import type { FC } from "hono/jsx";
 import type { ChangeComment, ChangeReview } from "../../storage/change-reviews";
 import type { CostSummaryEntry } from "../../storage/costs";
+import { type DiffFile, DiffView } from "../components/diff-view";
 import { Layout } from "../layout";
 
 interface ChangeDetailProps {
@@ -35,6 +36,8 @@ interface ChangeDetailProps {
   comments?: ChangeComment[];
   reviews?: ChangeReview[];
   costs?: CostSummaryEntry[];
+  /** Parsed diff between workspace and project; null when unavailable. */
+  diff?: DiffFile[] | null;
   /** Whether the current user may submit review verdicts. */
   canReview?: boolean;
   user?: { id: string; email: string; username: string } | null;
@@ -84,11 +87,16 @@ export const ChangeDetailPage: FC<ChangeDetailProps> = ({
   comments = [],
   reviews = [],
   costs = [],
+  diff = null,
   canReview = false,
   user,
 }) => {
   return (
-    <Layout title={`Change ${change.id}`} user={user}>
+    <Layout
+      title={`Change ${change.id}`}
+      user={user}
+      {...(change.status === "open" ? { refreshSeconds: 10 } : {})}
+    >
       <div class="page-header">
         <h1>
           <span class="mono">{change.id}</span>{" "}
@@ -239,6 +247,13 @@ export const ChangeDetailPage: FC<ChangeDetailProps> = ({
             <dt>Merged</dt>
             <dd>{new Date(provenance.mergedAt).toLocaleString()}</dd>
           </dl>
+        </div>
+      )}
+
+      {diff !== null && (
+        <div class="card">
+          <h2>Files changed</h2>
+          <DiffView files={diff} />
         </div>
       )}
 

--- a/src/ui/pages/file-viewer.tsx
+++ b/src/ui/pages/file-viewer.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from "hono/jsx";
 import type { FC } from "hono/jsx";
 import type { FileContentResult } from "../file-content";
+import { highlightCode } from "../highlight";
 import { Layout } from "../layout";
 
 const extensionToLanguage: Record<string, string> = {
@@ -94,11 +95,23 @@ export const FileViewerPage: FC<FileViewerPageProps> = ({ project, path, content
       </div>
 
       <div class="card file-viewer-content">
-        {content.kind === "content" && (
-          <pre>
-            <code class={`language-${language}`}>{content.value}</code>
-          </pre>
-        )}
+        {content.kind === "content" &&
+          (() => {
+            // highlightCode escapes its input; the returned markup is trusted.
+            const highlighted = highlightCode(content.value, language);
+            return (
+              <pre>
+                {highlighted !== null ? (
+                  <code
+                    class={`highlighted language-${language}`}
+                    dangerouslySetInnerHTML={{ __html: highlighted }}
+                  />
+                ) : (
+                  <code class={`language-${language}`}>{content.value}</code>
+                )}
+              </pre>
+            );
+          })()}
         {content.kind === "binary" && <p class="file-viewer-message">Binary file — not shown.</p>}
         {content.kind === "oversize" && (
           <p class="file-viewer-message">File too large to display (&gt; 512 KB).</p>

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -523,6 +523,34 @@ a:hover { text-decoration: underline; }
   padding: 0.5rem; border-radius: 4px; font-family: inherit;
 }
 
+/* Syntax highlighting (server-side lexer) */
+.tok-comment { color: #6a737d; font-style: italic; }
+.tok-string { color: #9ecbff; }
+.tok-number { color: #f8c555; }
+.tok-keyword { color: #f97583; }
+
+/* Diff viewer */
+.diff-view { display: flex; flex-direction: column; gap: 0.75rem; }
+.diff-empty { color: #666; font-size: 0.85rem; }
+.diff-file { border: 1px solid #2a2a2a; border-radius: 6px; overflow: hidden; }
+.diff-file-header {
+  display: flex; justify-content: space-between; align-items: baseline; gap: 1rem;
+  padding: 0.5rem 0.75rem; background: #181818; cursor: pointer;
+  font-family: 'JetBrains Mono', monospace; font-size: 0.8rem;
+}
+.diff-file-path { color: #e8e8e8; word-break: break-all; }
+.diff-file-stats { flex-shrink: 0; }
+.diff-stat-add { color: #4ade80; }
+.diff-stat-del { color: #f87171; }
+.diff-file-body {
+  margin: 0; padding: 0.5rem 0; overflow-x: auto;
+  font-size: 0.8rem; line-height: 1.5; background: #0d0d0d;
+}
+.diff-line { display: block; padding: 0 0.75rem; white-space: pre; }
+.diff-add { background: rgba(74, 222, 128, 0.12); color: #b9f0cd; }
+.diff-del { background: rgba(248, 113, 113, 0.12); color: #f5c2c2; }
+.diff-hunk { color: #7cb7ff; background: #14181f; }
+
 /* Costs */
 .cost-list { list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #ccc; }
 .cost-list li { padding: 0.2rem 0; }

--- a/tests/file-viewer.test.tsx
+++ b/tests/file-viewer.test.tsx
@@ -43,8 +43,10 @@ describe("FileViewerPage", () => {
         user={user}
       />,
     );
-    expect(html).toContain('class="language-typescript"');
-    expect(html).toContain("const x = 1;");
+    expect(html).toContain("language-typescript");
+    // Content is now server-side highlighted into token spans.
+    expect(html).toContain('<span class="tok-keyword">const</span>');
+    expect(html).toContain('<span class="tok-number">1</span>');
   });
 
   it("HTML-escapes file content — XSS test", () => {

--- a/tests/highlight.test.ts
+++ b/tests/highlight.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { parseUnifiedDiff } from "../src/ui/components/diff-view";
+import { highlightCode } from "../src/ui/highlight";
+
+describe("highlightCode", () => {
+  it("returns null for unsupported languages and oversized files", () => {
+    expect(highlightCode("code", "brainfuck")).toBeNull();
+    expect(highlightCode("x".repeat(300 * 1024), "typescript")).toBeNull();
+  });
+
+  it("escapes HTML in all emitted output", () => {
+    const html = highlightCode('const xss = "<script>alert(1)</script>";', "typescript");
+    expect(html).not.toBeNull();
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("escapes HTML inside comments and plain code", () => {
+    const html = highlightCode("// <img onerror=x>\nlet a = b < c;", "typescript");
+    expect(html).not.toContain("<img");
+    expect(html).toContain("&lt;img");
+  });
+
+  it("marks keywords, strings, numbers, and comments in TypeScript", () => {
+    const html = highlightCode('// note\nconst greeting = "hello";\nreturn 42;', "typescript");
+    expect(html).toContain('<span class="tok-comment">// note</span>');
+    expect(html).toContain('<span class="tok-keyword">const</span>');
+    expect(html).toContain('<span class="tok-string">&quot;hello&quot;</span>');
+    expect(html).toContain('<span class="tok-keyword">return</span>');
+    expect(html).toContain('<span class="tok-number">42</span>');
+  });
+
+  it("handles block comments spanning lines", () => {
+    const html = highlightCode("/* multi\nline */ const x = 1;", "typescript");
+    expect(html).toContain('<span class="tok-comment">/* multi\nline */</span>');
+  });
+
+  it("does not treat comment markers inside strings as comments", () => {
+    const html = highlightCode('const url = "https://example.com";', "typescript");
+    expect(html).toContain('<span class="tok-string">&quot;https://example.com&quot;</span>');
+    expect(html).not.toContain("tok-comment");
+  });
+
+  it("respects escaped quotes inside strings", () => {
+    const html = highlightCode('const s = "say \\"hi\\"" + done;', "typescript");
+    expect(html).toContain("tok-string");
+    // The string token ends at the escaped-quote-aware terminator.
+    expect(html).toContain("done");
+  });
+
+  it("does not highlight keywords embedded in identifiers", () => {
+    const html = highlightCode("const classNameThing = 1;", "typescript");
+    expect(html).not.toContain('<span class="tok-keyword">class</span>');
+  });
+
+  it("highlights Python with # comments and its keyword set", () => {
+    const html = highlightCode("# comment\ndef f():\n    return None", "python");
+    expect(html).toContain('<span class="tok-comment"># comment</span>');
+    expect(html).toContain('<span class="tok-keyword">def</span>');
+    expect(html).toContain('<span class="tok-keyword">None</span>');
+  });
+
+  it("highlights SQL keywords case-insensitively", () => {
+    const html = highlightCode("SELECT id FROM users WHERE active = 1;", "sql");
+    expect(html).toContain('<span class="tok-keyword">SELECT</span>');
+    expect(html).toContain('<span class="tok-keyword">FROM</span>');
+  });
+
+  it("treats Go backtick strings as strings", () => {
+    const html = highlightCode("s := `raw\nstring`", "go");
+    expect(html).toContain('<span class="tok-string">`raw\nstring`</span>');
+  });
+});
+
+describe("parseUnifiedDiff", () => {
+  const sample = [
+    "Index: src/a.ts",
+    "===================================================================",
+    "--- a/src/a.ts",
+    "+++ b/src/a.ts",
+    "@@ -1,3 +1,4 @@",
+    " context line",
+    "-removed line",
+    "+added line one",
+    "+added line two",
+    "--- a/src/b.ts",
+    "+++ b/src/b.ts",
+    "@@ -5,2 +5,1 @@",
+    "-gone",
+    " kept",
+  ].join("\n");
+
+  it("splits a unified diff into files with counts", () => {
+    const files = parseUnifiedDiff(sample);
+    expect(files.map((f) => f.path)).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(files[0]?.additions).toBe(2);
+    expect(files[0]?.deletions).toBe(1);
+    expect(files[1]?.additions).toBe(0);
+    expect(files[1]?.deletions).toBe(1);
+  });
+
+  it("classifies line kinds", () => {
+    const files = parseUnifiedDiff(sample);
+    const kinds = files[0]?.lines.map((l) => l.kind);
+    expect(kinds).toEqual(["hunk", "context", "del", "add", "add"]);
+  });
+
+  it("returns an empty list for an empty diff", () => {
+    expect(parseUnifiedDiff("")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Completes the remaining master-plan Phase 2.8 UI items:

- **Server-side syntax highlighting** in the file viewer: a compact dependency-free lexer (`src/ui/highlight.ts`) covering comments, strings (escape-aware, incl. backtick raw strings), numbers, and per-language keyword sets for ~20 languages. Everything it emits is HTML-escaped; unknown languages and files >256KB fall back to plain text. *Why not highlight.js:* its type definitions carry `/// <reference lib="dom" />`, which merges DOM globals into the Workers type program and breaks `KVNamespace` type identity across the codebase — a dependency that corrupts the global type scope isn't worth grammars we mostly don't need.
- **Diff viewer on the change page**: `Files changed` section rendering the workspace↔project unified diff as per-file collapsible sections with add/del/hunk coloring and +N/−N stats (server-rendered, JSX-escaped). Loads only while the change is still reviewable; failures degrade to no section.
- **Eval status polling**: pages for `open` changes auto-refresh every 10s via `<meta http-equiv=refresh>` — no client JS.

## Testing

- 14 new tests: XSS escaping (code, comments), token classes, comment-marker-in-string, escaped quotes, keyword/identifier boundaries, Python/SQL/Go specifics, size/language fallbacks, unified-diff parsing (multi-file counts, line kinds, empty input)
- Full suite: 705 passing; lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)