### PR TITLE
feat: CSRF protection + API key rotation + settings UI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { setCookie } from "hono/cookie";
 import { githubWebhookRouter } from "./github/webhooks";
 import { analyticsMiddleware } from "./middleware/analytics";
 import { authMiddleware } from "./middleware/auth";
+import { csrfMiddleware } from "./middleware/csrf";
 import { rateLimitMiddleware } from "./middleware/rate-limit";
 import { handleEventQueue, sweepStaleEvents } from "./queue/event-consumer";
 import type { EventQueueMessage } from "./queue/events";
@@ -39,6 +40,7 @@ const app = new Hono<{ Bindings: Env }>();
 
 app.use("*", analyticsMiddleware);
 app.use("*", authMiddleware);
+app.use("*", csrfMiddleware);
 app.use("*", rateLimitMiddleware());
 
 app.get("/health", (c) => c.json({ status: "ok", service: "stratum" }));

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -12,6 +12,8 @@ declare module "hono" {
     username: string;
     agentId?: string;
     agentOwnerId?: string;
+    /** How the caller authenticated — CSRF checks apply to "session" only. */
+    authVia?: "token" | "session";
     logger: Logger;
   }
 }
@@ -55,6 +57,7 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
       }
       c.set("userId", userResult.data.id);
       c.set("username", userResult.data.username);
+      c.set("authVia", "token");
       logger.debug("Auth success - user", {
         userId: userResult.data.id,
         username: userResult.data.username,
@@ -74,6 +77,7 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
       }
       c.set("agentId", agentResult.data.id);
       c.set("agentOwnerId", agentResult.data.ownerId);
+      c.set("authVia", "token");
       logger.debug("Auth success - agent", {
         agentId: agentResult.data.id,
         ownerId: agentResult.data.ownerId,
@@ -99,6 +103,7 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
         await deleteSession(c.env.DB, sessionId, userId, logger);
       } else {
         c.set("userId", sessionResult.data.userId);
+        c.set("authVia", "session");
 
         // Fetch username for the session user
         const userResult = await getUser(c.env.DB, sessionResult.data.userId, logger);

--- a/src/middleware/csrf.ts
+++ b/src/middleware/csrf.ts
@@ -1,0 +1,67 @@
+import type { MiddlewareHandler } from "hono";
+import type { Env } from "../types";
+import { createLogger } from "../utils/logger";
+
+const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * CSRF protection for cookie-authenticated requests.
+ *
+ * Bearer-token requests are immune (cross-site attackers cannot set the
+ * Authorization header), so only session-cookie auth is checked. The session
+ * cookie is SameSite=Lax — this middleware is the defense-in-depth layer:
+ * state-changing requests must present an Origin (or Referer) matching the
+ * request host. Requests with neither header are rejected; every modern
+ * browser sends Origin on cross-origin POSTs and form submissions.
+ */
+export const csrfMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
+  if (!STATE_CHANGING_METHODS.has(c.req.method)) {
+    await next();
+    return;
+  }
+  // Only session-cookie auth is forgeable cross-site.
+  if (c.get("authVia") !== "session") {
+    await next();
+    return;
+  }
+
+  const requestHost = new URL(c.req.url).host;
+  const logger = c.get("logger") ?? createLogger({ path: c.req.path, method: c.req.method });
+
+  const origin = c.req.header("Origin");
+  if (origin) {
+    let originHost: string;
+    try {
+      originHost = new URL(origin).host;
+    } catch {
+      logger.warn("CSRF rejected - malformed Origin header", { origin });
+      return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
+    }
+    if (originHost !== requestHost) {
+      logger.warn("CSRF rejected - Origin mismatch", { origin, requestHost });
+      return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
+    }
+    await next();
+    return;
+  }
+
+  const referer = c.req.header("Referer");
+  if (referer) {
+    let refererHost: string;
+    try {
+      refererHost = new URL(referer).host;
+    } catch {
+      logger.warn("CSRF rejected - malformed Referer header", {});
+      return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
+    }
+    if (refererHost !== requestHost) {
+      logger.warn("CSRF rejected - Referer mismatch", { requestHost });
+      return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
+    }
+    await next();
+    return;
+  }
+
+  logger.warn("CSRF rejected - no Origin or Referer on session-authenticated mutation", {});
+  return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
+};

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { createAgent, deleteAgent, getAgent, listAgents } from "../storage/agents";
 import { listComments, listReviews } from "../storage/change-reviews";
 import { getChange, listChanges } from "../storage/changes";
 import { getChangeCostSummary } from "../storage/costs";
@@ -17,7 +18,7 @@ import {
   listWorkspaces,
 } from "../storage/state";
 import { getProjectSourceUrl, getSyncStatus } from "../storage/sync";
-import { getUser } from "../storage/users";
+import { getUser, rotateUserToken } from "../storage/users";
 import { listDeliveries, listWebhooks } from "../storage/webhooks";
 import type { Env, ProjectEntry } from "../types";
 import { parseUnifiedDiff } from "../ui/components/diff-view";
@@ -30,6 +31,7 @@ import { HomePage } from "../ui/pages/home";
 import { IssueDetailPage, IssuesPage, NewIssuePage } from "../ui/pages/issues";
 import { NewProjectPage } from "../ui/pages/new-project";
 import { RepoPage } from "../ui/pages/repo";
+import { SettingsPage } from "../ui/pages/settings";
 import { SyncPage } from "../ui/pages/sync";
 import { WebhooksPage } from "../ui/pages/webhooks";
 import { WorkspacesPage } from "../ui/pages/workspaces";
@@ -114,6 +116,98 @@ app.get("/new", async (c) => {
 
   logger.debug("Rendering new project page");
   return c.html(<NewProjectPage user={user} />);
+});
+
+async function loadAgentSummaries(
+  db: D1Database,
+  userId: string,
+  logger: ReturnType<typeof createLogger>,
+): Promise<Array<{ id: string; name: string; model?: string; createdAt: string }>> {
+  const agentsResult = await listAgents(db, userId, logger);
+  if (!agentsResult.success) return [];
+  return agentsResult.data.map((agent) => ({
+    id: agent.id,
+    name: agent.name,
+    ...(agent.model !== undefined ? { model: agent.model } : {}),
+    createdAt: agent.createdAt,
+  }));
+}
+
+// GET /settings — Account, API key, and agent token management
+app.get("/settings", async (c) => {
+  const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
+  const user = await getCurrentUser(c, logger);
+  if (!user) return c.redirect("/auth/email");
+
+  const agents = await loadAgentSummaries(c.env.DB, user.id, logger);
+  return c.html(<SettingsPage user={user} agents={agents} />);
+});
+
+// POST /settings/rotate-token — Rotate the API key; renders the new key once
+app.post("/settings/rotate-token", async (c) => {
+  const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
+  const user = await getCurrentUser(c, logger);
+  if (!user) return c.redirect("/auth/email");
+
+  const rotateResult = await rotateUserToken(c.env.DB, user.id, logger);
+  if (!rotateResult.success) {
+    logger.error("Failed to rotate API key", rotateResult.error);
+    return c.html(issuePageError(500), 500);
+  }
+
+  const agents = await loadAgentSummaries(c.env.DB, user.id, logger);
+  // Rendered in the POST response so the secret never lands in a URL or log.
+  return c.html(
+    <SettingsPage
+      user={user}
+      agents={agents}
+      freshToken={{ kind: "api-key", value: rotateResult.data }}
+    />,
+  );
+});
+
+// POST /settings/agents — Create an agent token; renders it once
+app.post("/settings/agents", async (c) => {
+  const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
+  const user = await getCurrentUser(c, logger);
+  if (!user) return c.redirect("/auth/email");
+
+  const form = await c.req.parseBody();
+  const name = typeof form.name === "string" ? form.name.trim().slice(0, 100) : "";
+  if (!name) return c.html(issuePageError(400), 400);
+  const model =
+    typeof form.model === "string" && form.model.trim()
+      ? form.model.trim().slice(0, 100)
+      : undefined;
+
+  const createResult = await createAgent(c.env.DB, user.id, name, logger, model);
+  if (!createResult.success) {
+    logger.error("Failed to create agent", createResult.error);
+    return c.html(issuePageError(500), 500);
+  }
+
+  const agents = await loadAgentSummaries(c.env.DB, user.id, logger);
+  return c.html(
+    <SettingsPage
+      user={user}
+      agents={agents}
+      freshToken={{ kind: "agent", value: createResult.data.plaintext, agentName: name }}
+    />,
+  );
+});
+
+// POST /settings/agents/:id/delete — Revoke an agent token
+app.post("/settings/agents/:id/delete", async (c) => {
+  const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
+  const user = await getCurrentUser(c, logger);
+  if (!user) return c.redirect("/auth/email");
+
+  const { id } = c.req.param();
+  const agentResult = await getAgent(c.env.DB, id, logger);
+  if (agentResult.success && agentResult.data.ownerId === user.id) {
+    await deleteAgent(c.env.DB, id, logger);
+  }
+  return c.redirect("/settings", 302);
 });
 
 // GET /p/:name — Repo view (files + commit log) - DEPRECATED: Use /:namespace/:slug

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { createUser, getUser, getUserByUsername } from "../storage/users";
+import { createUser, getUser, getUserByUsername, rotateUserToken } from "../storage/users";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
 import { badRequest, created, ok } from "../utils/response";
@@ -60,6 +60,30 @@ app.get("/me", async (c) => {
   logger.debug("User retrieved", { userId });
 
   return ok({ id: user.id, email: user.email, createdAt: user.createdAt });
+});
+
+// POST /api/users/me/rotate-token - Replace the caller's API key
+app.post("/me/rotate-token", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    path: c.req.path,
+    method: c.req.method,
+    userId: c.get("userId"),
+  });
+
+  const userId = c.get("userId");
+  if (!userId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const result = await rotateUserToken(c.env.DB, userId, logger);
+  if (!result.success) {
+    logger.error("Failed to rotate API key", result.error, { userId });
+    return c.json({ error: "Failed to rotate API key" }, 500);
+  }
+
+  // The old key is invalid as of this response; the new one is shown once.
+  return ok({ token: result.data });
 });
 
 // GET /api/users/check-username - Check if username is available

--- a/src/storage/users.ts
+++ b/src/storage/users.ts
@@ -119,6 +119,37 @@ export async function createUser(
   }
 }
 
+/**
+ * Rotate a user's API key: generates a new key and invalidates the old one
+ * in a single update. Returns the new plaintext key — shown once, never stored.
+ */
+export async function rotateUserToken(
+  db: D1Database,
+  userId: string,
+  logger: Logger,
+): Promise<Result<string, AppError>> {
+  try {
+    const plaintext = await generateApiKey("stratum_user");
+    const tokenHash = await hashToken(plaintext);
+
+    const result = await db
+      .prepare("UPDATE users SET token_hash = ? WHERE id = ?")
+      .bind(tokenHash, userId)
+      .run();
+    if (result.meta.changes === 0) {
+      return err(new AppError(`User '${userId}' not found`, "NOT_FOUND", 404, { userId }));
+    }
+
+    logger.info("User API key rotated", { userId });
+    return ok(plaintext);
+  } catch (error) {
+    logger.error("Failed to rotate user token", error instanceof Error ? error : undefined, {
+      userId,
+    });
+    return err(new AppError("Failed to rotate API key", "STORAGE_ERROR", 500, { userId }));
+  }
+}
+
 export async function getUser(
   db: D1Database,
   id: string,

--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -32,6 +32,9 @@ export const Layout: FC<LayoutProps> = ({ title, user, refreshSeconds, children 
             {user ? (
               <>
                 <span class="nav-user">{user.username ?? user.email}</span>
+                <a href="/settings" class="nav-auth-link">
+                  settings
+                </a>
                 <a href="/auth/logout" class="nav-auth-link">
                   logout
                 </a>

--- a/src/ui/pages/settings.tsx
+++ b/src/ui/pages/settings.tsx
@@ -1,0 +1,115 @@
+import type { FC } from "hono/jsx";
+import { Layout } from "../layout";
+
+interface AgentSummary {
+  id: string;
+  name: string;
+  model?: string;
+  createdAt: string;
+}
+
+interface SettingsPageProps {
+  user: { id: string; email: string; username: string };
+  agents: AgentSummary[];
+  /** Freshly created credential, shown exactly once after a rotate/create POST. */
+  freshToken?: { kind: "api-key" | "agent"; value: string; agentName?: string };
+}
+
+export const SettingsPage: FC<SettingsPageProps> = ({ user, agents, freshToken }) => {
+  return (
+    <Layout title="Settings" user={user}>
+      <div class="page-header">
+        <h1>Settings</h1>
+      </div>
+
+      {freshToken && (
+        <div class="card settings-token-reveal">
+          <h3 style={{ marginTop: 0 }}>
+            {freshToken.kind === "api-key"
+              ? "Your new API key"
+              : `Token for agent ${freshToken.agentName ?? ""}`}
+          </h3>
+          <p class="settings-help">
+            Copy it now — it is shown only once.{" "}
+            {freshToken.kind === "api-key" ? "Your previous key no longer works." : ""}
+          </p>
+          <code class="settings-token">{freshToken.value}</code>
+        </div>
+      )}
+
+      <div class="card">
+        <h3 style={{ marginTop: 0 }}>Account</h3>
+        <dl class="detail-list">
+          <dt>Username</dt>
+          <dd>@{user.username}</dd>
+          <dt>Email</dt>
+          <dd>{user.email}</dd>
+        </dl>
+      </div>
+
+      <div class="card">
+        <h3 style={{ marginTop: 0 }}>API key</h3>
+        <p class="settings-help">
+          Used as <code>Authorization: Bearer stratum_user_…</code> for the API and CLI. Rotating
+          invalidates the current key immediately.
+        </p>
+        <form method="post" action="/settings/rotate-token">
+          <button type="submit" class="btn btn-danger">
+            Rotate API key
+          </button>
+        </form>
+      </div>
+
+      <div class="card">
+        <h3 style={{ marginTop: 0 }}>Agents</h3>
+        <p class="settings-help">
+          Agent tokens let automated agents fork workspaces, commit, and open changes under your
+          account. Reviews remain human-only.
+        </p>
+        {agents.length === 0 ? (
+          <p class="settings-help">No agents yet.</p>
+        ) : (
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Model</th>
+                <th>Created</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {agents.map((agent) => (
+                <tr key={agent.id}>
+                  <td>{agent.name}</td>
+                  <td>{agent.model ?? "—"}</td>
+                  <td>{new Date(agent.createdAt).toLocaleDateString()}</td>
+                  <td>
+                    <form method="post" action={`/settings/agents/${agent.id}/delete`}>
+                      <button type="submit" class="btn btn-small btn-danger">
+                        Revoke
+                      </button>
+                    </form>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        <form method="post" action="/settings/agents" class="settings-agent-form">
+          <label>
+            Agent name
+            <input type="text" name="name" required maxlength={100} />
+          </label>
+          <label>
+            Model (optional)
+            <input type="text" name="model" placeholder="claude-sonnet-4-6" maxlength={100} />
+          </label>
+          <button type="submit" class="btn btn-primary">
+            Create agent token
+          </button>
+        </form>
+      </div>
+    </Layout>
+  );
+};

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -551,6 +551,21 @@ a:hover { text-decoration: underline; }
 .diff-del { background: rgba(248, 113, 113, 0.12); color: #f5c2c2; }
 .diff-hunk { color: #7cb7ff; background: #14181f; }
 
+/* Settings */
+.settings-help { font-size: 0.85rem; color: #888; }
+.settings-token-reveal { border: 1px solid #2d4f2d; background: #101a10; }
+.settings-token {
+  display: block; padding: 0.6rem 0.75rem; background: #0d0d0d;
+  border: 1px solid #333; border-radius: 4px; word-break: break-all;
+  font-size: 0.85rem; color: #9ecbff;
+}
+.settings-agent-form { display: flex; flex-direction: column; gap: 0.75rem; max-width: 420px; margin-top: 1rem; }
+.settings-agent-form label { display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.85rem; color: #aaa; }
+.settings-agent-form input {
+  background: #111; border: 1px solid #333; color: #eee;
+  padding: 0.5rem; border-radius: 4px; font-family: inherit;
+}
+
 /* Costs */
 .cost-list { list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #ccc; }
 .cost-list li { padding: 0.2rem 0; }

--- a/tests/csrf.test.ts
+++ b/tests/csrf.test.ts
@@ -1,0 +1,77 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { csrfMiddleware } from "../src/middleware/csrf";
+import type { Env } from "../src/types";
+
+function makeApp(authVia?: "token" | "session") {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", async (c, next) => {
+    if (authVia) c.set("authVia", authVia);
+    await next();
+  });
+  app.use("*", csrfMiddleware);
+  app.post("/mutate", (c) => c.json({ ok: true }));
+  app.get("/read", (c) => c.json({ ok: true }));
+  return app;
+}
+
+const env = {} as Env;
+
+function post(headers: Record<string, string> = {}): Request {
+  return new Request("https://app.example.com/mutate", { method: "POST", headers });
+}
+
+describe("csrfMiddleware", () => {
+  it("allows GET requests regardless of headers", async () => {
+    const app = makeApp("session");
+    const res = await app.fetch(new Request("https://app.example.com/read"), env);
+    expect(res.status).toBe(200);
+  });
+
+  it("allows bearer-token mutations without Origin", async () => {
+    const app = makeApp("token");
+    const res = await app.fetch(post(), env);
+    expect(res.status).toBe(200);
+  });
+
+  it("allows unauthenticated mutations (no session to forge)", async () => {
+    const app = makeApp(undefined);
+    const res = await app.fetch(post(), env);
+    expect(res.status).toBe(200);
+  });
+
+  it("allows session mutations with a same-origin Origin header", async () => {
+    const app = makeApp("session");
+    const res = await app.fetch(post({ Origin: "https://app.example.com" }), env);
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects session mutations from a different origin", async () => {
+    const app = makeApp("session");
+    const res = await app.fetch(post({ Origin: "https://evil.example.net" }), env);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("CSRF");
+  });
+
+  it("falls back to Referer when Origin is absent", async () => {
+    const app = makeApp("session");
+    const ok = await app.fetch(post({ Referer: "https://app.example.com/some/page" }), env);
+    expect(ok.status).toBe(200);
+
+    const bad = await app.fetch(post({ Referer: "https://evil.example.net/attack" }), env);
+    expect(bad.status).toBe(403);
+  });
+
+  it("rejects session mutations with neither Origin nor Referer", async () => {
+    const app = makeApp("session");
+    const res = await app.fetch(post(), env);
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects malformed Origin headers", async () => {
+    const app = makeApp("session");
+    const res = await app.fetch(post({ Origin: "not a url" }), env);
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/token-rotation.test.ts
+++ b/tests/token-rotation.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { getUserByToken, rotateUserToken } from "../src/storage/users";
+import { hashToken } from "../src/utils/crypto";
+import type { Logger } from "../src/utils/logger";
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+interface UserRow {
+  id: string;
+  email: string;
+  username: string;
+  token_hash: string;
+  github_id: string | null;
+  github_username: string | null;
+  created_at: string;
+}
+
+function makeUsersD1(rows: UserRow[]): D1Database {
+  function makeStmt(sql: string, bindings: unknown[]) {
+    const upper = sql.trim().toUpperCase();
+    return {
+      bind: (...args: unknown[]) => makeStmt(sql, args),
+      run: async () => {
+        if (upper.startsWith("UPDATE USERS SET TOKEN_HASH")) {
+          const row = rows.find((r) => r.id === bindings[1]);
+          if (!row) return { success: true, meta: { changes: 0 } };
+          row.token_hash = bindings[0] as string;
+          return { success: true, meta: { changes: 1 } };
+        }
+        return { success: true, meta: { changes: 0 } };
+      },
+      first: async <T>() => {
+        if (upper.includes("WHERE TOKEN_HASH = ?")) {
+          return (rows.find((r) => r.token_hash === bindings[0]) ?? null) as T | null;
+        }
+        if (upper.includes("WHERE ID = ?")) {
+          return (rows.find((r) => r.id === bindings[0]) ?? null) as T | null;
+        }
+        return null;
+      },
+    };
+  }
+  return { prepare: (sql: string) => makeStmt(sql, []) } as unknown as D1Database;
+}
+
+describe("rotateUserToken", () => {
+  it("invalidates the old key and makes the new one resolvable", async () => {
+    const oldPlaintext = "stratum_user_oldoldoldoldoldoldoldold";
+    const rows: UserRow[] = [
+      {
+        id: "usr_1",
+        email: "a@example.com",
+        username: "a",
+        token_hash: await hashToken(oldPlaintext),
+        github_id: null,
+        github_username: null,
+        created_at: "2026-01-01T00:00:00.000Z",
+      },
+    ];
+    const db = makeUsersD1(rows);
+
+    const before = await getUserByToken(db, oldPlaintext, mockLogger);
+    expect(before.success).toBe(true);
+
+    const rotated = await rotateUserToken(db, "usr_1", mockLogger);
+    expect(rotated.success).toBe(true);
+    if (!rotated.success) return;
+    expect(rotated.data).toMatch(/^stratum_user_[0-9a-f]{32}$/);
+    expect(rotated.data).not.toBe(oldPlaintext);
+
+    const oldLookup = await getUserByToken(db, oldPlaintext, mockLogger);
+    expect(oldLookup.success).toBe(false);
+
+    const newLookup = await getUserByToken(db, rotated.data, mockLogger);
+    expect(newLookup.success).toBe(true);
+    if (!newLookup.success) return;
+    expect(newLookup.data.id).toBe("usr_1");
+  });
+
+  it("returns NOT_FOUND for unknown users", async () => {
+    const db = makeUsersD1([]);
+    const result = await rotateUserToken(db, "usr_ghost", mockLogger);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+});


### PR DESCRIPTION
## Summary

Auth hardening from the master plan's Phase 4 security list and the project TODO:

- **CSRF middleware**: POST/PUT/PATCH/DELETE requests authenticated via the session cookie must present a same-origin `Origin` header (`Referer` fallback; neither → 403 `CSRF`). Defense-in-depth over the existing `SameSite=Lax` cookie. Bearer-token and unauthenticated requests are exempt — there's nothing to forge. Auth middleware now records `authVia: token|session` to scope the check precisely.
- **API key rotation**: `rotateUserToken` swaps the stored hash atomically (404 on unknown user); exposed as `POST /api/users/me/rotate-token` and from the settings page.
- **Settings UI** (`/settings`, linked from the nav): account info, rotate-API-key, and agent token management (create with name/model, revoke — ownership-checked). Fresh secrets render once in the POST response body, never in URLs, redirects, or logs.

## Testing

- 10 new tests: CSRF allow/deny matrix (GET, bearer, unauthenticated, same-origin, cross-origin, Referer fallback, missing headers, malformed Origin), rotation round-trip (old key dies, new key resolves), unknown-user rotation
- Full suite: 715 passing; lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)