### PR TITLE
feat: audit logging for sensitive operations (Phase 4)

### DIFF
--- a/migrations/022_audit_log.sql
+++ b/migrations/022_audit_log.sql
@@ -1,0 +1,18 @@
+-- Append-only audit trail for sensitive operations: authentication,
+-- credential lifecycle, webhook configuration, and forced merges.
+
+CREATE TABLE IF NOT EXISTS audit_log (
+  id TEXT PRIMARY KEY,
+  action TEXT NOT NULL,
+  actor_type TEXT NOT NULL CHECK(actor_type IN ('user','agent','system')),
+  actor_id TEXT,
+  subject TEXT,
+  detail TEXT NOT NULL DEFAULT '{}',
+  created_at DATETIME NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_created ON audit_log(created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_actor ON audit_log(actor_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_log(action, created_at DESC);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import type { EventQueueMessage } from "./queue/events";
 import { handleImportQueue } from "./queue/import-queue";
 import { runTtlSweep } from "./queue/ttl-sweep";
 import { agentsRouter } from "./routes/agents";
+import { auditRouter } from "./routes/audit";
 import { authRouter } from "./routes/auth";
 import { bulkImportRouter } from "./routes/bulk-import";
 import { changesRouter } from "./routes/changes";
@@ -110,6 +111,9 @@ app.route("/api/health", healthRouter);
 
 // Admin metrics endpoint
 app.route("/api/admin/metrics", metricsRouter);
+
+// Admin audit trail endpoint
+app.route("/api/admin/audit", auditRouter);
 
 // Redirects from old /ui/* URLs to new paths (backward compatibility)
 app.get("/ui", (c) => c.redirect("/", 301));

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { createAgent, deleteAgent, getAgent, listAgents } from "../storage/agents";
+import { recordAudit } from "../storage/audit";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
 import { badRequest, created, ok } from "../utils/response";
@@ -51,6 +52,13 @@ app.post("/", async (c) => {
 
   const { agent, plaintext } = result.data;
   logger.info("Agent created", { agentId: agent.id, userId });
+  await recordAudit(c.env.DB, logger, {
+    action: "agent.created",
+    actorType: "user",
+    actorId: userId,
+    subject: agent.id,
+    detail: { name: agent.name },
+  });
 
   return created({
     agent: {
@@ -176,6 +184,13 @@ app.delete("/:id", async (c) => {
     logger.error("Failed to delete agent", deleteResult.error, { agentId: id });
     return c.json({ error: "Failed to delete agent" }, 500);
   }
+
+  await recordAudit(c.env.DB, logger, {
+    action: "agent.revoked",
+    actorType: "user",
+    actorId: userId,
+    subject: id,
+  });
 
   logger.info("Agent deleted", { agentId: id, userId });
   return ok({ deleted: true, id });

--- a/src/routes/audit.ts
+++ b/src/routes/audit.ts
@@ -1,0 +1,48 @@
+import { Hono } from "hono";
+import { listAuditLog } from "../storage/audit";
+import type { Env } from "../types";
+import { isAdminRequest } from "../utils/admin";
+import { createLogger } from "../utils/logger";
+import { forbidden, internalError, ok } from "../utils/response";
+
+const app = new Hono<{ Bindings: Env }>();
+
+// GET /api/admin/audit — Query the audit trail (admins only)
+app.get("/", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const isAdmin = await isAdminRequest(
+    c.env,
+    {
+      ...(c.req.header("X-Admin-API-Key") !== undefined
+        ? { adminApiKeyHeader: c.req.header("X-Admin-API-Key") }
+        : {}),
+      ...(c.get("userId") !== undefined ? { userId: c.get("userId") } : {}),
+    },
+    logger,
+  );
+  if (!isAdmin) return forbidden("Administrator access required");
+
+  const action = c.req.query("action");
+  const actorId = c.req.query("actor");
+  const limitParam = Number(c.req.query("limit"));
+  const limit = Number.isInteger(limitParam) && limitParam > 0 ? limitParam : undefined;
+
+  const result = await listAuditLog(c.env.DB, logger, {
+    ...(action !== undefined ? { action } : {}),
+    ...(actorId !== undefined ? { actorId } : {}),
+    ...(limit !== undefined ? { limit } : {}),
+  });
+  if (!result.success) {
+    return internalError(result.error.message);
+  }
+
+  return ok({ entries: result.data });
+});
+
+export { app as auditRouter };

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { recordAudit } from "../storage/audit";
 import { createSession, deleteSession, getSession } from "../storage/sessions";
 import { upsertGitHubUser } from "../storage/users";
 import type { Env } from "../types";
@@ -159,6 +160,14 @@ app.get("/github/callback", async (c) => {
   const sessionLogger = logger.child({ userId: user.id });
 
   const sessionResult = await createSession(c.env.DB, user.id, sessionLogger);
+  if (sessionResult.success) {
+    await recordAudit(c.env.DB, sessionLogger, {
+      action: "session.created",
+      actorType: "user",
+      actorId: user.id,
+      detail: { method: "github-oauth" },
+    });
+  }
   if (!sessionResult.success) {
     sessionLogger.error("Failed to create session");
     return c.json({ error: "Failed to create session" }, 500);

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -14,6 +14,7 @@ import { runPostMergeCheck } from "../merge/post-merge";
 import { checkMergeProtection } from "../merge/protection";
 import { type EventActor, emitEvent } from "../queue/events";
 import type { MergeOutcome } from "../queue/merge-queue";
+import { recordAudit } from "../storage/audit";
 import { createChange, getChange, listChanges, updateChangeStatus } from "../storage/changes";
 import { type CostSample, getChangeCostSummary, recordCosts } from "../storage/costs";
 import { listEvalRuns, recordEvalRuns } from "../storage/eval-runs";
@@ -519,6 +520,16 @@ app.post("/changes/:id/merge", async (c) => {
       commit: result.commit,
     });
 
+    if (force) {
+      await recordAudit(c.env.DB, logger, {
+        action: "merge.forced",
+        actorType: "user",
+        actorId: userId,
+        subject: id,
+        detail: { project: change.project },
+      });
+    }
+
     const postMergeViaQueue = result.commit
       ? await runPostMergeCheck(
           c.env,
@@ -638,6 +649,16 @@ app.post("/changes/:id/merge", async (c) => {
     workspace: change.workspace,
     commit,
   });
+
+  if (force) {
+    await recordAudit(c.env.DB, logger, {
+      action: "merge.forced",
+      actorType: "user",
+      actorId: userId,
+      subject: id,
+      detail: { project: change.project },
+    });
+  }
 
   const postMerge = await runPostMergeCheck(
     c.env,

--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { getMagicLinkEmail } from "../email/templates";
+import { recordAudit } from "../storage/audit";
 import { createSession } from "../storage/sessions";
 import { createUser, getUserByEmail, getUserByUsername } from "../storage/users";
 import type { Env } from "../types";
@@ -696,6 +697,14 @@ async function createSessionAndRedirect(
 ): Promise<Response> {
   const sessionLogger = logger.child({ userId });
   const sessionResult = await createSession(c.env.DB, userId, sessionLogger, rememberMe);
+  if (sessionResult.success) {
+    await recordAudit(c.env.DB, sessionLogger, {
+      action: "session.created",
+      actorType: "user",
+      actorId: userId,
+      detail: { method: "magic-link" },
+    });
+  }
 
   if (!sessionResult.success) {
     sessionLogger.error("Failed to create session");

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -6,36 +6,28 @@
 import { Hono } from "hono";
 import { getMetricsSummary, getQueueDepth } from "../storage/metrics";
 import type { Env } from "../types";
+import { isAdminRequest } from "../utils/admin";
 import { createLogger } from "../utils/logger";
 import { internalError, ok, unauthorized } from "../utils/response";
 
 const app = new Hono<{ Bindings: Env }>();
 
-/**
- * Simple admin check - can be enhanced with proper role-based access control
- * For now, checks if user is authenticated
- */
 async function isAdmin(c: {
   env: Env;
   req: { header: (name: string) => string | undefined };
   get: <T>(key: string) => T | undefined;
 }): Promise<boolean> {
-  // Check for API key authentication (for service-to-service calls)
-  const apiKey = c.req.header("X-Admin-API-Key");
-  if (apiKey && c.env.ADMIN_API_KEY && apiKey === c.env.ADMIN_API_KEY) {
-    return true;
-  }
-
-  // Check for session-based authentication
-  const userId = c.get("userId");
-  if (!userId) {
-    return false;
-  }
-
-  // TODO: Add proper admin role checking
-  // For now, any authenticated user can view metrics
-  // In production, this should check for admin role
-  return true;
+  const logger = createLogger({ component: "MetricsAdmin" });
+  return isAdminRequest(
+    c.env,
+    {
+      ...(c.req.header("X-Admin-API-Key") !== undefined
+        ? { adminApiKeyHeader: c.req.header("X-Admin-API-Key") }
+        : {}),
+      ...(c.get<string>("userId") !== undefined ? { userId: c.get<string>("userId") } : {}),
+    },
+    logger,
+  );
 }
 
 // GET /api/admin/metrics - Get import metrics dashboard data

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { createAgent, deleteAgent, getAgent, listAgents } from "../storage/agents";
+import { recordAudit } from "../storage/audit";
 import { listComments, listReviews } from "../storage/change-reviews";
 import { getChange, listChanges } from "../storage/changes";
 import { getChangeCostSummary } from "../storage/costs";
@@ -155,6 +156,12 @@ app.post("/settings/rotate-token", async (c) => {
     return c.html(issuePageError(500), 500);
   }
 
+  await recordAudit(c.env.DB, logger, {
+    action: "token.rotated",
+    actorType: "user",
+    actorId: user.id,
+  });
+
   const agents = await loadAgentSummaries(c.env.DB, user.id, logger);
   // Rendered in the POST response so the secret never lands in a URL or log.
   return c.html(
@@ -186,6 +193,14 @@ app.post("/settings/agents", async (c) => {
     return c.html(issuePageError(500), 500);
   }
 
+  await recordAudit(c.env.DB, logger, {
+    action: "agent.created",
+    actorType: "user",
+    actorId: user.id,
+    subject: createResult.data.agent.id,
+    detail: { name },
+  });
+
   const agents = await loadAgentSummaries(c.env.DB, user.id, logger);
   return c.html(
     <SettingsPage
@@ -205,7 +220,15 @@ app.post("/settings/agents/:id/delete", async (c) => {
   const { id } = c.req.param();
   const agentResult = await getAgent(c.env.DB, id, logger);
   if (agentResult.success && agentResult.data.ownerId === user.id) {
-    await deleteAgent(c.env.DB, id, logger);
+    const deleteResult = await deleteAgent(c.env.DB, id, logger);
+    if (deleteResult.success) {
+      await recordAudit(c.env.DB, logger, {
+        action: "agent.revoked",
+        actorType: "user",
+        actorId: user.id,
+        subject: id,
+      });
+    }
   }
   return c.redirect("/settings", 302);
 });

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { recordAudit } from "../storage/audit";
 import { createUser, getUser, getUserByUsername, rotateUserToken } from "../storage/users";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
@@ -81,6 +82,12 @@ app.post("/me/rotate-token", async (c) => {
     logger.error("Failed to rotate API key", result.error, { userId });
     return c.json({ error: "Failed to rotate API key" }, 500);
   }
+
+  await recordAudit(c.env.DB, logger, {
+    action: "token.rotated",
+    actorType: "user",
+    actorId: userId,
+  });
 
   // The old key is invalid as of this response; the new one is shown once.
   return ok({ token: result.data });

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { recordAudit } from "../storage/audit";
 import { getProjectByPath } from "../storage/state";
 import {
   createWebhook,
@@ -130,6 +131,14 @@ app.post("/:namespace/:slug/webhooks", async (c) => {
     return internalError(webhookResult.error.message);
   }
 
+  await recordAudit(c.env.DB, logger, {
+    action: "webhook.created",
+    actorType: "user",
+    actorId: userId,
+    subject: webhookResult.data.id,
+    detail: { project: project.name, url: webhookResult.data.url },
+  });
+
   if (!contentType.includes("application/json")) {
     return c.redirect(`/${project.namespace}/${project.slug}/webhooks`, 302);
   }
@@ -215,6 +224,14 @@ app.post("/:namespace/:slug/webhooks/:id/toggle", async (c) => {
     return internalError(updateResult.error.message);
   }
 
+  await recordAudit(c.env.DB, logger, {
+    action: "webhook.toggled",
+    actorType: "user",
+    actorId: c.get("userId"),
+    subject: id,
+    detail: { project: project.name, active: !webhookResult.data.active },
+  });
+
   const contentType = c.req.header("content-type") ?? "";
   if (!contentType.includes("application/json")) {
     return c.redirect(`/${project.namespace}/${project.slug}/webhooks`, 302);
@@ -248,6 +265,14 @@ app.delete("/:namespace/:slug/webhooks/:id", async (c) => {
     return internalError(deleteResult.error.message);
   }
 
+  await recordAudit(c.env.DB, logger, {
+    action: "webhook.deleted",
+    actorType: "user",
+    actorId: c.get("userId"),
+    subject: id,
+    detail: { project: project.name },
+  });
+
   return ok({ deleted: true, id });
 });
 
@@ -276,6 +301,14 @@ app.post("/:namespace/:slug/webhooks/:id/delete", async (c) => {
   if (!deleteResult.success) {
     return internalError(deleteResult.error.message);
   }
+
+  await recordAudit(c.env.DB, logger, {
+    action: "webhook.deleted",
+    actorType: "user",
+    actorId: c.get("userId"),
+    subject: id,
+    detail: { project: project.name },
+  });
 
   return c.redirect(`/${project.namespace}/${project.slug}/webhooks`, 302);
 });

--- a/src/storage/audit.ts
+++ b/src/storage/audit.ts
@@ -1,0 +1,143 @@
+import { AppError } from "../utils/errors";
+import { newId } from "../utils/ids";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+
+/** Sensitive operations worth an audit trail. */
+export type AuditAction =
+  | "session.created"
+  | "token.rotated"
+  | "agent.created"
+  | "agent.revoked"
+  | "webhook.created"
+  | "webhook.toggled"
+  | "webhook.deleted"
+  | "merge.forced";
+
+export interface AuditEntry {
+  id: string;
+  action: AuditAction | string;
+  actorType: "user" | "agent" | "system";
+  actorId?: string;
+  subject?: string;
+  detail: Record<string, unknown>;
+  createdAt: string;
+}
+
+interface AuditRow {
+  id: string;
+  action: string;
+  actor_type: string;
+  actor_id: string | null;
+  subject: string | null;
+  detail: string;
+  created_at: string;
+}
+
+function rowToEntry(row: AuditRow): AuditEntry {
+  let detail: Record<string, unknown> = {};
+  try {
+    const parsed: unknown = JSON.parse(row.detail);
+    if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      detail = parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Malformed detail renders as empty; the row itself is still useful.
+  }
+  const entry: AuditEntry = {
+    id: row.id,
+    action: row.action,
+    actorType: row.actor_type as AuditEntry["actorType"],
+    detail,
+    createdAt: row.created_at,
+  };
+  if (row.actor_id !== null) entry.actorId = row.actor_id;
+  if (row.subject !== null) entry.subject = row.subject;
+  return entry;
+}
+
+/**
+ * Record an audit entry. Best-effort by contract: failures are logged and
+ * returned, but audited operations must not fail because auditing did.
+ */
+export async function recordAudit(
+  db: D1Database,
+  logger: Logger,
+  opts: {
+    action: AuditAction;
+    actorType: "user" | "agent" | "system";
+    actorId?: string;
+    subject?: string;
+    detail?: Record<string, unknown>;
+  },
+): Promise<Result<void, AppError>> {
+  try {
+    await db
+      .prepare(
+        "INSERT INTO audit_log (id, action, actor_type, actor_id, subject, detail, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .bind(
+        newId("aud"),
+        opts.action,
+        opts.actorType,
+        opts.actorId ?? null,
+        opts.subject ?? null,
+        JSON.stringify(opts.detail ?? {}),
+        new Date().toISOString(),
+      )
+      .run();
+    return ok(undefined);
+  } catch (error) {
+    const appError =
+      error instanceof AppError
+        ? error
+        : new AppError(
+            error instanceof Error ? error.message : "Failed to record audit entry",
+            "DATABASE_ERROR",
+            500,
+            { operation: "recordAudit", action: opts.action },
+          );
+    logger.error("Failed to record audit entry", appError, { action: opts.action });
+    return err(appError);
+  }
+}
+
+export async function listAuditLog(
+  db: D1Database,
+  logger: Logger,
+  opts: { action?: string; actorId?: string; limit?: number } = {},
+): Promise<Result<AuditEntry[], AppError>> {
+  const limit = Math.min(Math.max(opts.limit ?? 100, 1), 500);
+  try {
+    const conditions: string[] = [];
+    const bindings: unknown[] = [];
+    if (opts.action) {
+      conditions.push("action = ?");
+      bindings.push(opts.action);
+    }
+    if (opts.actorId) {
+      conditions.push("actor_id = ?");
+      bindings.push(opts.actorId);
+    }
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    bindings.push(limit);
+
+    const result = await db
+      .prepare(`SELECT * FROM audit_log ${where} ORDER BY created_at DESC LIMIT ?`)
+      .bind(...bindings)
+      .all<AuditRow>();
+    return ok(result.results.map(rowToEntry));
+  } catch (error) {
+    const appError =
+      error instanceof AppError
+        ? error
+        : new AppError(
+            error instanceof Error ? error.message : "Failed to list audit log",
+            "DATABASE_ERROR",
+            500,
+            { operation: "listAuditLog" },
+          );
+    logger.error("Failed to list audit log", appError);
+    return err(appError);
+  }
+}

--- a/src/utils/admin.ts
+++ b/src/utils/admin.ts
@@ -1,0 +1,29 @@
+import { getUser } from "../storage/users";
+import type { Env } from "../types";
+import type { Logger } from "./logger";
+
+/**
+ * Whether the caller is an administrator. Two paths:
+ * - service-to-service: X-Admin-API-Key matching the ADMIN_API_KEY secret
+ * - human: an authenticated user whose email matches the ADMIN_EMAIL secret
+ *
+ * Fails closed when neither secret is configured.
+ */
+export async function isAdminRequest(
+  env: Env,
+  opts: { adminApiKeyHeader?: string; userId?: string },
+  logger: Logger,
+): Promise<boolean> {
+  if (opts.adminApiKeyHeader && env.ADMIN_API_KEY && opts.adminApiKeyHeader === env.ADMIN_API_KEY) {
+    return true;
+  }
+
+  if (opts.userId && env.ADMIN_EMAIL) {
+    const userResult = await getUser(env.DB, opts.userId, logger);
+    if (userResult.success && userResult.data.email === env.ADMIN_EMAIL) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import { listAuditLog, recordAudit } from "../src/storage/audit";
+import type { Env } from "../src/types";
+import { isAdminRequest } from "../src/utils/admin";
+import type { Logger } from "../src/utils/logger";
+
+vi.mock("../src/storage/users", () => ({
+  getUser: vi.fn(),
+}));
+
+import { getUser } from "../src/storage/users";
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+interface AuditRow {
+  id: string;
+  action: string;
+  actor_type: string;
+  actor_id: string | null;
+  subject: string | null;
+  detail: string;
+  created_at: string;
+}
+
+function makeAuditD1(): { db: D1Database; rows: AuditRow[] } {
+  const rows: AuditRow[] = [];
+  function makeStmt(sql: string, bindings: unknown[]) {
+    const upper = sql.trim().toUpperCase();
+    return {
+      bind: (...args: unknown[]) => makeStmt(sql, args),
+      run: async () => {
+        if (upper.startsWith("INSERT INTO AUDIT_LOG")) {
+          rows.push({
+            id: bindings[0] as string,
+            action: bindings[1] as string,
+            actor_type: bindings[2] as string,
+            actor_id: bindings[3] as string | null,
+            subject: bindings[4] as string | null,
+            detail: bindings[5] as string,
+            created_at: bindings[6] as string,
+          });
+        }
+        return { success: true, meta: {} };
+      },
+      all: async <T>() => {
+        let results = [...rows];
+        let bindIndex = 0;
+        if (upper.includes("ACTION = ?")) {
+          const action = bindings[bindIndex++];
+          results = results.filter((r) => r.action === action);
+        }
+        if (upper.includes("ACTOR_ID = ?")) {
+          const actor = bindings[bindIndex++];
+          results = results.filter((r) => r.actor_id === actor);
+        }
+        const limit = bindings[bindIndex] as number;
+        results = results.sort((a, b) => b.created_at.localeCompare(a.created_at)).slice(0, limit);
+        return { results: results as T[], success: true, meta: {} };
+      },
+    };
+  }
+  const db = { prepare: (sql: string) => makeStmt(sql, []) } as unknown as D1Database;
+  return { db, rows };
+}
+
+describe("audit storage", () => {
+  it("records and lists entries with parsed detail", async () => {
+    const { db } = makeAuditD1();
+    await recordAudit(db, mockLogger, {
+      action: "token.rotated",
+      actorType: "user",
+      actorId: "usr_1",
+    });
+    await recordAudit(db, mockLogger, {
+      action: "webhook.created",
+      actorType: "user",
+      actorId: "usr_2",
+      subject: "wh_1",
+      detail: { project: "p", url: "https://example.com" },
+    });
+
+    const all = await listAuditLog(db, mockLogger);
+    expect(all.success).toBe(true);
+    if (!all.success) return;
+    expect(all.data).toHaveLength(2);
+    const webhookEntry = all.data.find((e) => e.action === "webhook.created");
+    expect(webhookEntry?.subject).toBe("wh_1");
+    expect(webhookEntry?.detail).toEqual({ project: "p", url: "https://example.com" });
+  });
+
+  it("filters by action and actor", async () => {
+    const { db } = makeAuditD1();
+    await recordAudit(db, mockLogger, { action: "token.rotated", actorType: "user", actorId: "a" });
+    await recordAudit(db, mockLogger, { action: "agent.created", actorType: "user", actorId: "a" });
+    await recordAudit(db, mockLogger, { action: "token.rotated", actorType: "user", actorId: "b" });
+
+    const byAction = await listAuditLog(db, mockLogger, { action: "token.rotated" });
+    expect(byAction.success && byAction.data).toHaveLength(2);
+
+    const byBoth = await listAuditLog(db, mockLogger, { action: "token.rotated", actorId: "b" });
+    expect(byBoth.success && byBoth.data).toHaveLength(1);
+  });
+
+  it("never throws when the database fails", async () => {
+    const badDb = {
+      prepare: () => {
+        throw new Error("down");
+      },
+    } as unknown as D1Database;
+    const result = await recordAudit(badDb, mockLogger, {
+      action: "token.rotated",
+      actorType: "user",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("isAdminRequest", () => {
+  const baseEnv = { DB: {} as D1Database } as Env;
+
+  it("accepts a matching admin API key", async () => {
+    const env = { ...baseEnv, ADMIN_API_KEY: "sekret" } as Env;
+    expect(await isAdminRequest(env, { adminApiKeyHeader: "sekret" }, mockLogger)).toBe(true);
+    expect(await isAdminRequest(env, { adminApiKeyHeader: "wrong" }, mockLogger)).toBe(false);
+  });
+
+  it("accepts the configured admin user by email", async () => {
+    const env = { ...baseEnv, ADMIN_EMAIL: "admin@example.com" } as Env;
+    vi.mocked(getUser).mockResolvedValueOnce({
+      success: true,
+      data: {
+        id: "usr_admin",
+        email: "admin@example.com",
+        username: "admin",
+        tokenHash: "h",
+        createdAt: "",
+      },
+    });
+    expect(await isAdminRequest(env, { userId: "usr_admin" }, mockLogger)).toBe(true);
+
+    vi.mocked(getUser).mockResolvedValueOnce({
+      success: true,
+      data: {
+        id: "usr_other",
+        email: "other@example.com",
+        username: "other",
+        tokenHash: "h",
+        createdAt: "",
+      },
+    });
+    expect(await isAdminRequest(env, { userId: "usr_other" }, mockLogger)).toBe(false);
+  });
+
+  it("fails closed when no admin secrets are configured", async () => {
+    expect(
+      await isAdminRequest(baseEnv, { adminApiKeyHeader: "x", userId: "usr_1" }, mockLogger),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the audit-logging item from the master plan's Phase 4 hardening list:

- **`audit_log` table** (append-only): action, actor type/id, subject, JSON detail. Recorded actions: `session.created` (magic link + GitHub OAuth), `token.rotated`, `agent.created`/`agent.revoked` (API + settings UI), `webhook.created`/`webhook.toggled`/`webhook.deleted`, `merge.forced`. Recording is best-effort — audited operations never fail because auditing did; entries record only after the underlying operation succeeds.
- **Admin query API**: `GET /api/admin/audit?action=&actor=&limit=` (capped at 500).
- **Real admin gating**: shared `isAdminRequest` — `X-Admin-API-Key` match or authenticated user whose email equals `ADMIN_EMAIL`; fails closed when neither secret is configured. This also replaces the metrics endpoint's flagged placeholder that let **any authenticated user** through.

## Testing

- 6 new tests: record/list round-trip with JSON detail, action/actor filtering, DB-failure containment, admin-key accept/reject, admin-email accept/reject, fail-closed default
- Full suite: 721 passing; lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)