### PR TITLE
feat: Google OAuth (Phase 2.1) + capability docs refresh

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,150 +1,24 @@
-# Stratum TODO List
+# Stratum TODO
 
-## 🔐 Authentication & Authorization
+The master-plan feature roadmap (stratum-master-plan-v2.md, Phases 0–3 plus the
+code-level Phase 4 hardening items) is complete as of 2026-06-11. See
+docs/CURRENT_CAPABILITIES.md for what exists and its limitations.
 
-### 1. Magic Link Authentication (HIGH PRIORITY - ✅ COMPLETE)
-- [x] Research current auth system
-- [x] Create `/auth/email` endpoint to request magic link
-  - [x] Accept email address from user
-  - [x] Generate unique magic link token (32-byte secure random)
-  - [x] Store token in KV with expiration (15 min)
-  - [x] Send email via Cloudflare Email binding
-  - [x] Create email template for magic link (built into endpoint)
-- [x] Create `/auth/email/verify` endpoint to verify magic link
-  - [x] Validate token from URL
-  - [x] Look up user by email or create new user
-  - [x] Create session
-  - [x] Set session cookie
-  - [x] Redirect to dashboard
-- [x] Create `/auth/email` UI page
-  - [x] Email input form
-  - [x] "Check your email" confirmation state
-  - [x] Error handling
-- [x] Add rate limiting for magic link requests (5 per hour per email)
-- [x] Write tests for magic link flow
-- [x] Address CodeRabbit security review comments
-  - [x] Hash email in rate limit key (PII protection)
-  - [x] Add try/catch around rate limit KV read (fail open)
-  - [x] Validate redirect cookie (prevent open redirect)
+## Remaining (operational / scale — master-plan Phase 4, Stratum Cloud)
 
-### 2. Session Management Improvements (✅ COMPLETE)
-- [x] Add session refresh endpoint
-- [x] Implement session invalidation on logout from all devices
-- [x] Add "Remember me" option (30 days vs 1 day session)
-- [x] Add session listing endpoint
-- [x] Add individual session deletion endpoint
-- [x] Write tests for session management
+- [ ] Load testing: 1000+ concurrent workspaces per repo
+- [ ] D1 hot/cold rotation (>30-day data → R2)
+- [ ] Batch merging in the merge queue Durable Object
+- [ ] SSO/SAML
+- [ ] Multi-tenancy and billing for Stratum Cloud
+- [ ] Backup strategy for D1 and Artifacts data
+- [ ] Monitoring dashboard UI (metrics API exists at /api/admin/metrics)
 
-**PR**: #24
+## Engineering debt
 
-## 📧 Email System
-
-### 3. Email Templates (IN PROGRESS)
-- [x] Create HTML email template for magic links
-- [x] Create plain text fallback
-- [x] Style with Stratum branding
-- [x] Dark mode support
-- [x] Mobile responsive
-- [x] Security warning section
-- [ ] Extract other email templates (optional)
-
-## 🎯 Core Features
-
-### 4. Project Import Enhancements (IN PROGRESS)
-- [x] Complete Git sync functionality
-  - [x] Sync UI with progress indicator (already existed)
-  - [x] Sync status/management page
-  - [x] Sync status API endpoints
-  - [x] Conflict resolution UI component
-  - [ ] Conflict resolution API implementation
-  - [ ] Auto-sync on schedule (optional)
-- [ ] Bulk import improvements
-  - [ ] Add UI for bulk import
-  - [ ] Support CSV upload
-  - [ ] Progress tracking for batch jobs
-- [ ] Template system
-  - [ ] Create project from template UI
-  - [ ] Template gallery
-
-### 5. Multi-Provider Support (GitLab/Bitbucket)
-- [ ] Add provider-specific OAuth flows
-- [ ] Add provider icons in UI
-- [ ] Handle provider-specific errors
-
-## 🔍 Observability
-
-### 6. Monitoring Dashboard
-- [ ] Create admin metrics dashboard UI
-- [ ] Add real-time queue depth visualization
-- [ ] Add import success/failure rate charts
-- [ ] Set up alerting thresholds
-
-## 🧪 Testing
-
-### 7. Test Coverage Improvements
-- [ ] Add tests for git provider implementations
-- [ ] Add integration tests for queue processing
-- [ ] Add smoke tests for critical paths
-- [ ] Achieve 80% test coverage
-
-## 🔒 Security
-
-### 8. Security Hardening
-- [ ] Add CSRF protection
-- [ ] Add rate limiting for all endpoints
-- [ ] Implement API key rotation
-- [ ] Add audit logging for sensitive operations
-- [ ] Security headers review
-
-## 📝 Documentation
-
-### 9. Documentation Improvements
-- [ ] API reference with examples
-- [ ] Troubleshooting guide for common errors
-- [ ] Architecture diagrams
-- [ ] Deployment guide for self-hosting
-
-## 🚀 Performance
-
-### 10. Performance Optimizations
-- [ ] Add caching for project listings
-- [ ] Optimize D1 queries with proper indexing
-- [ ] Lazy load git provider implementations
-- [ ] Add CDN caching for static assets
-
-## 🎨 UI/UX
-
-### 11. UI Improvements
-- [ ] Dark mode support
-- [ ] Mobile responsive design
-- [ ] Loading states for all async operations
-- [ ] Error boundary for crash recovery
-- [ ] Keyboard shortcuts
-
-## 🔄 DevOps
-
-### 12. CI/CD Improvements
-- [ ] Add integration tests to PR pipeline
-- [ ] Set up staging environment auto-deploy
-- [ ] Add performance benchmarks
-- [ ] Add bundle size monitoring
-
-## 🐛 Known Issues
-
-### 13. Bug Fixes
-- [ ] Fix TypeScript strict mode errors
-- [ ] Fix race conditions in import cancellation
-- [ ] Handle GitHub API rate limiting gracefully
-- [ ] Fix memory leaks in long-running processes
-
----
-
-## Current Priority
-**FOCUS: Complete magic link authentication**
-
-Next steps:
-1. Implement `/auth/email` request endpoint
-2. Implement `/auth/email/callback` verify endpoint
-3. Create UI pages
-4. Write tests
-5. Create PR (DO NOT MERGE)
+- [ ] Migrate project/workspace identity from KV to D1 (unblocks
+      workspace.deleted events and removes the scan fallback in getProject)
+- [ ] Async evaluation worker (evaluation currently runs synchronously at
+      change creation; fine at current scale)
+- [ ] Per-project team permission grants (currently org-wide)
+- [ ] Publish @stratum/cli and @stratum/agent to npm

--- a/docs/CURRENT_CAPABILITIES.md
+++ b/docs/CURRENT_CAPABILITIES.md
@@ -1,23 +1,74 @@
 # Stratum Current Capabilities
 
-## Implemented now
+Last updated: 2026-06-11 — reflects completion of the master-plan feature roadmap
+(Phases 0–3 plus the code-level Phase 4 hardening items).
 
-- Cloudflare Worker API using Hono, Artifacts, KV, D1, Queues, and a merge Durable Object binding.
-- User and agent API tokens with hashed storage, plus GitHub OAuth session login plumbing.
-- Project creation/import, workspace fork/commit/delete, change creation, evaluation-gated merge, and provenance records.
-- Per-change evaluator evidence for secret scanning, diff checks, webhook checks, LLM checks when AI is configured, and sandbox checks when Sandboxes are configured.
-- Read-only web UI for projects, files, commit logs, workspaces, changes, evaluator evidence, and merge provenance.
+## Core platform
 
-## Not yet production-complete
+- Cloudflare Worker (Hono) on Artifacts, KV, D1, Queues, and a merge Durable Object.
+- Project create/import (GitHub/GitLab/Bitbucket), workspace fork/commit/delete,
+  change creation with synchronous evaluation, evaluation-gated merge, provenance.
+- Project resolution accepts namespace/slug refs, legacy names, and falls back to a
+  scan — the change/review APIs work for all project generations.
+- Org-owned projects: org membership grants read; org owner/admin role or a
+  write/admin team grants write. Agents inherit their owning user's access.
 
-- Project/workspace identity still lives in KV; D1 stores changes and provenance only.
-- Authorization is owner-based and intentionally minimal; org/team permissions are not wired into project access yet.
-- Git operations still run inside the Worker with in-memory repositories.
-- The merge coordinator serializes merges but is not a full async queue with retries or dead-letter behavior.
-- Sandbox execution depends on Cloudflare Sandboxes access and fails closed when the binding is absent.
+## Evaluation & merge pipeline
 
-## Public-copy gap to revisit before early access
+- Evaluators: secret scan (always on, blocking), diff, webhook, LLM (AI binding),
+  sandbox (Sandboxes binding; fails closed when absent). Per-change evaluator
+  evidence and estimated resource costs (LLM tokens, sandbox time, git ops).
+- Branch protection in `.stratum/policy.yaml` (`merge:`): required evaluators
+  (latest run per type), required human approvals, force-merge control, and
+  `requireFreshBase` staleness rejection (409 STALE_BASE).
+- Post-merge smoke command in a sandbox with auto-revert (forward revert commit,
+  change marked `reverted`, `change.reverted` event).
+- Human reviews (approve / request changes) move the change state machine and are
+  human-only; agents cannot approve work.
 
-- The product can support evaluated agent changes, but behavioral artifacts beyond evaluator evidence are not built yet.
-- Provenance tracks agent/change/workspace/commit/evaluation score, but not full prompts, model metadata, or reasoning traces.
-- The UI is a functional review surface, not a full GitHub-class code browser or diff viewer.
+## Events & integrations
+
+- Durable event outbox in D1 → queue consumer with handler registry → 5-minute
+  sweep cron re-enqueues stale events. At-least-once processing.
+- Per-project activity feed (UI + API) over the event stream.
+- Per-project webhooks with HMAC-SHA256-signed deliveries, event filters,
+  delivery log, SSRF-guarded URLs.
+- Issue tracker with per-project numbering and auto-close when a linked change
+  merges. Bidirectional GitHub sync (inbound webhooks, outbound PR promotion).
+
+## Auth & security
+
+- Magic-link email auth, GitHub OAuth, Google OAuth (email-identity model), and
+  API keys; short-lived agent tokens scoped to an owning user.
+- CSRF protection (Origin/Referer enforcement for session-cookie mutations),
+  API key rotation, settings UI for key + agent token management.
+- Append-only audit trail for sensitive operations with an admin query API;
+  admin access requires `ADMIN_API_KEY` or the `ADMIN_EMAIL` user (fails closed).
+- Rate limiting (global + import-specific), secret scanning on every change,
+  workspace TTL sweep.
+
+## UI
+
+- Server-rendered (Hono JSX): dashboard, repo browser with collapsible file tree,
+  syntax-highlighted file viewer (dependency-free lexer), commit log, changes with
+  diff viewer + evaluator evidence + costs + reviews + comments, issues, activity,
+  webhooks management, settings. Open changes poll via meta refresh.
+
+## Tooling
+
+- `cli/` — @stratum/cli at full API parity (projects, workspaces, commits,
+  changes incl. review/merge, issues, activity).
+- `agent/` — @stratum/agent reference agent: identity → fork → Claude edit plan
+  → commit → Change with evaluation.
+
+## Known limitations / future work
+
+- Project/workspace identity lives in KV; changes, issues, events, costs, and
+  audit live in D1. Full identity migration to D1 is future work (so is
+  `workspace.deleted` event emission, blocked on an id→name index).
+- Evaluation runs synchronously at change creation; the event pipeline is async
+  but evaluation itself has no queue worker yet.
+- Team permissions are org-wide; per-project team grants are not implemented.
+- Phase 4 operational items remain: load testing at 1000+ concurrent workspaces,
+  D1 hot/cold rotation, SSO/SAML, multi-tenancy/billing for Stratum Cloud,
+  backup strategy.

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { recordAudit } from "../storage/audit";
 import { createSession, deleteSession, getSession } from "../storage/sessions";
-import { upsertGitHubUser } from "../storage/users";
+import { createUser, getUserByEmail, upsertGitHubUser } from "../storage/users";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
 
@@ -197,6 +197,153 @@ app.get("/github/callback", async (c) => {
   }
 
   return c.redirect(redirectTo);
+});
+
+app.get("/google", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const clientId = c.env.GOOGLE_CLIENT_ID;
+  const redirectUri = c.env.GOOGLE_REDIRECT_URI;
+
+  if (!clientId || !c.env.GOOGLE_CLIENT_SECRET || !redirectUri) {
+    logger.warn("Google OAuth not configured");
+    return c.json({ error: "Google OAuth is not configured" }, 501);
+  }
+
+  const state = crypto.randomUUID().replace(/-/g, "");
+  await c.env.STATE.put(`oauth_state:${state}`, "1", { expirationTtl: 600 });
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: "openid email profile",
+    state,
+  });
+
+  logger.debug("Redirecting to Google OAuth");
+  return c.redirect(`https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`);
+});
+
+app.get("/google/callback", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const clientId = c.env.GOOGLE_CLIENT_ID;
+  const clientSecret = c.env.GOOGLE_CLIENT_SECRET;
+  const redirectUri = c.env.GOOGLE_REDIRECT_URI;
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    logger.warn("Google OAuth not configured");
+    return c.json({ error: "Google OAuth is not configured" }, 501);
+  }
+
+  const { code, state } = c.req.query();
+
+  if (!state) {
+    return c.json({ error: "Missing state parameter" }, 400);
+  }
+  const stateKey = `oauth_state:${state}`;
+  const storedState = await c.env.STATE.get(stateKey);
+  if (!storedState) {
+    logger.warn("Invalid or expired state", { statePrefix: state.slice(0, 8) });
+    return c.json({ error: "Invalid or expired state" }, 400);
+  }
+  await c.env.STATE.delete(stateKey);
+
+  if (!code) {
+    return c.json({ error: "Missing code parameter" }, 400);
+  }
+
+  logger.debug("Exchanging code for Google token");
+  const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      grant_type: "authorization_code",
+      redirect_uri: redirectUri,
+    }),
+  });
+
+  if (!tokenRes.ok) {
+    logger.error("Failed to exchange code for Google token");
+    return c.json({ error: "Failed to exchange code for token" }, 502);
+  }
+
+  const tokenData = await tokenRes.json<{ access_token?: string; error?: string }>();
+  if (!tokenData.access_token) {
+    logger.error("Google OAuth error", undefined, { error: tokenData.error });
+    return c.json({ error: "Google OAuth error" }, 502);
+  }
+
+  const userRes = await fetch("https://www.googleapis.com/oauth2/v3/userinfo", {
+    headers: { Authorization: `Bearer ${tokenData.access_token}` },
+  });
+  if (!userRes.ok) {
+    logger.error("Failed to fetch Google user data");
+    return c.json({ error: "Failed to fetch Google user data" }, 502);
+  }
+
+  const googleUser = await userRes.json<{
+    sub: string;
+    email?: string;
+    email_verified?: boolean;
+  }>();
+
+  if (!googleUser.email || googleUser.email_verified !== true) {
+    logger.warn("Google account has no verified email");
+    return c.json({ error: "No verified email on Google account" }, 422);
+  }
+
+  // Google identity maps onto the email-based account model: an existing
+  // account with this email is reused, otherwise one is created — the same
+  // semantics as magic-link sign-in.
+  const existing = await getUserByEmail(c.env.DB, googleUser.email, logger);
+  let userId: string;
+  if (existing.success) {
+    userId = existing.data.id;
+  } else {
+    const createdResult = await createUser(c.env.DB, googleUser.email, logger);
+    if (!createdResult.success) {
+      logger.error("Failed to create user from Google sign-in", createdResult.error);
+      return c.json({ error: "Failed to create user" }, 500);
+    }
+    userId = createdResult.data.user.id;
+  }
+
+  const sessionLogger = logger.child({ userId });
+  const sessionResult = await createSession(c.env.DB, userId, sessionLogger);
+  if (!sessionResult.success) {
+    sessionLogger.error("Failed to create session");
+    return c.json({ error: "Failed to create session" }, 500);
+  }
+  await recordAudit(c.env.DB, sessionLogger, {
+    action: "session.created",
+    actorType: "user",
+    actorId: userId,
+    detail: { method: "google-oauth" },
+  });
+
+  setCookie(c, "stratum_session", sessionResult.data.id, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "Lax",
+    maxAge: 2592000,
+    path: "/",
+  });
+
+  sessionLogger.info("Google OAuth successful, session created");
+  return c.redirect("/");
 });
 
 app.get("/logout", async (c) => {

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -465,6 +465,22 @@ app.get("/", (c) => {
                   Continue with GitHub
                 </a>
 
+                <a href="/auth/google" class="btn btn-github" style={{ marginTop: "0.5rem" }}>
+                  <svg
+                    style={{ marginRight: "0.5rem" }}
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    role="img"
+                    aria-label="Google"
+                  >
+                    <title>Google</title>
+                    <path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z" />
+                  </svg>
+                  Continue with Google
+                </a>
+
                 <div class="auth-footer">
                   <p class="auth-footer-text">
                     Don't have an account? <a href="/auth/signup">Sign up</a>

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,9 @@ export interface Env {
   STRATUM_TELEMETRY_DISABLED?: string;
   GITHUB_CLIENT_ID?: string;
   GITHUB_CLIENT_SECRET?: string;
+  GOOGLE_CLIENT_ID?: string;
+  GOOGLE_CLIENT_SECRET?: string;
+  GOOGLE_REDIRECT_URI?: string;
   GITHUB_WEBHOOK_SECRET?: string;
   OAUTH_REDIRECT_URI?: string;
   // Git provider API tokens for sync

--- a/tests/google-oauth.test.ts
+++ b/tests/google-oauth.test.ts
@@ -1,0 +1,201 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { authRouter } from "../src/routes/auth";
+import type { Env } from "../src/types";
+
+vi.mock("../src/storage/users", () => ({
+  createUser: vi.fn(),
+  getUserByEmail: vi.fn(),
+  upsertGitHubUser: vi.fn(),
+}));
+
+vi.mock("../src/storage/sessions", () => ({
+  createSession: vi.fn(),
+  deleteSession: vi.fn(),
+  getSession: vi.fn(),
+}));
+
+vi.mock("../src/storage/audit", () => ({
+  recordAudit: vi.fn().mockResolvedValue({ success: true, data: undefined }),
+}));
+
+import { createSession } from "../src/storage/sessions";
+import { createUser, getUserByEmail } from "../src/storage/users";
+
+const fetchMock = vi.fn();
+
+function makeApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.route("/auth", authRouter);
+  return app;
+}
+
+function makeKv(initial: Record<string, string> = {}): KVNamespace {
+  const store = new Map(Object.entries(initial));
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+  } as unknown as KVNamespace;
+}
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    ARTIFACTS: {} as Env["ARTIFACTS"],
+    STATE: makeKv(),
+    DB: {} as D1Database,
+    GOOGLE_CLIENT_ID: "google-client",
+    GOOGLE_CLIENT_SECRET: "google-secret",
+    GOOGLE_REDIRECT_URI: "https://app.example.com/auth/google/callback",
+    ...overrides,
+  } as Env;
+}
+
+describe("Google OAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 501 when not configured", async () => {
+    const app = makeApp();
+    const env = makeEnv({ GOOGLE_CLIENT_ID: undefined });
+    const res = await app.fetch(new Request("http://localhost/auth/google"), env);
+    expect(res.status).toBe(501);
+  });
+
+  it("redirects to Google with a stored state", async () => {
+    const app = makeApp();
+    const env = makeEnv();
+    const res = await app.fetch(new Request("http://localhost/auth/google"), env);
+    expect(res.status).toBe(302);
+    const location = res.headers.get("Location") ?? "";
+    expect(location).toContain("https://accounts.google.com/o/oauth2/v2/auth");
+    expect(location).toContain("client_id=google-client");
+    expect(location).toContain("scope=openid+email+profile");
+  });
+
+  it("rejects callbacks with an unknown state", async () => {
+    const app = makeApp();
+    const env = makeEnv();
+    const res = await app.fetch(
+      new Request("http://localhost/auth/google/callback?code=x&state=forged"),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a session for a verified Google account", async () => {
+    const app = makeApp();
+    const env = makeEnv({ STATE: makeKv({ "oauth_state:goodstate": "1" }) });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith("https://oauth2.googleapis.com/token")) {
+        return new Response(JSON.stringify({ access_token: "google-token" }), { status: 200 });
+      }
+      if (url.startsWith("https://www.googleapis.com/oauth2/v3/userinfo")) {
+        return new Response(
+          JSON.stringify({ sub: "g-123", email: "user@example.com", email_verified: true }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.mocked(getUserByEmail).mockResolvedValue({
+      success: true,
+      data: {
+        id: "usr_1",
+        email: "user@example.com",
+        username: "user",
+        tokenHash: "h",
+        createdAt: "",
+      },
+    });
+    vi.mocked(createSession).mockResolvedValue({
+      success: true,
+      data: { id: "sess_1", userId: "usr_1", expiresAt: "2099-01-01T00:00:00.000Z" },
+    });
+
+    const res = await app.fetch(
+      new Request("http://localhost/auth/google/callback?code=ok&state=goodstate"),
+      env,
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Set-Cookie")).toContain("stratum_session=sess_1");
+    expect(createUser).not.toHaveBeenCalled();
+  });
+
+  it("creates a new account when the email is unknown", async () => {
+    const app = makeApp();
+    const env = makeEnv({ STATE: makeKv({ "oauth_state:goodstate": "1" }) });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith("https://oauth2.googleapis.com/token")) {
+        return new Response(JSON.stringify({ access_token: "google-token" }), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({ sub: "g-9", email: "new@example.com", email_verified: true }),
+        { status: 200 },
+      );
+    });
+
+    vi.mocked(getUserByEmail).mockResolvedValue({
+      success: false,
+      error: new Error("not found") as never,
+    });
+    vi.mocked(createUser).mockResolvedValue({
+      success: true,
+      data: {
+        user: {
+          id: "usr_new",
+          email: "new@example.com",
+          username: "new",
+          tokenHash: "h",
+          createdAt: "",
+        },
+        plaintext: "stratum_user_x",
+      },
+    });
+    vi.mocked(createSession).mockResolvedValue({
+      success: true,
+      data: { id: "sess_2", userId: "usr_new", expiresAt: "2099-01-01T00:00:00.000Z" },
+    });
+
+    const res = await app.fetch(
+      new Request("http://localhost/auth/google/callback?code=ok&state=goodstate"),
+      env,
+    );
+    expect(res.status).toBe(302);
+    expect(createUser).toHaveBeenCalledWith(env.DB, "new@example.com", expect.any(Object));
+  });
+
+  it("rejects unverified Google emails", async () => {
+    const app = makeApp();
+    const env = makeEnv({ STATE: makeKv({ "oauth_state:goodstate": "1" }) });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith("https://oauth2.googleapis.com/token")) {
+        return new Response(JSON.stringify({ access_token: "google-token" }), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({ sub: "g-1", email: "x@example.com", email_verified: false }),
+        { status: 200 },
+      );
+    });
+
+    const res = await app.fetch(
+      new Request("http://localhost/auth/google/callback?code=ok&state=goodstate"),
+      env,
+    );
+    expect(res.status).toBe(422);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -77,6 +77,9 @@ name = "EMAIL"
 # STRATUM_TELEMETRY_DISABLED = "true"  # uncomment to disable telemetry for self-hosted
 # GITHUB_CLIENT_ID =
 # GITHUB_CLIENT_SECRET =
+# GOOGLE_CLIENT_ID =
+# GOOGLE_CLIENT_SECRET =
+# GOOGLE_REDIRECT_URI = "https://yourdomain.com/auth/google/callback"
 # EMAIL_FROM_ADDRESS = "noreply@yourdomain.com"  # for magic link emails
 
 # Staging environment


### PR DESCRIPTION
## Summary

Closes the last feature gap in the master plan:

- **Google OAuth** (`/auth/google` + callback): KV-stored state with 10-minute TTL, form-encoded token exchange, `email_verified` required (422 otherwise), 501 when unconfigured. Identity maps by email — an existing account with the same address is reused, matching magic-link semantics, so no schema change. Sessions audited as `session.created {method: google-oauth}`. Login page gains the button; wrangler.toml documents the new secrets.
- **Docs**: `TODO.md` and `docs/CURRENT_CAPABILITIES.md` were a year of drift behind the code — both rewritten to describe the shipped platform, its known limitations, and the remaining Phase 4 operational items (load testing, SSO/SAML, billing, D1 rotation).

## Testing

- 6 new tests: unconfigured 501, authorize redirect shape, forged-state rejection, existing-account session, new-account creation, unverified-email rejection
- Full suite: 731 passing; lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)