### PR TITLE
fix: packages CI job — local vitest configs + run on PRs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,6 +10,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  packages:
+    name: CLI & Agent Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: CLI — install, typecheck, test, build
+        working-directory: cli
+        run: |
+          npm install
+          npm run typecheck
+          npm test
+          npm run build
+
+      - name: Agent — install, typecheck, test, build
+        working-directory: agent
+        run: |
+          npm install
+          npm run typecheck
+          npm test
+          npm run build
+
   # ========================================================================
   # Code Quality Checks
   # ========================================================================

--- a/agent/vitest.config.ts
+++ b/agent/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+// Without a local config, vitest climbs to the repo root and loads the
+// Worker's vitest.config.ts — which needs the root node_modules that the
+// packages CI job doesn't install.
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+// Without a local config, vitest climbs to the repo root and loads the
+// Worker's vitest.config.ts — which needs the root node_modules that the
+// packages CI job doesn't install.
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
The `packages` job added in #76 failed on main: `vitest run` inside `cli/`/`agent/` climbs to the repo root and loads the Worker's `vitest.config.ts`, which needs the root `node_modules` the job doesn't install. Each package now has its own minimal vitest config, and the job also runs in PR checks so this class of failure surfaces before merge.

Verified locally in both packages; main suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)