### PR TITLE
fix: bind OAuth state to the initiating browser (login CSRF)

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -8,6 +8,61 @@ import { createLogger } from "../utils/logger";
 
 const app = new Hono<{ Bindings: Env }>();
 
+const OAUTH_STATE_COOKIE = "stratum_oauth_state";
+const OAUTH_STATE_TTL_SECONDS = 600;
+
+/** Constant-time string equality — OAuth state values are attacker-influenced. */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/**
+ * Mint an OAuth state, persist it in KV (replay prevention), and bind it to
+ * the initiating browser via a short-lived cookie (login-CSRF prevention).
+ */
+async function issueOAuthState(
+  c: Parameters<typeof setCookie>[0],
+  kv: KVNamespace,
+): Promise<string> {
+  const state = crypto.randomUUID().replace(/-/g, "");
+  await kv.put(`oauth_state:${state}`, "1", { expirationTtl: OAUTH_STATE_TTL_SECONDS });
+  setCookie(c, OAUTH_STATE_COOKIE, state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "Lax",
+    maxAge: OAUTH_STATE_TTL_SECONDS,
+    path: "/auth",
+  });
+  return state;
+}
+
+/**
+ * Validate a callback's state: it must match the browser's state cookie
+ * (constant-time) AND exist in KV. Consumes both on success.
+ */
+async function consumeOAuthState(
+  c: Parameters<typeof getCookie>[0] & Parameters<typeof deleteCookie>[0],
+  kv: KVNamespace,
+  state: string,
+): Promise<boolean> {
+  const cookieState = getCookie(c, OAUTH_STATE_COOKIE);
+  if (!cookieState || !timingSafeEqual(cookieState, state)) {
+    return false;
+  }
+  deleteCookie(c, OAUTH_STATE_COOKIE, { path: "/auth" });
+
+  const stateKey = `oauth_state:${state}`;
+  const stored = await kv.get(stateKey);
+  if (!stored) return false;
+  await kv.delete(stateKey);
+  return true;
+}
+
 app.get("/github", async (c) => {
   const logger = createLogger({
     requestId: crypto.randomUUID(),
@@ -23,8 +78,7 @@ app.get("/github", async (c) => {
     return c.json({ error: "GitHub OAuth is not configured" }, 501);
   }
 
-  const state = crypto.randomUUID().replace(/-/g, "");
-  await c.env.STATE.put(`oauth_state:${state}`, "1", { expirationTtl: 600 });
+  const state = await issueOAuthState(c, c.env.STATE);
 
   const params = new URLSearchParams({
     client_id: clientId,
@@ -60,13 +114,10 @@ app.get("/github/callback", async (c) => {
     return c.json({ error: "Missing state parameter" }, 400);
   }
 
-  const stateKey = `oauth_state:${state}`;
-  const storedState = await c.env.STATE.get(stateKey);
-  if (!storedState) {
-    logger.warn("Invalid or expired state", { statePrefix: state.slice(0, 8) });
+  if (!(await consumeOAuthState(c, c.env.STATE, state))) {
+    logger.warn("Invalid, expired, or unbound state", { statePrefix: state.slice(0, 8) });
     return c.json({ error: "Invalid or expired state" }, 400);
   }
-  await c.env.STATE.delete(stateKey);
 
   if (!code) {
     logger.warn("Missing code parameter");
@@ -214,8 +265,7 @@ app.get("/google", async (c) => {
     return c.json({ error: "Google OAuth is not configured" }, 501);
   }
 
-  const state = crypto.randomUUID().replace(/-/g, "");
-  await c.env.STATE.put(`oauth_state:${state}`, "1", { expirationTtl: 600 });
+  const state = await issueOAuthState(c, c.env.STATE);
 
   const params = new URLSearchParams({
     client_id: clientId,
@@ -250,13 +300,10 @@ app.get("/google/callback", async (c) => {
   if (!state) {
     return c.json({ error: "Missing state parameter" }, 400);
   }
-  const stateKey = `oauth_state:${state}`;
-  const storedState = await c.env.STATE.get(stateKey);
-  if (!storedState) {
-    logger.warn("Invalid or expired state", { statePrefix: state.slice(0, 8) });
+  if (!(await consumeOAuthState(c, c.env.STATE, state))) {
+    logger.warn("Invalid, expired, or unbound state", { statePrefix: state.slice(0, 8) });
     return c.json({ error: "Invalid or expired state" }, 400);
   }
-  await c.env.STATE.delete(stateKey);
 
   if (!code) {
     return c.json({ error: "Missing code parameter" }, 400);

--- a/tests/auth-signup-login.test.ts
+++ b/tests/auth-signup-login.test.ts
@@ -1221,7 +1221,9 @@ describe("Auth Signup/Login Integration Tests", () => {
       await env.STATE.put(`oauth_state:${state}`, "1", { expirationTtl: 600 });
 
       const res = await app.fetch(
-        request(`/auth/github/callback?code=test-code&state=${state}`),
+        request(`/auth/github/callback?code=test-code&state=${state}`, {
+          headers: { Cookie: `stratum_oauth_state=${state}` },
+        }),
         env,
       );
 
@@ -1242,11 +1244,42 @@ describe("Auth Signup/Login Integration Tests", () => {
       expect(body.error).toContain("Invalid or expired state");
     });
 
+    it("rejects a known state when the browser cookie is missing (login CSRF)", async () => {
+      const state = "test-state-csrf";
+      await env.STATE.put(`oauth_state:${state}`, "1", { expirationTtl: 600 });
+
+      const res = await app.fetch(
+        request(`/auth/github/callback?code=test-code&state=${state}`),
+        env,
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects when the cookie state does not match the query state", async () => {
+      const state = "test-state-mismatch";
+      await env.STATE.put(`oauth_state:${state}`, "1", { expirationTtl: 600 });
+
+      const res = await app.fetch(
+        request(`/auth/github/callback?code=test-code&state=${state}`, {
+          headers: { Cookie: "stratum_oauth_state=other-state-value" },
+        }),
+        env,
+      );
+
+      expect(res.status).toBe(400);
+    });
+
     it("rejects missing code parameter", async () => {
       const state = "test-state-456";
       await env.STATE.put(`oauth_state:${state}`, "1", { expirationTtl: 600 });
 
-      const res = await app.fetch(request(`/auth/github/callback?state=${state}`), env);
+      const res = await app.fetch(
+        request(`/auth/github/callback?state=${state}`, {
+          headers: { Cookie: `stratum_oauth_state=${state}` },
+        }),
+        env,
+      );
 
       expect(res.status).toBe(400);
       const body = (await res.json()) as { error: string };

--- a/tests/google-oauth.test.ts
+++ b/tests/google-oauth.test.ts
@@ -83,6 +83,16 @@ describe("Google OAuth", () => {
     expect(location).toContain("scope=openid+email+profile");
   });
 
+  it("rejects a known state without the binding cookie (login CSRF)", async () => {
+    const app = makeApp();
+    const env = makeEnv({ STATE: makeKv({ "oauth_state:goodstate": "1" }) });
+    const res = await app.fetch(
+      new Request("http://localhost/auth/google/callback?code=ok&state=goodstate"),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("rejects callbacks with an unknown state", async () => {
     const app = makeApp();
     const env = makeEnv();
@@ -126,7 +136,9 @@ describe("Google OAuth", () => {
     });
 
     const res = await app.fetch(
-      new Request("http://localhost/auth/google/callback?code=ok&state=goodstate"),
+      new Request("http://localhost/auth/google/callback?code=ok&state=goodstate", {
+        headers: { Cookie: "stratum_oauth_state=goodstate" },
+      }),
       env,
     );
     expect(res.status).toBe(302);
@@ -171,7 +183,9 @@ describe("Google OAuth", () => {
     });
 
     const res = await app.fetch(
-      new Request("http://localhost/auth/google/callback?code=ok&state=goodstate"),
+      new Request("http://localhost/auth/google/callback?code=ok&state=goodstate", {
+        headers: { Cookie: "stratum_oauth_state=goodstate" },
+      }),
       env,
     );
     expect(res.status).toBe(302);
@@ -193,7 +207,9 @@ describe("Google OAuth", () => {
     });
 
     const res = await app.fetch(
-      new Request("http://localhost/auth/google/callback?code=ok&state=goodstate"),
+      new Request("http://localhost/auth/google/callback?code=ok&state=goodstate", {
+        headers: { Cookie: "stratum_oauth_state=goodstate" },
+      }),
       env,
     );
     expect(res.status).toBe(422);


### PR DESCRIPTION
Security fix flagged by automated review: OAuth `state` was validated only against KV, so any server-minted state passed regardless of which browser presented it — an attacker could complete their own OAuth flow inside a victim's browser (login CSRF), logging the victim into the attacker's account.

Both GitHub and Google flows now set a short-lived (`600s`) `Secure; HttpOnly; SameSite=Lax` state cookie scoped to `/auth`; callbacks require a **constant-time** match between cookie and query state before consuming the KV entry (which still prevents replay). Shared `issueOAuthState`/`consumeOAuthState` helpers keep the two flows identical.

New tests: known-KV-state without the cookie rejected (the CSRF case), cookie/query mismatch rejected, happy paths updated to carry the cookie. Full suite: 734 passing; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)