### PR TITLE
fix: API route shadowing, namespaced change creation, form-post redirects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,6 @@ app.route("/auth/email", emailAuthRouter);
 app.route("/auth/login", loginRouter);
 app.route("/auth/signup", signupRouter);
 app.route("/auth/sessions", sessionRouter);
-app.route("/", uiRouter); // Mount UI at root
 app.route("/api/projects", webhooksRouter);
 app.route("/api/projects", issuesRouter);
 app.route("/api/projects", projectsRouter);
@@ -154,6 +153,9 @@ app.route("/api", syncRouter);
 app.route("/api", syncManagementRouter);
 app.route("/api/bulk-import", bulkImportRouter);
 app.route("/api/webhooks/github", githubWebhookRouter);
+// Mount the UI router last: its /:namespace/:slug catch-all would otherwise
+// shadow two-segment API paths like GET /api/projects.
+app.route("/", uiRouter);
 
 app.notFound((c) => c.json({ error: "Not found" }, 404));
 app.onError((err, c) => {

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import {
   CompositeEvaluator,
   DiffEvaluator,
@@ -43,6 +43,22 @@ function parseGitHubRepo(url: string): { owner: string; repo: string } | null {
 }
 
 const MERGEABLE_STATUSES: Change["status"][] = ["approved", "accepted", "promoted"];
+
+/**
+ * Success response for endpoints that the change-detail UI posts to with plain HTML forms.
+ * Browsers send a form content type; API/CLI/agent callers send JSON or no body at all,
+ * so only form posts are redirected back to the change page.
+ */
+function okOrFormRedirect<T>(c: Context<{ Bindings: Env }>, changeId: string, data: T): Response {
+  const contentType = c.req.header("content-type") ?? "";
+  if (
+    contentType.includes("application/x-www-form-urlencoded") ||
+    contentType.includes("multipart/form-data")
+  ) {
+    return c.redirect(`/changes/${changeId}`, 302);
+  }
+  return ok(data);
+}
 
 /** Current project HEAD: cheap KV snapshot first, single-commit clone as fallback. */
 async function resolveProjectHead(
@@ -123,7 +139,9 @@ app.post("/projects/:name/changes", async (c) => {
   }
   const workspace = workspaceResult.data;
 
-  if (workspace.parent !== projectName) {
+  // Workspaces created via the namespaced API store the project id in `parent`;
+  // legacy workspaces stored the project name.
+  if (workspace.parent !== project.id && workspace.parent !== projectName) {
     return badRequest(`Workspace '${body.workspace}' does not belong to project '${projectName}'`);
   }
 
@@ -539,7 +557,7 @@ app.post("/changes/:id/merge", async (c) => {
         )
       : { status: "skipped" as const };
 
-    return ok({
+    return okOrFormRedirect(c, id, {
       merged: true,
       changeId: id,
       project: change.project,
@@ -667,7 +685,7 @@ app.post("/changes/:id/merge", async (c) => {
     logger,
   );
 
-  return ok({
+  return okOrFormRedirect(c, id, {
     merged: true,
     changeId: id,
     project: change.project,
@@ -736,7 +754,7 @@ app.post("/changes/:id/reject", async (c) => {
   );
 
   logger.info("Change rejected", { changeId: id, project: change.project });
-  return ok({ rejected: true, changeId: id });
+  return okOrFormRedirect(c, id, { rejected: true, changeId: id });
 });
 
 app.post("/changes/:id/evaluate", async (c) => {
@@ -911,7 +929,7 @@ app.post("/changes/:id/evaluate", async (c) => {
     evalScore: evalResult.score,
     passed: evalResult.passed,
   });
-  return ok({ changeId: id, eval: evalResult, evalRuns: recordResult.data });
+  return okOrFormRedirect(c, id, { changeId: id, eval: evalResult, evalRuns: recordResult.data });
 });
 
 app.post("/changes/:id/github-pr", async (c) => {
@@ -1013,7 +1031,7 @@ app.post("/changes/:id/github-pr", async (c) => {
     prNumber: pr.number,
     repo: `${repo.owner}/${repo.repo}`,
   });
-  return ok({
+  return okOrFormRedirect(c, id, {
     changeId: id,
     github: {
       owner: repo.owner,

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -550,6 +550,19 @@ describe("POST /api/projects/:name/changes", () => {
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("does not belong to project");
   });
+
+  it("accepts a workspace whose parent stores the project id", async () => {
+    // Workspaces created via the namespaced API store the project id, not its name.
+    vi.mocked(getWorkspace).mockResolvedValue({
+      success: true,
+      data: { ...mockWorkspace, parent: mockProject.id },
+    });
+    const res = await app.fetch(
+      request("POST", "/api/projects/my-project/changes", { workspace: "fix-bug" }, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(201);
+  });
 });
 
 describe("GET /api/projects/:name/changes", () => {
@@ -866,6 +879,28 @@ describe("POST /api/changes/:id/merge", () => {
       "merged",
       expect.objectContaining({ mergedAt: expect.any(String) }),
     );
+  });
+
+  it("redirects browser form posts back to the change page after merging", async () => {
+    const acceptedChange: Change = { ...mockChange, status: "accepted" };
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: acceptedChange,
+    });
+
+    const res = await app.fetch(
+      new Request("http://localhost/api/changes/chg_abc123/merge", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          ...USER_AUTH,
+        },
+        body: "",
+      }),
+      env,
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/changes/chg_abc123");
   });
 
   it("merges an accepted change", async () => {
@@ -1208,6 +1243,34 @@ describe("POST /api/changes/:id/reject", () => {
     const body = (await res.json()) as { rejected: boolean; changeId: string };
     expect(body.rejected).toBe(true);
     expect(body.changeId).toBe("chg_abc123");
+    expect(updateChangeStatus).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      "chg_abc123",
+      "rejected",
+      expect.any(Object),
+    );
+  });
+
+  it("redirects browser form posts back to the change page", async () => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: mockChange,
+    });
+
+    const res = await app.fetch(
+      new Request("http://localhost/api/changes/chg_abc123/reject", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          ...USER_AUTH,
+        },
+        body: "",
+      }),
+      env,
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/changes/chg_abc123");
     expect(updateChangeStatus).toHaveBeenCalledWith(
       env.DB,
       expect.any(Object),

--- a/tests/namespace-routes.test.ts
+++ b/tests/namespace-routes.test.ts
@@ -780,4 +780,29 @@ describe("Namespace Routes", () => {
       expect(res.status).toBe(200);
     });
   });
+
+  describe("API route mount order", () => {
+    // Regression: the UI router's /:namespace/:slug catch-all used to be mounted before
+    // the API routers and swallowed two-segment API paths like GET /api/projects,
+    // returning an HTML error page instead of JSON.
+    it("GET /api/projects reaches the API router and returns JSON", async () => {
+      await createTestProject(env, "@testuser", "my-project", "user_test", "private");
+
+      const res = await app.fetch(request("GET", "/api/projects", undefined, AUTH_HEADERS), env);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      const body = (await res.json()) as { projects: Array<{ slug: string }> };
+      expect(body.projects.map((p) => p.slug)).toContain("my-project");
+    });
+
+    it("GET /api/projects without auth returns an empty JSON list, not HTML", async () => {
+      const res = await app.fetch(request("GET", "/api/projects"), env);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      const body = (await res.json()) as { projects: unknown[] };
+      expect(body.projects).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Three functional bugs found during a full UI/UX audit (all reachable from the UI):

- **API route shadowing** — `app.route("/", uiRouter)` was mounted before the API routers, so the UI's `/:namespace/:slug` catch-all swallowed two-segment API paths: `GET /api/projects` returned an HTML "Invalid namespace format" page instead of JSON. The UI router is now mounted last.
- **Change creation broken for namespaced workspaces** — workspaces created via `POST /api/projects/:namespace/:slug/workspaces` store the project **id** in `parent`, but `POST /api/projects/:name/changes` compared it against the project **name** and rejected every request. The check now accepts the id (new) or the name (legacy).
- **Form posts landed on raw JSON** — the change-detail page posts plain HTML forms to `/api/changes/:id/{merge,reject,evaluate,github-pr}`, which always returned JSON. Browsers now get redirected back to `/changes/:id`; only explicit form content types are redirected, so JSON and bodiless CLI/agent calls are unchanged.

## Tests
- Mount-order regression tests (`GET /api/projects` authed + unauthed returns JSON).
- Change creation with id-parent workspace.
- Form-post redirect tests for merge and reject.
- Full suite: 739 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API route handling to prevent shadowing by the UI router, ensuring proper request routing.
  * Enhanced workspace validation to accept both legacy and namespaced project identifiers.

* **New Features**
  * Form submissions for merge, reject, and evaluate actions now redirect to the relevant change page instead of returning JSON responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->