### PR TITLE
fix: responsive layout, sync page styling, merge from UI, MergeQueue RPC

### DIFF
--- a/scripts/seed-preview.ts
+++ b/scripts/seed-preview.ts
@@ -89,7 +89,7 @@ async function main() {
     let project: Awaited<ReturnType<typeof createProject>>;
     try {
       project = await createProject(name, true);
-      console.log(`✓  ${BASE_URL}/${project.path}`);
+      console.log(`✓  ${BASE_URL}${project.path}`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("already exists")) {

--- a/src/queue/merge-queue.ts
+++ b/src/queue/merge-queue.ts
@@ -1,3 +1,4 @@
+import { DurableObject } from "cloudflare:workers";
 import { getChange, updateChangeStatus } from "../storage/changes";
 import { mergeWorkspaceIntoProject } from "../storage/git-ops";
 import { recordProvenance } from "../storage/provenance";
@@ -14,15 +15,9 @@ export interface MergeOutcome {
   error?: string;
 }
 
-export class MergeQueue {
-  env: Env;
-  ctx: DurableObjectState;
-
-  constructor(ctx: DurableObjectState, env: Env) {
-    this.ctx = ctx;
-    this.env = env;
-  }
-
+// Must extend DurableObject: callers invoke merge() over RPC, which the runtime
+// only enables for classes that extend the special base class.
+export class MergeQueue extends DurableObject<Env> {
   async merge(changeId: string, logger?: Logger): Promise<MergeOutcome> {
     const log = logger ?? createLogger({ changeId });
     const changeResult = await getChange(this.env.DB, log, changeId);

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -58,6 +58,30 @@ async function getCurrentUser(
   return { id: user.id, email: user.email, username: user.username };
 }
 
+/**
+ * Resolve issue author ids to display names ("@username" for users, the agent's
+ * name for agents). Unresolvable authors fall back to their author type.
+ */
+async function resolveIssueAuthors(
+  db: D1Database,
+  issues: Array<{ authorType: "user" | "agent"; authorId: string }>,
+  logger: ReturnType<typeof createLogger>,
+): Promise<Record<string, string>> {
+  const entries = await Promise.all(
+    [...new Map(issues.map((issue) => [issue.authorId, issue.authorType]))].map(
+      async ([authorId, authorType]): Promise<readonly [string, string]> => {
+        if (authorType === "user") {
+          const result = await getUser(db, authorId, logger);
+          return [authorId, result.success ? `@${result.data.username}` : "user"];
+        }
+        const result = await getAgent(db, authorId, logger);
+        return [authorId, result.success ? `${result.data.name} (agent)` : "agent"];
+      },
+    ),
+  );
+  return Object.fromEntries(entries);
+}
+
 // GET / — Dashboard (list projects)
 app.get("/", async (c) => {
   const userId = c.get("userId");
@@ -623,7 +647,6 @@ app.get("/p/:name/workspaces", async (c) => {
 
   const view = workspacesResult.data.map((ws) => ({
     name: ws.name,
-    parent: ws.parent,
     createdAt: ws.createdAt,
   }));
 
@@ -823,12 +846,18 @@ app.get("/:namespace/:slug/issues", async (c) => {
     return c.html(issuePageError(500), 500);
   }
 
+  const [authors, canWrite] = await Promise.all([
+    resolveIssueAuthors(c.env.DB, issuesResult.data, logger),
+    canWriteProject(c.env.DB, project, userId),
+  ]);
+
   return c.html(
     <IssuesPage
       project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
       issues={issuesResult.data}
+      authors={authors}
       filter={filter}
-      canWrite={await canWriteProject(c.env.DB, project, userId)}
+      canWrite={canWrite}
       user={user}
     />,
   );
@@ -873,11 +902,17 @@ app.get("/:namespace/:slug/issues/:number", async (c) => {
     );
   }
 
+  const [authors, canWrite] = await Promise.all([
+    resolveIssueAuthors(c.env.DB, [issueResult.data], logger),
+    canWriteProject(c.env.DB, project, userId),
+  ]);
+
   return c.html(
     <IssueDetailPage
       project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
       issue={issueResult.data}
-      canWrite={await canWriteProject(c.env.DB, project, userId)}
+      authors={authors}
+      canWrite={canWrite}
       user={user}
     />,
   );
@@ -1000,7 +1035,6 @@ app.get("/:namespace/:slug/workspaces", async (c) => {
 
   const workspaces = workspacesResult.data.map((ws) => ({
     name: ws.name,
-    parent: ws.parent,
     createdAt: ws.createdAt,
   }));
 
@@ -1031,7 +1065,7 @@ app.get("/:namespace/:slug/sync", async (c) => {
     return c.redirect("/auth/email");
   }
 
-  const [_userResult, projectResult] = await Promise.all([
+  const [userResult, projectResult] = await Promise.all([
     getCurrentUser(c, logger),
     getProjectByPath(c.env.STATE, namespace, slug, logger),
   ]);
@@ -1060,7 +1094,9 @@ app.get("/:namespace/:slug/sync", async (c) => {
   const syncStatus = {
     namespace,
     slug,
-    sourceUrl: project.remote || "",
+    // Only external import sources are shown; the internal artifacts remote is not a
+    // sync source and must not leak into the page.
+    sourceUrl: getProjectSourceUrl(project) ?? "",
     sourceBranch: "main",
     lastSyncStatus: (stored?.lastSyncStatus ?? "idle") as
       | "success"
@@ -1087,6 +1123,7 @@ app.get("/:namespace/:slug/sync", async (c) => {
       }}
       syncStatus={syncStatus}
       syncHistory={[]}
+      user={userResult}
     />,
   );
 });

--- a/src/ui/pages/change-detail.tsx
+++ b/src/ui/pages/change-detail.tsx
@@ -66,6 +66,9 @@ function statusBadgeClass(status: string): string {
 
 const REVIEWABLE_STATUSES = ["open", "needs_changes", "accepted", "approved"];
 
+/** Mirrors MERGEABLE_STATUSES in routes/changes.ts — the API rejects other statuses. */
+const MERGEABLE_STATUSES = ["approved", "accepted", "promoted"];
+
 function describeCost(entry: CostSummaryEntry): string {
   const prefix = entry.estimated ? "~" : "";
   switch (entry.kind) {
@@ -116,6 +119,13 @@ export const ChangeDetailPage: FC<ChangeDetailProps> = ({
             </a>
           ) : (
             <>
+              {canReview && MERGEABLE_STATUSES.includes(change.status) && (
+                <form method="post" action={`/api/changes/${change.id}/merge`}>
+                  <button type="submit" class="btn btn-primary">
+                    Merge change
+                  </button>
+                </form>
+              )}
               {(change.status === "accepted" || change.status === "promoted") && (
                 <form method="post" action={`/api/changes/${change.id}/github-pr`}>
                   <button type="submit" class="btn btn-primary">
@@ -192,41 +202,43 @@ export const ChangeDetailPage: FC<ChangeDetailProps> = ({
             <p>No evaluator evidence recorded.</p>
           </div>
         ) : (
-          <table class="table">
-            <thead>
-              <tr>
-                <th>Evaluator</th>
-                <th>Status</th>
-                <th>Score</th>
-                <th>Reason</th>
-              </tr>
-            </thead>
-            <tbody>
-              {evalRuns.map((run) => (
-                <tr key={run.id}>
-                  <td>{run.evaluatorType}</td>
-                  <td>
-                    {run.passed ? (
-                      <span class="badge badge-approved">passed</span>
-                    ) : (
-                      <span class="badge badge-rejected">failed</span>
-                    )}
-                  </td>
-                  <td>{Math.round(run.score * 100)}%</td>
-                  <td>
-                    {run.reason}
-                    {run.issues !== undefined && run.issues.length > 0 && (
-                      <ul class="issue-list">
-                        {run.issues.map((issue) => (
-                          <li key={issue}>{issue}</li>
-                        ))}
-                      </ul>
-                    )}
-                  </td>
+          <div class="table-scroll">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Evaluator</th>
+                  <th>Status</th>
+                  <th>Score</th>
+                  <th>Reason</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {evalRuns.map((run) => (
+                  <tr key={run.id}>
+                    <td>{run.evaluatorType}</td>
+                    <td>
+                      {run.passed ? (
+                        <span class="badge badge-approved">passed</span>
+                      ) : (
+                        <span class="badge badge-rejected">failed</span>
+                      )}
+                    </td>
+                    <td>{Math.round(run.score * 100)}%</td>
+                    <td>
+                      {run.reason}
+                      {run.issues !== undefined && run.issues.length > 0 && (
+                        <ul class="issue-list">
+                          {run.issues.map((issue) => (
+                            <li key={issue}>{issue}</li>
+                          ))}
+                        </ul>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
 

--- a/src/ui/pages/changes.tsx
+++ b/src/ui/pages/changes.tsx
@@ -23,10 +23,14 @@ function statusBadgeClass(status: string): string {
     case "open":
       return "badge badge-open";
     case "approved":
+    case "accepted":
       return "badge badge-approved";
     case "merged":
+    case "promoted":
       return "badge badge-merged";
     case "rejected":
+    case "reverted":
+    case "needs_changes":
       return "badge badge-rejected";
     default:
       return "badge";
@@ -48,34 +52,36 @@ export const ChangesPage: FC<ChangesProps> = ({ project, changes, user }) => {
           <p>No changes yet.</p>
         </div>
       ) : (
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Workspace</th>
-              <th>Status</th>
-              <th>Eval score</th>
-              <th>Created</th>
-              <th />
-            </tr>
-          </thead>
-          <tbody>
-            {changes.map((change) => (
-              <tr key={change.id}>
-                <td>{change.workspace}</td>
-                <td>
-                  <span class={statusBadgeClass(change.status)}>{change.status}</span>
-                </td>
-                <td>
-                  {change.evalScore !== undefined ? `${Math.round(change.evalScore * 100)}%` : "—"}
-                </td>
-                <td>{new Date(change.createdAt).toLocaleDateString()}</td>
-                <td>
-                  <a href={`/changes/${change.id}`}>View</a>
-                </td>
+        <div class="table-scroll">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Workspace</th>
+                <th>Status</th>
+                <th>Eval score</th>
+                <th>Created</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {changes.map((change) => (
+                <tr key={change.id}>
+                  <td>
+                    <a href={`/changes/${change.id}`}>{change.workspace}</a>
+                  </td>
+                  <td>
+                    <span class={statusBadgeClass(change.status)}>{change.status}</span>
+                  </td>
+                  <td>
+                    {change.evalScore !== undefined
+                      ? `${Math.round(change.evalScore * 100)}%`
+                      : "—"}
+                  </td>
+                  <td>{new Date(change.createdAt).toLocaleDateString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </Layout>
   );

--- a/src/ui/pages/home.tsx
+++ b/src/ui/pages/home.tsx
@@ -62,6 +62,9 @@ export const HomePage: FC<HomeProps> = ({ projects, user }) => {
                 {project.name}
                 {project.visibility === "public" && <span class="badge badge-public">public</span>}
               </div>
+              <div class="card-meta">
+                {project.namespace}/{project.slug}
+              </div>
               <div class="card-meta">{new Date(project.createdAt).toLocaleDateString()}</div>
             </a>
           ))}

--- a/src/ui/pages/issues.tsx
+++ b/src/ui/pages/issues.tsx
@@ -11,6 +11,8 @@ interface ProjectRef {
 interface IssuesPageProps {
   project: ProjectRef;
   issues: Issue[];
+  /** Author display names keyed by author id. */
+  authors: Record<string, string>;
   filter: "open" | "closed" | "all";
   canWrite: boolean;
   user?: { id: string; email: string; username: string } | null;
@@ -19,7 +21,14 @@ interface IssuesPageProps {
 const statusBadge = (status: Issue["status"]) =>
   status === "open" ? "badge badge-open" : "badge badge-merged";
 
-export const IssuesPage: FC<IssuesPageProps> = ({ project, issues, filter, canWrite, user }) => {
+export const IssuesPage: FC<IssuesPageProps> = ({
+  project,
+  issues,
+  authors,
+  filter,
+  canWrite,
+  user,
+}) => {
   const base = `/${project.namespace}/${project.slug}/issues`;
   return (
     <Layout title={`Issues — ${project.name}`} user={user}>
@@ -67,7 +76,8 @@ export const IssuesPage: FC<IssuesPageProps> = ({ project, issues, filter, canWr
                 </a>
               )}
               <span class="issues-meta">
-                opened {new Date(issue.createdAt).toLocaleDateString()} by {issue.authorType}
+                opened {new Date(issue.createdAt).toLocaleDateString()} by{" "}
+                {authors[issue.authorId] ?? issue.authorType}
               </span>
             </li>
           ))}
@@ -80,11 +90,19 @@ export const IssuesPage: FC<IssuesPageProps> = ({ project, issues, filter, canWr
 interface IssueDetailPageProps {
   project: ProjectRef;
   issue: Issue;
+  /** Author display names keyed by author id. */
+  authors: Record<string, string>;
   canWrite: boolean;
   user?: { id: string; email: string; username: string } | null;
 }
 
-export const IssueDetailPage: FC<IssueDetailPageProps> = ({ project, issue, canWrite, user }) => {
+export const IssueDetailPage: FC<IssueDetailPageProps> = ({
+  project,
+  issue,
+  authors,
+  canWrite,
+  user,
+}) => {
   const base = `/${project.namespace}/${project.slug}/issues`;
   const apiBase = `/api/projects/${project.namespace}/${project.slug}/issues`;
   return (
@@ -101,7 +119,8 @@ export const IssueDetailPage: FC<IssueDetailPageProps> = ({ project, issue, canW
       <div class="issue-status-row">
         <span class={statusBadge(issue.status)}>{issue.status}</span>
         <span class="issues-meta">
-          opened {new Date(issue.createdAt).toLocaleString()} by {issue.authorType}
+          opened {new Date(issue.createdAt).toLocaleString()} by{" "}
+          {authors[issue.authorId] ?? issue.authorType}
           {issue.closedAt ? ` · closed ${new Date(issue.closedAt).toLocaleString()}` : ""}
           {issue.closedBy === "system" ? " (auto-closed by merged change)" : ""}
         </span>

--- a/src/ui/pages/new-project.tsx
+++ b/src/ui/pages/new-project.tsx
@@ -100,14 +100,9 @@ export const NewProjectPage: FC<NewProjectProps> = ({ user, error }) => {
             </label>
           </div>
 
-          <div style={{ display: "flex", gap: "0.75rem" }}>
-            <button type="submit" class="btn btn-primary">
-              Create Project
-            </button>
-            <a href="/" class="btn">
-              Cancel
-            </a>
-          </div>
+          <button type="submit" class="btn btn-primary">
+            Create Project
+          </button>
         </form>
       </div>
 

--- a/src/ui/pages/sync.tsx
+++ b/src/ui/pages/sync.tsx
@@ -52,16 +52,18 @@ interface SyncPageProps {
     commitsSynced: number;
     error?: string;
   }>;
+  user?: { id: string; email: string; username: string } | null;
 }
 
-export const SyncPage: FC<SyncPageProps> = ({ project, syncStatus, syncHistory }) => {
+export const SyncPage: FC<SyncPageProps> = ({ project, syncStatus, syncHistory, user }) => {
   const isSyncing = syncStatus.lastSyncStatus === "in_progress";
   const hasError = syncStatus.lastSyncStatus === "failed";
   const hasUpdates =
     syncStatus.hasUpdates && syncStatus.commitsBehind && syncStatus.commitsBehind > 0;
+  const hasSource = syncStatus.sourceUrl !== "";
 
   return (
-    <Layout title={`Sync - ${project.name}`}>
+    <Layout title={`Sync — ${project.name}`} user={user}>
       <div class="container">
         <div class="page-header">
           <h1>Sync Status</h1>
@@ -72,157 +74,173 @@ export const SyncPage: FC<SyncPageProps> = ({ project, syncStatus, syncHistory }
           </div>
         </div>
 
-        {/* Status Card */}
-        <div class={`card sync-status-card status-${syncStatus.lastSyncStatus}`}>
-          <div class="status-header">
-            <div class="status-indicator">
-              {isSyncing && <span class="spinner" />}
-              {syncStatus.lastSyncStatus === "success" && <span class="icon-success">✓</span>}
-              {hasError && <span class="icon-error">✗</span>}
-              {syncStatus.lastSyncStatus === "idle" && <span class="icon-idle">○</span>}
-            </div>
-            <div class="status-info">
-              <h2>
-                {isSyncing && "Syncing..."}
-                {syncStatus.lastSyncStatus === "success" && "Up to Date"}
-                {hasError && "Sync Failed"}
-                {syncStatus.lastSyncStatus === "idle" && "Not Synced"}
-              </h2>
-              <p class="status-meta">
-                {syncStatus.lastSyncedAt
-                  ? `Last synced: ${new Date(syncStatus.lastSyncedAt).toLocaleString()}`
-                  : "Never synced"}
-              </p>
-            </div>
-            <div class="status-actions">
-              {!isSyncing && (
-                <form
-                  method="post"
-                  action={`/api/projects/${project.namespace}/${project.slug}/sync`}
-                  onsubmit="event.preventDefault(); handleSyncSubmit(this);"
-                >
-                  <button
-                    type="submit"
-                    id="sync-button"
-                    class={`btn ${hasUpdates ? "btn-primary" : "btn-secondary"}`}
-                    data-original-class={hasUpdates ? "btn-primary" : "btn-secondary"}
-                    disabled={isSyncing}
-                  >
-                    {hasUpdates
-                      ? `Sync Now (${syncStatus.commitsBehind} commit${syncStatus.commitsBehind === 1 ? "" : "s"} behind)`
-                      : "Check for Updates"}
-                  </button>
-                </form>
-              )}
-            </div>
+        {!hasSource && (
+          <div class="card">
+            <h3>Not connected</h3>
+            <p class="help-text">
+              This project was not imported from an external repository, so there is nothing to
+              sync.
+            </p>
           </div>
+        )}
 
-          {hasError && syncStatus.lastSyncError && (
-            <div class="error-message">
-              <strong>Error:</strong> {syncStatus.lastSyncError}
+        {/* Status Card */}
+        {hasSource && (
+          <div class={`card sync-status-card status-${syncStatus.lastSyncStatus}`}>
+            <div class="status-header">
+              <div class="status-indicator">
+                {isSyncing && <span class="spinner" />}
+                {syncStatus.lastSyncStatus === "success" && <span class="icon-success">✓</span>}
+                {hasError && <span class="icon-error">✗</span>}
+                {syncStatus.lastSyncStatus === "idle" && <span class="icon-idle">○</span>}
+              </div>
+              <div class="status-info">
+                <h2>
+                  {isSyncing && "Syncing..."}
+                  {syncStatus.lastSyncStatus === "success" && "Up to Date"}
+                  {hasError && "Sync Failed"}
+                  {syncStatus.lastSyncStatus === "idle" && "Not Synced"}
+                </h2>
+                <p class="status-meta">
+                  {syncStatus.lastSyncedAt
+                    ? `Last synced: ${new Date(syncStatus.lastSyncedAt).toLocaleString()}`
+                    : "Never synced"}
+                </p>
+              </div>
+              <div class="status-actions">
+                {!isSyncing && (
+                  <form
+                    method="post"
+                    action={`/api/projects/${project.namespace}/${project.slug}/sync`}
+                    onsubmit="event.preventDefault(); handleSyncSubmit(this);"
+                  >
+                    <button
+                      type="submit"
+                      id="sync-button"
+                      class={`btn ${hasUpdates ? "btn-primary" : "btn-secondary"}`}
+                      data-original-class={hasUpdates ? "btn-primary" : "btn-secondary"}
+                      disabled={isSyncing}
+                    >
+                      {hasUpdates
+                        ? `Sync Now (${syncStatus.commitsBehind} commit${syncStatus.commitsBehind === 1 ? "" : "s"} behind)`
+                        : "Check for Updates"}
+                    </button>
+                  </form>
+                )}
+              </div>
             </div>
-          )}
-        </div>
+
+            {hasError && syncStatus.lastSyncError && (
+              <div class="error-message">
+                <strong>Error:</strong> {syncStatus.lastSyncError}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Source Info */}
-        <div class="card source-info-card">
-          <h3>Source Repository</h3>
-          <div class="info-grid">
-            <div class="info-item">
-              <label>URL</label>
-              {(() => {
-                const safeUrl = validateSafeUrl(syncStatus.sourceUrl);
-                if (safeUrl) {
-                  return (
-                    <a href={safeUrl} target="_blank" rel="noreferrer">
-                      {syncStatus.sourceUrl}
-                    </a>
-                  );
-                }
-                return <span class="text-muted">{syncStatus.sourceUrl || "Not available"}</span>;
-              })()}
-            </div>
-            <div class="info-item">
-              <label>Branch</label>
-              <code>{syncStatus.sourceBranch}</code>
-            </div>
-            <div class="info-item">
-              <label>Latest Commit</label>
-              <code>{syncStatus.latestCommit?.slice(0, 7) || "N/A"}</code>
-            </div>
-            <div class="info-item">
-              <label>Last Checked</label>
-              <span>{new Date(syncStatus.lastCheckedAt).toLocaleString()}</span>
+        {hasSource && (
+          <div class="card source-info-card">
+            <h3>Source Repository</h3>
+            <div class="info-grid">
+              <div class="info-item">
+                <label>URL</label>
+                {(() => {
+                  const safeUrl = validateSafeUrl(syncStatus.sourceUrl);
+                  if (safeUrl) {
+                    return (
+                      <a href={safeUrl} target="_blank" rel="noreferrer">
+                        {syncStatus.sourceUrl}
+                      </a>
+                    );
+                  }
+                  return <span class="text-muted">{syncStatus.sourceUrl || "Not available"}</span>;
+                })()}
+              </div>
+              <div class="info-item">
+                <label>Branch</label>
+                <code>{syncStatus.sourceBranch}</code>
+              </div>
+              <div class="info-item">
+                <label>Latest Commit</label>
+                <code>{syncStatus.latestCommit?.slice(0, 7) || "N/A"}</code>
+              </div>
+              <div class="info-item">
+                <label>Last Checked</label>
+                <span>{new Date(syncStatus.lastCheckedAt).toLocaleString()}</span>
+              </div>
             </div>
           </div>
-        </div>
+        )}
 
         {/* Auto-Sync Settings */}
-        <div class="card auto-sync-card">
-          <h3>Auto-Sync Settings</h3>
-          <form
-            method="post"
-            action={`/api/projects/${project.namespace}/${project.slug}/sync/settings`}
-            class="auto-sync-form"
-            onsubmit="event.preventDefault(); handleSettingsSubmit(this);"
-          >
-            <div class="form-group">
-              <label class="checkbox-label">
-                <input
-                  type="checkbox"
-                  name="autoSyncEnabled"
-                  checked={syncStatus.autoSyncEnabled}
-                  onchange="toggleSyncFrequency(this)"
-                />
-                Enable automatic sync
-              </label>
-              <p class="help-text">
-                When enabled, the project will automatically sync when new commits are detected.
-              </p>
-            </div>
+        {hasSource && (
+          <div class="card auto-sync-card">
+            <h3>Auto-Sync Settings</h3>
+            <form
+              method="post"
+              action={`/api/projects/${project.namespace}/${project.slug}/sync/settings`}
+              class="auto-sync-form"
+              onsubmit="event.preventDefault(); handleSettingsSubmit(this);"
+            >
+              <div class="form-group">
+                <label class="checkbox-label">
+                  <input
+                    type="checkbox"
+                    name="autoSyncEnabled"
+                    checked={syncStatus.autoSyncEnabled}
+                    onchange="toggleSyncFrequency(this)"
+                  />
+                  Enable automatic sync
+                </label>
+                <p class="help-text">
+                  When enabled, the project will automatically sync when new commits are detected.
+                </p>
+              </div>
 
-            <div class="form-group">
-              <label>Sync Frequency</label>
-              <select
-                id="syncFrequency"
-                name="syncFrequency"
-                disabled={!syncStatus.autoSyncEnabled}
-              >
-                <option
-                  value="5"
-                  selected={
-                    syncStatus.syncFrequency === 5 ||
-                    (!syncStatus.syncFrequency && syncStatus.autoSyncEnabled)
-                  }
+              <div class="form-group">
+                <label>Sync Frequency</label>
+                <select
+                  id="syncFrequency"
+                  name="syncFrequency"
+                  disabled={!syncStatus.autoSyncEnabled}
                 >
-                  Every 5 minutes
-                </option>
-                <option value="15" selected={syncStatus.syncFrequency === 15}>
-                  Every 15 minutes
-                </option>
-                <option value="30" selected={syncStatus.syncFrequency === 30}>
-                  Every 30 minutes
-                </option>
-                <option value="60" selected={syncStatus.syncFrequency === 60}>
-                  Every hour
-                </option>
-                <option value="360" selected={syncStatus.syncFrequency === 360}>
-                  Every 6 hours
-                </option>
-                <option value="720" selected={syncStatus.syncFrequency === 720}>
-                  Every 12 hours
-                </option>
-                <option value="1440" selected={syncStatus.syncFrequency === 1440}>
-                  Every 24 hours
-                </option>
-              </select>
-            </div>
+                  <option
+                    value="5"
+                    selected={
+                      syncStatus.syncFrequency === 5 ||
+                      (!syncStatus.syncFrequency && syncStatus.autoSyncEnabled)
+                    }
+                  >
+                    Every 5 minutes
+                  </option>
+                  <option value="15" selected={syncStatus.syncFrequency === 15}>
+                    Every 15 minutes
+                  </option>
+                  <option value="30" selected={syncStatus.syncFrequency === 30}>
+                    Every 30 minutes
+                  </option>
+                  <option value="60" selected={syncStatus.syncFrequency === 60}>
+                    Every hour
+                  </option>
+                  <option value="360" selected={syncStatus.syncFrequency === 360}>
+                    Every 6 hours
+                  </option>
+                  <option value="720" selected={syncStatus.syncFrequency === 720}>
+                    Every 12 hours
+                  </option>
+                  <option value="1440" selected={syncStatus.syncFrequency === 1440}>
+                    Every 24 hours
+                  </option>
+                </select>
+              </div>
 
-            <button type="submit" class="btn btn-secondary" data-original-class="btn-secondary">
-              Save Settings
-            </button>
-          </form>
-        </div>
+              <button type="submit" class="btn btn-secondary" data-original-class="btn-secondary">
+                Save Settings
+              </button>
+            </form>
+          </div>
+        )}
 
         {/* Sync History */}
         <div class="card sync-history-card">
@@ -230,40 +248,42 @@ export const SyncPage: FC<SyncPageProps> = ({ project, syncStatus, syncHistory }
           {syncHistory.length === 0 ? (
             <p class="empty-state">No sync history yet.</p>
           ) : (
-            <table class="table sync-history-table">
-              <thead>
-                <tr>
-                  <th>Started</th>
-                  <th>Status</th>
-                  <th>Commits</th>
-                  <th>Duration</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {syncHistory.map((sync) => (
-                  <tr key={sync.id} class={`sync-row status-${sync.status}`}>
-                    <td>{new Date(sync.startedAt).toLocaleString()}</td>
-                    <td>
-                      <span class={`badge badge-${sync.status}`}>{sync.status}</span>
-                    </td>
-                    <td>{sync.commitsSynced}</td>
-                    <td>
-                      {sync.completedAt
-                        ? `${Math.round((new Date(sync.completedAt).getTime() - new Date(sync.startedAt).getTime()) / 1000)}s`
-                        : "-"}
-                    </td>
-                    <td>
-                      {sync.error && (
-                        <span class="error-hint" title={sync.error}>
-                          Error details
-                        </span>
-                      )}
-                    </td>
+            <div class="table-scroll">
+              <table class="table sync-history-table">
+                <thead>
+                  <tr>
+                    <th>Started</th>
+                    <th>Status</th>
+                    <th>Commits</th>
+                    <th>Duration</th>
+                    <th>Actions</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {syncHistory.map((sync) => (
+                    <tr key={sync.id} class={`sync-row status-${sync.status}`}>
+                      <td>{new Date(sync.startedAt).toLocaleString()}</td>
+                      <td>
+                        <span class={`badge badge-${sync.status}`}>{sync.status}</span>
+                      </td>
+                      <td>{sync.commitsSynced}</td>
+                      <td>
+                        {sync.completedAt
+                          ? `${Math.round((new Date(sync.completedAt).getTime() - new Date(sync.startedAt).getTime()) / 1000)}s`
+                          : "-"}
+                      </td>
+                      <td>
+                        {sync.error && (
+                          <span class="error-hint" title={sync.error}>
+                            Error details
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
         </div>
 

--- a/src/ui/pages/workspaces.tsx
+++ b/src/ui/pages/workspaces.tsx
@@ -7,7 +7,7 @@ interface WorkspacesProps {
     namespace: string;
     slug: string;
   };
-  workspaces: Array<{ name: string; parent: string; createdAt: string }>;
+  workspaces: Array<{ name: string; createdAt: string }>;
   user?: { id: string; email: string; username: string } | null;
 }
 
@@ -26,24 +26,24 @@ export const WorkspacesPage: FC<WorkspacesProps> = ({ project, workspaces, user 
           <p>No workspaces yet.</p>
         </div>
       ) : (
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Parent</th>
-              <th>Created</th>
-            </tr>
-          </thead>
-          <tbody>
-            {workspaces.map((ws) => (
-              <tr key={ws.name}>
-                <td>{ws.name}</td>
-                <td>{ws.parent}</td>
-                <td>{new Date(ws.createdAt).toLocaleDateString()}</td>
+        <div class="table-scroll">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Created</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {workspaces.map((ws) => (
+                <tr key={ws.name}>
+                  <td>{ws.name}</td>
+                  <td>{new Date(ws.createdAt).toLocaleDateString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </Layout>
   );

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -18,9 +18,15 @@ a:hover { text-decoration: underline; }
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.35rem 1.25rem;
   padding: 0.75rem 1.5rem;
   border-bottom: 1px solid #1e1e1e;
   background: #0d0d0d;
+}
+
+@media (max-width: 600px) {
+  .nav { padding: 0.6rem 1rem; }
 }
 
 .nav-brand {
@@ -69,10 +75,12 @@ a:hover { text-decoration: underline; }
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
   margin-bottom: 1.5rem;
 }
 
-.page-header h1 { font-size: 1.4rem; font-weight: 700; }
+.page-header h1 { font-size: 1.4rem; font-weight: 700; overflow-wrap: anywhere; }
 
 .card {
   background: #111;
@@ -100,6 +108,8 @@ a:hover { text-decoration: underline; }
 .card-title { font-weight: 600; color: #f0f0f0; margin-bottom: 0.25rem; }
 .card-meta { font-size: 0.8rem; color: #666; }
 
+.table-scroll { overflow-x: auto; }
+
 .table { width: 100%; border-collapse: collapse; }
 .table th { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #1e1e1e; color: #888; font-weight: 500; font-size: 0.85rem; }
 .table td { padding: 0.5rem 0.75rem; border-bottom: 1px solid #111; vertical-align: middle; }
@@ -114,6 +124,8 @@ a:hover { text-decoration: underline; }
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+  background: #1a1a1a;
+  color: #888;
 }
 .badge-open     { background: #1a3a6e; color: #7ca9f7; }
 .badge-approved { background: #1a3d2b; color: #4ade80; }
@@ -218,16 +230,6 @@ a:hover { text-decoration: underline; }
 .icon-success { color: #4ade80; }
 .icon-error { color: #f87171; }
 .icon-cancelled { color: #888; }
-
-.badge {
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  background: #1a1a1a;
-  color: #888;
-}
 
 .badge-queued { background: #1a1a1a; color: #888; }
 .badge-cloning { background: #1a3a6e; color: #7ca9f7; }
@@ -491,7 +493,6 @@ a:hover { text-decoration: underline; }
 .webhook-delivery-meta { color: #777; }
 .webhook-delivery-time { color: #555; margin-left: auto; }
 .btn-small { font-size: 0.75rem; padding: 0.25rem 0.6rem; }
-.btn-danger { color: #f87171; border-color: #5f1e1e; }
 
 /* Issues */
 .page-header-actions { display: flex; gap: 0.5rem; }
@@ -566,6 +567,38 @@ a:hover { text-decoration: underline; }
   padding: 0.5rem; border-radius: 4px; font-family: inherit;
 }
 
+/* Sync page */
+.status-header { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+.status-indicator { font-size: 1.1rem; flex-shrink: 0; }
+.status-info { flex: 1; min-width: 200px; }
+.status-info h2 { margin-bottom: 0.15rem; }
+.status-meta { color: #777; font-size: 0.85rem; margin: 0; }
+.status-actions { flex-shrink: 0; }
+.icon-idle { color: #888; }
+.info-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.85rem 1.5rem; }
+.info-item label {
+  display: block; color: #666; font-size: 0.75rem;
+  text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 0.2rem;
+}
+.info-item a, .info-item span, .info-item code { font-size: 0.85rem; word-break: break-all; }
+.form-group { margin-bottom: 1rem; }
+.form-group > label { display: block; color: #aaa; font-size: 0.85rem; margin-bottom: 0.25rem; }
+.form-group select {
+  background: #111; border: 1px solid #333; color: #eee;
+  padding: 0.5rem; border-radius: 4px; font-family: inherit; font-size: 0.85rem;
+}
+.form-group select:disabled { color: #555; }
+.checkbox-label, .form-group > label.checkbox-label {
+  display: flex; align-items: center; gap: 0.5rem; color: #ccc; cursor: pointer; margin-bottom: 0;
+}
+.help-text { color: #666; font-size: 0.8rem; margin-top: 0.25rem; }
+.error-message {
+  margin-top: 0.75rem; padding: 0.6rem 0.75rem; border-radius: 4px;
+  background: #1a0a0a; border: 1px solid #3d1a1a; color: #fca5a5; font-size: 0.85rem;
+}
+.btn-success { background: #1a3d2b; border-color: #2a6e4a; color: #4ade80; }
+.btn-info { background: #1a3a6e; border-color: #2a5aae; color: #7ca9f7; }
+
 /* Costs */
 .cost-list { list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #ccc; }
 .cost-list li { padding: 0.2rem 0; }
@@ -592,6 +625,7 @@ a:hover { text-decoration: underline; }
   background: #111; border: 1px solid #333; color: #eee;
   padding: 0.5rem; border-radius: 4px; font-family: inherit;
 }
+.comment-form button { align-self: flex-start; }
 
 /* File Viewer */
 .file-viewer-breadcrumb {

--- a/tests/helpers/cloudflare-workers-stub.ts
+++ b/tests/helpers/cloudflare-workers-stub.ts
@@ -1,0 +1,14 @@
+/**
+ * Test stub for the `cloudflare:workers` virtual module, which only exists inside
+ * the workerd runtime. Mirrors the DurableObject base class shape that
+ * src/queue/merge-queue.ts relies on (ctx/env assignment in the constructor).
+ */
+export class DurableObject<TEnv = unknown> {
+  ctx: DurableObjectState;
+  env: TEnv;
+
+  constructor(ctx: DurableObjectState, env: TEnv) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,15 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // The `cloudflare:workers` virtual module only exists inside workerd.
+      "cloudflare:workers": fileURLToPath(
+        new URL("./tests/helpers/cloudflare-workers-stub.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],


### PR DESCRIPTION
## Summary

Second half of the UI/UX audit (after #84). Audited every UI page in a real browser at 375/768/1280/1920px.

**Responsive layout**
- Nav wraps with proper gaps instead of jamming brand/links/user together and forcing 8px of horizontal scroll on every page at mobile widths.
- `.page-header` wraps — page titles no longer collide with action buttons.
- Wide tables (changes, workspaces, eval evidence, sync history) scroll inside a `.table-scroll` wrapper. Zero horizontal page overflow on any page at any tested width.

**Styling bugs**
- A duplicate `.badge` definition later in the stylesheet overrode every status badge color — OPEN/MERGED/ACCEPTED all rendered gray. Single base definition now; `.btn-danger` deduped; changes list maps accepted/promoted/needs_changes/reverted.
- The sync page referenced ~12 CSS classes that didn't exist (`info-grid`, `status-header`, `checkbox-label`, `form-group`, …) so labels and values rendered jammed together ("URLhttps://…"). All defined now.

**Sync page correctness**
- Passes the signed-in user to the layout (previously showed "sign in" while authenticated).
- Shows only real import sources via `getProjectSourceUrl` — the internal artifacts remote (account-hash URL) no longer leaks; non-imported projects get a clear "Not connected" state.

**Merge from the UI + MergeQueue RPC bug**
- Change detail now offers **Merge change** to writers on approved/accepted/promoted changes (`/api/changes/:id/merge` existed; the UI had no merge path).
- Exercising it live exposed a runtime bug: `MergeQueue` did not extend `DurableObject`, so the RPC `stub.merge()` call threw whenever the `MERGE_QUEUE` binding was present (i.e. in every deployed environment). It now extends the base class; vitest resolves `cloudflare:workers` via a test-stub alias. Verified end-to-end in the browser: click Merge → workspace merged → redirected back with status `merged`.

**Content polish**
- Issues show author usernames ("@seed") instead of the literal author type ("user").
- Workspaces table drops the raw project-UUID "Parent" column.
- Changes rows link from the workspace cell (dropped the lone "View" column).
- Dashboard cards show `namespace/slug`; single Cancel on the new-project form; seed script URL double-slash fixed.

## Testing
- `tsc --noEmit`, `npm test` (739 passed), `biome check` all green.
- Playwright sweep: 13 pages × 4 viewports, zero horizontal overflow; live merge flow verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)