### PR TITLE
fix: hide change actions that the API forbids for terminal statuses

### DIFF
--- a/src/ui/pages/change-detail.tsx
+++ b/src/ui/pages/change-detail.tsx
@@ -69,6 +69,10 @@ const REVIEWABLE_STATUSES = ["open", "needs_changes", "accepted", "approved"];
 /** Mirrors MERGEABLE_STATUSES in routes/changes.ts — the API rejects other statuses. */
 const MERGEABLE_STATUSES = ["approved", "accepted", "promoted"];
 
+/** No further actions apply: merged changes can't be rejected (API enforces it), and
+ * rejecting an already rejected/reverted change is meaningless. */
+const TERMINAL_STATUSES = ["merged", "rejected", "reverted"];
+
 function describeCost(entry: CostSummaryEntry): string {
   const prefix = entry.estimated ? "~" : "";
   switch (entry.kind) {
@@ -94,6 +98,11 @@ export const ChangeDetailPage: FC<ChangeDetailProps> = ({
   canReview = false,
   user,
 }) => {
+  const hasGithubPr = change.githubPrUrl !== undefined;
+  const canMerge = !hasGithubPr && canReview && MERGEABLE_STATUSES.includes(change.status);
+  const canReject = !TERMINAL_STATUSES.includes(change.status);
+  const hasActions = hasGithubPr || canMerge || canReject;
+
   return (
     <Layout
       title={`Change ${change.id}`}
@@ -110,45 +119,49 @@ export const ChangeDetailPage: FC<ChangeDetailProps> = ({
         </a>
       </div>
 
-      <div class="card">
-        <h2>Actions</h2>
-        <div class="action-row">
-          {change.githubPrUrl !== undefined ? (
-            <a class="btn btn-primary" href={change.githubPrUrl} target="_blank" rel="noreferrer">
-              Open GitHub PR
-            </a>
-          ) : (
-            <>
-              {canReview && MERGEABLE_STATUSES.includes(change.status) && (
-                <form method="post" action={`/api/changes/${change.id}/merge`}>
-                  <button type="submit" class="btn btn-primary">
-                    Merge change
-                  </button>
-                </form>
-              )}
-              {(change.status === "accepted" || change.status === "promoted") && (
-                <form method="post" action={`/api/changes/${change.id}/github-pr`}>
-                  <button type="submit" class="btn btn-primary">
-                    Promote to GitHub
-                  </button>
-                </form>
-              )}
-              {(change.status === "open" || change.status === "needs_changes") && (
-                <form method="post" action={`/api/changes/${change.id}/evaluate`}>
-                  <button type="submit" class="btn">
-                    Run evaluations again
-                  </button>
-                </form>
-              )}
-            </>
-          )}
-          <form method="post" action={`/api/changes/${change.id}/reject`}>
-            <button type="submit" class="btn btn-danger">
-              Reject change
-            </button>
-          </form>
+      {hasActions && (
+        <div class="card">
+          <h2>Actions</h2>
+          <div class="action-row">
+            {hasGithubPr ? (
+              <a class="btn btn-primary" href={change.githubPrUrl} target="_blank" rel="noreferrer">
+                Open GitHub PR
+              </a>
+            ) : (
+              <>
+                {canMerge && (
+                  <form method="post" action={`/api/changes/${change.id}/merge`}>
+                    <button type="submit" class="btn btn-primary">
+                      Merge change
+                    </button>
+                  </form>
+                )}
+                {(change.status === "accepted" || change.status === "promoted") && (
+                  <form method="post" action={`/api/changes/${change.id}/github-pr`}>
+                    <button type="submit" class="btn btn-primary">
+                      Promote to GitHub
+                    </button>
+                  </form>
+                )}
+                {(change.status === "open" || change.status === "needs_changes") && (
+                  <form method="post" action={`/api/changes/${change.id}/evaluate`}>
+                    <button type="submit" class="btn">
+                      Run evaluations again
+                    </button>
+                  </form>
+                )}
+              </>
+            )}
+            {canReject && (
+              <form method="post" action={`/api/changes/${change.id}/reject`}>
+                <button type="submit" class="btn btn-danger">
+                  Reject change
+                </button>
+              </form>
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       <div class="card">
         <dl class="detail-list">

--- a/tests/change-detail-page.test.tsx
+++ b/tests/change-detail-page.test.tsx
@@ -1,0 +1,55 @@
+import { renderToString } from "hono/jsx/dom/server";
+import { describe, expect, it } from "vitest";
+import { ChangeDetailPage } from "../src/ui/pages/change-detail";
+
+const baseChange = {
+  id: "chg_test123",
+  project: "my-project",
+  workspace: "fix-bug",
+  createdAt: "2026-01-01T02:00:00.000Z",
+};
+
+function render(status: string, canReview = true): string {
+  return renderToString(
+    <ChangeDetailPage
+      change={{ ...baseChange, status }}
+      evalRuns={[]}
+      provenance={null}
+      canReview={canReview}
+      user={null}
+    />,
+  );
+}
+
+describe("ChangeDetailPage actions", () => {
+  it("offers reject and re-evaluation on an open change", () => {
+    const html = render("open");
+    expect(html).toContain("Reject change");
+    expect(html).toContain("Run evaluations again");
+    expect(html).not.toContain("Merge change");
+  });
+
+  it("offers merge to reviewers on an approved change", () => {
+    const html = render("approved");
+    expect(html).toContain("Merge change");
+    expect(html).toContain("Reject change");
+  });
+
+  it("hides merge from non-reviewers", () => {
+    const html = render("approved", false);
+    expect(html).not.toContain("Merge change");
+  });
+
+  it("offers no actions on a merged change", () => {
+    const html = render("merged");
+    expect(html).not.toContain("Reject change");
+    expect(html).not.toContain("Merge change");
+    expect(html).not.toContain("<h2>Actions</h2>");
+  });
+
+  it("offers no actions on a rejected change", () => {
+    const html = render("rejected");
+    expect(html).not.toContain("Reject change");
+    expect(html).not.toContain("<h2>Actions</h2>");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up from a re-review pass after #84/#86 (browser sweep of 22 pages × 4 viewports plus interactive flows — close/reopen issue, comment, approve, merge, logout — this was the only issue found).

The change-detail page offered **Reject change** on merged/rejected/reverted changes. The API correctly refuses (`400 Cannot reject a merged change`), but error responses don't form-redirect, so clicking stranded the user on raw JSON. Action visibility is now derived from the change status, and the Actions card is omitted entirely when nothing applies (a merged change with no GitHub PR previously would have shown an empty card).

Verified live in the browser: merged change → no Actions card; approved change → Merge + Reject; non-reviewer → no Merge.

## Tests
New `ChangeDetailPage` render tests covering per-status action visibility (744 total passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)