### PR TITLE
Optional closed-beta referral gate at signup

### DIFF
--- a/src/beta/gate.ts
+++ b/src/beta/gate.ts
@@ -1,0 +1,112 @@
+/**
+ * Closed-beta gate (Stratum Cloud only).
+ *
+ * This is the ONLY core hook into the referral/beta program. The program itself
+ * lives in the cloud/landing layer; core just calls it. When the gate env vars
+ * are unset (the default for OSS self-hosters) every function here is inert and
+ * account creation is unchanged.
+ *
+ * - betaGateEnabled: is the gate switched on and pointed at a service?
+ * - validateInviteCode: is this code redeemable? (pre-createUser check)
+ * - admitUser: record the redemption + mint the user's 5 codes (post-createUser)
+ */
+import type { Env } from "../types";
+import type { Logger } from "../utils/logger";
+
+export interface InviteValidation {
+  valid: boolean;
+  referrerUserId: string | null;
+}
+
+export interface AdmitResult {
+  codes: string[];
+  referrerUserId: string | null;
+}
+
+/** True only when the gate is explicitly enabled AND a service URL is configured. */
+export function betaGateEnabled(env: Env): boolean {
+  return env.BETA_GATE === "1" && !!env.REFERRAL_SERVICE_URL;
+}
+
+function serviceUrl(env: Env, path: string): string {
+  return `${(env.REFERRAL_SERVICE_URL ?? "").replace(/\/$/, "")}${path}`;
+}
+
+/**
+ * Check whether an invite code can currently be redeemed. Fails closed
+ * ({ valid: false }) on any network/parse error so a service outage cannot
+ * silently let ungated users through the beta wall.
+ */
+export async function validateInviteCode(
+  env: Env,
+  code: string,
+  logger: Logger,
+): Promise<InviteValidation> {
+  const trimmed = (code ?? "").trim().toUpperCase();
+  if (!trimmed) return { valid: false, referrerUserId: null };
+
+  try {
+    const res = await fetch(serviceUrl(env, "/api/referral/validate"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code: trimmed }),
+    });
+    if (!res.ok) {
+      logger.warn("Invite validation returned non-OK", { status: res.status });
+      return { valid: false, referrerUserId: null };
+    }
+    const data = (await res.json()) as InviteValidation;
+    return {
+      valid: data.valid === true,
+      referrerUserId: data.referrerUserId ?? null,
+    };
+  } catch (error) {
+    logger.error("Invite validation request failed", error instanceof Error ? error : undefined);
+    return { valid: false, referrerUserId: null };
+  }
+}
+
+/**
+ * Record a redemption and mint the new user's 5 shareable codes. Called AFTER
+ * the account is created, so a failure here must never throw into the signup
+ * path — the user already exists. Returns an empty code list on failure; callers
+ * should log and continue (codes can be re-fetched later via the service).
+ */
+export async function admitUser(
+  env: Env,
+  params: { userId: string; email: string; code: string; source: string },
+  logger: Logger,
+): Promise<AdmitResult> {
+  try {
+    const res = await fetch(serviceUrl(env, "/api/referral/admit"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${env.REFERRAL_SERVICE_SECRET ?? ""}`,
+      },
+      body: JSON.stringify({
+        userId: params.userId,
+        email: params.email,
+        code: params.code.trim().toUpperCase(),
+        source: params.source,
+      }),
+    });
+    if (!res.ok) {
+      logger.error("admitUser returned non-OK", undefined, { status: res.status });
+      return { codes: [], referrerUserId: null };
+    }
+    const data = (await res.json()) as {
+      codes?: string[];
+      referrerUserId?: string | null;
+    };
+    return {
+      codes: Array.isArray(data.codes) ? data.codes : [],
+      referrerUserId: data.referrerUserId ?? null,
+    };
+  } catch (error) {
+    logger.error("admitUser request failed", error instanceof Error ? error : undefined, {
+      userId: params.userId,
+    });
+    return { codes: [], referrerUserId: null };
+  }
+}

--- a/src/beta/gate.ts
+++ b/src/beta/gate.ts
@@ -23,6 +23,10 @@ export interface AdmitResult {
   referrerUserId: string | null;
 }
 
+// Cap how long a signup can wait on the referral service. validateInviteCode
+// runs inline in the signup request, so a hung service must not hang signup.
+const REFERRAL_TIMEOUT_MS = 5000;
+
 /** True only when the gate is explicitly enabled AND a service URL is configured. */
 export function betaGateEnabled(env: Env): boolean {
   return env.BETA_GATE === "1" && !!env.REFERRAL_SERVICE_URL;
@@ -50,6 +54,7 @@ export async function validateInviteCode(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ code: trimmed }),
+      signal: AbortSignal.timeout(REFERRAL_TIMEOUT_MS),
     });
     if (!res.ok) {
       logger.warn("Invite validation returned non-OK", { status: res.status });
@@ -90,6 +95,7 @@ export async function admitUser(
         code: params.code.trim().toUpperCase(),
         source: params.source,
       }),
+      signal: AbortSignal.timeout(REFERRAL_TIMEOUT_MS),
     });
     if (!res.ok) {
       logger.error("admitUser returned non-OK", undefined, { status: res.status });

--- a/src/email/templates.ts
+++ b/src/email/templates.ts
@@ -234,6 +234,66 @@ Your code management platform`;
   return { subject, text, html };
 }
 
+export interface InviteCodesEmailData {
+  email: string;
+  codes: string[];
+  /** Origin for building share links, e.g. https://usestratum.dev */
+  shareBaseUrl?: string;
+}
+
+/**
+ * Beta-program email delivering a newly admitted user their personal referral
+ * codes to share. Sent after account creation when the closed-beta gate is on.
+ */
+export function getInviteCodesEmail(data: InviteCodesEmailData): {
+  subject: string;
+  text: string;
+  html: string;
+} {
+  const { codes } = data;
+  const base = (data.shareBaseUrl ?? "").replace(/\/$/, "");
+  const subject = "Your Stratum invite codes";
+
+  const shareLine = (code: string) => (base ? `${base}/?ref=${code}` : code);
+
+  const text = `Welcome to the Stratum beta!
+
+You have ${codes.length} invite codes to share. Each lets one person join:
+
+${codes.map((c) => `  ${c}${base ? `   (${shareLine(c)})` : ""}`).join("\n")}
+
+Share a link and you'll see who joins from it.
+
+--
+Stratum
+Your code management platform`;
+
+  const rows = codes
+    .map(
+      (code) => `
+      <tr>
+        <td style="padding: 10px 14px; border: 1px solid #333; border-radius: 8px; font-family: 'SFMono-Regular', Menlo, monospace; font-size: 18px; letter-spacing: 2px; color: #e5e5e5; background-color: #0f0f0f;">
+          ${escapeHtml(code)}
+        </td>
+      </tr>
+      <tr><td style="height: 10px;"></td></tr>`,
+    )
+    .join("");
+
+  const body = `
+    <div class="text-primary" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 20px; font-weight: 600; color: #e5e5e5; padding-bottom: 16px;">
+      Welcome to the Stratum beta
+    </div>
+    <div class="text-secondary" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.6; color: #a0a0a0; padding-bottom: 24px;">
+      You've got <strong style="color: #e5e5e5;">${codes.length} invite codes</strong> to share. Each one lets a friend join the beta${base ? ` &mdash; share <code style="color:#e5e5e5;">${escapeHtml(base)}/?ref=CODE</code>` : ""}.
+    </div>
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+      ${rows}
+    </table>`;
+
+  return { subject, text, html: wrapEmail({ title: subject, body }) };
+}
+
 /**
  * Generic email template wrapper with Stratum branding
  * TODO: Use this for future email templates (notifications, invites, etc.)

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { betaGateEnabled } from "../beta/gate";
 import { recordAudit } from "../storage/audit";
 import { createSession, deleteSession, getSession } from "../storage/sessions";
-import { createUser, getUserByEmail, upsertGitHubUser } from "../storage/users";
+import { createUser, getUserByEmail, getUserByGitHubId, upsertGitHubUser } from "../storage/users";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
 
@@ -192,6 +193,17 @@ app.get("/github/callback", async (c) => {
   const emailPrefix = primaryEmail.split("@")[0];
   logger.info("Upserting GitHub user", { githubId: githubUser.id, emailPrefix });
 
+  // Closed beta: OAuth is login-only. A brand-new account (no match by GitHub id
+  // or email) must be created through the invite-gated magic-link flow first.
+  if (betaGateEnabled(c.env)) {
+    const byGithub = await getUserByGitHubId(c.env.DB, String(githubUser.id), logger);
+    const byEmail = await getUserByEmail(c.env.DB, primaryEmail, logger);
+    if (!byGithub.success && !byEmail.success) {
+      logger.warn("Blocked GitHub signup — closed beta", { githubId: githubUser.id });
+      return c.redirect("/auth/signup?error=invite_required");
+    }
+  }
+
   const userResult = await upsertGitHubUser(
     c.env.DB,
     {
@@ -360,6 +372,11 @@ app.get("/google/callback", async (c) => {
   if (existing.success) {
     userId = existing.data.id;
   } else {
+    // Closed beta: OAuth is login-only — new accounts require an invite code.
+    if (betaGateEnabled(c.env)) {
+      logger.warn("Blocked Google signup — closed beta");
+      return c.redirect("/auth/signup?error=invite_required");
+    }
     const createdResult = await createUser(c.env.DB, googleUser.email, logger);
     if (!createdResult.success) {
       logger.error("Failed to create user from Google sign-in", createdResult.error);

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -197,8 +197,13 @@ app.get("/github/callback", async (c) => {
   // or email) must be created through the invite-gated magic-link flow first.
   if (betaGateEnabled(c.env)) {
     const byGithub = await getUserByGitHubId(c.env.DB, String(githubUser.id), logger);
-    const byEmail = await getUserByEmail(c.env.DB, primaryEmail, logger);
-    if (!byGithub.success && !byEmail.success) {
+    // Match an existing account only by a *verified* email — never the unverified
+    // fallback used for primaryEmail, which could be attacker-controlled and let
+    // someone slip past the gate by claiming a beta user's address.
+    const verifiedEmail =
+      emails.find((e) => e.primary && e.verified)?.email ?? emails.find((e) => e.verified)?.email;
+    const byEmail = verifiedEmail ? await getUserByEmail(c.env.DB, verifiedEmail, logger) : null;
+    if (!byGithub.success && !byEmail?.success) {
       logger.warn("Blocked GitHub signup — closed beta", { githubId: githubUser.id });
       return c.redirect("/auth/signup?error=invite_required");
     }

--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -1,12 +1,13 @@
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
-import { getMagicLinkEmail } from "../email/templates";
+import { admitUser, betaGateEnabled, validateInviteCode } from "../beta/gate";
+import { getInviteCodesEmail, getMagicLinkEmail } from "../email/templates";
 import { recordAudit } from "../storage/audit";
 import { createSession } from "../storage/sessions";
 import { createUser, getUserByEmail, getUserByUsername } from "../storage/users";
 import type { Env } from "../types";
-import { createLogger } from "../utils/logger";
+import { type Logger, createLogger } from "../utils/logger";
 import { validateUsername } from "../utils/username-validation";
 import { validateEmail } from "../utils/validation";
 
@@ -270,6 +271,8 @@ app.post("/send-signup", async (c) => {
   const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
   const username = typeof body.username === "string" ? body.username.trim().toLowerCase() : "";
   const rememberMe = body.rememberMe === "true";
+  const inviteCode =
+    typeof body.inviteCode === "string" ? body.inviteCode.trim().toUpperCase() : "";
 
   // Validate email format
   const emailValidation = validateEmail(email, logger);
@@ -287,6 +290,19 @@ app.post("/send-signup", async (c) => {
 
   const emailHash = hashEmail(email);
   logger.info("Processing signup request", { emailHash, username });
+
+  // Closed-beta gate: require a valid invite code before sending the magic link
+  // (fast feedback). The code is re-checked and consumed at verify time.
+  if (betaGateEnabled(c.env)) {
+    if (!inviteCode) {
+      return emailAuthRedirect(c, "error", "invite_required", "/auth/signup");
+    }
+    const inviteCheck = await validateInviteCode(c.env, inviteCode, logger);
+    if (!inviteCheck.valid) {
+      logger.warn("Invalid invite code at signup", { emailHash });
+      return emailAuthRedirect(c, "error", "invalid_invite", "/auth/signup");
+    }
+  }
 
   // Check if email sending is configured
   if (!c.env.EMAIL) {
@@ -345,6 +361,7 @@ app.post("/send-signup", async (c) => {
         intent: "signup",
         createdAt: Date.now(),
         rememberMe,
+        inviteCode,
       }),
       { expirationTtl: 15 * 60 }, // 15 minutes TTL
     );
@@ -626,7 +643,7 @@ app.get("/verify", async (c) => {
 
     if (intent === "signup") {
       // Signup flow
-      const { username } = tokenData;
+      const { username, inviteCode = "" } = tokenData;
       logger.info("Processing signup verification", { emailHash, username });
 
       // Double-check email doesn't already exist (race condition protection)
@@ -636,6 +653,15 @@ app.get("/verify", async (c) => {
         // User already exists, treat as login
         const userId = existingUserByEmail.data.id;
         return await createSessionAndRedirect(c, userId, emailHash, rememberMe, logger);
+      }
+
+      // Closed-beta gate: re-validate the invite code before creating the account.
+      if (betaGateEnabled(c.env)) {
+        const inviteCheck = await validateInviteCode(c.env, inviteCode, logger);
+        if (!inviteCheck.valid) {
+          logger.warn("Invite code no longer valid at verification", { emailHash });
+          return emailAuthRedirect(c, "error", "invalid_invite", "/auth/signup");
+        }
       }
 
       // Double-check username is still available (race condition protection)
@@ -654,6 +680,12 @@ app.get("/verify", async (c) => {
 
       const userId = createResult.data.user.id;
       logger.info("New user created via signup", { userId, emailHash, username });
+
+      // Beta program: record the redemption, mint this user's 5 codes, and email
+      // them. Best-effort — never blocks the now-created account.
+      if (betaGateEnabled(c.env)) {
+        await admitAndDeliverCodes(c, { userId, email, inviteCode, source: "magic_link" }, logger);
+      }
 
       // Create session and redirect to welcome/onboarding
       return await createSessionAndRedirect(c, userId, emailHash, rememberMe, logger, "/welcome");
@@ -685,6 +717,50 @@ app.get("/verify", async (c) => {
     return emailAuthRedirect(c, "error", "verify_failed");
   }
 });
+
+// Beta program: redeem the invite code, mint the user's 5 shareable codes, and
+// email them. Best-effort — failures are logged and swallowed so a created
+// account is never left in a broken state by a referral-service hiccup.
+async function admitAndDeliverCodes(
+  c: Context<{ Bindings: Env }>,
+  params: { userId: string; email: string; inviteCode: string; source: string },
+  logger: Logger,
+): Promise<void> {
+  try {
+    const result = await admitUser(
+      c.env,
+      {
+        userId: params.userId,
+        email: params.email,
+        code: params.inviteCode,
+        source: params.source,
+      },
+      logger,
+    );
+    if (result.codes.length === 0) {
+      logger.warn("No invite codes minted for new user", { userId: params.userId });
+      return;
+    }
+    const fromAddress = c.env.EMAIL_FROM_ADDRESS;
+    if (!c.env.EMAIL || !fromAddress) return;
+    const emailContent = getInviteCodesEmail({
+      email: params.email,
+      codes: result.codes,
+      shareBaseUrl: c.env.REFERRAL_SERVICE_URL,
+    });
+    await c.env.EMAIL.send({
+      to: params.email,
+      from: { email: fromAddress, name: "Stratum" },
+      subject: emailContent.subject,
+      text: emailContent.text,
+      html: emailContent.html,
+    });
+  } catch (err) {
+    logger.error("Failed to deliver invite codes", err instanceof Error ? err : undefined, {
+      userId: params.userId,
+    });
+  }
+}
 
 // Helper function to create session and redirect
 async function createSessionAndRedirect(

--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { betaGateEnabled } from "../beta/gate";
 import type { Env } from "../types";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -15,6 +16,8 @@ const ERROR_MESSAGES: Record<string, string> = {
   send_failed: "Failed to send email. Please try again later.",
   signup_failed: "Failed to create account. Please try again.",
   rate_limited: "Too many requests. Please try again later.",
+  invite_required: "Stratum is in closed beta — an invite code is required to sign up.",
+  invalid_invite: "That invite code isn't valid or has already been used.",
 };
 
 const SUCCESS_MESSAGES: Record<string, string> = {
@@ -26,6 +29,8 @@ app.get("/", (c) => {
   const errorCode = c.req.query("error");
   const successCode = c.req.query("success");
   const prefillEmail = c.req.query("email") ?? "";
+  const betaGate = betaGateEnabled(c.env);
+  const prefillInvite = c.req.query("ref") ?? c.req.query("invite") ?? "";
   const error =
     errorCode !== undefined
       ? (ERROR_MESSAGES[errorCode] ?? "Signup failed. Please try again.")
@@ -423,6 +428,28 @@ app.get("/", (c) => {
                     </div>
                     <div class="username-status" id="usernameStatus" />
                   </div>
+
+                  {betaGate ? (
+                    <div class="form-group">
+                      <label class="form-label" for="inviteCode">
+                        Invite code <span>(required during beta)</span>
+                      </label>
+                      <input
+                        type="text"
+                        id="inviteCode"
+                        name="inviteCode"
+                        class="form-input"
+                        placeholder="ABCDE12345"
+                        value={prefillInvite}
+                        required
+                        autocomplete="off"
+                        spellcheck={false}
+                      />
+                      <div class="input-hint">
+                        Have a referral link? Your code is filled in automatically.
+                      </div>
+                    </div>
+                  ) : null}
 
                   <div class="checkbox-group">
                     <input

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,12 @@ export interface Env {
   EMAIL_FROM_ADDRESS?: string;
   ADMIN_EMAIL?: string;
   ADMIN_API_KEY?: string;
+  // Closed-beta gate (optional; OSS self-hosters leave these unset → no gating).
+  // When BETA_GATE is enabled AND REFERRAL_SERVICE_URL is set, new-account creation
+  // requires a valid referral/invite code validated against the cloud referral service.
+  BETA_GATE?: string;
+  REFERRAL_SERVICE_URL?: string;
+  REFERRAL_SERVICE_SECRET?: string;
   ANALYTICS?: AnalyticsEngineDataset;
   SANDBOX?: SandboxBinding;
   AI?: AiBinding;

--- a/tests/beta-gate.test.ts
+++ b/tests/beta-gate.test.ts
@@ -115,4 +115,14 @@ describe("admitUser", () => {
     );
     expect(result.codes).toEqual([]);
   });
+
+  it("returns no codes on a non-OK response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("unauthorized", { status: 401 }));
+    const result = await admitUser(
+      e,
+      { userId: "u", email: "a@b.com", code: "X", source: "magic_link" },
+      noopLogger,
+    );
+    expect(result).toEqual({ codes: [], referrerUserId: null });
+  });
 });

--- a/tests/beta-gate.test.ts
+++ b/tests/beta-gate.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { admitUser, betaGateEnabled, validateInviteCode } from "../src/beta/gate";
+import type { Env } from "../src/types";
+import type { Logger } from "../src/utils/logger";
+
+const noopLogger: Logger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  child: () => noopLogger,
+};
+
+function env(overrides: Partial<Env> = {}): Env {
+  return overrides as Env;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("betaGateEnabled", () => {
+  it("is off by default (no env)", () => {
+    expect(betaGateEnabled(env())).toBe(false);
+  });
+
+  it("is off when BETA_GATE set but no service URL", () => {
+    expect(betaGateEnabled(env({ BETA_GATE: "1" }))).toBe(false);
+  });
+
+  it("is off when service URL set but BETA_GATE not '1'", () => {
+    expect(betaGateEnabled(env({ REFERRAL_SERVICE_URL: "https://x.dev" }))).toBe(false);
+    expect(betaGateEnabled(env({ BETA_GATE: "true", REFERRAL_SERVICE_URL: "https://x.dev" }))).toBe(
+      false,
+    );
+  });
+
+  it("is on only when both are configured", () => {
+    expect(betaGateEnabled(env({ BETA_GATE: "1", REFERRAL_SERVICE_URL: "https://x.dev" }))).toBe(
+      true,
+    );
+  });
+});
+
+describe("validateInviteCode", () => {
+  const e = env({ BETA_GATE: "1", REFERRAL_SERVICE_URL: "https://x.dev/" });
+
+  it("returns invalid for an empty code without calling the service", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const result = await validateInviteCode(e, "  ", noopLogger);
+    expect(result.valid).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes through a valid response and uppercases/trims the code", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ valid: true, referrerUserId: "usr_1" }), {
+        status: 200,
+      }),
+    );
+    const result = await validateInviteCode(e, " abc123 ", noopLogger);
+    expect(result).toEqual({ valid: true, referrerUserId: "usr_1" });
+    const body = JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body));
+    expect(body.code).toBe("ABC123");
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe("https://x.dev/api/referral/validate");
+  });
+
+  it("fails closed on a non-OK response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 500 }));
+    expect((await validateInviteCode(e, "ABC", noopLogger)).valid).toBe(false);
+  });
+
+  it("fails closed when the request throws", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+    expect((await validateInviteCode(e, "ABC", noopLogger)).valid).toBe(false);
+  });
+});
+
+describe("admitUser", () => {
+  const e = env({
+    BETA_GATE: "1",
+    REFERRAL_SERVICE_URL: "https://x.dev",
+    REFERRAL_SERVICE_SECRET: "s3cret",
+  });
+
+  it("returns minted codes and sends the bearer secret", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ codes: ["A", "B", "C", "D", "E"], referrerUserId: "usr_ref" }),
+          { status: 200 },
+        ),
+      );
+    const result = await admitUser(
+      e,
+      { userId: "usr_new", email: "a@b.com", code: "abc", source: "magic_link" },
+      noopLogger,
+    );
+    expect(result.codes).toHaveLength(5);
+    expect(result.referrerUserId).toBe("usr_ref");
+    const init = fetchSpy.mock.calls[0]?.[1];
+    expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer s3cret");
+    expect(JSON.parse(String(init?.body)).code).toBe("ABC");
+  });
+
+  it("returns no codes (never throws) on failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("down"));
+    const result = await admitUser(
+      e,
+      { userId: "u", email: "a@b.com", code: "X", source: "magic_link" },
+      noopLogger,
+    );
+    expect(result.codes).toEqual([]);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -63,6 +63,11 @@ crons = ["0 6 * * *", "*/5 * * * *"]
 [vars]
 POSTHOG_HOST = "https://app.posthog.com"
 OAUTH_REDIRECT_URI = "http://localhost:8787/auth/github/callback"
+# Closed-beta gate (Stratum Cloud only — leave unset/commented for ungated self-hosting).
+# The gate turns ON only when BETA_GATE = "1" AND REFERRAL_SERVICE_URL is set.
+# REFERRAL_SERVICE_URL is the landing/cloud origin that serves /api/referral/*.
+# BETA_GATE = "1"
+# REFERRAL_SERVICE_URL = "https://usestratum.dev"
 
 # Email Sending — configure via: wrangler email sending enable yourdomain.com
 [[send_email]]
@@ -81,6 +86,8 @@ name = "EMAIL"
 # GOOGLE_CLIENT_SECRET =
 # GOOGLE_REDIRECT_URI = "https://yourdomain.com/auth/google/callback"
 # EMAIL_FROM_ADDRESS = "noreply@yourdomain.com"  # for magic link emails
+# REFERRAL_SERVICE_SECRET =  # closed-beta gate shared secret; must match the value
+#                            # set on the referral service. set via: wrangler secret put REFERRAL_SERVICE_SECRET
 
 # Staging environment
 [env.staging]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -63,11 +63,6 @@ crons = ["0 6 * * *", "*/5 * * * *"]
 [vars]
 POSTHOG_HOST = "https://app.posthog.com"
 OAUTH_REDIRECT_URI = "http://localhost:8787/auth/github/callback"
-# Closed-beta gate (Stratum Cloud only — leave unset/commented for ungated self-hosting).
-# The gate turns ON only when BETA_GATE = "1" AND REFERRAL_SERVICE_URL is set.
-# REFERRAL_SERVICE_URL is the landing/cloud origin that serves /api/referral/*.
-# BETA_GATE = "1"
-# REFERRAL_SERVICE_URL = "https://usestratum.dev"
 
 # Email Sending — configure via: wrangler email sending enable yourdomain.com
 [[send_email]]
@@ -86,8 +81,6 @@ name = "EMAIL"
 # GOOGLE_CLIENT_SECRET =
 # GOOGLE_REDIRECT_URI = "https://yourdomain.com/auth/google/callback"
 # EMAIL_FROM_ADDRESS = "noreply@yourdomain.com"  # for magic link emails
-# REFERRAL_SERVICE_SECRET =  # closed-beta gate shared secret; must match the value
-#                            # set on the referral service. set via: wrangler secret put REFERRAL_SERVICE_SECRET
 
 # Staging environment
 [env.staging]


### PR DESCRIPTION
## What

Adds an **optional** closed-beta gate: when enabled, **no one can create an account without a valid referral code**. It's the app-side enforcement for the referral service in `jlamoreaux/stratum-landing#7`.

**Fully opt-in / no-op by default.** The gate is active only when `BETA_GATE="1"` **and** `REFERRAL_SERVICE_URL` are set, so OSS self-hosters are unaffected. Existing auth tests pass unchanged.

### Behavior when the gate is ON
- **Magic-link signup** — an invite code is required; validated before the email is sent and re-validated before `createUser`. After creation, the user's **5** codes are minted via the service and emailed (`getInviteCodesEmail`).
- **GitHub / Google OAuth** — login-only during beta. A first-time OAuth user with no existing account is redirected to `/auth/signup?error=invite_required`, so OAuth can't bypass the gate.
- The landing **waitlist stays open** (no code needed to join); the gate is on account creation, not the waitlist.

### Files
- `src/beta/gate.ts` — `betaGateEnabled` / `validateInviteCode` / `admitUser`. Fails closed on service errors; `admitUser` never throws into the signup path.
- `src/routes/email-auth.tsx`, `src/routes/auth.ts`, `src/routes/signup.tsx` — wiring at the three account-creation paths + a conditional invite field (prefilled from `?ref=`).
- `src/email/templates.ts` — `getInviteCodesEmail`.
- `src/types.ts`, `wrangler.toml` — new optional env vars.
- `tests/beta-gate.test.ts` — 10 unit tests (enable/disable, fail-closed, bearer auth).

## How to enable (Stratum Cloud)

```bash
cd stratum
```

1. In `wrangler.toml` `[vars]`, uncomment:
   ```toml
   BETA_GATE = "1"
   REFERRAL_SERVICE_URL = "https://usestratum.dev"
   ```
2. Set the shared secret — **must equal the value set on stratum-landing**:
   ```bash
   wrangler secret put REFERRAL_SERVICE_SECRET
   ```
3. `wrangler deploy`.

**Local dev:** the two `[vars]` apply automatically; put the secret in `stratum/.dev.vars`:
```
REFERRAL_SERVICE_SECRET=dev-secret-value
```
Point `REFERRAL_SERVICE_URL` at your local landing (`wrangler dev`) to exercise the flow. To disable the gate, comment out `BETA_GATE` (or set it to anything other than `"1"`) and redeploy.

## Depends on
`jlamoreaux/stratum-landing#7` (the referral service + `REFERRAL_SERVICE_SECRET` it shares). Until seed codes are minted there, account creation is fully closed — expected for a closed beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Closed-beta invite-code gating for sign-ups (includes OAuth and magic-link flows)
  * Users receive shareable invite codes emailed to them after signup
  * Signup form shows an invite-code field when the beta gate is active

* **Tests**
  * Added tests covering gate logic, invite validation, and admit/redeem behaviors

* **Documentation**
  * Added configuration guidance for enabling the closed-beta gate in deployment config
<!-- end of auto-generated comment: release notes by coderabbit.ai -->