### PR TITLE
Restructure wrangler config: generic self-host default + [env.production] (app.usestratum.dev)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           echo "Applying D1 migrations for production..."
-          npx wrangler d1 migrations apply stratum
+          npx wrangler d1 migrations apply stratum --env=production
           echo "✓ Migrations applied successfully"
 
       - name: Deploy to Cloudflare Production
@@ -174,7 +174,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          npx wrangler deploy
+          npx wrangler deploy --env=production
           SUBDOMAIN=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
             "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/subdomain" \
             | jq -r '.result.subdomain')

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx wrangler deploy
+        run: npx wrangler deploy --env=production
 
       - name: Smoke test
         env:

--- a/docs/LAUNCH_CHECKLIST.md
+++ b/docs/LAUNCH_CHECKLIST.md
@@ -1,0 +1,52 @@
+# Closed-Beta Launch Checklist
+
+Tracks what remains to take the closed-beta referral program live. Spans two
+repos: **stratum** (this repo, the app) and **stratum-landing** (marketing site +
+referral service).
+
+## Already done
+- `REFERRAL_SERVICE_SECRET` set on both the `stratum` and `stratum-landing` Workers.
+- `stratum-referral` D1 database created and schema applied.
+- Landing Worker deployed; referral endpoints (`validate`/`admit`/`seed`/`codes`)
+  verified working at the `*.workers.dev` URL.
+
+## A. Merge the PRs
+- [ ] Merge **#93** (config restructure: generic self-host default + `[env.production]`,
+      `app.usestratum.dev`). Deploys production via `--env=production`.
+- [ ] Merge **#92** (closed-beta gate). No longer touches `wrangler.toml`, so it
+      merges cleanly in any order relative to #93.
+
+## B. Core app → `app.usestratum.dev` (after #93)
+- [ ] `npm run deploy:staging`, verify, then run the **Deploy Production** workflow
+      (or `npm run deploy:production`). The custom domain + TLS cert provision on deploy.
+- [ ] Register OAuth callback URLs (sign-in breaks without them):
+  - GitHub OAuth app → `https://app.usestratum.dev/auth/github/callback`
+    (+ `https://staging.app.usestratum.dev/auth/github/callback`)
+  - Google OAuth client → `https://app.usestratum.dev/auth/google/callback` (+ staging)
+- [ ] Verify `https://app.usestratum.dev/health` responds.
+
+## C. Landing apex `usestratum.dev` → Worker (Cloudflare dashboard)
+- [ ] Remove `usestratum.dev` (and `www`) from the **Pages project** custom domains.
+- [ ] Add `usestratum.dev` as a custom domain on the **`stratum-landing` Worker**.
+- [ ] Verify it serves the Worker, not Pages:
+      `curl -X POST https://usestratum.dev/api/referral/validate -d '{"code":"X"}'`
+      → `200` JSON (a `405` means it's still on Pages).
+- [ ] `wrangler secret put POSTHOG_API_KEY` on the landing Worker.
+- [ ] Replace `POSTHOG_API_KEY_PLACEHOLDER` in `stratum-landing/public/index.html`.
+- [ ] Settle the CD path: the landing GitHub Actions workflow now deploys on push to
+      `main` (Cloudflare's Workers Builds only *builds*, it didn't deploy on merge).
+      Keep Workers Builds as build-only, or disconnect it, to avoid double-deploys.
+
+## D. Turn the beta on (only after B **and** C)
+- [ ] In `wrangler.toml` `[env.production.vars]`, uncomment `BETA_GATE = "1"` and
+      `REFERRAL_SERVICE_URL = "https://usestratum.dev"`, then deploy production.
+      ⚠️ Not before the apex cutover — it would hit old Pages (405) and block signups.
+- [ ] Mint seed codes:
+      `curl -X POST https://usestratum.dev/api/referral/seed -H "Authorization: Bearer <secret>" -d '{"count":25}'`
+- [ ] End-to-end test: redeem a seed code → account created → 5 codes emailed.
+
+## E. Housekeeping (optional)
+- [ ] Rotate `REFERRAL_SERVICE_SECRET` on both Workers (it was generated in a chat session).
+- [ ] Delete the old Pages project once the apex cutover is confirmed.
+- [ ] (Open-core) abstract referral specifics out of core's auth path behind a
+      generic signup-policy hook, so core carries no go-to-market vocabulary.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "deploy:production": "wrangler deploy --env=production",
+    "deploy:staging": "wrangler deploy --env=staging",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -186,6 +186,12 @@ POSTHOG_HOST = "https://app.posthog.com"
 # in the GitHub and Google OAuth app settings.
 OAUTH_REDIRECT_URI = "https://app.usestratum.dev/auth/github/callback"
 GOOGLE_REDIRECT_URI = "https://app.usestratum.dev/auth/google/callback"
+# Closed beta — uncomment BOTH lines to require an invite code at signup.
+# ⚠️ Only AFTER usestratum.dev is cut over to the landing Worker, or this hits the
+# old Pages site (405) and blocks ALL signups. REFERRAL_SERVICE_SECRET must
+# already be set (wrangler secret put) and match the referral service.
+# BETA_GATE = "1"
+# REFERRAL_SERVICE_URL = "https://usestratum.dev"
 
 # =============================================================================
 # [env.staging]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -194,6 +194,11 @@ GOOGLE_REDIRECT_URI = "https://app.usestratum.dev/auth/google/callback"
 [env.staging]
 name = "stratum-staging"
 
+# Staging custom domain (matches the staging OAuth callback host below).
+routes = [
+  { pattern = "staging.app.usestratum.dev", custom_domain = true }
+]
+
 # Observability for staging - full sampling for debugging
 [env.staging.observability]
 enabled = true

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,36 +1,48 @@
+# =============================================================================
+# Stratum Worker configuration
+#
+# The TOP-LEVEL config below is a GENERIC self-hosting template. To run your own
+# instance: replace the binding ids (KV/D1) with your own, set your domain/OAuth
+# values, then `wrangler deploy`.
+#
+# The maintainer's hosted instance is NOT the default — it lives in
+# [env.production] (and [env.staging]) and is deployed with:
+#   wrangler deploy --env production
+# See .github/workflows/deploy-production.yml and ci.yml.
+# =============================================================================
+
 name = "stratum"
 main = "src/index.ts"
 compatibility_date = "2026-04-29"
 compatibility_flags = ["nodejs_compat"]
 
-# Production custom domain. With custom_domain = true, Cloudflare provisions the
-# DNS record + TLS cert for this hostname on deploy (the usestratum.dev zone is in
-# this account). The workers.dev URL keeps working alongside it.
-routes = [
-  { pattern = "app.usestratum.dev", custom_domain = true }
-]
+# Durable Object migrations — defined once, inherited by all environments.
+[[migrations]]
+tag = "v1"
+new_classes = ["MergeQueue"]
 
 # Observability - Workers Logs and Traces
 [observability]
 enabled = true
-head_sampling_rate = 1.0  # 100% sampling for full visibility
+head_sampling_rate = 1.0
 
 [observability.traces]
 enabled = true
-head_sampling_rate = 0.1  # 10% sampling for traces to manage cost
+head_sampling_rate = 0.1
 
+# --- Bindings: replace the ids with your own Cloudflare resources -------------
 [[artifacts]]
 binding = "ARTIFACTS"
-namespace = "stratum-prod"
+namespace = "stratum"
 
 [[kv_namespaces]]
 binding = "STATE"
-id = "2285977f426647cf9e3db347cbc0f03b"
+id = "0000000000000000000000000000000a"  # replace: wrangler kv namespace create STATE
 
 [[d1_databases]]
 binding = "DB"
 database_name = "stratum"
-database_id = "de9b583b-d5f3-4868-a1eb-2208b76c7062"
+database_id = "00000000-0000-0000-0000-00000000000a"  # replace: wrangler d1 create stratum
 migrations_dir = "migrations"
 
 [[analytics_engine_datasets]]
@@ -67,13 +79,6 @@ retry_delay = 30    # Wait 30 seconds between retries
 [triggers]
 crons = ["0 6 * * *", "*/5 * * * *"]
 
-[vars]
-POSTHOG_HOST = "https://app.posthog.com"
-# Production OAuth callbacks must use the production host. The matching callback
-# URLs must also be registered in the GitHub and Google OAuth app settings.
-OAUTH_REDIRECT_URI = "https://app.usestratum.dev/auth/github/callback"
-GOOGLE_REDIRECT_URI = "https://app.usestratum.dev/auth/google/callback"
-
 # Email Sending — configure via: wrangler email sending enable yourdomain.com
 [[send_email]]
 name = "EMAIL"
@@ -82,6 +87,17 @@ name = "EMAIL"
 # [[sandboxes]]
 # binding = "SANDBOX"
 
+[vars]
+POSTHOG_HOST = "https://app.posthog.com"
+# Set these to your own host when self-hosting (and register the callback URLs
+# in your GitHub/Google OAuth apps):
+OAUTH_REDIRECT_URI = "http://localhost:8787/auth/github/callback"
+# GOOGLE_REDIRECT_URI = "https://your-app.example.com/auth/google/callback"
+# Closed-beta gate (hosted-only; leave unset/commented for ungated self-hosting).
+# The gate turns ON only when BETA_GATE = "1" AND REFERRAL_SERVICE_URL is set.
+# BETA_GATE = "1"
+# REFERRAL_SERVICE_URL = "https://your-referral-service.example.com"
+
 # Secrets — set via: wrangler secret put <NAME>
 # POSTHOG_API_KEY =
 # STRATUM_TELEMETRY_DISABLED = "true"  # uncomment to disable telemetry for self-hosted
@@ -89,10 +105,92 @@ name = "EMAIL"
 # GITHUB_CLIENT_SECRET =
 # GOOGLE_CLIENT_ID =
 # GOOGLE_CLIENT_SECRET =
-# GOOGLE_REDIRECT_URI = "https://yourdomain.com/auth/google/callback"
 # EMAIL_FROM_ADDRESS = "noreply@yourdomain.com"  # for magic link emails
+# REFERRAL_SERVICE_SECRET =  # closed-beta gate shared secret (must match the referral service)
 
-# Staging environment
+# =============================================================================
+# [env.production] — the maintainer's hosted instance (app.usestratum.dev).
+# Deploy with: wrangler deploy --env production
+# Named environments do NOT inherit top-level bindings/vars/routes, so the real
+# configuration is fully declared here.
+# =============================================================================
+[env.production]
+name = "stratum"
+
+# Production custom domain. With custom_domain = true, Cloudflare provisions the
+# DNS record + TLS cert for this hostname on deploy. workers.dev keeps working.
+routes = [
+  { pattern = "app.usestratum.dev", custom_domain = true }
+]
+
+[env.production.observability]
+enabled = true
+head_sampling_rate = 1.0
+
+[env.production.observability.traces]
+enabled = true
+head_sampling_rate = 0.1
+
+[[env.production.artifacts]]
+binding = "ARTIFACTS"
+namespace = "stratum-prod"
+
+[[env.production.kv_namespaces]]
+binding = "STATE"
+id = "2285977f426647cf9e3db347cbc0f03b"
+
+[[env.production.d1_databases]]
+binding = "DB"
+database_name = "stratum"
+database_id = "de9b583b-d5f3-4868-a1eb-2208b76c7062"
+migrations_dir = "migrations"
+
+[[env.production.analytics_engine_datasets]]
+binding = "ANALYTICS"
+dataset = "stratum_requests"
+
+[env.production.ai]
+binding = "AI"
+
+[[env.production.durable_objects.bindings]]
+name = "MERGE_QUEUE"
+class_name = "MergeQueue"
+script_name = "stratum"
+
+[[env.production.queues.producers]]
+binding = "EVENTS_QUEUE"
+queue = "stratum-events"
+
+[[env.production.queues.producers]]
+binding = "IMPORT_QUEUE"
+queue = "stratum-imports"
+
+[[env.production.queues.consumers]]
+queue = "stratum-events"
+
+[[env.production.queues.consumers]]
+queue = "stratum-imports"
+max_batch_size = 1
+max_retries = 3
+retry_delay = 30
+
+[env.production.triggers]
+crons = ["0 6 * * *", "*/5 * * * *"]
+
+[[env.production.send_email]]
+name = "EMAIL"
+
+[env.production.vars]
+POSTHOG_HOST = "https://app.posthog.com"
+# Production OAuth callbacks. The matching callback URLs must also be registered
+# in the GitHub and Google OAuth app settings.
+OAUTH_REDIRECT_URI = "https://app.usestratum.dev/auth/github/callback"
+GOOGLE_REDIRECT_URI = "https://app.usestratum.dev/auth/google/callback"
+
+# =============================================================================
+# [env.staging]
+# Deploy with: wrangler deploy --env staging
+# =============================================================================
 [env.staging]
 name = "stratum-staging"
 
@@ -104,10 +202,6 @@ head_sampling_rate = 1.0
 [env.staging.observability.traces]
 enabled = true
 head_sampling_rate = 1.0  # 100% sampling in staging for debugging
-
-[[migrations]]
-tag = "v1"
-new_classes = ["MergeQueue"]
 
 [[env.staging.artifacts]]
 binding = "ARTIFACTS"
@@ -148,7 +242,7 @@ queue = "stratum-imports"
 # Enable when running integration tests: wrangler deploy --env=staging
 # [[env.staging.queues.consumers]]
 # queue = "stratum-events-staging"
-# 
+#
 # [[env.staging.queues.consumers]]
 # queue = "stratum-imports-staging"
 # max_batch_size = 1

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -116,6 +116,9 @@ OAUTH_REDIRECT_URI = "http://localhost:8787/auth/github/callback"
 # =============================================================================
 [env.production]
 name = "stratum"
+# Keep the *.workers.dev URL enabled alongside the custom domain (wrangler
+# disables it by default once `routes` is set). The deploy smoke tests hit it.
+workers_dev = true
 
 # Production custom domain. With custom_domain = true, Cloudflare provisions the
 # DNS record + TLS cert for this hostname on deploy. workers.dev keeps working.
@@ -199,6 +202,8 @@ GOOGLE_REDIRECT_URI = "https://app.usestratum.dev/auth/google/callback"
 # =============================================================================
 [env.staging]
 name = "stratum-staging"
+# Keep *.workers.dev enabled alongside the custom domain (the smoke tests use it).
+workers_dev = true
 
 # Staging custom domain (matches the staging OAuth callback host below).
 routes = [

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,13 @@ main = "src/index.ts"
 compatibility_date = "2026-04-29"
 compatibility_flags = ["nodejs_compat"]
 
+# Production custom domain. With custom_domain = true, Cloudflare provisions the
+# DNS record + TLS cert for this hostname on deploy (the usestratum.dev zone is in
+# this account). The workers.dev URL keeps working alongside it.
+routes = [
+  { pattern = "app.usestratum.dev", custom_domain = true }
+]
+
 # Observability - Workers Logs and Traces
 [observability]
 enabled = true
@@ -62,7 +69,10 @@ crons = ["0 6 * * *", "*/5 * * * *"]
 
 [vars]
 POSTHOG_HOST = "https://app.posthog.com"
-OAUTH_REDIRECT_URI = "http://localhost:8787/auth/github/callback"
+# Production OAuth callbacks must use the production host. The matching callback
+# URLs must also be registered in the GitHub and Google OAuth app settings.
+OAUTH_REDIRECT_URI = "https://app.usestratum.dev/auth/github/callback"
+GOOGLE_REDIRECT_URI = "https://app.usestratum.dev/auth/google/callback"
 
 # Email Sending — configure via: wrangler email sending enable yourdomain.com
 [[send_email]]


### PR DESCRIPTION
## What

Two things, both about the open-core boundary in `wrangler.toml`:

1. **Templatize the config for self-hosting.** The top-level `wrangler.toml` is now a **generic self-host template** — placeholder KV/D1 ids, `localhost` OAuth, no custom domain, beta gate off. A cloner edits the top level and runs `wrangler deploy` without inheriting the maintainer's domains, account ids, or go-to-market config.
2. **Move the hosted instance into `[env.production]`** (mirrors the existing `[env.staging]`): real KV/D1 ids, the `app.usestratum.dev` custom domain, and production OAuth callbacks. This also puts the core app on **`app.usestratum.dev`** (it was only on `*.workers.dev`).

### Deploy command changed
Production now deploys with `wrangler deploy --env=production`. Updated atomically:
- `.github/workflows/deploy-production.yml` — deploy step.
- `.github/workflows/ci.yml` — production deploy + D1 migrations apply.
- Added `deploy:production` / `deploy:staging` npm scripts. (`d1-migrate.yml` already parameterized `--env`; `[env.production]` now actually exists for it.)

Validated with `wrangler deploy --dry-run` for the default, `--env=production`, and `--env=staging` configs — all bundle, with the right bindings/vars per env.

## ⚠️ Review / merge checklist (production-critical)
- This changes how **production** deploys. Core has **no** Cloudflare Workers Builds integration (GitHub Actions only), so the two workflow edits fully control prod — but please **deploy to staging first** (`wrangler deploy --env=staging`) to confirm, then trigger the production workflow.
- The prod worker keeps `name = "stratum"` (smoke-test URLs unchanged) and the same KV/D1/queue/DO bindings — no resource identity change.
- Manual `wrangler deploy` (no `--env`) now targets the *template*; the placeholder ids make it fail rather than clobber prod. Use `npm run deploy:production`.

## On deploy
1. The `app.usestratum.dev` custom domain + cert provision during the production deploy.
2. Register the callback URLs in the OAuth apps:
   - GitHub → `https://app.usestratum.dev/auth/github/callback`
   - Google → `https://app.usestratum.dev/auth/google/callback`

Supersedes the original domain-only version of this PR. Independent of #92 (beta gate) and stratum-landing#7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)