### PR TITLE
feat(beta): enable closed-beta invite gate (staging + production)

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -189,12 +189,17 @@ POSTHOG_HOST = "https://app.posthog.com"
 # in the GitHub and Google OAuth app settings.
 OAUTH_REDIRECT_URI = "https://app.usestratum.dev/auth/github/callback"
 GOOGLE_REDIRECT_URI = "https://app.usestratum.dev/auth/google/callback"
-# Closed beta — uncomment BOTH lines to require an invite code at signup.
-# ⚠️ Only AFTER usestratum.dev is cut over to the landing Worker, or this hits the
-# old Pages site (405) and blocks ALL signups. REFERRAL_SERVICE_SECRET must
-# already be set (wrangler secret put) and match the referral service.
-# BETA_GATE = "1"
-# REFERRAL_SERVICE_URL = "https://usestratum.dev"
+# Closed beta — invite code required at signup. The gate fails closed, so
+# REFERRAL_SERVICE_URL must point at a LIVE referral service over a real public
+# hostname: Worker->Worker subrequests over *.workers.dev are intermittently
+# 404'd by the edge, so the referral service has its own custom domain
+# (referral.usestratum.dev -> stratum-landing Worker). The apex usestratum.dev
+# is still on the legacy Pages project; fold this into usestratum.dev after that
+# cutover if desired.
+# REFERRAL_SERVICE_SECRET is set out-of-band via `wrangler secret put` and must
+# match the value on the stratum-landing Worker.
+BETA_GATE = "1"
+REFERRAL_SERVICE_URL = "https://referral.usestratum.dev"
 
 # =============================================================================
 # [env.staging]
@@ -272,3 +277,7 @@ name = "EMAIL"
 POSTHOG_HOST = "https://app.posthog.com"
 OAUTH_REDIRECT_URI = "https://staging.app.usestratum.dev/auth/github/callback"
 EMAIL_FROM_ADDRESS = "noreply@staging.app.usestratum.dev"
+# Closed beta — validate the invite gate on staging before prod. Points at the
+# live stratum-landing Worker (see [env.production.vars] cutover note).
+BETA_GATE = "1"
+REFERRAL_SERVICE_URL = "https://referral.usestratum.dev"


### PR DESCRIPTION
## What
Turns on the closed-beta invite gate for **staging** and **production** by enabling `BETA_GATE` and pointing `REFERRAL_SERVICE_URL` at the referral service. New account signups now require a valid invite code.

## Why a custom domain (referral.usestratum.dev) and not *.workers.dev
The gate (`src/beta/gate.ts`) fails **closed** — any non-OK/error from the referral service rejects the signup. Pointing `REFERRAL_SERVICE_URL` at `stratum-landing.jlmx.workers.dev` caused core→landing Worker subrequests to be **intermittently 404'd by the edge before reaching the landing Worker** (verified with `wrangler tail` on both sides: direct curl → 200, core subrequest → never arrives, core logs `Invite validation returned non-OK {status:404}`). Valid codes were rejected ~half the time. Routing through a real public custom domain (`referral.usestratum.dev` → `stratum-landing` Worker) fixes it.

## Validation (staging)
- no code → `error=invite_required` (consistent)
- bad code → `error=invalid_invite`
- valid code → passes the gate **5/5 consistent** (then `send_failed`, expected: staging sender domain unverified)

## Ops done out-of-band
- `REFERRAL_SERVICE_SECRET` set to one shared value across core prod, core staging, and stratum-landing.
- `referral.usestratum.dev` custom domain attached to stratum-landing.
- 25 launch invite codes seeded.

## Deploy
Production deploy is `workflow_dispatch` only — the gate goes live in prod when this merges **and** production is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Beta invite gate is now active in production and staging environments
* Referral service routing configured across all environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->