### PR TITLE
fix(ui): group nav left + add favicon

### DIFF
--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -18,6 +18,10 @@ export const Layout: FC<LayoutProps> = ({ title, user, refreshSeconds, children 
           <meta http-equiv="refresh" content={String(refreshSeconds)} />
         )}
         <title>{title} — Stratum</title>
+        <link
+          rel="icon"
+          href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='6'%20fill='%230d0d0d'/%3E%3Ctext%20x='16'%20y='23'%20font-family='monospace'%20font-size='20'%20font-weight='700'%20fill='%237ca9f7'%20text-anchor='middle'%3ES%3C/text%3E%3C/svg%3E"
+        />
         <link rel="stylesheet" href="/ui.css" />
       </head>
       <body>

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -17,7 +17,7 @@ a:hover { text-decoration: underline; }
 .nav {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   flex-wrap: wrap;
   gap: 0.35rem 1.25rem;
   padding: 0.75rem 1.5rem;
@@ -37,7 +37,7 @@ a:hover { text-decoration: underline; }
 }
 .nav-brand:hover { text-decoration: none; color: #7ca9f7; }
 
-.nav-links { display: flex; gap: 1.25rem; }
+.nav-links { display: flex; gap: 1.25rem; margin-right: auto; }
 .nav-links a { color: #999; font-size: 0.9rem; }
 .nav-links a:hover { color: #f0f0f0; text-decoration: none; }
 


### PR DESCRIPTION
## UI review pass

Audited the app end-to-end with Playwright (dashboard, repo, file viewer, new-project, issues list/create/detail, changes) at desktop (1280) and mobile (390) widths. The UI is clean and responsive; found and fixed two real issues:

### 1. Nav: `projects` orphaned in the center
`.nav` used `justify-content: space-between` with three children (brand / links / auth), floating the lone `projects` link into the middle of the bar. Now brand + links sit together on the left and auth is pushed right (`justify-content: flex-start` + `margin-right: auto` on `.nav-links`). Verified on desktop and wrapping on mobile.

### 2. `favicon.ico` 404 on every page
No icon was declared, so every page logged `GET /favicon.ico 404`. Added an inline SVG favicon (theme-matched) in the layout `<head>`; console is now clean (0 errors).

## Verification
- Local `wrangler dev`, all screens re-checked after the fix
- Issue creation exercised end-to-end (form → submit → detail renders)
- `typecheck` + `lint` clean, `755` tests pass

## Noted, not changed (follow-up)
- File viewer has no line-number gutter. Adding it safely means restructuring the `dangerouslySetInnerHTML` highlighter output per-line; out of scope for this low-risk pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a custom favicon for the application, visible in browser tabs and bookmarks.

* **Style**
  * Refined navigation bar layout with adjusted item alignment and spacing distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->