### PR TITLE
fix(ui): add favicon to auth pages

### DIFF
--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -91,6 +91,10 @@ app.get("/", (c) => {
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Sign In — Stratum</title>
+        <link
+          rel="icon"
+          href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='6'%20fill='%230d0d0d'/%3E%3Ctext%20x='16'%20y='23'%20font-family='monospace'%20font-size='20'%20font-weight='700'%20fill='%237ca9f7'%20text-anchor='middle'%3ES%3C/text%3E%3C/svg%3E"
+        />
         <link rel="stylesheet" href="/ui.css" />
         <style>{`
           .auth-container {

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -32,6 +32,10 @@ app.get("/", (c) => {
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Sign In — Stratum</title>
+        <link
+          rel="icon"
+          href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='6'%20fill='%230d0d0d'/%3E%3Ctext%20x='16'%20y='23'%20font-family='monospace'%20font-size='20'%20font-weight='700'%20fill='%237ca9f7'%20text-anchor='middle'%3ES%3C/text%3E%3C/svg%3E"
+        />
         <link rel="stylesheet" href="/ui.css" />
         <style>{`
           :root {

--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -46,6 +46,10 @@ app.get("/", (c) => {
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Create Account — Stratum</title>
+        <link
+          rel="icon"
+          href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='6'%20fill='%230d0d0d'/%3E%3Ctext%20x='16'%20y='23'%20font-family='monospace'%20font-size='20'%20font-weight='700'%20fill='%237ca9f7'%20text-anchor='middle'%3ES%3C/text%3E%3C/svg%3E"
+        />
         <link rel="stylesheet" href="/ui.css" />
         <style>{`
 					.signup-container {


### PR DESCRIPTION
Follow-up to #98. The auth pages (`login.tsx`, `signup.tsx`, `email-auth.tsx`) render their own `<head>` rather than the shared `Layout`, so they still logged `GET /favicon.ico 404` — and these are the first pages every beta signup hits. Adds the same inline SVG favicon to all three.

`typecheck` + `lint` clean, 755 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added custom favicon to authentication pages (email choice, login, and signup) for improved visual presentation in browser tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->