### PR TITLE
fix(dashboard): show only the caller's own projects, not the public firehose

### DIFF
--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -41,7 +41,12 @@ import { SettingsPage } from "../ui/pages/settings";
 import { SyncPage } from "../ui/pages/sync";
 import { WebhooksPage } from "../ui/pages/webhooks";
 import { WorkspacesPage } from "../ui/pages/workspaces";
-import { canReadProject, canWriteProject, filterReadableProjects } from "../utils/authz";
+import {
+  canReadProject,
+  canWriteProject,
+  filterMemberProjects,
+  filterReadableProjects,
+} from "../utils/authz";
 import { createLogger } from "../utils/logger";
 import { isValidNamespace, isValidSlug } from "../utils/validation";
 import { SUBSCRIBABLE_EVENTS } from "./webhooks";
@@ -112,12 +117,13 @@ app.get("/", async (c) => {
   }
 
   const user = userResult;
-  const projects = await filterReadableProjects(
-    c.env.DB,
-    allProjectsResult.data,
-    userId,
-    agentOwnerId,
-  );
+  // The dashboard is the caller's personal workspace: signed-in users see only
+  // the projects that are theirs (owned + org/team), NOT the whole instance's
+  // public projects. Signed-out visitors still get a public showcase.
+  const isAuthenticated = userId !== undefined || agentOwnerId !== undefined;
+  const projects = isAuthenticated
+    ? await filterMemberProjects(c.env.DB, allProjectsResult.data, userId, agentOwnerId)
+    : await filterReadableProjects(c.env.DB, allProjectsResult.data, userId, agentOwnerId);
   const view = projects.map((p) => ({
     name: p.name,
     namespace: p.namespace,

--- a/src/utils/authz.ts
+++ b/src/utils/authz.ts
@@ -94,3 +94,39 @@ export async function filterReadableProjects(
     return false;
   });
 }
+
+/**
+ * Filter a project list down to the ones that belong to the caller: projects
+ * they directly own, plus org-owned projects they're a member of. Unlike
+ * {@link filterReadableProjects}, this deliberately EXCLUDES other people's
+ * public projects — it answers "what's mine?", not "what can I see?". This is
+ * what the personal dashboard wants, so a user's home shows their own work
+ * rather than the whole instance's public firehose. Returns an empty list for
+ * an unauthenticated caller (no actor to own anything).
+ */
+export async function filterMemberProjects(
+  db: D1Database,
+  projects: ProjectEntry[],
+  userId?: string,
+  agentOwnerId?: string,
+): Promise<ProjectEntry[]> {
+  const actor = userId ?? agentOwnerId;
+  if (!actor) return [];
+
+  const orgLevels = new Map<string, OrgAccessLevel>();
+  const orgIds = new Set(projects.filter((p) => p.ownerType === "org").map((p) => p.ownerId));
+  for (const orgId of orgIds) {
+    orgLevels.set(orgId, await getOrgAccessLevel(db, logger, orgId, actor));
+  }
+  const orgLevel = (orgId: string): OrgAccessLevel => orgLevels.get(orgId) ?? "none";
+
+  return projects.filter((project) => {
+    if (project.importCompleted === false) {
+      if (isDirectOwner(project, userId, agentOwnerId)) return true;
+      return project.ownerType === "org" && levelAllowsWrite(orgLevel(project.ownerId));
+    }
+    if (isDirectOwner(project, userId, agentOwnerId)) return true;
+    if (project.ownerType === "org") return orgLevel(project.ownerId) !== "none";
+    return false;
+  });
+}

--- a/tests/org-authz.test.ts
+++ b/tests/org-authz.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getOrgAccessLevel } from "../src/storage/orgs";
 import type { ProjectEntry } from "../src/types";
-import { canReadProject, canWriteProject, filterReadableProjects } from "../src/utils/authz";
+import {
+  canReadProject,
+  canWriteProject,
+  filterMemberProjects,
+  filterReadableProjects,
+} from "../src/utils/authz";
 import type { Logger } from "../src/utils/logger";
 
 vi.mock("../src/storage/orgs", () => ({
@@ -117,5 +122,50 @@ describe("org project authorization", () => {
     vi.mocked(getOrgAccessLevel).mockResolvedValue("write");
     const writable = await filterReadableProjects(db, [incomplete], "user_writer");
     expect(writable).toHaveLength(1);
+  });
+});
+
+describe("filterMemberProjects (personal dashboard scope)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("includes the caller's own + org projects but NOT others' public projects", async () => {
+    // Caller is a member of org_1 only; org_2 is someone else's org.
+    vi.mocked(getOrgAccessLevel).mockImplementation(async (_db, _logger, orgId) =>
+      orgId === "org_1" ? "read" : "none",
+    );
+    const projects = [
+      makeProject({ id: "mine", ownerId: "user_me" }),
+      makeProject({ id: "myorg", ownerId: "org_1", ownerType: "org" }),
+      // Other people's public projects — readable, but NOT mine.
+      makeProject({ id: "pub", ownerId: "user_other", visibility: "public" }),
+      makeProject({ id: "pub_org", ownerId: "org_2", ownerType: "org", visibility: "public" }),
+    ];
+
+    const mine = await filterMemberProjects(db, projects, "user_me");
+    expect(mine.map((p) => p.id)).toEqual(["mine", "myorg"]);
+  });
+
+  it("still includes my own project even when it is public", async () => {
+    vi.mocked(getOrgAccessLevel).mockResolvedValue("none");
+    const projects = [makeProject({ id: "mine_pub", ownerId: "user_me", visibility: "public" })];
+    const mine = await filterMemberProjects(db, projects, "user_me");
+    expect(mine.map((p) => p.id)).toEqual(["mine_pub"]);
+  });
+
+  it("returns an empty list for an unauthenticated caller", async () => {
+    const projects = [makeProject({ id: "pub", ownerId: "user_other", visibility: "public" })];
+    const mine = await filterMemberProjects(db, projects);
+    expect(mine).toHaveLength(0);
+    // No actor — no org lookups needed.
+    expect(getOrgAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it("excludes org projects the caller is not a member of", async () => {
+    vi.mocked(getOrgAccessLevel).mockResolvedValue("none");
+    const projects = [makeProject({ id: "foreign_org", ownerId: "org_x", ownerType: "org" })];
+    const mine = await filterMemberProjects(db, projects, "user_me");
+    expect(mine).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Problem
`GET /` rendered every project the caller could **read** (`filterReadableProjects`), and "readable" includes **every public project on the instance**. So a signed-in user's dashboard — including a brand-new user with no projects — showed strangers' public repos in arbitrary (storage) order, and the "No projects yet → Create your first project" onboarding only fired when there were *zero* readable projects (public ones included). The personal home wasn't personal.

## Fix
- New `filterMemberProjects(db, projects, userId, agentOwnerId)` in `authz.ts`: returns projects the caller **owns** + **org/team** projects they're a member of, deliberately **excluding** other people's public projects. Returns `[]` for an unauthenticated caller.
- Dashboard route uses it for authenticated callers; signed-out visitors keep the public showcase (`filterReadableProjects`) unchanged.
- Public projects remain fully reachable by direct URL — only the dashboard listing changed.

## Verification
Local `wrangler dev`, two users:
- Fresh user **alice**: dashboard shows **no** other users' public repos + the "Create your first project" onboarding ✅
- **jordan**: still sees his own (incl. his public) projects ✅
- Logged-out visitor: still sees the public showcase ✅

4 new unit tests in `org-authz.test.ts` (excludes others' public, keeps own-public, empty for anon, excludes non-member orgs). `typecheck` + `lint` clean, 769 tests pass.

## Follow-up (not in this PR)
Public-project discovery deserves a dedicated, ranked `/explore` surface rather than leaking into the personal dashboard — left as a future enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The dashboard now displays projects tailored to your account status—personal and team projects for logged-in users, or the public project showcase for visitors.

* **Tests**
  * Added comprehensive test coverage for project display logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->