### PR TITLE
fix(ui): private-by-default, personal dashboard, recency sort, nav/empty-state polish

### DIFF
--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -41,12 +41,7 @@ import { SettingsPage } from "../ui/pages/settings";
 import { SyncPage } from "../ui/pages/sync";
 import { WebhooksPage } from "../ui/pages/webhooks";
 import { WorkspacesPage } from "../ui/pages/workspaces";
-import {
-  canReadProject,
-  canWriteProject,
-  filterMemberProjects,
-  filterReadableProjects,
-} from "../utils/authz";
+import { canReadProject, canWriteProject, filterMemberProjects } from "../utils/authz";
 import { createLogger } from "../utils/logger";
 import { isValidNamespace, isValidSlug } from "../utils/validation";
 import { SUBSCRIBABLE_EVENTS } from "./webhooks";
@@ -117,14 +112,23 @@ app.get("/", async (c) => {
   }
 
   const user = userResult;
-  // The dashboard is the caller's personal workspace: signed-in users see only
-  // the projects that are theirs (owned + org/team), NOT the whole instance's
-  // public projects. Signed-out visitors still get a public showcase.
-  const isAuthenticated = userId !== undefined || agentOwnerId !== undefined;
-  const projects = isAuthenticated
-    ? await filterMemberProjects(c.env.DB, allProjectsResult.data, userId, agentOwnerId)
-    : await filterReadableProjects(c.env.DB, allProjectsResult.data, userId, agentOwnerId);
-  const view = projects.map((p) => ({
+  // The dashboard is the caller's personal workspace: it lists only the projects
+  // that are theirs (owned + org/team), never the whole instance's public
+  // projects. Signed-out visitors get an empty list and a sign-in prompt; public
+  // projects remain reachable by direct URL.
+  const memberProjects = await filterMemberProjects(
+    c.env.DB,
+    allProjectsResult.data,
+    userId,
+    agentOwnerId,
+  );
+  // Most-recently-created first. createdAt is ISO-8601, so lexicographic order
+  // matches chronological order.
+  memberProjects.sort((a, b) => {
+    if (a.createdAt === b.createdAt) return 0;
+    return a.createdAt < b.createdAt ? 1 : -1;
+  });
+  const view = memberProjects.map((p) => ({
     name: p.name,
     namespace: p.namespace,
     slug: p.slug,

--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -29,9 +29,6 @@ export const Layout: FC<LayoutProps> = ({ title, user, refreshSeconds, children 
           <a class="nav-brand" href="/">
             stratum
           </a>
-          <div class="nav-links">
-            <a href="/">projects</a>
-          </div>
           <div class="nav-auth">
             {user ? (
               <>

--- a/src/ui/pages/changes.tsx
+++ b/src/ui/pages/changes.tsx
@@ -50,6 +50,9 @@ export const ChangesPage: FC<ChangesProps> = ({ project, changes, user }) => {
       {changes.length === 0 ? (
         <div class="empty-state">
           <p>No changes yet.</p>
+          <p class="empty-state-hint">
+            Open a change to propose edits and gate them on tests and review before they merge.
+          </p>
         </div>
       ) : (
         <div class="table-scroll">

--- a/src/ui/pages/home.tsx
+++ b/src/ui/pages/home.tsx
@@ -39,13 +39,13 @@ export const HomePage: FC<HomeProps> = ({ projects, user }) => {
             </>
           ) : (
             <>
-              <p>No public projects available.</p>
+              <p>Sign in to view your projects.</p>
               <a
                 href="/auth/email"
                 class="btn btn-primary"
                 style={{ marginTop: "1rem", display: "inline-block" }}
               >
-                Sign in to see your projects
+                Sign in
               </a>
             </>
           )}

--- a/src/ui/pages/issues.tsx
+++ b/src/ui/pages/issues.tsx
@@ -61,6 +61,9 @@ export const IssuesPage: FC<IssuesPageProps> = ({
       {issues.length === 0 ? (
         <div class="empty-state">
           <p>No {filter === "all" ? "" : `${filter} `}issues.</p>
+          <p class="empty-state-hint">
+            Open an issue to track work, bugs, or ideas for this project.
+          </p>
         </div>
       ) : (
         <ul class="issues-list">

--- a/src/ui/pages/new-project.tsx
+++ b/src/ui/pages/new-project.tsx
@@ -72,10 +72,10 @@ export const NewProjectPage: FC<NewProjectProps> = ({ user, error }) => {
                 fontFamily: "inherit",
               }}
             >
-              <option value="public" selected>
-                Public (anyone can see it)
+              <option value="public">Public (anyone can see it)</option>
+              <option value="private" selected>
+                Private (only you can see it)
               </option>
-              <option value="private">Private (only you can see it)</option>
             </select>
           </div>
 
@@ -176,10 +176,10 @@ export const NewProjectPage: FC<NewProjectProps> = ({ user, error }) => {
                 fontFamily: "inherit",
               }}
             >
-              <option value="public" selected>
-                Public (anyone can see it)
+              <option value="public">Public (anyone can see it)</option>
+              <option value="private" selected>
+                Private (only you can see it)
               </option>
-              <option value="private">Private (only you can see it)</option>
             </select>
           </div>
 

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -34,12 +34,9 @@ a:hover { text-decoration: underline; }
   font-weight: 700;
   color: #f0f0f0;
   letter-spacing: 0.05em;
+  margin-right: auto;
 }
 .nav-brand:hover { text-decoration: none; color: #7ca9f7; }
-
-.nav-links { display: flex; gap: 1.25rem; margin-right: auto; }
-.nav-links a { color: #999; font-size: 0.9rem; }
-.nav-links a:hover { color: #f0f0f0; text-decoration: none; }
 
 .nav-auth {
   display: flex;
@@ -171,6 +168,7 @@ a:hover { text-decoration: underline; }
 .btn-danger:hover  { background: #4d2020; color: #fca5a5; }
 
 .empty-state { padding: 2rem 0; color: #555; text-align: center; }
+.empty-state-hint { margin-top: 0.4rem; font-size: 0.85rem; color: #4d4d4d; }
 
 .file-list { list-style: none; }
 .file-item { padding: 0.3rem 0; border-bottom: 1px solid #161616; font-size: 0.85rem; color: #ccc; }


### PR DESCRIPTION
Four follow-ups to the dashboard-scoping fix (#103), same class of issue (over-exposing defaults / arbitrary surfaces).

## Changes
1. **New projects default to Private.** Both the create and GitHub-import forms had `<option value="public" selected>`. On a code host during an invite-only beta that publishes users' code by default. The API already defaults to `private` (`src/routes/projects.ts`); this just aligns the form. Public is now a deliberate opt-in.
2. **Personal dashboard for everyone.** `GET /` now uses `filterMemberProjects` for all callers, so signed-out visitors get a sign-in prompt instead of the instance's public project list. Public projects stay reachable by direct URL.
3. **Recency sort.** Dashboard projects sort newest-first by `createdAt` (ISO-8601 → lexicographic == chronological), with a proper three-way comparator.
4. **Polish.** Removed the redundant `projects` nav link (brand already links home; moved `margin-right:auto` to `.nav-brand`); added a one-line hint under the bare `changes`/`issues` empty states.

## Verification
Local `wrangler dev`: forms render Private selected; anon root hides public repos + shows the sign-in prompt; `newer-repo` sorts before `older-repo`; nav has no duplicate link. A code-review pass flagged one improper sort comparator (didn't return 0 on equal) — fixed. `typecheck` + `lint` clean, 769 tests pass.

## Not in scope
A ranked `/explore` discovery page (future) — public projects intentionally don't appear on the personal dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Navigation layout refined with improved spacing and positioning
  * Added contextual hints to empty states on Changes and Issues pages for better user guidance

* **Changes**
  * Default new project visibility changed from Public to Private in creation forms
  * Sign-in button text simplified and home page messaging updated for logged-out users
  * Empty states now include actionable hints to guide users on next steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->