### PR TITLE
docs: ADR 004 + spike plan for high-frequency agent commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ npx wrangler d1 migrations apply stratum --remote  # for production
 - [ADR 001: Namespace Support](docs/adr/001-namespace-support.md)
 - [ADR 002: Queue-Based Imports](docs/adr/002-queue-based-imports.md)
 - [ADR 003: D1 for Import State](docs/adr/003-d1-for-import-state.md)
+- [ADR 004: High-Frequency Agent Commits](docs/adr/004-high-frequency-agent-commits.md)
 
 ## Architecture
 

--- a/docs/adr/004-high-frequency-agent-commits.md
+++ b/docs/adr/004-high-frequency-agent-commits.md
@@ -1,0 +1,209 @@
+# ADR 004: High-Frequency Agent Commits to a Shared Repo
+
+## Status
+
+Proposed
+
+## Context
+
+The current commit/merge path was designed for a fork-per-workspace model:
+each agent or human works in an isolated workspace repo and merges into the
+project repo deliberately, through an evaluation gate. That model is safe and
+correct, but it assumes merges are *infrequent*.
+
+A growing class of workloads breaks that assumption: **many agents editing the
+same repository concurrently, at high frequency.** Competing forges are now
+demonstrating sustained single-repo throughput (~20+ commits/sec into one repo,
+plus hundreds of thousands of clones/pushes per hour) explicitly to remove Git
+as a bottleneck once a swarm of agents edits one codebase at once.
+
+We believe this parallel-agent pattern is where the ecosystem is heading, and
+Stratum should be able to compete on it rather than only on isolation.
+
+### Why we cannot do this today
+
+Two architectural walls, both in `src/storage/git-ops.ts` and
+`src/queue/merge-queue.ts`:
+
+1. **Heavy work inside the serialization window.** Every merge does a full
+   `git.clone` (`depth: 50`) into an in-memory filesystem, fetches the
+   workspace remote, runs a three-way merge, and pushes the whole result back —
+   and the push body is fully buffered because Workers cannot half-duplex
+   stream (`git-ops.ts`, the custom `http.request`). Each commit is seconds of
+   cold network round-trips to Artifacts.
+
+2. **Per-project serialization with no fast path.** Merges run through the
+   `MergeQueue` Durable Object (`merge-queue.ts`), one project per DO, one merge
+   in flight at a time. That caps a single repo at ~1–2 merges/sec — and the DO
+   does the heavy git work *itself*, so the cap is on seconds-long operations,
+   not on the underlying coordination primitive.
+
+`TODO.md` already lists the relevant gaps: "Batch merging in the merge queue
+Durable Object" and "Load testing: 1000+ concurrent workspaces per repo."
+
+### The core insight
+
+A git commit is two operations with opposite concurrency profiles:
+
+- **Object writes** (blobs, trees, commit objects) are content-addressed and
+  immutable. They need **zero coordination** — the hash is the address, so any
+  number of agents can write objects in parallel and never collide.
+- **The ref update** (`refs/heads/main`: oldOid → newOid) is the *only*
+  serialization point in git, and it is a compare-and-swap — microseconds, not
+  seconds.
+
+High single-repo throughput is not hard because of the CAS; it is hard because
+today we do *seconds of heavy work inside the CAS window*. The fix is to move
+everything except the ref CAS out of the serialized path.
+
+## Decision
+
+Adopt a **three-plane architecture** that separates object writes, ref updates,
+and conflict resolution, and roll it out in two stages (Option B first, then
+Option A if the metric still warrants it — see Alternatives).
+
+```
+        ┌─────────────────────────────────────────────┐
+Agents  │   OBJECT PLANE  (no coordination)            │
+  ──────┼──▶  write blobs/trees/commits ──▶  store     │  infinite fan-out
+        │                                              │
+        │   REF PLANE     (one authority per repo)      │
+  ──────┼──▶  RepoDO: CAS on refs/heads/main           │  microsecond serialize
+        │         ├─ fast-forward? done.                │
+        │         └─ raced? ─┐                           │
+        │                    ▼                           │
+        │   RESOLVE PLANE (async, off the hot path)      │
+        │      3-way tree merge → LLM only on overlap    │  true conflicts only
+        └─────────────────────────────────────────────┘
+```
+
+1. **Object plane — no coordination.** Commit objects are written to the object
+   store directly and in parallel. Because they are content-addressed, there is
+   nothing to serialize. This is the part that must absorb "hundreds of
+   thousands of writes/hour."
+
+2. **Ref plane — one authority per repo.** Promote the per-project Durable
+   Object from "merge serializer" to **repo ref authority**. It holds packed
+   refs and a hot object index in memory (not the whole repo; large blobs stay
+   in the object store). A commit becomes: *write objects → ask the DO to
+   advance the ref.* The DO does an in-memory compare-and-swap:
+   - `head == expectedParent` → fast-forward, return. This is the overwhelming
+     majority of commits at high frequency, because concurrent agents mostly
+     touch different files. The hot path is now a pointer write; a single DO
+     sustains tens of thousands/sec.
+   - `head != expectedParent` → the commit raced; hand it to the resolve plane.
+     **Never reject on a race.**
+
+3. **Resolve plane — async, off the hot path.** When the CAS loses a race,
+   rebase the incoming tree onto the new head. Most races are not real
+   conflicts (different files three-way merge mechanically). Only a genuine
+   same-hunk overlap escalates, and *that* is where the existing LLM evaluator
+   (AI Gateway) becomes an auto-resolver: it produces a resolved tree, which
+   re-attempts the CAS like any other commit. The LLM call happens in the
+   async resolve plane and never blocks the commit loop. This is the
+   "automatic conflict resolution" capability, built from infrastructure we
+   already have (`resolveConflict` in `git-ops.ts`, the LLM evaluator, and the
+   `conflict-resolution.tsx` UI).
+
+4. **Batch the CAS.** The DO drains N queued ref advances, computes one combined
+   tree, performs one CAS, and writes one pack. This makes the already-cheap
+   serialization point cheaper still and turns the existing "batch merging in
+   the merge queue DO" TODO item into a load-bearing component.
+
+### Rollout: Option B first
+
+We will ship **Option B (warm DO cache in front of Artifacts)** first to stop
+the clone-per-operation bleeding and obtain a real, measured single-repo
+throughput number, *before* committing to the larger Option A rewrite.
+
+- **Option B — keep Artifacts as the object store, add a warm `RepoDO` cache.**
+  The DO caches refs and a hot object index so commits stop re-negotiating a
+  packfile from a cold clone on every operation. Smaller lift (target: a 1–2
+  week spike). Ref-path latency is still bounded by how fast Artifacts can
+  apply a ref update, so this may not reach a true microsecond CAS — but it
+  removes the dominant cost and tells us whether the remaining gap is worth
+  Option A.
+
+- **Option A — own the object store (object store + DO directly).** Maximum
+  control over the ref-CAS path and true fast-forward semantics, at the cost of
+  maintaining git plumbing (pack format, object writes) ourselves. This is the
+  "warm git backend" the README has long called for. Pursue only if Option B's
+  measured number shows the shared-repo benchmark still matters and the gap is
+  real.
+
+Heavy operations that need a real filesystem (gc, repacking, very large packs)
+move to a Cloudflare Container running native git and syncing packs to the
+object store — independent of the A/B choice.
+
+## Consequences
+
+### Positive
+
+- Single-repo commit throughput is bounded by an in-memory CAS, not by
+  seconds-long clones — the architectural ceiling moves by orders of magnitude.
+- Object writes scale horizontally with zero coordination.
+- Automatic conflict resolution becomes a first-class, async forge primitive
+  reusing the existing LLM evaluator, instead of a synchronous manual gate.
+- Stage B is a small, measurable spike; we buy data before betting a quarter on
+  Stage A.
+- Directly retires two `TODO.md` Phase-4 items (batch merging, high-concurrency
+  load testing).
+
+### Negative / risks
+
+- A single repo's ref authority is a single DO. This is correct for
+  serialization but means the DO must do *only* CAS + orchestration and never
+  heavy git work, or the ceiling returns. Discipline required in the boundary.
+- Option A means owning git plumbing we currently delegate to Artifacts —
+  meaningful new surface area and maintenance.
+- Optimistic concurrency + async resolution is more moving parts than the
+  current synchronous merge; observability and retry/poison-message handling on
+  the resolve queue become load-bearing.
+- The fork-per-workspace model that gives us isolation/correctness still exists
+  alongside this; we must keep both coherent rather than fragmenting the commit
+  path.
+
+### Product bet
+
+This work is justified by a deliberate bet: **many agents working in parallel on
+a shared repository is the future.** If that bet is wrong and the world stays on
+"N agents on N branches merged through a gate," our existing fork-per-workspace
+model already serves it and this architecture is unnecessary. We are recording
+that we accept this bet, while staging the rollout (B before A) so the
+investment scales with measured evidence.
+
+## Alternatives Considered
+
+### Keep clone-per-operation, just raise limits
+
+Tune depth, parallelism, and DO count. **Rejected:** the cost is structural —
+seconds of work inside the serialization window — so no amount of tuning reaches
+high single-repo throughput.
+
+### Drop serialization, accept eventual ref consistency
+
+Let agents push refs without a single authority. **Rejected:** loses git's one
+correctness guarantee (atomic ref advance) and reintroduces lost-update races.
+
+### Jump straight to Option A
+
+Build the owned object store now. **Rejected for now:** quarter-scale
+investment on faith. Option B first yields a measured number for the decision.
+
+## Related Decisions
+
+- [ADR 002: Queue-Based Imports](./002-queue-based-imports.md) — async heavy
+  work off the request path
+- [ADR 003: D1 for Import State](./003-d1-for-import-state.md) — optimistic
+  locking via a `version` CAS, the same primitive applied to refs here
+
+## References
+
+- Current commit/merge path: `src/storage/git-ops.ts`,
+  `src/queue/merge-queue.ts`
+- Conflict resolution scaffolding: `resolveConflict` in `src/storage/git-ops.ts`,
+  `src/ui/components/conflict-resolution.tsx`
+- Open items this addresses: `TODO.md` (batch merging in the merge queue DO;
+  load testing 1000+ concurrent workspaces per repo)
+- [Durable Objects](https://developers.cloudflare.com/durable-objects/)
+- [Cloudflare Containers](https://developers.cloudflare.com/containers/)

--- a/docs/research/option-b-warm-repo-do-spike.md
+++ b/docs/research/option-b-warm-repo-do-spike.md
@@ -1,0 +1,110 @@
+# Spike Plan: Option B — Warm RepoDO Cache
+
+**Goal:** Kill clone-per-operation on the commit/merge hot path and produce a
+**measured** single-repo throughput number (commits/sec, p50/p95 latency, and a
+per-phase breakdown). This is the evidence-gathering stage from
+[ADR 004](../adr/004-high-frequency-agent-commits.md) — it does **not** build the
+owned object store (Option A). We instrument first, warm the cache second, then
+decide whether the remaining gap justifies Option A.
+
+**Target effort:** ~1–2 weeks. **Exit criterion:** a before/after number we
+trust, plus a go/no-go recommendation on Option A.
+
+---
+
+## Phase 0 — Instrument the current path (get the "before" number)
+
+We cannot improve what we have not measured. Before touching architecture,
+capture where the seconds go today.
+
+- [ ] Add phase timings around each step in the merge path: token mint, clone,
+      fetch, merge, push, D1 update. Wrap the calls in
+      `src/storage/git-ops.ts` (`mergeWorkspaceIntoProject`, `cloneRepo`,
+      `commitAndPush`) and `src/queue/merge-queue.ts` (`MergeQueue.merge`).
+- [ ] Emit timings through the existing metrics path
+      (`src/storage/metrics.ts`, surfaced at `/api/admin/metrics`) rather than
+      inventing a new sink. Add a `commit_phase_timings` table/rollup or reuse
+      the import-metrics shape.
+- [ ] Write a load harness under `scripts/` (e.g. `bench-commit-throughput.ts`,
+      alongside the existing `scripts/*.ts`) that fires N concurrent commits at
+      **one** repo and reports: commits/sec, p50/p95/p99 end-to-end latency, and
+      the per-phase breakdown. Parameterize N (1, 5, 25, 100) and commit size.
+- [ ] Run it against staging. Record the baseline in this doc's Results table.
+
+**Deliverable:** the honest current number, replacing "I think ~1–2/sec," and a
+breakdown proving clone+push dominate (the ADR's hypothesis).
+
+## Phase 1 — Warm RepoDO cache (remove clone-per-op)
+
+- [ ] Introduce a per-repo Durable Object (extend `MergeQueue` into `RepoDO`, or
+      add `RepoDO` and have `MergeQueue` delegate). One instance per project
+      repo, keyed by project id.
+- [ ] Cache warm state in DO storage between operations: packed refs + a hot
+      object index, so a commit no longer triggers a cold `git.clone`
+      (`depth: 50`) every time. Large blobs stay in Artifacts; the DO holds
+      refs + index, not the whole working tree.
+- [ ] Route commits through the DO: write objects, then ask the DO to apply the
+      change against its warm state and push to Artifacts. Keep the existing
+      cold path as a fallback when the cache is empty or stale.
+- [ ] Keep the persisted commit/merge semantics identical — this phase is a
+      latency change, not a behavior change. Existing tests
+      (`tests/git-ops.test.ts`, `tests/changes.test.ts`,
+      `tests/merge-protection.test.ts`) must stay green.
+
+**Deliverable:** commits that reuse warm state instead of re-cloning; the
+clone phase drops out of the Phase 0 breakdown.
+
+## Phase 2 — Fast-forward CAS + optimistic concurrency
+
+- [ ] Commit carries `expectedParent`. The DO does an in-memory compare-and-swap
+      on `refs/heads/main`: if `head == expectedParent`, fast-forward and return;
+      this is the common case at high frequency (concurrent agents mostly touch
+      different files). Mirrors the optimistic-locking `version` CAS already used
+      for import state in [ADR 003](../adr/003-d1-for-import-state.md).
+- [ ] On CAS miss (raced), **do not reject** — enqueue to a resolve step that
+      rebases the incoming tree onto the new head and re-attempts the CAS. For
+      this spike the resolver can be the mechanical three-way tree merge only;
+      LLM auto-resolution of true same-hunk overlaps is explicitly out of scope
+      (it lives in the resolve plane and reuses the existing evaluator later).
+- [ ] (Stretch) Batch: drain N queued advances, one combined tree, one CAS, one
+      push — the load-bearing version of the `TODO.md` "batch merging" item.
+
+**Deliverable:** the serialization window shrinks from a full merge to a ref
+CAS; throughput should jump on the concurrent-N runs.
+
+## Phase 3 — Re-measure and decide
+
+- [ ] Re-run the Phase 0 harness unchanged. Fill in the "after" column.
+- [ ] Compare against the ~20+ commits/sec single-repo target and write a
+      go/no-go recommendation on Option A: if Option B (bounded by Artifacts'
+      ref-update latency) lands close enough, Option A may be unnecessary; if a
+      real gap remains, the measured number justifies the quarter-scale build.
+- [ ] Update ADR 004 status (Proposed → Accepted/Superseded) based on findings.
+
+---
+
+## Out of scope for this spike
+
+- Owning the object store / R2-direct plumbing (Option A).
+- LLM-assisted conflict resolution (resolve plane intelligence).
+- Containerized native-git backend for gc/repack/large packs.
+- Changing the fork-per-workspace model; this runs alongside it.
+
+## Results (fill in as we go)
+
+| Metric (single repo)        | Before (Phase 0) | After (Phase 2) | Target |
+|-----------------------------|------------------|-----------------|--------|
+| Commits/sec (N=25)          | TBD              | TBD             | ~20+   |
+| p50 end-to-end latency      | TBD              | TBD             | —      |
+| p95 end-to-end latency      | TBD              | TBD             | —      |
+| Clone phase share of total  | TBD              | ~0 (removed)    | —      |
+
+## References
+
+- [ADR 004](../adr/004-high-frequency-agent-commits.md) — the architecture this
+  spike de-risks
+- Hot path: `src/storage/git-ops.ts`, `src/queue/merge-queue.ts`
+- Metrics: `src/storage/metrics.ts`, `src/routes/metrics.ts`
+  (`/api/admin/metrics`)
+- Related tests: `tests/git-ops.test.ts`, `tests/merge-protection.test.ts`,
+  `tests/conflict-resolution.test.ts`


### PR DESCRIPTION
## Why

Competing forges are demonstrating sustained **single-repo** throughput (~20+ commits/sec into one repo, plus hundreds of thousands of clones/pushes hourly) to support swarms of agents editing one codebase at once. Our current commit/merge path can't approach that on a single repo, and it's an architectural ceiling, not a tuning knob:

- Every merge does a full cold `git.clone` (`depth: 50`) into an in-memory FS, then a buffered push — seconds of network round-trips inside the critical path (`src/storage/git-ops.ts`).
- Merges serialize through a per-project Durable Object that does the heavy git work *itself*, capping a single repo at ~1–2 merges/sec (`src/queue/merge-queue.ts`).

This PR is **docs only** — it records the architecture and a staged, evidence-first rollout for review *before* any code lands.

## What's here

- **[ADR 004: High-Frequency Agent Commits](docs/adr/004-high-frequency-agent-commits.md)** (status: `Proposed`)
  - Core insight: git objects parallelize with zero coordination; only the ref update serializes, and it's a microsecond CAS. Our problem is doing seconds of work *inside* that window.
  - Three-plane design: object plane (parallel writes) / ref plane (per-repo `RepoDO` doing a fast-forward CAS) / resolve plane (async 3-way merge, LLM only on true same-hunk overlaps, reusing the existing evaluator).
  - Staged rollout: **Option B first** (warm DO cache in front of Artifacts) to get a measured number, then Option A (owned object store) only if the gap warrants it.
  - States the product bet explicitly: parallel agents on a shared repo is the future.
- **[Option B spike plan](docs/research/option-b-warm-repo-do-spike.md)**
  - Phase 0 instrument the current path (trusted "before" number), Phase 1 warm `RepoDO` cache (kill clone-per-op), Phase 2 fast-forward CAS + optimistic concurrency, Phase 3 re-measure + go/no-go on Option A.
  - References the real hot-path files, the existing `/api/admin/metrics` endpoint, and the tests that must stay green.

## Decisions to confirm in review

1. **The product bet** — do we commit to competing on shared-repo throughput, or differentiate on isolation/correctness and let that lane go?
2. **ADR status** — flip `Proposed` → `Accepted` if you're ratifying the direction.
3. Scope of the Option B spike before we open implementation tasks.

Retires the "batch merging in the merge queue Durable Object" and "load testing: 1000+ concurrent workspaces per repo" items in `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeZHxK84qjxEh2m219b6Pp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeZHxK84qjxEh2m219b6Pp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Architecture Decision Record 004 outlining design approach for handling concurrent commits and multi-phase implementation strategy.
  * Added implementation spike-plan document detailing workflow phases and measurement approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->