### PR TITLE
High-frequency agent commits: batch-merge clears 22.6 c/s (ADR 004)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .wrangler/
+.dev.vars
 .DS_Store
 coverage/
 .claude/

--- a/migrations/023_commit_metrics.sql
+++ b/migrations/023_commit_metrics.sql
@@ -1,0 +1,33 @@
+-- Commit/merge hot-path phase timings (ADR 004, Phase 0 instrumentation).
+-- One row per merge attempt. Distinct from import_metrics on purpose: different
+-- shape (per-phase spans, not a single value), different lifecycle.
+
+CREATE TABLE IF NOT EXISTS commit_metrics (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project TEXT NOT NULL,
+  change_id TEXT NOT NULL,
+  outcome TEXT NOT NULL,            -- 'fast_forward' | 'cold_fallback' | 'squash'
+  conflict_mode TEXT,              -- 'none' | 'same' | NULL (benchmark context)
+  concurrency_n INTEGER,           -- N concurrent writers during a bench run, or NULL
+
+  -- Per-phase wall-clock spans in milliseconds. NULL when a phase did not run
+  -- (e.g. project_clone is NULL on a fast-forward). Spans may include
+  -- interleaved CPU and must NOT be summed into total_ms (see PhaseTimer docs).
+  token_mint_ms REAL,
+  project_clone_ms REAL,
+  workspace_fetch_ms REAL,
+  merge_ms REAL,
+  push_ms REAL,
+  ref_advance_ms REAL,
+  d1_update_ms REAL,
+  provenance_ms REAL,
+
+  total_ms REAL NOT NULL,          -- end-to-end wall clock of the merge attempt
+  recorded_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- getCommitMetrics reads the most recent rows ordered by time; that's the only
+-- query path today. Keep indexes minimal — this is a high-frequency write table,
+-- so every extra index taxes the hot path. (Add a project index if/when a
+-- per-project query is introduced.)
+CREATE INDEX IF NOT EXISTS idx_commit_metrics_recorded_at ON commit_metrics(recorded_at);

--- a/scripts/bench-commit-throughput.ts
+++ b/scripts/bench-commit-throughput.ts
@@ -60,12 +60,22 @@ export function parseArgs(argv: string[]): BenchArgs {
     return eq === -1 ? "true" : hit.slice(eq + 1);
   };
 
+  const parseIntFlag = (name: string, fallback: number, min: number): number => {
+    const raw = get(name);
+    if (raw === undefined) return fallback;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed)) throw new Error(`--${name} must be an integer, got '${raw}'`);
+    return Math.max(min, parsed);
+  };
+
   const conflictRaw = get("conflict") ?? "none";
   if (conflictRaw !== "none" && conflictRaw !== "same") {
     throw new Error(`--conflict must be 'none' or 'same', got '${conflictRaw}'`);
   }
 
-  const concurrencies = (get("n") ?? "1,5,25,100")
+  const batch = get("batch") === "true";
+  // Batch mode's server cap is 80; keep the default levels within bounds.
+  const concurrencies = (get("n") ?? (batch ? "1,5,25,50,64" : "1,5,25,100"))
     .split(",")
     .map((s) => Number.parseInt(s.trim(), 10))
     .filter((n) => Number.isInteger(n) && n > 0);
@@ -75,14 +85,14 @@ export function parseArgs(argv: string[]): BenchArgs {
     baseUrl: (get("url") ?? process.env.STRATUM_URL ?? "http://localhost:8787").replace(/\/$/, ""),
     concurrencies,
     conflict: conflictRaw,
-    repeat: Math.max(1, Number.parseInt(get("repeat") ?? "1", 10)),
-    warmup: Math.max(0, Number.parseInt(get("warmup") ?? "1", 10)),
+    repeat: parseIntFlag("repeat", 1, 1),
+    warmup: parseIntFlag("warmup", 1, 0),
     project: get("project") ?? "bench-throughput",
     allowProd: get("i-understand-this-writes-real-commits") === "true",
     r2Bench: get("r2-bench") === "true",
-    batch: get("batch") === "true",
-    bytes: Math.max(1, Number.parseInt(get("bytes") ?? "256", 10)),
-    durationMs: Math.max(200, Number.parseInt(get("duration") ?? "3000", 10)),
+    batch,
+    bytes: parseIntFlag("bytes", 256, 1),
+    durationMs: parseIntFlag("duration", 3000, 200),
   };
 }
 
@@ -297,9 +307,13 @@ async function runR2Bench(args: BenchArgs): Promise<void> {
     const workers = Array.from({ length: n }, async (_u, worker) => {
       const url = `${args.baseUrl}/api/admin/metrics/bench?repo=${repo}&bytes=${args.bytes}&path=${pathFor(worker)}`;
       while (!stop) {
-        const res = await fetch(url, { method: "POST", headers });
-        if (res.ok) completed += 1;
-        else failed += 1;
+        try {
+          const res = await fetch(url, { method: "POST", headers });
+          if (res.ok) completed += 1;
+          else failed += 1;
+        } catch {
+          failed += 1;
+        }
       }
     });
     await new Promise((r) => setTimeout(r, args.durationMs));
@@ -371,7 +385,10 @@ async function runBatchMerge(
     );
 
     const t0 = Date.now();
-    const res = await post(`/api/projects/${project.name}/changes/merge-batch`, { changeIds });
+    const res = await post(`/api/projects/${project.name}/changes/merge-batch`, {
+      changeIds,
+      force: true,
+    });
     const ms = Date.now() - t0;
     const bodyJson = (res.ok ? await res.json() : { error: await res.text() }) as {
       merged?: string[];
@@ -474,8 +491,12 @@ async function runBatch(
   const results = await Promise.all(
     changeIds.map(async (id) => {
       const t0 = Date.now();
-      const res = await post(`/api/changes/${id}/merge?force=true`, {});
-      return { ok: res.ok, ms: Date.now() - t0, status: res.status };
+      try {
+        const res = await post(`/api/changes/${id}/merge?force=true`, {});
+        return { ok: res.ok, ms: Date.now() - t0, status: res.status };
+      } catch {
+        return { ok: false, ms: Date.now() - t0, status: 0 };
+      }
     }),
   );
   const wallMs = Date.now() - wallStart;

--- a/scripts/bench-commit-throughput.ts
+++ b/scripts/bench-commit-throughput.ts
@@ -1,0 +1,495 @@
+/**
+ * Single-repo commit/merge throughput harness (ADR 004, Phase 0).
+ *
+ * Fires N concurrent commit -> merge cycles at ONE project repo and reports
+ * commits/sec plus per-phase breakdown, for both conflict modes. Produces the
+ * "before" (flag off) and "after" (REPO_DO_ENABLED) numbers for the spike-plan
+ * Results table.
+ *
+ * Usage:
+ *   STRATUM_URL=http://localhost:8787 \
+ *   STRATUM_SESSION=<cookie> \
+ *   npx tsx scripts/bench-commit-throughput.ts --n=1,5,25,100 --conflict=none --repeat=3
+ *
+ * Safety: refuses production hosts unless --i-understand-this-writes-real-commits
+ * is passed, because each merge pushes a real commit to a real Artifacts repo.
+ */
+
+// Minimal ambient for the Node runtime (this repo's tsconfig targets Workers and
+// does not pull in @types/node; this script runs under tsx).
+declare const process: {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  exit(code?: number): never;
+};
+
+export interface BenchArgs {
+  baseUrl: string;
+  concurrencies: number[];
+  conflict: "none" | "same";
+  repeat: number;
+  warmup: number;
+  project: string;
+  allowProd: boolean;
+  /** Drive the Phase 2 R2 object-plane + group-commit endpoint instead of full merges. */
+  r2Bench: boolean;
+  /** Drive the server-side batch-merge endpoint (N changes per request). */
+  batch: boolean;
+  bytes: number;
+  durationMs: number;
+}
+
+const PRODUCTION_HOST_PATTERNS = [/(^|\.)app\.usestratum\.dev$/i, /(^|\.)usestratum\.dev$/i];
+
+/** True when the URL points at a known production host. */
+export function isProductionHost(url: string): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return false;
+  }
+  return PRODUCTION_HOST_PATTERNS.some((p) => p.test(host));
+}
+
+export function parseArgs(argv: string[]): BenchArgs {
+  const get = (name: string): string | undefined => {
+    const hit = argv.find((a) => a === `--${name}` || a.startsWith(`--${name}=`));
+    if (!hit) return undefined;
+    const eq = hit.indexOf("=");
+    return eq === -1 ? "true" : hit.slice(eq + 1);
+  };
+
+  const conflictRaw = get("conflict") ?? "none";
+  if (conflictRaw !== "none" && conflictRaw !== "same") {
+    throw new Error(`--conflict must be 'none' or 'same', got '${conflictRaw}'`);
+  }
+
+  const concurrencies = (get("n") ?? "1,5,25,100")
+    .split(",")
+    .map((s) => Number.parseInt(s.trim(), 10))
+    .filter((n) => Number.isInteger(n) && n > 0);
+  if (concurrencies.length === 0) throw new Error("--n must list positive integers");
+
+  return {
+    baseUrl: (get("url") ?? process.env.STRATUM_URL ?? "http://localhost:8787").replace(/\/$/, ""),
+    concurrencies,
+    conflict: conflictRaw,
+    repeat: Math.max(1, Number.parseInt(get("repeat") ?? "1", 10)),
+    warmup: Math.max(0, Number.parseInt(get("warmup") ?? "1", 10)),
+    project: get("project") ?? "bench-throughput",
+    allowProd: get("i-understand-this-writes-real-commits") === "true",
+    r2Bench: get("r2-bench") === "true",
+    batch: get("batch") === "true",
+    bytes: Math.max(1, Number.parseInt(get("bytes") ?? "256", 10)),
+    durationMs: Math.max(200, Number.parseInt(get("duration") ?? "3000", 10)),
+  };
+}
+
+/** Throws if the target is production and the operator hasn't opted in. */
+export function assertSafeTarget(args: BenchArgs): void {
+  if (isProductionHost(args.baseUrl) && !args.allowProd) {
+    throw new Error(
+      `Refusing to run against production host ${args.baseUrl}. ` +
+        "This writes real commits. Re-run with --i-understand-this-writes-real-commits if intentional.",
+    );
+  }
+}
+
+export function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(Math.max(Math.ceil((p / 100) * sorted.length) - 1, 0), sorted.length - 1);
+  return sorted[idx] ?? 0;
+}
+
+export interface RunStats {
+  n: number;
+  conflict: "none" | "same";
+  landed: number;
+  failed: number;
+  wallMs: number;
+  commitsPerSec: number;
+  /** Per-op latency percentiles are only meaningful at low N (single-DO queue). */
+  latency?: { p50: number; p95: number; p99: number };
+}
+
+export function summarizeRun(
+  n: number,
+  conflict: "none" | "same",
+  endToEndMs: number[],
+  failures: number,
+  wallMs: number,
+): RunStats {
+  const landed = endToEndMs.length;
+  const base: RunStats = {
+    n,
+    conflict,
+    landed,
+    failed: failures,
+    wallMs,
+    commitsPerSec: wallMs > 0 ? Math.round((landed / wallMs) * 1000 * 100) / 100 : 0,
+  };
+  // At N >= 25 the single DO serializes advances, so per-op latency is dominated
+  // by queue wait, not work — report throughput only.
+  if (n <= 5) {
+    base.latency = {
+      p50: percentile(endToEndMs, 50),
+      p95: percentile(endToEndMs, 95),
+      p99: percentile(endToEndMs, 99),
+    };
+  }
+  return base;
+}
+
+export function formatReport(stats: RunStats[]): string {
+  const lines: string[] = [];
+  lines.push("Commit throughput (single repo)");
+  lines.push("  N | mode | landed | failed | wall(ms) | commits/sec | p50/p95/p99(ms)");
+  for (const s of stats) {
+    const lat = s.latency
+      ? `${s.latency.p50}/${s.latency.p95}/${s.latency.p99}`
+      : "(suppressed: single-DO queue)";
+    lines.push(
+      `  ${s.n} | ${s.conflict} | ${s.landed} | ${s.failed} | ${s.wallMs} | ${s.commitsPerSec} | ${lat}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+// --- Live run (only when executed directly, not when imported by tests) ---
+
+interface ProjectInfo {
+  id: string;
+  namespace: string;
+  slug: string;
+  name: string;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  assertSafeTarget(args);
+
+  // Node's default fetch pool caps concurrent connections per origin, which would
+  // serialize the merge burst at the CLIENT and hide the server's real throughput.
+  // Raise it so N concurrent merges actually hit the server concurrently.
+  try {
+    const { Agent, setGlobalDispatcher } = (await import("undici")) as {
+      Agent: new (o: { connections: number }) => unknown;
+      setGlobalDispatcher: (d: unknown) => void;
+    };
+    setGlobalDispatcher(new Agent({ connections: 256 }));
+  } catch {
+    // undici not available — proceed with the default dispatcher.
+  }
+
+  // The R2 throughput probe authenticates with an admin key, not a user session.
+  if (args.r2Bench) {
+    await runR2Bench(args);
+    return;
+  }
+
+  const session = process.env.STRATUM_SESSION;
+  const token = process.env.STRATUM_TOKEN;
+  if (!session && !token) {
+    throw new Error("Set STRATUM_SESSION (stratum_session cookie) or STRATUM_TOKEN");
+  }
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  else if (session) headers.Cookie = `stratum_session=${session}`;
+
+  const api = (path: string, init?: RequestInit) =>
+    fetch(`${args.baseUrl}${path}`, {
+      ...init,
+      headers: { ...headers, ...(init?.headers as Record<string, string>) },
+    });
+
+  const post = async (path: string, body: unknown): Promise<Response> =>
+    api(path, { method: "POST", body: JSON.stringify(body) });
+
+  console.log(`\nBenchmarking ${args.baseUrl} (conflict=${args.conflict})`);
+  console.log("Throughput is the headline metric. Per-op latency is reported only at N<=5.");
+  console.log("Server-side per-phase breakdown: GET /api/admin/metrics (commits block).");
+  console.log(
+    "Timing caveats: Workers freeze the clock between I/O — CPU spans are lower bounds.\n",
+  );
+
+  const me = await api("/api/users/me");
+  if (!me.ok) throw new Error(`Auth check failed: ${me.status} — check STRATUM_SESSION/TOKEN`);
+
+  if (args.batch) {
+    await runBatchMerge(args, post);
+    return;
+  }
+
+  // One disposable, uniquely-named project per run, seeded so clones have
+  // representative history.
+  const projectName = `${args.project}-${Math.random().toString(36).slice(2, 8)}`;
+  const project = await createProject(post, projectName);
+  console.log(`Target project: ${project.namespace}/${project.slug} (id=${project.id})`);
+  // Let the seeded fork settle in Artifacts before forking workspaces off it.
+  await new Promise((r) => setTimeout(r, 2000));
+  console.log("");
+
+  // Each measured batch needs FRESH changes (a merged change cannot re-merge), so
+  // every batch builds N workspaces+changes, then fires N merges concurrently. A
+  // warmup batch is discarded; `repeat` measured batches follow.
+  const allStats: RunStats[] = [];
+  for (const n of args.concurrencies) {
+    for (let w = 0; w < args.warmup; w++) {
+      await runBatch(post, project, n, args.conflict, /*nonce*/ `warm-${n}-${w}`);
+    }
+    let landed = 0;
+    let failed = 0;
+    let wallMs = 0;
+    const latencies: number[] = [];
+    for (let r = 0; r < args.repeat; r++) {
+      const batch = await runBatch(post, project, n, args.conflict, `run-${n}-${r}`);
+      landed += batch.latencies.length;
+      failed += batch.failed;
+      wallMs += batch.wallMs;
+      latencies.push(...batch.latencies);
+    }
+    const stat = summarizeRun(n, args.conflict, latencies, failed, wallMs);
+    allStats.push(stat);
+    console.log(`  N=${n}: ${stat.commitsPerSec} commits/sec (${landed} landed, ${failed} failed)`);
+  }
+
+  console.log(`\n${formatReport(allStats)}`);
+
+  // Let the off-ack-path metric writes settle, then surface the server breakdown.
+  await new Promise((res) => setTimeout(res, 1500));
+  const metrics = await api("/api/admin/metrics");
+  if (metrics.ok) {
+    const body = (await metrics.json()) as { commits?: unknown };
+    console.log("\nServer-side commit metrics (/api/admin/metrics .commits):");
+    console.log(JSON.stringify(body.commits ?? "unavailable (admin access / no rows)", null, 2));
+  } else {
+    console.log(`\n/api/admin/metrics returned ${metrics.status} (need admin access for breakdown)`);
+  }
+}
+
+/**
+ * Phase 2 throughput run: hammer the admin bench endpoint (R2 object write +
+ * group-commit ref advance) concurrently and measure commits/sec. Uses an admin
+ * key (STRATUM_ADMIN_KEY); object writes parallelize and the DO batches the ref
+ * advances — this is the path that crosses the target.
+ */
+async function runR2Bench(args: BenchArgs): Promise<void> {
+  const adminKey = process.env.STRATUM_ADMIN_KEY;
+  if (!adminKey) throw new Error("Set STRATUM_ADMIN_KEY for --r2-bench");
+  const headers = { "X-Admin-API-Key": adminKey };
+  const repo = `r2bench-${Math.random().toString(36).slice(2, 8)}`;
+  // conflict=same -> every writer hits one path (server-side conflict resolution
+  // exercised); conflict=none -> distinct path per writer (no conflicts).
+  const pathFor = (worker: number) =>
+    args.conflict === "same" ? "shared.txt" : `f${worker}.txt`;
+
+  console.log(
+    `\n[R2 + real git objects + group-commit] repo=${repo}, conflict=${args.conflict}, bytes=${args.bytes}, ${args.durationMs}ms/level`,
+  );
+  const stats: RunStats[] = [];
+  for (const n of args.concurrencies) {
+    let completed = 0;
+    let failed = 0;
+    let stop = false;
+    const start = Date.now();
+    const workers = Array.from({ length: n }, async (_u, worker) => {
+      const url = `${args.baseUrl}/api/admin/metrics/bench?repo=${repo}&bytes=${args.bytes}&path=${pathFor(worker)}`;
+      while (!stop) {
+        const res = await fetch(url, { method: "POST", headers });
+        if (res.ok) completed += 1;
+        else failed += 1;
+      }
+    });
+    await new Promise((r) => setTimeout(r, args.durationMs));
+    stop = true;
+    const counted = completed;
+    const elapsedMs = Date.now() - start;
+    await Promise.all(workers);
+    const stat = summarizeRun(n, args.conflict, [], failed, elapsedMs);
+    stat.landed = counted;
+    stat.latency = undefined; // per-op latency not measured in the R2 throughput probe
+    stat.commitsPerSec = elapsedMs > 0 ? Math.round((counted / elapsedMs) * 1000 * 100) / 100 : 0;
+    stats.push(stat);
+    console.log(`  N=${n}: ${stat.commitsPerSec} commits/sec (${counted} landed, ${failed} failed)`);
+  }
+  console.log(`\n${formatReport(stats)}`);
+
+  const statsRes = await fetch(`${args.baseUrl}/api/admin/metrics/bench-stats?repo=${repo}`, {
+    headers,
+  });
+  if (statsRes.ok) {
+    console.log("\nServer bench stats (real git objects):");
+    console.log(JSON.stringify(await statsRes.json(), null, 2));
+  }
+}
+
+/**
+ * Server-side batch merge (ADR 004): set up N changes (each staged to R2 at
+ * commit), then merge ALL of them in ONE request via /changes/merge-batch — the
+ * path that realizes the group-commit throughput despite per-request DO RPC
+ * serialization.
+ */
+async function runBatchMerge(
+  args: BenchArgs,
+  post: (p: string, b: unknown) => Promise<Response>,
+): Promise<void> {
+  const projectName = `${args.project}-${Math.random().toString(36).slice(2, 8)}`;
+  // Unseeded: minimal base tree, so the merge cost reflects the CHANGE, not the
+  // whole seeded repo (merge cost scales with tree size).
+  const project = await createProject(post, projectName, false);
+  console.log(`Target project: ${project.namespace}/${project.slug} (unseeded)`);
+  await new Promise((r) => setTimeout(r, 2000));
+
+  console.log(`\n[batch-merge] conflict=${args.conflict}`);
+  for (const n of args.concurrencies) {
+    const changeIds = await Promise.all(
+      Array.from({ length: n }, (_u, i) =>
+        retry(async () => {
+          const wsName = `w${Math.random().toString(36).slice(2, 10)}${i}`;
+          const ws = await post(`/api/workspaces/${project.namespace}/${project.slug}/workspaces`, {
+            name: wsName,
+          });
+          if (!ws.ok) throw new Error(`workspace ${ws.status} ${await ws.text()}`);
+          const { workspace } = (await ws.json()) as { workspace: string };
+          const path = args.conflict === "same" ? "shared.txt" : `f${i}.txt`;
+          const commit = await post(`/api/workspaces/${workspace}/commit`, {
+            projectId: project.id,
+            message: `c${i}`,
+            files: { [path]: `worker ${i}\n` },
+          });
+          if (!commit.ok) throw new Error(`commit ${commit.status} ${await commit.text()}`);
+          const change = await post(`/api/projects/${project.name}/changes`, { workspace });
+          if (!change.ok) throw new Error(`change ${change.status} ${await change.text()}`);
+          const created = (await change.json()) as { id?: string; change?: { id: string } };
+          const id = created.change?.id ?? created.id;
+          if (!id) throw new Error("no change id");
+          return id;
+        }),
+      ),
+    );
+
+    const t0 = Date.now();
+    const res = await post(`/api/projects/${project.name}/changes/merge-batch`, { changeIds });
+    const ms = Date.now() - t0;
+    const bodyJson = (res.ok ? await res.json() : { error: await res.text() }) as {
+      merged?: string[];
+      conflicted?: string[];
+      error?: string;
+      timings?: { resolveMs: number; batchMs: number; persistMs: number; serverMs: number };
+    };
+    const merged = bodyJson.merged?.length ?? 0;
+    const cps = ms > 0 ? Math.round((merged / (ms / 1000)) * 100) / 100 : 0;
+    const t = bodyJson.timings;
+    // Server-side throughput excludes client<->edge RTT (the basis the r2flow probe used).
+    const serverCps =
+      t && t.serverMs > 0 ? Math.round((merged / (t.serverMs / 1000)) * 100) / 100 : 0;
+    const phases = t
+      ? ` [server=${t.serverMs}ms → ${serverCps} c/s | resolve=${t.resolveMs} batch=${t.batchMs} persist=${t.persistMs}]`
+      : "";
+    console.log(
+      `  N=${n}: ${cps} c/s wall (${merged} merged, ${bodyJson.conflicted?.length ?? 0} conflicted, ${ms}ms)${phases}${bodyJson.error ? ` ERROR: ${bodyJson.error}` : ""}`,
+    );
+  }
+}
+
+async function createProject(
+  post: (p: string, b: unknown) => Promise<Response>,
+  name: string,
+  seed = true,
+): Promise<ProjectInfo> {
+  const res = await post("/api/projects", { name, visibility: "private", seed });
+  if (!res.ok) {
+    throw new Error(`Failed to create project '${name}': ${res.status} ${await res.text()}`);
+  }
+  const p = (await res.json()) as ProjectInfo;
+  return { ...p, name };
+}
+
+interface BatchResult {
+  latencies: number[];
+  failed: number;
+  wallMs: number;
+}
+
+/** Retry transient failures (e.g. Artifacts 500s during setup) with backoff. */
+async function retry<T>(fn: () => Promise<T>, attempts = 3, baseMs = 500): Promise<T> {
+  let last: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      last = e;
+      await new Promise((r) => setTimeout(r, baseMs * (i + 1)));
+    }
+  }
+  throw last;
+}
+
+async function runBatch(
+  post: (p: string, b: unknown) => Promise<Response>,
+  project: ProjectInfo,
+  n: number,
+  conflict: "none" | "same",
+  nonce: string,
+): Promise<BatchResult> {
+  // Setup (not measured): N workspaces, each with one committed file, each yielding
+  // a change. conflict=none -> distinct file per worker; conflict=same -> shared file.
+  const changeIds = await Promise.all(
+    Array.from({ length: n }, (_unused, i) =>
+      retry(async () => {
+        // Workspace names become Artifacts fork repo names — keep them alphanumeric
+        // and globally unique (dashed/multi-segment names are rejected with a 500).
+        const wsName = `w${Math.random().toString(36).slice(2, 10)}${i}`;
+        const ws = await post(`/api/workspaces/${project.namespace}/${project.slug}/workspaces`, {
+          name: wsName,
+        });
+        if (!ws.ok) throw new Error(`workspace create failed: ${ws.status} ${await ws.text()}`);
+        const { workspace } = (await ws.json()) as { workspace: string };
+
+        const path = conflict === "same" ? "bench/shared.txt" : `bench/worker-${i}.txt`;
+        const commit = await post(`/api/workspaces/${workspace}/commit`, {
+          projectId: project.id,
+          message: `bench ${nonce} worker ${i}`,
+          files: { [path]: `worker ${i} @ ${nonce}\n` },
+        });
+        if (!commit.ok) throw new Error(`commit failed: ${commit.status} ${await commit.text()}`);
+
+        const change = await post(`/api/projects/${project.name}/changes`, { workspace });
+        if (!change.ok)
+          throw new Error(`change create failed: ${change.status} ${await change.text()}`);
+        // The create response nests the change: { change: { id, ... }, eval, evalRuns }.
+        const created = (await change.json()) as { id?: string; change?: { id: string } };
+        const changeId = created.change?.id ?? created.id;
+        if (!changeId) throw new Error("change create returned no id");
+        return changeId;
+      }),
+    ),
+  );
+
+  // Measured: fire N merges concurrently (force bypasses eval/approval + protection
+  // so we measure raw merge mechanics, not the policy gate).
+  const wallStart = Date.now();
+  const results = await Promise.all(
+    changeIds.map(async (id) => {
+      const t0 = Date.now();
+      const res = await post(`/api/changes/${id}/merge?force=true`, {});
+      return { ok: res.ok, ms: Date.now() - t0, status: res.status };
+    }),
+  );
+  const wallMs = Date.now() - wallStart;
+
+  const latencies = results.filter((r) => r.ok).map((r) => r.ms);
+  const failed = results.filter((r) => !r.ok).length;
+  return { latencies, failed, wallMs };
+}
+
+const invokedDirectly =
+  typeof process !== "undefined" && /bench-commit-throughput\.ts$/.test(process.argv[1] ?? "");
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error("\n❌", err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import type { Env, ImportJobMessage, MessageBatch, SyncJobMessage } from "./type
 import { CSS } from "./ui/styles";
 import { createLogger } from "./utils/logger";
 export { MergeQueue } from "./queue/merge-queue";
+export { RepoDO } from "./queue/repo-do";
 
 const app = new Hono<{ Bindings: Env }>();
 

--- a/src/queue/group-commit.ts
+++ b/src/queue/group-commit.ts
@@ -1,0 +1,113 @@
+/**
+ * Group-commit batch coordinator (ADR 004, the throughput mechanism).
+ *
+ * The single-repo throughput ceiling is set by the *serialized* ref advance and
+ * its durable write — object writes are content-addressed and parallelize freely,
+ * so they never gate. Group commit (the database WAL technique) amortizes that
+ * one serialized durable write across every ref advance that arrives while it is
+ * in flight: drain N queued advances, fold them into ONE batched durable write,
+ * then resolve each. Throughput becomes batchSize / durableWriteLatency instead
+ * of 1 / durableWriteLatency.
+ *
+ * `durableWrite` returns a **per-item outcome** (same order + length as the
+ * batch), so one item failing/conflicting does NOT fail the rest of the batch —
+ * the real merge flow needs "one conflict, the others still land." A thrown
+ * `durableWrite` (catastrophic, e.g. the push failed) rejects the whole batch.
+ *
+ * Decoupled from Cloudflare: `durableWrite` is injected (RepoDO supplies the real
+ * merge+push; tests/benchmarks inject a model).
+ */
+
+export type ItemOutcome<R> = { ok: true; value: R } | { ok: false; error: unknown };
+
+export interface GroupCommitStats {
+  batches: number;
+  items: number;
+  maxBatchSize: number;
+  avgBatchSize: number;
+}
+
+export interface GroupCommitOptions<T, R> {
+  /** Upper bound on how many advances fold into one durable write. */
+  maxBatchSize: number;
+  /**
+   * Accumulation window (ms) before draining a batch — the WAL `commit_delay`.
+   * When submits arrive staggered (e.g. each request does its own reads before
+   * submitting), waiting briefly lets them coalesce into one batch instead of
+   * draining one-at-a-time. 0/undefined = drain on the next microtask.
+   */
+  batchWindowMs?: number;
+  /**
+   * Durably persist one drained batch and return one outcome per item, in the
+   * same order. Throwing rejects the entire batch (use for catastrophic failures
+   * like a failed push); a per-item `{ ok: false }` rejects only that item.
+   */
+  durableWrite: (batch: T[]) => Promise<ItemOutcome<R>[]>;
+}
+
+interface Pending<T, R> {
+  item: T;
+  resolve: (value: R) => void;
+  reject: (err: unknown) => void;
+}
+
+export class GroupCommitCoordinator<T, R = void> {
+  private readonly queue: Pending<T, R>[] = [];
+  private draining = false;
+  private batches = 0;
+  private items = 0;
+  private maxBatch = 0;
+
+  constructor(private readonly opts: GroupCommitOptions<T, R>) {}
+
+  /** Submit one advance; resolves with its per-item value (or rejects per-item). */
+  submit(item: T): Promise<R> {
+    return new Promise<R>((resolve, reject) => {
+      this.queue.push({ item, resolve, reject });
+      if (!this.draining) void this.drainLoop();
+    });
+  }
+
+  private async drainLoop(): Promise<void> {
+    this.draining = true;
+    try {
+      while (this.queue.length > 0) {
+        // Wait the accumulation window (or one microtask) so a burst of
+        // staggered submits coalesces into this batch instead of draining alone.
+        const window = this.opts.batchWindowMs ?? 0;
+        if (window > 0) await new Promise((r) => setTimeout(r, window));
+        else await Promise.resolve();
+        const batch = this.queue.splice(0, this.opts.maxBatchSize);
+        this.batches += 1;
+        this.items += batch.length;
+        if (batch.length > this.maxBatch) this.maxBatch = batch.length;
+        try {
+          const outcomes = await this.opts.durableWrite(batch.map((b) => b.item));
+          if (outcomes.length !== batch.length) {
+            throw new Error(
+              `durableWrite returned ${outcomes.length} outcomes for ${batch.length} items`,
+            );
+          }
+          batch.forEach((b, i) => {
+            const outcome = outcomes[i];
+            if (outcome?.ok) b.resolve(outcome.value);
+            else b.reject(outcome?.error ?? new Error("missing outcome"));
+          });
+        } catch (err) {
+          for (const b of batch) b.reject(err);
+        }
+      }
+    } finally {
+      this.draining = false;
+    }
+  }
+
+  get stats(): GroupCommitStats {
+    return {
+      batches: this.batches,
+      items: this.items,
+      maxBatchSize: this.maxBatch,
+      avgBatchSize: this.batches > 0 ? this.items / this.batches : 0,
+    };
+  }
+}

--- a/src/queue/group-commit.ts
+++ b/src/queue/group-commit.ts
@@ -58,7 +58,11 @@ export class GroupCommitCoordinator<T, R = void> {
   private items = 0;
   private maxBatch = 0;
 
-  constructor(private readonly opts: GroupCommitOptions<T, R>) {}
+  constructor(private readonly opts: GroupCommitOptions<T, R>) {
+    if (!Number.isInteger(opts.maxBatchSize) || opts.maxBatchSize < 1) {
+      throw new Error("GroupCommitCoordinator.maxBatchSize must be an integer >= 1");
+    }
+  }
 
   /** Submit one advance; resolves with its per-item value (or rejects per-item). */
   submit(item: T): Promise<R> {

--- a/src/queue/merge-queue.ts
+++ b/src/queue/merge-queue.ts
@@ -85,7 +85,7 @@ export class MergeQueue extends DurableObject<Env> {
         return { success: false, error: updateResult.error.message };
       }
 
-      await timer.measure("provenanceMs", () =>
+      const provenanceResult = await timer.measure("provenanceMs", () =>
         recordProvenance(this.env.DB, log, {
           commitSha: commit,
           project: change.project,
@@ -95,6 +95,9 @@ export class MergeQueue extends DurableObject<Env> {
           ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
         }),
       );
+      if (!provenanceResult.success) {
+        log.error("Failed to record provenance after merge", provenanceResult.error);
+      }
 
       // The classic MergeQueue always runs the full cold merge path.
       const metricsResult = await recordCommitMetrics(

--- a/src/queue/merge-queue.ts
+++ b/src/queue/merge-queue.ts
@@ -1,10 +1,12 @@
 import { DurableObject } from "cloudflare:workers";
 import { getChange, updateChangeStatus } from "../storage/changes";
 import { freshRepoToken, mergeWorkspaceIntoProject } from "../storage/git-ops";
+import { commitPhasesFromSpans, recordCommitMetrics } from "../storage/metrics";
 import { recordProvenance } from "../storage/provenance";
 import { getProject, getWorkspace } from "../storage/state";
 import type { Env } from "../types";
 import { type Logger, createLogger } from "../utils/logger";
+import { PhaseTimer } from "../utils/phase-timer";
 
 const MERGEABLE_STATUSES = new Set(["approved", "accepted", "promoted"]);
 
@@ -20,6 +22,8 @@ export interface MergeOutcome {
 export class MergeQueue extends DurableObject<Env> {
   async merge(changeId: string, logger?: Logger): Promise<MergeOutcome> {
     const log = logger ?? createLogger({ changeId });
+    const timer = new PhaseTimer();
+    const startedAt = Date.now();
     const changeResult = await getChange(this.env.DB, log, changeId);
     if (!changeResult.success) {
       return { success: false, error: changeResult.error.message };
@@ -45,10 +49,12 @@ export class MergeQueue extends DurableObject<Env> {
 
       // Merge clones the workspace fork (read) and pushes to the project (write).
       // Mint both tokens fresh: no token is persisted.
-      const [projectToken, workspaceToken] = await Promise.all([
-        freshRepoToken(this.env.ARTIFACTS, project.remote, "write", log),
-        freshRepoToken(this.env.ARTIFACTS, workspace.remote, "read", log),
-      ]);
+      const [projectToken, workspaceToken] = await timer.measure("tokenMintMs", () =>
+        Promise.all([
+          freshRepoToken(this.env.ARTIFACTS, project.remote, "write", log),
+          freshRepoToken(this.env.ARTIFACTS, workspace.remote, "read", log),
+        ]),
+      );
       if (!projectToken.success) return { success: false, error: projectToken.error.message };
       if (!workspaceToken.success) return { success: false, error: workspaceToken.error.message };
 
@@ -58,7 +64,7 @@ export class MergeQueue extends DurableObject<Env> {
         workspace.remote,
         workspaceToken.data,
         log,
-        { strategy: "merge" },
+        { strategy: "merge", timer },
       );
 
       if (!commitResult.success) {
@@ -66,25 +72,45 @@ export class MergeQueue extends DurableObject<Env> {
       }
       const commit = commitResult.data;
 
-      const updateResult = await updateChangeStatus(this.env.DB, log, changeId, "merged", {
-        ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
-        ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
-        ...(change.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
-        mergedAt: new Date().toISOString(),
-      });
+      const updateResult = await timer.measure("d1UpdateMs", () =>
+        updateChangeStatus(this.env.DB, log, changeId, "merged", {
+          ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+          ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
+          ...(change.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
+          mergedAt: new Date().toISOString(),
+        }),
+      );
 
       if (!updateResult.success) {
         return { success: false, error: updateResult.error.message };
       }
 
-      await recordProvenance(this.env.DB, log, {
-        commitSha: commit,
-        project: change.project,
-        workspace: change.workspace,
-        changeId,
-        ...(change.agentId !== undefined ? { agentId: change.agentId } : {}),
-        ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
-      });
+      await timer.measure("provenanceMs", () =>
+        recordProvenance(this.env.DB, log, {
+          commitSha: commit,
+          project: change.project,
+          workspace: change.workspace,
+          changeId,
+          ...(change.agentId !== undefined ? { agentId: change.agentId } : {}),
+          ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+        }),
+      );
+
+      // The classic MergeQueue always runs the full cold merge path.
+      const metricsResult = await recordCommitMetrics(
+        this.env.DB,
+        {
+          project: change.project,
+          changeId,
+          outcome: "cold_fallback",
+          phases: commitPhasesFromSpans(timer.toObject()),
+          totalMs: Date.now() - startedAt,
+        },
+        log,
+      );
+      if (!metricsResult.success) {
+        log.warn("Failed to record commit metrics", { changeId });
+      }
 
       return { success: true, commit };
     } catch (err) {

--- a/src/queue/repo-do.ts
+++ b/src/queue/repo-do.ts
@@ -249,7 +249,9 @@ export class RepoDO extends DurableObject<Env> {
     });
     if (!updateResult.success) return { success: false, error: updateResult.error.message };
 
-    await recordProvenance(this.env.DB, log, {
+    // The commit is already durable; provenance is bookkeeping — log a failure for
+    // observability but don't fail the (successful) merge.
+    const provenanceResult = await recordProvenance(this.env.DB, log, {
       commitSha: result.commit,
       project: change.project,
       workspace: change.workspace,
@@ -257,9 +259,17 @@ export class RepoDO extends DurableObject<Env> {
       ...(change.agentId !== undefined ? { agentId: change.agentId } : {}),
       ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
     });
+    if (!provenanceResult.success) {
+      log.error("Failed to record provenance after R2 merge", provenanceResult.error);
+    }
 
     // GC the staged tree now that it has landed (Task 6).
-    await bucket.delete(key).catch(() => {});
+    await bucket.delete(key).catch((error) => {
+      log.warn("Failed to delete staged tree", {
+        key,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
     return { success: true, commit: result.commit };
   }
 
@@ -382,7 +392,7 @@ export class RepoDO extends DurableObject<Env> {
         return { success: false, error: updateResult.error.message };
       }
 
-      await timer.measure("provenanceMs", () =>
+      const provenanceResult = await timer.measure("provenanceMs", () =>
         recordProvenance(this.env.DB, log, {
           commitSha: mergedCommit,
           project: change.project,
@@ -392,6 +402,9 @@ export class RepoDO extends DurableObject<Env> {
           ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
         }),
       );
+      if (!provenanceResult.success) {
+        log.error("Failed to record provenance after merge", provenanceResult.error);
+      }
 
       const metricsResult = await recordCommitMetrics(
         this.env.DB,

--- a/src/queue/repo-do.ts
+++ b/src/queue/repo-do.ts
@@ -1,0 +1,417 @@
+import { DurableObject } from "cloudflare:workers";
+import { getChange, updateChangeStatus } from "../storage/changes";
+import { blobObject, commitObject, treeObject } from "../storage/git-objects";
+import {
+  type NodeFS,
+  type StagedItemResult,
+  type StagedTreeItem,
+  batchMergeStagedTrees,
+  cloneRepo,
+  fastForwardMerge,
+  freshRepoToken,
+  loadStagedTree,
+  mergeWorkspaceIntoProject,
+} from "../storage/git-ops";
+import { type CommitOutcome, commitPhasesFromSpans, recordCommitMetrics } from "../storage/metrics";
+import { putObject } from "../storage/object-store";
+import { recordProvenance } from "../storage/provenance";
+import { getProject, getWorkspace } from "../storage/state";
+import type { Env } from "../types";
+import { type Logger, createLogger } from "../utils/logger";
+import { PhaseTimer } from "../utils/phase-timer";
+import { GroupCommitCoordinator, type ItemOutcome } from "./group-commit";
+import type { MergeOutcome } from "./merge-queue";
+
+const MERGEABLE_STATUSES = new Set(["approved", "accepted", "promoted"]);
+const HEAD_KEY = "head";
+
+/**
+ * Per-repo ref authority (ADR 004, Phase 1). Tracks the project's main `head` and
+ * fast-forwards when a change's expected parent still equals it, skipping the
+ * project clone + 3-way merge. Every other case falls back to the proven cold
+ * merge. The cached head is an optimization only — correctness is anchored by
+ * Artifacts' non-force ref check on push (see fastForwardMerge).
+ *
+ * Objects still live in Artifacts this phase; the R2 object plane + group-commit
+ * (the part that crosses the throughput target) is a later pass.
+ */
+interface BenchAdvance {
+  path: string;
+  blobOid: string;
+}
+
+export class RepoDO extends DurableObject<Env> {
+  private coord?: GroupCommitCoordinator<BenchAdvance, void>;
+  // Phase 2 bench state: the working tree (path -> blob oid), the current commit,
+  // and counters. Real git objects; conflicts resolved server-side, never rejected.
+  private readonly benchTree = new Map<string, string>();
+  private benchHead?: string;
+  private benchBatches = 0;
+  private benchLanded = 0;
+  private benchConflicts = 0;
+
+  /**
+   * Per-repo group-commit coordinator (ADR 004 Phase 2). The durable write folds a
+   * batch of ref advances into ONE combined tree + ONE commit + ONE head write —
+   * the single serialized cost. Blob writes happen in the (parallel) object plane
+   * before submit.
+   */
+  private coordinator(): GroupCommitCoordinator<BenchAdvance, void> {
+    if (!this.coord) {
+      this.coord = new GroupCommitCoordinator<BenchAdvance, void>({
+        maxBatchSize: 64,
+        durableWrite: (batch) => this.landBatch(batch),
+      });
+    }
+    return this.coord;
+  }
+
+  /**
+   * Fold a batch into one real git commit, resolving same-path conflicts (last
+   * wins). Returns one outcome per item; the whole batch lands together here, so
+   * every item shares the batch's success (a thrown error rejects all).
+   */
+  private async landBatch(batch: BenchAdvance[]): Promise<ItemOutcome<void>[]> {
+    const bucket = this.env.REPO_OBJECTS;
+    if (!bucket) throw new Error("REPO_OBJECTS not bound");
+    const log = createLogger({ component: "RepoDO.bench" });
+
+    const seen = new Set<string>();
+    for (const adv of batch) {
+      // A write to a path already in the tree (or earlier in this same batch) is a
+      // concurrent conflict resolved server-side — last-writer-wins, not rejected.
+      if (this.benchTree.has(adv.path) || seen.has(adv.path)) this.benchConflicts += 1;
+      seen.add(adv.path);
+      this.benchTree.set(adv.path, adv.blobOid);
+    }
+
+    const entries = Array.from(this.benchTree, ([name, oid]) => ({ mode: "100644", name, oid }));
+    const tree = await treeObject(entries);
+    const treePut = await putObject(bucket, tree.oid, tree.bytes, log);
+    if (!treePut.success) throw new Error(treePut.error.message);
+
+    const commit = await commitObject({
+      tree: tree.oid,
+      parents: this.benchHead ? [this.benchHead] : [],
+      message: `batch ${this.benchBatches + 1} (${batch.length} commits)`,
+      timestamp: Math.floor(Date.now() / 1000),
+    });
+    const commitPut = await putObject(bucket, commit.oid, commit.bytes, log);
+    if (!commitPut.success) throw new Error(commitPut.error.message);
+
+    this.benchHead = commit.oid;
+    await this.ctx.storage.put("bench_head", commit.oid);
+    this.benchBatches += 1;
+    this.benchLanded += batch.length;
+    return batch.map(() => ({ ok: true, value: undefined }));
+  }
+
+  /**
+   * Ref-plane entry point (ADR 004 Phase 2): the blob was already written to the
+   * R2 object plane by the Worker (parallel, no coordination). The DO only folds
+   * the ref advance into the group-commit batch — keeping the single-threaded DO
+   * off the object-write path is what lets object writes parallelize.
+   */
+  async benchAdvance(path: string, blobOid: string): Promise<{ ok: true }> {
+    await this.coordinator().submit({ path, blobOid });
+    return { ok: true };
+  }
+
+  /**
+   * Convenience for tests: write the blob then advance. The live path does the
+   * blob write in the Worker (see the /bench route) so it does NOT serialize
+   * through the DO.
+   */
+  async benchCommit(path: string, sizeBytes: number): Promise<{ blob: string }> {
+    if (!this.env.REPO_OBJECTS) throw new Error("REPO_OBJECTS not bound");
+    const log = createLogger({ component: "RepoDO.bench" });
+    const content = crypto.getRandomValues(new Uint8Array(Math.max(1, sizeBytes)));
+    const blob = await blobObject(content);
+    const put = await putObject(this.env.REPO_OBJECTS, blob.oid, blob.bytes, log);
+    if (!put.success) throw new Error(put.error.message);
+    await this.benchAdvance(path, blob.oid);
+    return { blob: blob.oid };
+  }
+
+  /** Bench counters for the harness to read after a run. */
+  benchStats(): {
+    head: string | undefined;
+    batches: number;
+    landed: number;
+    conflictsResolved: number;
+    treeSize: number;
+  } {
+    return {
+      head: this.benchHead,
+      batches: this.benchBatches,
+      landed: this.benchLanded,
+      conflictsResolved: this.benchConflicts,
+      treeSize: this.benchTree.size,
+    };
+  }
+
+  // --- Production R2 merge path (ADR 004 Tasks 5/6) ---
+  private r2Coord?: GroupCommitCoordinator<StagedTreeItem, StagedItemResult>;
+  private projectRemote?: string;
+  // Warm project clone reused across batches: removes the per-batch clone so the
+  // durable write is just merge+push, which lets concurrent merges coalesce into
+  // large batches. Discarded on any push failure (stale head) -> re-clone next batch.
+  private warm?: { fs: NodeFS; dir: string };
+
+  /** Group-commit over R2-staged trees: batches concurrent merges, one push/batch. */
+  private r2Coordinator(): GroupCommitCoordinator<StagedTreeItem, StagedItemResult> {
+    if (!this.r2Coord) {
+      this.r2Coord = new GroupCommitCoordinator<StagedTreeItem, StagedItemResult>({
+        maxBatchSize: 64,
+        // Accumulate staggered merge requests into real batches (the lever for
+        // cross-request coalescing under a swarm).
+        batchWindowMs: 25,
+        durableWrite: async (batch) => {
+          const log = createLogger({ component: "RepoDO.r2.batch" });
+          if (!this.projectRemote) throw new Error("project remote unknown");
+          // Fresh write token per batch (Artifacts tokens are ~1h; never persisted).
+          const token = await freshRepoToken(this.env.ARTIFACTS, this.projectRemote, "write", log);
+          if (!token.success) throw new Error(token.error.message);
+          if (!this.warm) {
+            const cloned = await cloneRepo(this.projectRemote, token.data, log);
+            if (!cloned.success) throw new Error(cloned.error.message);
+            this.warm = { fs: cloned.data.fs, dir: cloned.data.dir };
+          }
+          const res = await batchMergeStagedTrees(
+            this.warm.fs,
+            this.warm.dir,
+            this.projectRemote,
+            token.data,
+            batch,
+            log,
+          );
+          if (!res.success) {
+            // Push rejected / stale warm head -> drop the warm clone so the next
+            // batch re-clones against the true remote head (correctness anchor:
+            // Artifacts' non-force push). The batch is rejected; changes re-merge.
+            this.warm = undefined;
+            throw new Error(res.error.message);
+          }
+          return res.data.map((r) => ({ ok: true as const, value: r }));
+        },
+      });
+    }
+    return this.r2Coord;
+  }
+
+  /**
+   * Merge a change via the R2 fetch-free path: load the workspace's staged tip
+   * tree from R2, group-commit-merge it onto the project head, push once. Returns
+   * `{ fallback: true }` when the R2 path can't apply (no staged tree / no base /
+   * not bound) so the caller takes the proven cold path.
+   */
+  async mergeViaR2(changeId: string, logger?: Logger): Promise<MergeOutcome | { fallback: true }> {
+    const log = logger ?? createLogger({ changeId, component: "RepoDO.r2" });
+    const bucket = this.env.REPO_OBJECTS;
+    if (!bucket) return { fallback: true };
+
+    const changeResult = await getChange(this.env.DB, log, changeId);
+    if (!changeResult.success) return { success: false, error: changeResult.error.message };
+    const change = changeResult.data;
+    if (!MERGEABLE_STATUSES.has(change.status)) {
+      return { success: false, error: "Change not found or not ready to merge" };
+    }
+    if (!change.baseSha) return { fallback: true }; // need a base for the synthetic merge
+
+    const projectResult = await getProject(this.env.STATE, change.project, log);
+    if (!projectResult.success) return { success: false, error: projectResult.error.message };
+    const project = projectResult.data;
+
+    const key = `repos/${project.id}/ws/${change.workspace}`;
+    const staged = await loadStagedTree(bucket, key);
+    if (!staged) return { fallback: true }; // not staged → cold path
+
+    this.projectRemote = project.remote;
+    let result: StagedItemResult;
+    try {
+      result = await this.r2Coordinator().submit({ changeId, baseSha: change.baseSha, staged });
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+    if (!result.merged || !result.commit) {
+      return { success: false, error: "Merge conflict: change could not be auto-merged" };
+    }
+
+    // Keep the cached head fresh so a later change that falls back to advance()
+    // predicts the fast-forward correctly instead of racing on a stale head.
+    await this.setHead(result.commit);
+
+    const updateResult = await updateChangeStatus(this.env.DB, log, changeId, "merged", {
+      ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+      ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
+      ...(change.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
+      mergedAt: new Date().toISOString(),
+    });
+    if (!updateResult.success) return { success: false, error: updateResult.error.message };
+
+    await recordProvenance(this.env.DB, log, {
+      commitSha: result.commit,
+      project: change.project,
+      workspace: change.workspace,
+      changeId,
+      ...(change.agentId !== undefined ? { agentId: change.agentId } : {}),
+      ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+    });
+
+    // GC the staged tree now that it has landed (Task 6).
+    await bucket.delete(key).catch(() => {});
+    return { success: true, commit: result.commit };
+  }
+
+  private async getHead(): Promise<string | undefined> {
+    return this.ctx.storage.get<string>(HEAD_KEY);
+  }
+
+  private async setHead(oid: string): Promise<void> {
+    await this.ctx.storage.put(HEAD_KEY, oid);
+  }
+
+  /**
+   * Serialize advances per repo: the head read-modify-write must not interleave
+   * across concurrent calls, or the cached head can record a value that isn't the
+   * latest ref. (Group-commit will replace this coarse serialization later.)
+   */
+  async advance(changeId: string, logger?: Logger): Promise<MergeOutcome> {
+    return this.ctx.blockConcurrencyWhile(() => this.advanceLocked(changeId, logger));
+  }
+
+  private async advanceLocked(changeId: string, logger?: Logger): Promise<MergeOutcome> {
+    const log = logger ?? createLogger({ changeId, component: "RepoDO" });
+    const timer = new PhaseTimer();
+    const startedAt = Date.now();
+
+    const changeResult = await getChange(this.env.DB, log, changeId);
+    if (!changeResult.success) {
+      return { success: false, error: changeResult.error.message };
+    }
+    const change = changeResult.data;
+    if (!MERGEABLE_STATUSES.has(change.status)) {
+      return { success: false, error: "Change not found or not ready to merge" };
+    }
+
+    try {
+      const projectResult = await getProject(this.env.STATE, change.project, log);
+      if (!projectResult.success) {
+        return { success: false, error: projectResult.error.message };
+      }
+      const project = projectResult.data;
+
+      const workspaceResult = await getWorkspace(this.env.STATE, project.id, change.workspace, log);
+      if (!workspaceResult.success) {
+        return { success: false, error: workspaceResult.error.message };
+      }
+      const workspace = workspaceResult.data;
+
+      const [projectToken, workspaceToken] = await timer.measure("tokenMintMs", () =>
+        Promise.all([
+          freshRepoToken(this.env.ARTIFACTS, project.remote, "write", log),
+          freshRepoToken(this.env.ARTIFACTS, workspace.remote, "read", log),
+        ]),
+      );
+      if (!projectToken.success) return { success: false, error: projectToken.error.message };
+      if (!workspaceToken.success) return { success: false, error: workspaceToken.error.message };
+
+      const expectedParent = change.baseSha;
+      const head = await this.getHead();
+
+      let commit: string | undefined;
+      let outcome: CommitOutcome = "cold_fallback";
+
+      // Fast-forward fast path: only when we believe the project head is still the
+      // change's base. A wrong cache cannot corrupt anything — the non-force push
+      // inside fastForwardMerge rejects, and we cold-merge below.
+      if (expectedParent && head && expectedParent === head) {
+        const ff = await fastForwardMerge(
+          project.remote,
+          projectToken.data,
+          workspace.remote,
+          workspaceToken.data,
+          expectedParent,
+          log,
+          timer,
+        );
+        if (ff.success && ff.data.fastForwarded && ff.data.commit) {
+          commit = ff.data.commit;
+          outcome = "fast_forward";
+        }
+      }
+
+      // Cold fallback for every non-fast-forward case (race, missing base, push
+      // rejection, or any FF error).
+      if (!commit) {
+        const coldResult = await mergeWorkspaceIntoProject(
+          project.remote,
+          projectToken.data,
+          workspace.remote,
+          workspaceToken.data,
+          log,
+          { strategy: "merge", timer },
+        );
+        if (!coldResult.success) {
+          return { success: false, error: coldResult.error.message };
+        }
+        commit = coldResult.data;
+        outcome = "cold_fallback";
+      }
+
+      if (!commit) {
+        return { success: false, error: "Merge did not produce a commit" };
+      }
+      const mergedCommit = commit;
+
+      // Persist the new head before the bookkeeping writes. A crash after this
+      // but before the status update leaves the change re-mergeable; a retry sees
+      // head !== base, cold-merges, and isomorphic-git treats an already-applied
+      // tree as up-to-date (content-addressed, no double apply).
+      await timer.measure("refAdvanceMs", () => this.setHead(mergedCommit));
+
+      const updateResult = await timer.measure("d1UpdateMs", () =>
+        updateChangeStatus(this.env.DB, log, changeId, "merged", {
+          ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+          ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
+          ...(change.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
+          mergedAt: new Date().toISOString(),
+        }),
+      );
+      if (!updateResult.success) {
+        return { success: false, error: updateResult.error.message };
+      }
+
+      await timer.measure("provenanceMs", () =>
+        recordProvenance(this.env.DB, log, {
+          commitSha: mergedCommit,
+          project: change.project,
+          workspace: change.workspace,
+          changeId,
+          ...(change.agentId !== undefined ? { agentId: change.agentId } : {}),
+          ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+        }),
+      );
+
+      const metricsResult = await recordCommitMetrics(
+        this.env.DB,
+        {
+          project: change.project,
+          changeId,
+          outcome,
+          phases: commitPhasesFromSpans(timer.toObject()),
+          totalMs: Date.now() - startedAt,
+        },
+        log,
+      );
+      if (!metricsResult.success) {
+        log.warn("Failed to record commit metrics", { changeId });
+      }
+
+      return { success: true, commit: mergedCommit };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return { success: false, error };
+    }
+  }
+}

--- a/src/queue/repo-do.ts
+++ b/src/queue/repo-do.ts
@@ -273,6 +273,62 @@ export class RepoDO extends DurableObject<Env> {
     return { success: true, commit: result.commit };
   }
 
+  // --- Hot object index (ADR 004): staged tip trees in the DO's local SQLite ---
+  // Reading them at merge time is a microsecond-scale local read instead of a
+  // ~30ms-per-change R2 GET — the resolve phase was the batch path's dominant cost.
+  private stagedTableReady = false;
+  private ensureStagedTable(): void {
+    if (this.stagedTableReady) return;
+    this.ctx.storage.sql.exec(
+      "CREATE TABLE IF NOT EXISTS staged_trees (workspace TEXT PRIMARY KEY, value BLOB NOT NULL, updated_at INTEGER NOT NULL)",
+    );
+    this.stagedTableReady = true;
+  }
+
+  /** Stage (upsert) a workspace's packed tip tree into the DO's local SQLite. */
+  async stageTree(workspace: string, value: ArrayBuffer): Promise<void> {
+    this.ensureStagedTable();
+    this.ctx.storage.sql.exec(
+      "INSERT OR REPLACE INTO staged_trees (workspace, value, updated_at) VALUES (?, ?, ?)",
+      workspace,
+      value,
+      Date.now(),
+    );
+  }
+
+  private readStagedTree(workspace: string): Uint8Array | null {
+    this.ensureStagedTable();
+    const rows = this.ctx.storage.sql
+      .exec<{ value: ArrayBuffer }>("SELECT value FROM staged_trees WHERE workspace = ?", workspace)
+      .toArray();
+    const row = rows[0];
+    return row ? new Uint8Array(row.value) : null;
+  }
+
+  /**
+   * Read many staged trees from the LOCAL SQLite hot index in one RPC — replaces the
+   * batch path's N per-change R2 GETs (~30ms each) with a single fast call. The
+   * caller does the actual clone+merge+push in the Worker (the merge runs measurably
+   * faster there than inside the DO).
+   */
+  async getStagedTrees(workspaces: string[]): Promise<{ workspace: string; value: Uint8Array }[]> {
+    const out: { workspace: string; value: Uint8Array }[] = [];
+    for (const ws of workspaces) {
+      const value = this.readStagedTree(ws);
+      if (value) out.push({ workspace: ws, value });
+    }
+    return out;
+  }
+
+  /** GC staged trees from the hot index after their changes have landed. */
+  async gcStagedTrees(workspaces: string[]): Promise<void> {
+    if (workspaces.length === 0) return;
+    this.ensureStagedTable();
+    for (const ws of workspaces) {
+      this.ctx.storage.sql.exec("DELETE FROM staged_trees WHERE workspace = ?", ws);
+    }
+  }
+
   private async getHead(): Promise<string | undefined> {
     return this.ctx.storage.get<string>(HEAD_KEY);
   }

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -67,6 +67,56 @@ const POLICY_CACHE_TTL_MS = 60_000;
 const policyCache = new Map<string, { policy: EvalPolicy; expires: number }>();
 const policyInflight = new Map<string, Promise<EvalPolicy>>();
 
+const policyKvKey = (projectId: string) => `policy:${projectId}`;
+
+/**
+ * Load a project's merge policy through a two-level cache so the hot merge paths
+ * don't clone the repo just to read `.stratum/policy.yaml`:
+ *   in-isolate Map  ->  KV (shared across isolates)  ->  clone (loadPolicy).
+ * Request-coalesced per project. Gated on REPO_DO_ENABLED so tests always load
+ * fresh (no KV access). The cache TTL bounds how long a branch-protection change
+ * takes to apply on these paths. Throws if the read token can't be minted.
+ */
+async function loadMergePolicyCached(
+  env: Env,
+  project: ProjectEntry,
+  logger: Logger,
+): Promise<EvalPolicy> {
+  const cacheable = env.REPO_DO_ENABLED === "true";
+  const cached = cacheable ? policyCache.get(project.id) : undefined;
+  if (cached && cached.expires > Date.now()) return cached.policy;
+  let inflight = cacheable ? policyInflight.get(project.id) : undefined;
+  if (!inflight) {
+    inflight = (async () => {
+      // Cross-isolate KV cache — avoids the repo clone on a cold isolate.
+      if (cacheable) {
+        const kvHit = await env.STATE.get<EvalPolicy>(policyKvKey(project.id), "json").catch(
+          () => null,
+        );
+        if (kvHit) {
+          policyCache.set(project.id, { policy: kvHit, expires: Date.now() + POLICY_CACHE_TTL_MS });
+          return kvHit;
+        }
+      }
+      const tok = await freshRepoToken(env.ARTIFACTS, project.remote, "read", logger);
+      if (!tok.success) throw new Error(tok.error.message);
+      const loaded = await loadPolicy(project.remote, tok.data, logger);
+      if (cacheable) {
+        policyCache.set(project.id, { policy: loaded, expires: Date.now() + POLICY_CACHE_TTL_MS });
+        await env.STATE.put(policyKvKey(project.id), JSON.stringify(loaded), {
+          expirationTtl: 60,
+        }).catch(() => {});
+      }
+      return loaded;
+    })();
+    if (cacheable) {
+      policyInflight.set(project.id, inflight);
+      void inflight.finally(() => policyInflight.delete(project.id));
+    }
+  }
+  return inflight;
+}
+
 function parseGitHubRepo(url: string): { owner: string; repo: string } | null {
   const match = url.match(/^https?:\/\/github\.com\/([^/]+)\/([^/\s]+?)(?:\.git|\/)?$/i);
   if (!match || !match[1] || !match[2]) return null;
@@ -509,38 +559,13 @@ app.post("/changes/:id/merge", async (c) => {
   if (!(await canWriteProject(c.env.DB, project, userId)))
     return forbidden("Project access denied");
 
-  // Branch protection: the policy's merge rules gate every merge path. See the
-  // policy-cache note above — avoid a per-merge clone under concurrency.
-  const cacheable = c.env.REPO_DO_ENABLED === "true";
-  const cachedPolicy = cacheable ? policyCache.get(project.id) : undefined;
+  // Branch protection: the policy's merge rules gate every merge path. Cached +
+  // coalesced so a swarm of merges doesn't each clone the repo for the policy file.
   let mergePolicy: EvalPolicy;
-  if (cachedPolicy && cachedPolicy.expires > Date.now()) {
-    mergePolicy = cachedPolicy.policy;
-  } else {
-    let inflight = cacheable ? policyInflight.get(project.id) : undefined;
-    if (!inflight) {
-      inflight = (async () => {
-        const tok = await freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger);
-        if (!tok.success) throw new Error(tok.error.message);
-        const loaded = await loadPolicy(project.remote, tok.data, logger);
-        if (cacheable) {
-          policyCache.set(project.id, {
-            policy: loaded,
-            expires: Date.now() + POLICY_CACHE_TTL_MS,
-          });
-        }
-        return loaded;
-      })();
-      if (cacheable) {
-        policyInflight.set(project.id, inflight);
-        void inflight.finally(() => policyInflight.delete(project.id));
-      }
-    }
-    try {
-      mergePolicy = await inflight;
-    } catch (e) {
-      return internalError(e instanceof Error ? e.message : "Failed to load policy");
-    }
+  try {
+    mergePolicy = await loadMergePolicyCached(c.env, project, logger);
+  } catch (e) {
+    return internalError(e instanceof Error ? e.message : "Failed to load policy");
   }
   const forceAllowed = mergePolicy.merge?.allowForce !== false;
   if (force && !forceAllowed) {
@@ -810,15 +835,33 @@ app.post("/projects/:name/changes/merge-batch", async (c) => {
 
   const { name: projectName } = c.req.param();
   const projectResult = await getProject(c.env.STATE, projectName, logger);
-  if (!projectResult.success) return notFound("Project", projectName);
+  if (!projectResult.success) {
+    if (projectResult.error.code === "NOT_FOUND") return notFound("Project", projectName);
+    logger.error("Failed to get project", projectResult.error);
+    return internalError(projectResult.error.message);
+  }
   const project = projectResult.data;
   if (!(await canWriteProject(c.env.DB, project, userId)))
     return forbidden("Project access denied");
 
-  const body = await c.req.json<{ changeIds?: unknown }>().catch(() => ({ changeIds: undefined }));
+  const body = await c.req
+    .json<{ changeIds?: unknown; force?: unknown }>()
+    .catch(() => ({ changeIds: undefined, force: undefined }));
   if (!Array.isArray(body.changeIds) || body.changeIds.length === 0) {
     return badRequest("changeIds (non-empty array) is required");
   }
+  const force = body.force === true;
+
+  // Branch-protection gate (same as the single-merge path; the batch path must not
+  // be a bypass). The policy + current-head reads are independent of the staged-tree
+  // resolve, so load them in PARALLEL with it — the policy-file read doesn't add
+  // serial latency to the hot path. Marked handled to avoid an unhandled rejection
+  // on an early return; the real awaits below surface failures.
+  const policyPromise = loadMergePolicyCached(c.env, project, logger);
+  void policyPromise.catch(() => {});
+  const headPromise: Promise<string | null> = force
+    ? Promise.resolve(null)
+    : resolveProjectHead(c.env, project, logger);
   // Dedupe: a repeated id would otherwise merge twice and write two provenance rows.
   const changeIds = [
     ...new Set(body.changeIds.filter((id): id is string => typeof id === "string")),
@@ -860,6 +903,23 @@ app.post("/projects/:name/changes/merge-batch", async (c) => {
         return { id, skip: "wrong project" };
       if (!MERGEABLE_STATUSES.includes(change.status)) return { id, skip: "not mergeable" };
       if (!change.baseSha) return { id, skip: "no base" };
+      if (!force) {
+        let mergePolicy: EvalPolicy;
+        try {
+          mergePolicy = await policyPromise;
+        } catch {
+          return { id, skip: "policy load failed" };
+        }
+        const protection = await checkMergeProtection(c.env.DB, logger, change, mergePolicy);
+        if (!protection.success) return { id, skip: "protection check failed" };
+        if (!protection.data.allowed) return { id, skip: "blocked by branch protection" };
+        if (mergePolicy.merge?.requireFreshBase === true) {
+          const currentHead = await headPromise;
+          if (currentHead !== null && change.baseSha !== currentHead) {
+            return { id, skip: "stale base" };
+          }
+        }
+      }
       const staged = await loadStagedTree(bucket, `repos/${project.id}/ws/${change.workspace}`);
       if (!staged) return { id, skip: "not staged" };
       return { id, change, item: { changeId: id, baseSha: change.baseSha, staged } };
@@ -871,6 +931,22 @@ app.post("/projects/:name/changes/merge-batch", async (c) => {
     } else if ("item" in r && r.item) {
       items.push(r.item);
       changeById.set(r.id, r.change);
+    }
+  }
+
+  // Enforce the force-allowed policy (loaded in parallel above). Done after resolve
+  // so the policy read overlaps the R2 loads rather than gating them.
+  if (force) {
+    let mergePolicy: EvalPolicy;
+    try {
+      mergePolicy = await policyPromise;
+    } catch (e) {
+      clonePromise.catch(() => {});
+      return internalError(e instanceof Error ? e.message : "Failed to load policy");
+    }
+    if (mergePolicy.merge?.allowForce === false) {
+      clonePromise.catch(() => {});
+      return badRequest("Force merge is disabled by this project's policy");
     }
   }
 

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -15,14 +15,25 @@ import { checkMergeProtection } from "../merge/protection";
 import { type EventActor, emitEvent } from "../queue/events";
 import type { MergeOutcome } from "../queue/merge-queue";
 import { recordAudit } from "../storage/audit";
-import { createChange, getChange, listChanges, updateChangeStatus } from "../storage/changes";
+import {
+  createChange,
+  getChange,
+  getChangesByIds,
+  listChanges,
+  updateChangeStatus,
+} from "../storage/changes";
 import { type CostSample, getChangeCostSummary, recordCosts } from "../storage/costs";
 import { listEvalRuns, recordEvalRuns } from "../storage/eval-runs";
 import {
   MergeConflictError,
+  type NodeFS,
+  type StagedTreeItem,
+  batchMergeStagedTrees,
+  cloneRepo,
   freshRepoToken,
   getCommitLog,
   getDiffBetweenRepos,
+  loadStagedTree,
   mergeWorkspaceIntoProject,
 } from "../storage/git-ops";
 import { recordProvenance } from "../storage/provenance";
@@ -31,6 +42,7 @@ import { getProject, getWorkspace } from "../storage/state";
 import type { Change, Env, ProjectEntry } from "../types";
 import { canReadProject, canWriteProject } from "../utils/authz";
 import type { AppError } from "../utils/errors";
+import { newId } from "../utils/ids";
 import { createLogger } from "../utils/logger";
 import type { Logger } from "../utils/logger";
 import {
@@ -45,6 +57,16 @@ import {
 import { ok as okResult } from "../utils/result";
 
 const app = new Hono<{ Bindings: Env }>();
+
+// Merge-policy cache (ADR 004). Reading the policy clones the repo; under a swarm
+// of concurrent merges that per-request clone both throttles and de-coalesces the
+// DO group-commit. Cache per project with a short TTL AND deduplicate concurrent
+// loads (one clone per burst, not N). Gated on REPO_DO_ENABLED so tests — which
+// don't set the flag — always call loadPolicy fresh (no cross-test pollution).
+const POLICY_CACHE_TTL_MS = 60_000;
+const policyCache = new Map<string, { policy: EvalPolicy; expires: number }>();
+const policyInflight = new Map<string, Promise<EvalPolicy>>();
+
 function parseGitHubRepo(url: string): { owner: string; repo: string } | null {
   const match = url.match(/^https?:\/\/github\.com\/([^/]+)\/([^/\s]+?)(?:\.git|\/)?$/i);
   if (!match || !match[1] || !match[2]) return null;
@@ -487,10 +509,39 @@ app.post("/changes/:id/merge", async (c) => {
   if (!(await canWriteProject(c.env.DB, project, userId)))
     return forbidden("Project access denied");
 
-  // Branch protection: the policy's merge rules gate every merge path.
-  const policyReadToken = await freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger);
-  if (!policyReadToken.success) return internalError(policyReadToken.error.message);
-  const mergePolicy = await loadPolicy(project.remote, policyReadToken.data, logger);
+  // Branch protection: the policy's merge rules gate every merge path. See the
+  // policy-cache note above — avoid a per-merge clone under concurrency.
+  const cacheable = c.env.REPO_DO_ENABLED === "true";
+  const cachedPolicy = cacheable ? policyCache.get(project.id) : undefined;
+  let mergePolicy: EvalPolicy;
+  if (cachedPolicy && cachedPolicy.expires > Date.now()) {
+    mergePolicy = cachedPolicy.policy;
+  } else {
+    let inflight = cacheable ? policyInflight.get(project.id) : undefined;
+    if (!inflight) {
+      inflight = (async () => {
+        const tok = await freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger);
+        if (!tok.success) throw new Error(tok.error.message);
+        const loaded = await loadPolicy(project.remote, tok.data, logger);
+        if (cacheable) {
+          policyCache.set(project.id, {
+            policy: loaded,
+            expires: Date.now() + POLICY_CACHE_TTL_MS,
+          });
+        }
+        return loaded;
+      })();
+      if (cacheable) {
+        policyInflight.set(project.id, inflight);
+        void inflight.finally(() => policyInflight.delete(project.id));
+      }
+    }
+    try {
+      mergePolicy = await inflight;
+    } catch (e) {
+      return internalError(e instanceof Error ? e.message : "Failed to load policy");
+    }
+  }
   const forceAllowed = mergePolicy.merge?.allowForce !== false;
   if (force && !forceAllowed) {
     return badRequest("Force merge is disabled by this project's policy");
@@ -533,12 +584,32 @@ app.post("/changes/:id/merge", async (c) => {
     }
   }
 
-  if (c.env.MERGE_QUEUE && strategy === "merge") {
-    const doId = c.env.MERGE_QUEUE.idFromName(change.project);
-    const stub = c.env.MERGE_QUEUE.get(doId);
-    const result = await (
-      stub as unknown as { merge(changeId: string): Promise<MergeOutcome> }
-    ).merge(id);
+  // Route serialized merges through a per-repo Durable Object. When REPO_DO_ENABLED
+  // is set, use the RepoDO ref authority (fast-forward fast path, ADR 004 Phase 1);
+  // otherwise the classic MergeQueue cold path. Both share the post-merge tail below.
+  // RepoDO is keyed by the canonical project.id so one repo maps to exactly one DO
+  // (change.project may be a name OR id depending on the creating path, which would
+  // otherwise split a repo's ref cache across DOs).
+  const useRepoDo = c.env.REPO_DO_ENABLED === "true" && c.env.REPO_DO !== undefined;
+  if ((useRepoDo || c.env.MERGE_QUEUE) && strategy === "merge") {
+    let result: MergeOutcome;
+    if (useRepoDo && c.env.REPO_DO) {
+      const stub = c.env.REPO_DO.get(c.env.REPO_DO.idFromName(project.id)) as unknown as {
+        mergeViaR2(changeId: string): Promise<MergeOutcome | { fallback: true }>;
+        advance(changeId: string): Promise<MergeOutcome>;
+      };
+      // Prefer the R2 fetch-free path; fall back to the Phase-1 FF/cold path when the
+      // change has no staged tree (e.g. committed before R2 staging was enabled).
+      const r2 = await stub.mergeViaR2(id);
+      result = "fallback" in r2 ? await stub.advance(id) : r2;
+    } else {
+      // biome-ignore lint/style/noNonNullAssertion: guarded by the if condition
+      const queue = c.env.MERGE_QUEUE!;
+      const stub = queue.get(queue.idFromName(change.project));
+      result = await (stub as unknown as { merge(changeId: string): Promise<MergeOutcome> }).merge(
+        id,
+      );
+    }
 
     if (!result.success) {
       return badRequest(result.error ?? "Merge failed");
@@ -556,6 +627,7 @@ app.post("/changes/:id/merge", async (c) => {
       changeId: id,
       project: change.project,
       commit: result.commit,
+      via: useRepoDo ? "repo-do" : "merge-queue",
     });
 
     if (force) {
@@ -720,6 +792,188 @@ app.post("/changes/:id/merge", async (c) => {
     workspace: change.workspace,
     commit,
     postMerge,
+  });
+});
+
+// POST /api/projects/:name/changes/merge-batch — merge MANY changes into one repo
+// in a single request (ADR 004). Per-request merge RPCs serialize at the Durable
+// Object (~one at a time), so the way to realize the group-commit throughput
+// (proven ~31 c/s) is to batch server-side: clone once, 3-way merge each staged
+// change onto the head, ONE push. Body: { changeIds: string[] }.
+app.post("/projects/:name/changes/merge-batch", async (c) => {
+  const tStart = Date.now();
+  const logger = createLogger({ requestId: crypto.randomUUID(), userId: c.get("userId") });
+  const userId = c.get("userId");
+  if (!userId) return unauthorized("Authentication required");
+  if (!c.env.REPO_OBJECTS) return internalError("R2 object store not bound");
+  const bucket = c.env.REPO_OBJECTS;
+
+  const { name: projectName } = c.req.param();
+  const projectResult = await getProject(c.env.STATE, projectName, logger);
+  if (!projectResult.success) return notFound("Project", projectName);
+  const project = projectResult.data;
+  if (!(await canWriteProject(c.env.DB, project, userId)))
+    return forbidden("Project access denied");
+
+  const body = await c.req.json<{ changeIds?: unknown }>().catch(() => ({ changeIds: undefined }));
+  if (!Array.isArray(body.changeIds) || body.changeIds.length === 0) {
+    return badRequest("changeIds (non-empty array) is required");
+  }
+  // Dedupe: a repeated id would otherwise merge twice and write two provenance rows.
+  const changeIds = [
+    ...new Set(body.changeIds.filter((id): id is string => typeof id === "string")),
+  ];
+  // Bound the per-request batch: very large N risks the Worker CPU/time limit in the
+  // single-FS merge loop. Callers should chunk above this; throughput is already
+  // maximized well under it (~27-30 c/s server-side at N=40-64).
+  const MAX_MERGE_BATCH = 80;
+  if (changeIds.length > MAX_MERGE_BATCH) {
+    return badRequest(`merge-batch accepts at most ${MAX_MERGE_BATCH} changes per request`);
+  }
+
+  // Kick off the write-token mint + project clone NOW, overlapping it with the
+  // resolve phase (R2 gets) below — neither depends on the other, so the ~300ms
+  // clone+token finishes "for free" during the staged-tree loads.
+  const clonePromise = (async () => {
+    const token = await freshRepoToken(c.env.ARTIFACTS, project.remote, "write", logger);
+    if (!token.success) throw new Error(token.error.message);
+    const cloned = await cloneRepo(project.remote, token.data, logger);
+    if (!cloned.success) throw new Error(cloned.error.message);
+    return { token: token.data, fs: cloned.data.fs, dir: cloned.data.dir };
+  })();
+
+  // Resolve each change to a staged-tree item; skip (report) ones not eligible.
+  const tResolve = Date.now();
+  const items: StagedTreeItem[] = [];
+  const skipped: { changeId: string; reason: string }[] = [];
+  const changeById = new Map<string, Change>();
+  // Fetch all changes in ONE D1 query, then load their staged trees CONCURRENTLY.
+  // (Per-change getChange + sequential awaits dominated the request — ~7s for 50.)
+  const changesResult = await getChangesByIds(c.env.DB, logger, changeIds);
+  if (!changesResult.success) return internalError(changesResult.error.message);
+  const changeMap = new Map(changesResult.data.map((ch) => [ch.id, ch]));
+  const resolved = await Promise.all(
+    changeIds.map(async (id) => {
+      const change = changeMap.get(id);
+      if (!change) return { id, skip: "not found" };
+      if (change.project !== projectName && change.project !== project.id)
+        return { id, skip: "wrong project" };
+      if (!MERGEABLE_STATUSES.includes(change.status)) return { id, skip: "not mergeable" };
+      if (!change.baseSha) return { id, skip: "no base" };
+      const staged = await loadStagedTree(bucket, `repos/${project.id}/ws/${change.workspace}`);
+      if (!staged) return { id, skip: "not staged" };
+      return { id, change, item: { changeId: id, baseSha: change.baseSha, staged } };
+    }),
+  );
+  for (const r of resolved) {
+    if ("skip" in r && r.skip) {
+      skipped.push({ changeId: r.id, reason: r.skip });
+    } else if ("item" in r && r.item) {
+      items.push(r.item);
+      changeById.set(r.id, r.change);
+    }
+  }
+
+  if (items.length === 0) {
+    clonePromise.catch(() => {}); // swallow the now-unused clone
+    return badRequest(`No eligible changes to merge (${skipped.length} skipped)`);
+  }
+
+  const resolveMs = Date.now() - tResolve;
+
+  const tBatch = Date.now();
+  let cloneData: { token: string; fs: NodeFS; dir: string };
+  try {
+    cloneData = await clonePromise;
+  } catch (e) {
+    return internalError(e instanceof Error ? e.message : "Failed to prepare repo");
+  }
+
+  const mergeResult = await batchMergeStagedTrees(
+    cloneData.fs,
+    cloneData.dir,
+    project.remote,
+    cloneData.token,
+    items,
+    logger,
+  );
+  if (!mergeResult.success) return internalError(mergeResult.error.message);
+  const batchMs = Date.now() - tBatch;
+
+  // Persist with just TWO statements regardless of N — one `UPDATE ... WHERE id IN`
+  // and one multi-row provenance INSERT — instead of 2N. Per-statement D1 cost (even
+  // batched) was halving throughput. GC the staged trees concurrently.
+  const tPersist = Date.now();
+  const merged: string[] = [];
+  const conflicted: string[] = [];
+  const landed: { changeId: string; commit: string; change: Change | undefined }[] = [];
+  const gcKeys: string[] = [];
+  for (const r of mergeResult.data) {
+    if (!r.merged || !r.commit) {
+      conflicted.push(r.changeId);
+      continue;
+    }
+    const change = changeById.get(r.changeId);
+    landed.push({ changeId: r.changeId, commit: r.commit, change });
+    gcKeys.push(`repos/${project.id}/ws/${change?.workspace}`);
+    merged.push(r.changeId);
+  }
+
+  // The merges are already DURABLE (pushed to Artifacts) — the D1 status/provenance
+  // writes and staged-tree GC are derived bookkeeping. Defer them past the response
+  // (waitUntil) so D1 transaction-commit latency (~1s) doesn't gate throughput.
+  const mergedAt = new Date().toISOString();
+  // D1 caps bound parameters at 100/statement: chunk so UPDATE (1 + ids) and the
+  // multi-row INSERT (8 binds/row) stay under it. All chunks ride one batch().
+  const UPDATE_CHUNK = 99;
+  const INSERT_CHUNK = 12;
+  const statements: D1PreparedStatement[] = [];
+  for (let i = 0; i < landed.length; i += UPDATE_CHUNK) {
+    const chunk = landed.slice(i, i + UPDATE_CHUNK);
+    const placeholders = chunk.map(() => "?").join(", ");
+    statements.push(
+      c.env.DB.prepare(
+        `UPDATE changes SET status = 'merged', merged_at = ? WHERE id IN (${placeholders})`,
+      ).bind(mergedAt, ...chunk.map((l) => l.changeId)),
+    );
+  }
+  for (let i = 0; i < landed.length; i += INSERT_CHUNK) {
+    const chunk = landed.slice(i, i + INSERT_CHUNK);
+    const rows = chunk.map(() => "(?, ?, ?, ?, ?, ?, ?, ?)").join(", ");
+    const binds = chunk.flatMap((l) => [
+      newId("prv"),
+      l.commit,
+      projectName,
+      l.change?.workspace ?? "",
+      l.changeId,
+      l.change?.agentId ?? null,
+      l.change?.evalScore ?? null,
+      mergedAt,
+    ]);
+    statements.push(
+      c.env.DB.prepare(
+        `INSERT INTO provenance (id, commit_sha, project, workspace, change_id, agent_id, eval_score, merged_at) VALUES ${rows}`,
+      ).bind(...binds),
+    );
+  }
+
+  const persist = (async () => {
+    if (statements.length > 0) await c.env.DB.batch(statements);
+    await Promise.all(gcKeys.map((k) => bucket.delete(k).catch(() => {})));
+  })();
+  if (c.executionCtx?.waitUntil) c.executionCtx.waitUntil(persist);
+  else await persist;
+
+  return ok({
+    merged,
+    conflicted,
+    skipped,
+    timings: {
+      resolveMs,
+      batchMs,
+      persistMs: Date.now() - tPersist,
+      serverMs: Date.now() - tStart,
+    },
   });
 });
 

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -874,9 +874,9 @@ app.post("/projects/:name/changes/merge-batch", async (c) => {
     return badRequest(`merge-batch accepts at most ${MAX_MERGE_BATCH} changes per request`);
   }
 
-  // Kick off the write-token mint + project clone NOW, overlapping it with the
-  // resolve phase (R2 gets) below — neither depends on the other, so the ~300ms
-  // clone+token finishes "for free" during the staged-tree loads.
+  // Mint the write token + clone NOW, overlapping it with the resolve phase (R2
+  // gets) below — the clone (~300-600ms) finishes within the resolve window, so it's
+  // off the critical path. (Measured: sequencing it after resolve is strictly worse.)
   const clonePromise = (async () => {
     const token = await freshRepoToken(c.env.ARTIFACTS, project.remote, "write", logger);
     if (!token.success) throw new Error(token.error.message);

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -33,8 +33,8 @@ import {
   freshRepoToken,
   getCommitLog,
   getDiffBetweenRepos,
-  loadStagedTree,
   mergeWorkspaceIntoProject,
+  parseStagedTree,
 } from "../storage/git-ops";
 import { recordProvenance } from "../storage/provenance";
 import { readRepoSnapshot } from "../storage/repo-snapshot";
@@ -830,8 +830,6 @@ app.post("/projects/:name/changes/merge-batch", async (c) => {
   const logger = createLogger({ requestId: crypto.randomUUID(), userId: c.get("userId") });
   const userId = c.get("userId");
   if (!userId) return unauthorized("Authentication required");
-  if (!c.env.REPO_OBJECTS) return internalError("R2 object store not bound");
-  const bucket = c.env.REPO_OBJECTS;
 
   const { name: projectName } = c.req.param();
   const projectResult = await getProject(c.env.STATE, projectName, logger);
@@ -874,24 +872,13 @@ app.post("/projects/:name/changes/merge-batch", async (c) => {
     return badRequest(`merge-batch accepts at most ${MAX_MERGE_BATCH} changes per request`);
   }
 
-  // Mint the write token + clone NOW, overlapping it with the resolve phase (R2
-  // gets) below — the clone (~300-600ms) finishes within the resolve window, so it's
-  // off the critical path. (Measured: sequencing it after resolve is strictly worse.)
-  const clonePromise = (async () => {
-    const token = await freshRepoToken(c.env.ARTIFACTS, project.remote, "write", logger);
-    if (!token.success) throw new Error(token.error.message);
-    const cloned = await cloneRepo(project.remote, token.data, logger);
-    if (!cloned.success) throw new Error(cloned.error.message);
-    return { token: token.data, fs: cloned.data.fs, dir: cloned.data.dir };
-  })();
-
-  // Resolve each change to a staged-tree item; skip (report) ones not eligible.
+  // Resolve every change in ONE D1 query and policy-gate it here; the MERGE runs in
+  // the per-repo Durable Object, which reads staged trees from its LOCAL SQLite hot
+  // index (microseconds) instead of a per-change R2 GET, on a warm reused clone.
   const tResolve = Date.now();
-  const items: StagedTreeItem[] = [];
   const skipped: { changeId: string; reason: string }[] = [];
   const changeById = new Map<string, Change>();
-  // Fetch all changes in ONE D1 query, then load their staged trees CONCURRENTLY.
-  // (Per-change getChange + sequential awaits dominated the request — ~7s for 50.)
+  const mergeItems: { changeId: string; workspace: string; baseSha: string }[] = [];
   const changesResult = await getChangesByIds(c.env.DB, logger, changeIds);
   if (!changesResult.success) return internalError(changesResult.error.message);
   const changeMap = new Map(changesResult.data.map((ch) => [ch.id, ch]));
@@ -920,51 +907,84 @@ app.post("/projects/:name/changes/merge-batch", async (c) => {
           }
         }
       }
-      const staged = await loadStagedTree(bucket, `repos/${project.id}/ws/${change.workspace}`);
-      if (!staged) return { id, skip: "not staged" };
-      return { id, change, item: { changeId: id, baseSha: change.baseSha, staged } };
+      return { id, change };
     }),
   );
   for (const r of resolved) {
     if ("skip" in r && r.skip) {
       skipped.push({ changeId: r.id, reason: r.skip });
-    } else if ("item" in r && r.item) {
-      items.push(r.item);
+    } else if ("change" in r && r.change && r.change.baseSha) {
       changeById.set(r.id, r.change);
+      mergeItems.push({ changeId: r.id, workspace: r.change.workspace, baseSha: r.change.baseSha });
     }
   }
 
-  // Enforce the force-allowed policy (loaded in parallel above). Done after resolve
-  // so the policy read overlaps the R2 loads rather than gating them.
+  // Enforce the force-allowed policy (loaded in parallel above).
   if (force) {
     let mergePolicy: EvalPolicy;
     try {
       mergePolicy = await policyPromise;
     } catch (e) {
-      clonePromise.catch(() => {});
       return internalError(e instanceof Error ? e.message : "Failed to load policy");
     }
     if (mergePolicy.merge?.allowForce === false) {
-      clonePromise.catch(() => {});
       return badRequest("Force merge is disabled by this project's policy");
     }
   }
 
+  if (mergeItems.length === 0) {
+    return badRequest(`No eligible changes to merge (${skipped.length} skipped)`);
+  }
+  const resolveMs = Date.now() - tResolve;
+
+  // Merge inside the per-repo DO: local SQLite hot-index reads + warm reused clone +
+  // one push. Keyed by project.id (same key the commit route seeds the index under).
+  if (!c.env.REPO_DO) return internalError("RepoDO not bound");
+  const stub = c.env.REPO_DO.get(c.env.REPO_DO.idFromName(project.id)) as unknown as {
+    getStagedTrees(workspaces: string[]): Promise<{ workspace: string; value: Uint8Array }[]>;
+    gcStagedTrees(workspaces: string[]): Promise<void>;
+  };
+
+  const tBatch = Date.now();
+  // Clone in the Worker (the merge runs faster here than inside the DO), overlapped
+  // with the SINGLE SQLite hot-index read that replaces N per-change R2 GETs.
+  const clonePromise = (async () => {
+    const token = await freshRepoToken(c.env.ARTIFACTS, project.remote, "write", logger);
+    if (!token.success) throw new Error(token.error.message);
+    const cloned = await cloneRepo(project.remote, token.data, logger);
+    if (!cloned.success) throw new Error(cloned.error.message);
+    return { token: token.data, fs: cloned.data.fs, dir: cloned.data.dir };
+  })();
+
+  const workspaces = [...new Set(mergeItems.map((m) => m.workspace))];
+  let stagedList: { workspace: string; value: Uint8Array }[];
+  try {
+    stagedList = await stub.getStagedTrees(workspaces);
+  } catch (e) {
+    clonePromise.catch(() => {});
+    return internalError(e instanceof Error ? e.message : "Failed to read staged trees");
+  }
+  const stagedByWs = new Map(stagedList.map((s) => [s.workspace, s.value]));
+  const items: StagedTreeItem[] = [];
+  for (const m of mergeItems) {
+    const value = stagedByWs.get(m.workspace);
+    if (!value) {
+      skipped.push({ changeId: m.changeId, reason: "not staged" });
+      continue;
+    }
+    items.push({ changeId: m.changeId, baseSha: m.baseSha, staged: parseStagedTree(value) });
+  }
   if (items.length === 0) {
-    clonePromise.catch(() => {}); // swallow the now-unused clone
+    clonePromise.catch(() => {});
     return badRequest(`No eligible changes to merge (${skipped.length} skipped)`);
   }
 
-  const resolveMs = Date.now() - tResolve;
-
-  const tBatch = Date.now();
   let cloneData: { token: string; fs: NodeFS; dir: string };
   try {
     cloneData = await clonePromise;
   } catch (e) {
     return internalError(e instanceof Error ? e.message : "Failed to prepare repo");
   }
-
   const mergeResult = await batchMergeStagedTrees(
     cloneData.fs,
     cloneData.dir,
@@ -976,14 +996,14 @@ app.post("/projects/:name/changes/merge-batch", async (c) => {
   if (!mergeResult.success) return internalError(mergeResult.error.message);
   const batchMs = Date.now() - tBatch;
 
-  // Persist with just TWO statements regardless of N — one `UPDATE ... WHERE id IN`
-  // and one multi-row provenance INSERT — instead of 2N. Per-statement D1 cost (even
-  // batched) was halving throughput. GC the staged trees concurrently.
+  // Bookkeeping after a durable push (deferred): status + provenance, and GC both the
+  // SQLite hot index (DO) and the R2 mirror of the staged tree.
   const tPersist = Date.now();
   const merged: string[] = [];
   const conflicted: string[] = [];
   const landed: { changeId: string; commit: string; change: Change | undefined }[] = [];
   const gcKeys: string[] = [];
+  const mergedWorkspaces: string[] = [];
   for (const r of mergeResult.data) {
     if (!r.merged || !r.commit) {
       conflicted.push(r.changeId);
@@ -992,12 +1012,9 @@ app.post("/projects/:name/changes/merge-batch", async (c) => {
     const change = changeById.get(r.changeId);
     landed.push({ changeId: r.changeId, commit: r.commit, change });
     gcKeys.push(`repos/${project.id}/ws/${change?.workspace}`);
+    if (change?.workspace) mergedWorkspaces.push(change.workspace);
     merged.push(r.changeId);
   }
-
-  // The merges are already DURABLE (pushed to Artifacts) — the D1 status/provenance
-  // writes and staged-tree GC are derived bookkeeping. Defer them past the response
-  // (waitUntil) so D1 transaction-commit latency (~1s) doesn't gate throughput.
   const mergedAt = new Date().toISOString();
   // D1 caps bound parameters at 100/statement: chunk so UPDATE (1 + ids) and the
   // multi-row INSERT (8 binds/row) stay under it. All chunks ride one batch().
@@ -1035,7 +1052,9 @@ app.post("/projects/:name/changes/merge-batch", async (c) => {
 
   const persist = (async () => {
     if (statements.length > 0) await c.env.DB.batch(statements);
-    await Promise.all(gcKeys.map((k) => bucket.delete(k).catch(() => {})));
+    await stub.gcStagedTrees(mergedWorkspaces).catch(() => {});
+    const objects = c.env.REPO_OBJECTS;
+    if (objects) await Promise.all(gcKeys.map((k) => objects.delete(k).catch(() => {})));
   })();
   if (c.executionCtx?.waitUntil) c.executionCtx.waitUntil(persist);
   else await persist;

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -1,10 +1,22 @@
 /**
  * Metrics Dashboard API
- * Admin endpoint for viewing import metrics
+ * Admin endpoint for viewing import metrics and commit/merge phase metrics (ADR 004).
  */
 
 import { Hono } from "hono";
-import { getMetricsSummary, getQueueDepth } from "../storage/metrics";
+import { blobObject, commitObject, treeObject } from "../storage/git-objects";
+import {
+  type BatchWorkspace,
+  type NodeFS,
+  batchMergeWorkspaces,
+  cloneRepo,
+  commitAndPush,
+  initAndPush,
+  mergeStagedCommits,
+} from "../storage/git-ops";
+import { getCommitMetrics, getMetricsSummary, getQueueDepth } from "../storage/metrics";
+import { packObjects, placeLooseObject, unpackObjects } from "../storage/object-loader";
+import { putObject } from "../storage/object-store";
 import type { Env } from "../types";
 import { isAdminRequest } from "../utils/admin";
 import { createLogger } from "../utils/logger";
@@ -30,7 +42,7 @@ async function isAdmin(c: {
   );
 }
 
-// GET /api/admin/metrics - Get import metrics dashboard data
+// GET /api/admin/metrics - Get import + commit/merge metrics dashboard data
 app.get("/", async (c) => {
   const logger = createLogger({
     requestId: crypto.randomUUID(),
@@ -87,8 +99,20 @@ app.get("/", async (c) => {
   const summary = summaryResult.data;
   const queueDepth = queueDepthResult.data;
 
+  // Commit/merge phase metrics (ADR 004). Best-effort: a failure here omits the
+  // block rather than failing the whole dashboard.
+  const commitMetricsResult = await getCommitMetrics(c.env.DB, logger);
+  if (!commitMetricsResult.success) {
+    logger.warn("Commit metrics unavailable; omitting from dashboard", {
+      error: commitMetricsResult.error.message,
+    });
+  }
+  const commits = commitMetricsResult.success ? commitMetricsResult.data : null;
+
   const response = {
     timestamp: new Date().toISOString(),
+
+    ...(commits ? { commits } : {}),
 
     // Overall stats
     totals: {
@@ -184,6 +208,341 @@ app.get("/health", async (c) => {
     return internalError("Failed to retrieve health metrics");
   }
 });
+
+// POST /api/admin/metrics/bench - Phase 2 throughput probe (ADR 004). Drives one
+// R2 object write + group-commit ref advance through the RepoDO. Admin-only;
+// intended to be hit concurrently by scripts/bench-commit-throughput.ts --r2-bench.
+app.post("/bench", async (c) => {
+  const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path });
+  if (!(await isAdmin(c))) return unauthorized("Admin access required");
+  if (!c.env.REPO_DO) return internalError("REPO_DO not bound");
+
+  if (!c.env.REPO_OBJECTS) return internalError("REPO_OBJECTS not bound");
+  const repo = c.req.query("repo") ?? "bench-repo";
+  const path = c.req.query("path") ?? "shared.txt";
+  const bytes = Number.parseInt(c.req.query("bytes") ?? "256", 10);
+  try {
+    // Object plane: build + write the real git blob HERE, in the Worker — this
+    // parallelizes across requests instead of serializing through the single DO.
+    const content = crypto.getRandomValues(
+      new Uint8Array(Math.max(1, Number.isFinite(bytes) ? bytes : 256)),
+    );
+    const blob = await blobObject(content);
+    const put = await putObject(c.env.REPO_OBJECTS, blob.oid, blob.bytes, logger);
+    if (!put.success) return internalError("object write failed");
+    // Ref plane: only the advance hits the DO (group-commit batches it).
+    const stub = c.env.REPO_DO.get(c.env.REPO_DO.idFromName(repo));
+    await (
+      stub as unknown as { benchAdvance(path: string, blobOid: string): Promise<{ ok: true }> }
+    ).benchAdvance(path, blob.oid);
+    return ok({ blob: blob.oid });
+  } catch (error) {
+    logger.error("bench commit failed", error instanceof Error ? error : undefined);
+    return internalError("bench commit failed");
+  }
+});
+
+// GET /api/admin/metrics/bench-stats?repo=... - read the bench DO's counters.
+app.get("/bench-stats", async (c) => {
+  if (!(await isAdmin(c))) return unauthorized("Admin access required");
+  if (!c.env.REPO_DO) return internalError("REPO_DO not bound");
+  const repo = c.req.query("repo") ?? "bench-repo";
+  const stub = c.env.REPO_DO.get(c.env.REPO_DO.idFromName(repo));
+  const stats = await (
+    stub as unknown as {
+      benchStats(): Promise<{
+        head: string | undefined;
+        batches: number;
+        landed: number;
+        conflictsResolved: number;
+        treeSize: number;
+      }>;
+    }
+  ).benchStats();
+  return ok(stats);
+});
+
+// POST /api/admin/artifacts-bench - measure Cloudflare Artifacts' REAL single-repo
+// ceiling with the group-commit pattern applied to Artifacts: warm-clone once, then
+// land `batch` file-changes per push (one push per batch) sequentially through one
+// authority. Serial warm-push rate is the ceiling a single-authority DO would hit.
+// Decides whether owning the object store (ADR 004 Option A) is actually necessary.
+app.post("/artifacts-bench", async (c) => {
+  const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path });
+  if (!(await isAdmin(c))) return unauthorized("Admin access required");
+
+  const iterations = clampInt(c.req.query("iterations"), 20, 1, 200);
+  const batch = clampInt(c.req.query("batch"), 1, 1, 256);
+  const bytes = clampInt(c.req.query("bytes"), 256, 1, 100_000);
+  const name = `artifacts-bench-${crypto.randomUUID().slice(0, 8)}`;
+
+  let repo: { remote: string; token: string };
+  try {
+    repo = await c.env.ARTIFACTS.create(name);
+  } catch (error) {
+    return internalError(
+      `Artifacts create failed: ${error instanceof Error ? error.message : error}`,
+    );
+  }
+
+  try {
+    const seed = await initAndPush(
+      repo.remote,
+      repo.token,
+      { "README.md": "bench\n" },
+      "init",
+      logger,
+    );
+    if (!seed.success) return internalError(`seed failed: ${seed.error.message}`);
+
+    const cloneStart = Date.now();
+    const cloned = await cloneRepo(repo.remote, repo.token, logger);
+    if (!cloned.success) return internalError(`warm clone failed: ${cloned.error.message}`);
+    const cloneMs = Date.now() - cloneStart;
+    const { fs, dir } = cloned.data;
+
+    const pushMs: number[] = [];
+    const loopStart = Date.now();
+    for (let i = 0; i < iterations; i++) {
+      const changes: Record<string, string> = {};
+      for (let b = 0; b < batch; b++)
+        changes[`benchf${b}.txt`] = `i=${i} b=${b} ${"x".repeat(bytes)}`;
+      const t0 = Date.now();
+      const pushed = await commitAndPush(
+        fs,
+        dir,
+        repo.remote,
+        repo.token,
+        changes,
+        `c${i}`,
+        logger,
+      );
+      if (!pushed.success) {
+        return ok({ aborted: true, error: pushed.error.message, completed: i, pushMs });
+      }
+      pushMs.push(Date.now() - t0);
+    }
+    const totalMs = Date.now() - loopStart;
+    const sorted = [...pushMs].sort((a, b) => a - b);
+    const pct = (p: number) =>
+      sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1))] ??
+      0;
+    const round = (n: number) => Math.round(n * 100) / 100;
+
+    return ok({
+      iterations,
+      batch,
+      bytes,
+      cloneMs,
+      totalMs,
+      pushLatencyMs: { p50: pct(50), p95: pct(95), p99: pct(99), min: sorted[0] ?? 0 },
+      pushesPerSec: round(pushMs.length / (totalMs / 1000)),
+      // One push lands `batch` logical commits -> effective single-repo commits/sec.
+      effectiveCommitsPerSec: round((iterations * batch) / (totalMs / 1000)),
+    });
+  } finally {
+    try {
+      await c.env.ARTIFACTS.delete(name);
+    } catch {
+      // best-effort cleanup of the disposable bench repo
+    }
+  }
+});
+
+// POST /api/admin/metrics/realflow-bench?n=25 - ADR 004 Task 1 GATE. Sets up a
+// project + N independent workspace forks (each base + one distinct-file commit),
+// then runs ONE batched merge: clone once, fetch the N workspaces CONCURRENTLY,
+// sequential 3-way merge, one push. Reports the fetch/merge/push breakdown so we
+// can see if the read side (concurrent fetch) overlaps — the question that decides
+// whether Option B on Artifacts is viable or we pivot to R2.
+app.post("/realflow-bench", async (c) => {
+  const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path });
+  if (!(await isAdmin(c))) return unauthorized("Admin access required");
+
+  const n = clampInt(c.req.query("n"), 25, 1, 50);
+  const created: string[] = [];
+  const projectName = `realflow-p-${crypto.randomUUID().slice(0, 8)}`;
+
+  try {
+    const project = await c.env.ARTIFACTS.create(projectName);
+    created.push(projectName);
+    const seed = await initAndPush(
+      project.remote,
+      project.token,
+      { "README.md": "base\n" },
+      "base",
+      logger,
+    );
+    if (!seed.success) return internalError(`seed failed: ${seed.error.message}`);
+
+    // Setup (excluded from timings): N independent forks, each = base + 1 commit.
+    const workspaces = await Promise.all(
+      Array.from({ length: n }, async (_u, i): Promise<BatchWorkspace | null> => {
+        const wsName = `realflow-w-${crypto.randomUUID().slice(0, 8)}`;
+        const ws = await c.env.ARTIFACTS.create(wsName);
+        created.push(wsName);
+        const cloned = await cloneRepo(project.remote, project.token, logger);
+        if (!cloned.success) return null;
+        const pushed = await commitAndPush(
+          cloned.data.fs,
+          cloned.data.dir,
+          ws.remote,
+          ws.token,
+          { [`f${i}.txt`]: `change ${i}\n` },
+          `ws ${i}`,
+          logger,
+        );
+        if (!pushed.success) return null;
+        return { changeId: `c${i}`, remote: ws.remote, token: ws.token };
+      }),
+    );
+    const ready = workspaces.filter((w): w is BatchWorkspace => w !== null);
+    if (ready.length === 0) return internalError("workspace setup failed");
+
+    const result = await batchMergeWorkspaces(project.remote, project.token, ready, logger);
+    if (!result.success) return internalError(`batch merge failed: ${result.error.message}`);
+
+    const { timings, landed, conflicted } = result.data;
+    const round = (x: number) => Math.round(x * 100) / 100;
+    return ok({
+      n: ready.length,
+      landed: landed.length,
+      conflicted: conflicted.length,
+      timings,
+      // One batch of `landed` commits in `totalMs`: effective single-repo c/s.
+      effectiveCommitsPerSec: round(landed.length / (timings.totalMs / 1000)),
+      // If fetch overlapped, fetchMs ≈ one fetch, NOT n × one fetch.
+      fetchMsPerWorkspace: round(timings.fetchMs / ready.length),
+    });
+  } catch (error) {
+    return internalError(`realflow-bench: ${error instanceof Error ? error.message : error}`);
+  } finally {
+    for (const name of created) {
+      try {
+        await c.env.ARTIFACTS.delete(name);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+});
+
+// POST /api/admin/metrics/r2flow-bench?n=25 - ADR 004 Task 1c. The R2-fed real
+// flow: stage N changes' objects to R2 (parallel), then clone the project once,
+// load the staged objects FROM R2 (concurrent — the read side that avoids the
+// connection-capped fork fetch), 3-way merge each, one push to Artifacts. Reports
+// the clone/load/merge/push breakdown + c/s. Answers whether R2 reads overlap (1a)
+// and whether the real flow clears the target (1c).
+app.post("/r2flow-bench", async (c) => {
+  const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path });
+  if (!(await isAdmin(c))) return unauthorized("Admin access required");
+  if (!c.env.REPO_OBJECTS) return internalError("REPO_OBJECTS not bound");
+  const bucket = c.env.REPO_OBJECTS;
+  const n = clampInt(c.req.query("n"), 25, 1, 50);
+  const projectName = `r2flow-${crypto.randomUUID().slice(0, 8)}`;
+
+  try {
+    const project = await c.env.ARTIFACTS.create(projectName);
+    const baseBlob = await blobObject(new TextEncoder().encode("base\n"));
+    const seed = await initAndPush(
+      project.remote,
+      project.token,
+      { "README.md": "base\n" },
+      "base",
+      logger,
+    );
+    if (!seed.success) return internalError(`seed failed: ${seed.error.message}`);
+    const baseCommitOid = seed.data;
+
+    // Build + stage N changes. The diagnosis showed the load cost is R2 GET COUNT
+    // (~21ms/get, not overlapping), NOT deflate — so stage each change's 3 objects
+    // as ONE packed R2 value => N gets at load, not 3N.
+    const packKey = (i: number) => `r2flowpack/${projectName}/${i}`;
+    const staged: { commitOid: string; objectCount: number }[] = await Promise.all(
+      Array.from({ length: n }, async (_u, i) => {
+        const blob = await blobObject(new TextEncoder().encode(`change ${i}\n`));
+        const tree = await treeObject([
+          { mode: "100644", name: "README.md", oid: baseBlob.oid },
+          { mode: "100644", name: `f${i}.txt`, oid: blob.oid },
+        ]);
+        const commit = await commitObject({
+          tree: tree.oid,
+          parents: [baseCommitOid],
+          message: `change ${i}`,
+          timestamp: 1700000000 + i,
+        });
+        await bucket.put(packKey(i), packObjects([blob, tree, commit]));
+        return { commitOid: commit.oid, objectCount: 3 };
+      }),
+    );
+
+    const objectsLoaded = staged.reduce((s, c) => s + c.objectCount, 0);
+    let r2GetMs = 0;
+    let placeMs = 0;
+    const loadStaged = async (fs: NodeFS, gitdir: string) => {
+      const getStart = Date.now();
+      const packs = await Promise.all(
+        staged.map(async (_s, i) => {
+          const obj = await bucket.get(packKey(i));
+          return obj ? new Uint8Array(await obj.arrayBuffer()) : null;
+        }),
+      );
+      r2GetMs = Date.now() - getStart;
+      const placeStart = Date.now();
+      for (const pack of packs) {
+        if (!pack) continue;
+        for (const { oid, bytes } of unpackObjects(pack)) {
+          await placeLooseObject(fs, gitdir, oid, bytes);
+        }
+      }
+      placeMs = Date.now() - placeStart;
+    };
+
+    const result = await mergeStagedCommits(
+      project.remote,
+      project.token,
+      staged.map((s) => s.commitOid),
+      loadStaged,
+      logger,
+    );
+    if (!result.success) return internalError(`staged merge failed: ${result.error.message}`);
+
+    const { timings, landed, conflicted } = result.data;
+    const round = (x: number) => Math.round(x * 100) / 100;
+    return ok({
+      n,
+      landed: landed.length,
+      conflicted: conflicted.length,
+      objectsLoaded,
+      r2GetsAtLoad: staged.length,
+      timings: { ...timings, r2GetMs, placeMs },
+      loadBreakdown: {
+        r2GetMsPerGet: round(r2GetMs / staged.length),
+        placeMsPerObject: round(placeMs / objectsLoaded),
+      },
+      effectiveCommitsPerSec: round(landed.length / (timings.totalMs / 1000)),
+    });
+  } catch (error) {
+    return internalError(`r2flow-bench: ${error instanceof Error ? error.message : error}`);
+  } finally {
+    try {
+      await c.env.ARTIFACTS.delete(projectName);
+      await Promise.all(
+        Array.from({ length: n }, (_u, i) =>
+          bucket.delete(`r2flowpack/${projectName}/${i}`).catch(() => {}),
+        ),
+      );
+    } catch {
+      // best-effort
+    }
+  }
+});
+
+function clampInt(raw: string | undefined, fallback: number, lo: number, hi: number): number {
+  const n = Number.parseInt(raw ?? "", 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(hi, Math.max(lo, n));
+}
 
 /**
  * Format duration in milliseconds to human-readable string

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -220,13 +220,11 @@ app.post("/bench", async (c) => {
   if (!c.env.REPO_OBJECTS) return internalError("REPO_OBJECTS not bound");
   const repo = c.req.query("repo") ?? "bench-repo";
   const path = c.req.query("path") ?? "shared.txt";
-  const bytes = Number.parseInt(c.req.query("bytes") ?? "256", 10);
+  const bytes = clampInt(c.req.query("bytes"), 256, 1, 100_000);
   try {
     // Object plane: build + write the real git blob HERE, in the Worker — this
     // parallelizes across requests instead of serializing through the single DO.
-    const content = crypto.getRandomValues(
-      new Uint8Array(Math.max(1, Number.isFinite(bytes) ? bytes : 256)),
-    );
+    const content = crypto.getRandomValues(new Uint8Array(bytes));
     const blob = await blobObject(content);
     const put = await putObject(c.env.REPO_OBJECTS, blob.oid, blob.bytes, logger);
     if (!put.success) return internalError("object write failed");

--- a/src/routes/workspaces.ts
+++ b/src/routes/workspaces.ts
@@ -242,6 +242,20 @@ app.post("/:name/commit", async (c) => {
       logger.warn("Failed to stage workspace tree to R2; merge will use cold path", {
         workspaceName,
       });
+    } else if (c.env.REPO_DO) {
+      // Also seed the per-repo DO's local hot index so the batch-merge path reads
+      // staged trees from SQLite (microseconds) instead of R2 (~30ms/change).
+      const stub = c.env.REPO_DO.get(c.env.REPO_DO.idFromName(body.projectId)) as unknown as {
+        stageTree(workspace: string, value: ArrayBuffer): Promise<void>;
+      };
+      await stub
+        .stageTree(workspaceName, stageResult.data.value.buffer as ArrayBuffer)
+        .catch((error) => {
+          logger.warn("Failed to seed DO hot index; batch merge will skip this change", {
+            workspaceName,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
     }
   }
 

--- a/src/routes/workspaces.ts
+++ b/src/routes/workspaces.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { type EventActor, emitEvent } from "../queue/events";
-import { cloneRepo, commitAndPush, freshRepoToken } from "../storage/git-ops";
+import { cloneRepo, commitAndPush, freshRepoToken, stageWorkspaceTree } from "../storage/git-ops";
 import {
   deleteWorkspace,
   getProjectByPath,
@@ -224,6 +224,25 @@ app.post("/:name/commit", async (c) => {
   if (!commitResult.success) {
     logger.error("Failed to commit and push", commitResult.error);
     return badRequest(commitResult.error.message);
+  }
+
+  // Stage the tip tree to R2 for the fetch-free merge path (ADR 004). Best-effort:
+  // a staging failure must not fail the commit — the merge falls back to the cold
+  // path when no staged tree is present.
+  if (c.env.REPO_DO_ENABLED === "true" && c.env.REPO_OBJECTS) {
+    const stageResult = await stageWorkspaceTree(
+      c.env.REPO_OBJECTS,
+      `repos/${body.projectId}/ws/${workspaceName}`,
+      fs,
+      dir,
+      commitResult.data,
+      logger,
+    );
+    if (!stageResult.success) {
+      logger.warn("Failed to stage workspace tree to R2; merge will use cold path", {
+        workspaceName,
+      });
+    }
   }
 
   logger.info("Changes committed", { workspaceName, commit: commitResult.data });

--- a/src/storage/changes.ts
+++ b/src/storage/changes.ts
@@ -118,6 +118,35 @@ export async function createChange(
   }
 }
 
+/** Fetch many changes in ONE query (avoids N round-trips for batch merge). */
+export async function getChangesByIds(
+  db: D1Database,
+  logger: Logger,
+  ids: string[],
+): Promise<Result<Change[], AppError>> {
+  if (ids.length === 0) return ok([]);
+  try {
+    const placeholders = ids.map(() => "?").join(", ");
+    const result = await db
+      .prepare(`SELECT * FROM changes WHERE id IN (${placeholders})`)
+      .bind(...ids)
+      .all<ChangeRow>();
+    return ok((result.results ?? []).map(rowToChange));
+  } catch (error) {
+    const appError =
+      error instanceof AppError
+        ? error
+        : new AppError(
+            error instanceof Error ? error.message : "Failed to get changes",
+            "DATABASE_ERROR",
+            500,
+            { operation: "getChangesByIds" },
+          );
+    logger.error("Failed to get changes by ids", appError);
+    return err(appError);
+  }
+}
+
 export async function getChange(
   db: D1Database,
   logger: Logger,

--- a/src/storage/git-objects.ts
+++ b/src/storage/git-objects.ts
@@ -1,0 +1,151 @@
+/**
+ * Real git object encoding (ADR 004 Phase 2, object plane).
+ *
+ * Produces genuine git blob/tree/commit objects addressed by SHA-1 — the same
+ * oids stock `git` computes (validated in tests against git's empty-blob oid
+ * e69de29…). Objects are stored in R2 uncompressed; standard git deflates loose
+ * objects, so a zlib pass belongs in the clone/fetch serving layer (deferred to
+ * the native-git Container), not in the write hot path measured here.
+ */
+
+const encoder = new TextEncoder();
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+async function sha1Hex(bytes: Uint8Array): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-1", bytes);
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+export interface GitObject {
+  oid: string;
+  /** Full loose object: `<type> <len>\0<content>`. */
+  bytes: Uint8Array;
+}
+
+/** Wrap content as a loose git object of the given type and hash it (SHA-1). */
+export async function hashObject(
+  type: "blob" | "tree" | "commit",
+  content: Uint8Array,
+): Promise<GitObject> {
+  const header = encoder.encode(`${type} ${content.length}\0`);
+  const bytes = concat([header, content]);
+  return { oid: await sha1Hex(bytes), bytes };
+}
+
+export function blobObject(content: Uint8Array): Promise<GitObject> {
+  return hashObject("blob", content);
+}
+
+export interface TreeEntry {
+  /** File mode; regular files are "100644". */
+  mode: string;
+  name: string;
+  oid: string;
+}
+
+/** Encode a git tree object. Entries are sorted by name (git's byte order). */
+export function treeObject(entries: TreeEntry[]): Promise<GitObject> {
+  const sorted = [...entries].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  const parts: Uint8Array[] = [];
+  for (const e of sorted) {
+    parts.push(encoder.encode(`${e.mode} ${e.name}\0`));
+    parts.push(hexToBytes(e.oid));
+  }
+  return hashObject("tree", concat(parts));
+}
+
+export interface CommitInput {
+  tree: string;
+  parents: string[];
+  message: string;
+  /** Unix seconds; passed in (Workers clock is fine here, it's just metadata). */
+  timestamp: number;
+  author?: { name: string; email: string };
+}
+
+export interface ParsedObject {
+  type: "blob" | "tree" | "commit";
+  content: Uint8Array;
+}
+
+/** Split a loose object (`<type> <len>\0<content>`) into its type and raw content. */
+export function parseLoose(bytes: Uint8Array): ParsedObject {
+  const nul = bytes.indexOf(0);
+  if (nul === -1) throw new Error("invalid loose object: no header NUL");
+  const header = new TextDecoder().decode(bytes.subarray(0, nul));
+  const type = header.split(" ")[0];
+  if (type !== "blob" && type !== "tree" && type !== "commit") {
+    throw new Error(`unsupported object type: ${type}`);
+  }
+  return { type, content: bytes.subarray(nul + 1) };
+}
+
+/** Decode a git tree object's content into its entries. */
+export function parseTree(content: Uint8Array): TreeEntry[] {
+  const entries: TreeEntry[] = [];
+  let i = 0;
+  while (i < content.length) {
+    const space = content.indexOf(0x20, i);
+    const nul = content.indexOf(0, space);
+    const mode = new TextDecoder().decode(content.subarray(i, space));
+    const name = new TextDecoder().decode(content.subarray(space + 1, nul));
+    const oidBytes = content.subarray(nul + 1, nul + 21);
+    const oid = Array.from(oidBytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+    entries.push({ mode, name, oid });
+    i = nul + 21;
+  }
+  return entries;
+}
+
+export interface ParsedCommit {
+  tree: string;
+  parents: string[];
+}
+
+/** Decode a git commit object's content into its tree + parent oids. */
+export function parseCommit(content: Uint8Array): ParsedCommit {
+  const text = new TextDecoder().decode(content);
+  let tree = "";
+  const parents: string[] = [];
+  for (const line of text.split("\n")) {
+    if (line === "") break; // headers end at the blank line before the message
+    const [key, value] = [line.slice(0, line.indexOf(" ")), line.slice(line.indexOf(" ") + 1)];
+    if (key === "tree") tree = value;
+    else if (key === "parent") parents.push(value);
+  }
+  return { tree, parents };
+}
+
+export function commitObject(input: CommitInput): Promise<GitObject> {
+  const who = input.author ?? { name: "Stratum", email: "system@usestratum.dev" };
+  const stamp = `${who.name} <${who.email}> ${input.timestamp} +0000`;
+  const lines = [`tree ${input.tree}`];
+  for (const p of input.parents) lines.push(`parent ${p}`);
+  lines.push(`author ${stamp}`);
+  lines.push(`committer ${stamp}`);
+  lines.push("");
+  lines.push(input.message);
+  return hashObject("commit", encoder.encode(`${lines.join("\n")}\n`));
+}

--- a/src/storage/git-objects.ts
+++ b/src/storage/git-objects.ts
@@ -29,6 +29,11 @@ async function sha1Hex(bytes: Uint8Array): Promise<string> {
 }
 
 function hexToBytes(hex: string): Uint8Array {
+  // Hard-fail on malformed oids: NaN would coerce to 0 and silently corrupt the
+  // tree bytes (and thus the computed oid).
+  if (!/^[0-9a-f]{40}$/i.test(hex)) {
+    throw new Error(`Invalid git oid hex: ${hex}`);
+  }
   const out = new Uint8Array(hex.length / 2);
   for (let i = 0; i < out.length; i++) {
     out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -3,82 +3,96 @@ import git from "isomorphic-git";
 import type { ArtifactsCreateResult, ArtifactsNamespace, Author, CommitLogEntry } from "../types";
 import { AppError, ExternalServiceError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
+import type { PhaseTimer } from "../utils/phase-timer";
 import { type Result, err, fromPromise, ok } from "../utils/result";
+import { commitObject } from "./git-objects";
 import { MemoryFS } from "./memory-fs";
+import { packObjects, placeLooseObject, unpackObjects } from "./object-loader";
 
 // Custom HTTP client for Cloudflare Workers
-// isomorphic-git/http/web expects browser APIs that don't exist in Workers
-const http = {
-  async request({
-    url,
-    method = "GET",
-    headers = {},
-    body: requestBody,
-  }: {
-    url: string;
-    method?: string;
-    headers?: Record<string, string>;
-    body?: AsyncIterableIterator<Uint8Array>;
-  }) {
-    // Buffer the full body before sending — Cloudflare Workers doesn't support
-    // half-duplex streaming on outbound fetch(), so a ReadableStream body may be
-    // silently dropped, causing the git server to return an empty response.
-    let body: Uint8Array | undefined;
-    if (requestBody) {
-      const chunks: Uint8Array[] = [];
-      for await (const chunk of requestBody) {
-        chunks.push(chunk);
-      }
-      const totalLength = chunks.reduce((sum, c) => sum + c.byteLength, 0);
-      body = new Uint8Array(totalLength);
-      let offset = 0;
-      for (const chunk of chunks) {
-        body.set(chunk, offset);
-        offset += chunk.byteLength;
-      }
-    }
-
-    const response = await fetch(url, {
-      method,
-      headers,
-      body,
-    });
-
-    const resHeaders: Record<string, string> = {};
-    response.headers.forEach((value, key) => {
-      resHeaders[key] = value;
-    });
-
-    // Stream response body instead of materializing to avoid high memory usage
-    async function* bodyGenerator(): AsyncIterableIterator<Uint8Array> {
-      if (!response.body) return;
-      const reader = response.body.getReader();
-      try {
-        while (true) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          yield value;
+// isomorphic-git/http/web expects browser APIs that don't exist in Workers.
+// Built via a factory so an instrumented variant can isolate the true network
+// leg (the single `await fetch`) from body-buffering and pack processing.
+export function createHttpClient(opts: { onNetworkMs?: (ms: number) => void } = {}) {
+  return {
+    async request({
+      url,
+      method = "GET",
+      headers = {},
+      body: requestBody,
+    }: {
+      url: string;
+      method?: string;
+      headers?: Record<string, string>;
+      body?: AsyncIterableIterator<Uint8Array>;
+    }) {
+      // Buffer the full body before sending — Cloudflare Workers doesn't support
+      // half-duplex streaming on outbound fetch(), so a ReadableStream body may be
+      // silently dropped, causing the git server to return an empty response.
+      let body: Uint8Array | undefined;
+      if (requestBody) {
+        const chunks: Uint8Array[] = [];
+        for await (const chunk of requestBody) {
+          chunks.push(chunk);
         }
-      } finally {
-        reader.releaseLock();
+        const totalLength = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+        body = new Uint8Array(totalLength);
+        let offset = 0;
+        for (const chunk of chunks) {
+          body.set(chunk, offset);
+          offset += chunk.byteLength;
+        }
       }
-    }
 
-    return {
-      url: response.url,
-      method,
-      statusCode: response.status,
-      statusMessage: response.statusText,
-      headers: resHeaders,
-      body: bodyGenerator(),
-    };
-  },
-};
+      const fetchStart = Date.now();
+      const response = await fetch(url, {
+        method,
+        headers,
+        body,
+      });
+      opts.onNetworkMs?.(Date.now() - fetchStart);
+
+      const resHeaders: Record<string, string> = {};
+      response.headers.forEach((value, key) => {
+        resHeaders[key] = value;
+      });
+
+      // Stream response body instead of materializing to avoid high memory usage
+      async function* bodyGenerator(): AsyncIterableIterator<Uint8Array> {
+        if (!response.body) return;
+        const reader = response.body.getReader();
+        try {
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            yield value;
+          }
+        } finally {
+          reader.releaseLock();
+        }
+      }
+
+      return {
+        url: response.url,
+        method,
+        statusCode: response.status,
+        statusMessage: response.statusText,
+        headers: resHeaders,
+        body: bodyGenerator(),
+      };
+    },
+  };
+}
+
+type HttpClient = ReturnType<typeof createHttpClient>;
+
+// Default (uninstrumented) client used by every non-benchmarked path.
+const http = createHttpClient();
 
 const DIR = "/";
 
 // Node.js-compatible FS interface (returned by MemoryFS.toNodeFS())
-interface NodeFS {
+export interface NodeFS {
   promises: {
     readFile(path: string, options?: { encoding?: string }): Promise<string | Uint8Array>;
     writeFile(path: string, data: string | Uint8Array): Promise<void>;
@@ -98,6 +112,8 @@ export type MergeStrategy = "merge" | "squash";
 export interface MergeWorkspaceOptions {
   author?: Author;
   strategy?: MergeStrategy;
+  /** Optional Phase 0 instrumentation; populates per-phase spans when present. */
+  timer?: PhaseTimer;
 }
 
 export class MergeConflictError extends AppError {
@@ -255,6 +271,7 @@ export async function cloneRepo(
   remote: string,
   token: string,
   logger: Logger,
+  httpClient: HttpClient = http,
 ): Promise<Result<{ fs: NodeFS; dir: string }, AppError>> {
   logger.debug("Cloning repository", { remote });
 
@@ -262,7 +279,7 @@ export async function cloneRepo(
   const cloneResult = await fromPromise(
     git.clone({
       fs,
-      http,
+      http: httpClient,
       dir: DIR,
       url: remote,
       ref: "main",
@@ -354,7 +371,13 @@ export async function mergeWorkspaceIntoProject(
   });
 
   const author = options.author ?? SYSTEM_AUTHOR;
-  const cloneResult = await cloneRepo(projectRemote, projectToken, logger);
+  const timer = options.timer;
+  const measure = <T>(name: string, fn: () => Promise<T>): Promise<T> =>
+    timer ? timer.measure(name, fn) : fn();
+
+  const cloneResult = await measure("projectCloneMs", () =>
+    cloneRepo(projectRemote, projectToken, logger),
+  );
   if (!cloneResult.success) return err(cloneResult.error);
   const { fs, dir } = cloneResult.data;
 
@@ -371,16 +394,18 @@ export async function mergeWorkspaceIntoProject(
     );
   }
 
-  const fetchResult = await fromPromise(
-    git.fetch({
-      fs,
-      http,
-      dir,
-      remote: "workspace",
-      ref: "main",
-      singleBranch: true,
-      onAuth: makeAuth(workspaceToken),
-    }),
+  const fetchResult = await measure("workspaceFetchMs", () =>
+    fromPromise(
+      git.fetch({
+        fs,
+        http,
+        dir,
+        remote: "workspace",
+        ref: "main",
+        singleBranch: true,
+        onAuth: makeAuth(workspaceToken),
+      }),
+    ),
   );
   if (!fetchResult.success) {
     logger.error("Failed to fetch workspace", fetchResult.error, { workspaceRemote });
@@ -414,15 +439,17 @@ export async function mergeWorkspaceIntoProject(
     return squashMerge(fs, dir, workspaceSha, projectRemote, projectToken, author, logger);
   }
 
-  const mergeResult = await fromPromise(
-    git.merge({
-      fs,
-      dir,
-      ours: "main",
-      theirs: workspaceSha,
-      author,
-      message: "Merge workspace into project",
-    }),
+  const mergeResult = await measure("mergeMs", () =>
+    fromPromise(
+      git.merge({
+        fs,
+        dir,
+        ours: "main",
+        theirs: workspaceSha,
+        author,
+        message: "Merge workspace into project",
+      }),
+    ),
   );
 
   if (!mergeResult.success) {
@@ -434,15 +461,17 @@ export async function mergeWorkspaceIntoProject(
     );
   }
 
-  const pushResult = await fromPromise(
-    git.push({
-      fs,
-      dir,
-      http,
-      url: projectRemote,
-      ref: "main",
-      onAuth: makeAuth(projectToken),
-    }),
+  const pushResult = await measure("pushMs", () =>
+    fromPromise(
+      git.push({
+        fs,
+        dir,
+        http,
+        url: projectRemote,
+        ref: "main",
+        onAuth: makeAuth(projectToken),
+      }),
+    ),
   );
   if (!pushResult.success) {
     logger.error("Failed to push merge result", pushResult.error, { projectRemote });
@@ -460,6 +489,492 @@ export async function mergeWorkspaceIntoProject(
     sha: mergeResult.data.oid,
   });
   return ok(mergeResult.data.oid);
+}
+
+export interface FastForwardResult {
+  /** false => a fast-forward was not possible; caller should cold-merge. */
+  fastForwarded: boolean;
+  commit?: string;
+}
+
+/**
+ * Attempt a fast-forward of the project's main to the workspace tip, skipping the
+ * project clone and the in-memory 3-way merge that {@link mergeWorkspaceIntoProject}
+ * performs. Correctness does not depend on a cached head: the non-force push is
+ * accepted by Artifacts only when the project ref is still `expectedParent` (a
+ * true fast-forward). Any race or non-descendant tip returns `fastForwarded:
+ * false` so the caller falls back to the proven cold merge.
+ *
+ * Note: this still fetches the workspace fork (its objects live in a separate
+ * Artifacts repo); what it removes is the project clone (`depth:50`) + `git.merge`.
+ */
+export async function fastForwardMerge(
+  projectRemote: string,
+  projectToken: string,
+  workspaceRemote: string,
+  workspaceToken: string,
+  expectedParent: string,
+  logger: Logger,
+  timer?: PhaseTimer,
+): Promise<Result<FastForwardResult, AppError>> {
+  const measure = <T>(name: string, fn: () => Promise<T>): Promise<T> =>
+    timer ? timer.measure(name, fn) : fn();
+
+  const cloneResult = await measure("workspaceFetchMs", () =>
+    cloneRepo(workspaceRemote, workspaceToken, logger),
+  );
+  if (!cloneResult.success) return err(cloneResult.error);
+  const { fs, dir } = cloneResult.data;
+
+  const tipResult = await fromPromise(git.resolveRef({ fs, dir, ref: "main" }));
+  if (!tipResult.success) {
+    return err(new ExternalServiceError("Git", "Failed to resolve workspace tip", tipResult.error));
+  }
+  const workspaceTip = tipResult.data;
+
+  // A fast-forward is only possible if the workspace tip descends from the
+  // project's current head. If not (or history is too shallow to tell), cold-merge.
+  const descResult = await fromPromise(
+    git.isDescendent({ fs, dir, oid: workspaceTip, ancestor: expectedParent, depth: -1 }),
+  );
+  if (!descResult.success) {
+    // Most commonly: expectedParent is older than the shallow workspace clone, so
+    // ancestry can't be proven. Log it — a repo that always lands here silently
+    // never fast-forwards and would otherwise look like the FF path "works".
+    logger.warn("Could not determine workspace descent; falling back to cold merge", {
+      workspaceRemote,
+      workspaceTip,
+      expectedParent,
+    });
+    return ok({ fastForwarded: false });
+  }
+  if (descResult.data !== true) {
+    return ok({ fastForwarded: false });
+  }
+
+  const pushResult = await measure("pushMs", () =>
+    fromPromise(
+      git.push({
+        fs,
+        dir,
+        http,
+        url: projectRemote,
+        ref: "main",
+        remoteRef: "main",
+        onAuth: makeAuth(projectToken),
+      }),
+    ),
+  );
+  if (!pushResult.success) {
+    logger.warn("Fast-forward push rejected; caller will cold-merge", { projectRemote });
+    return ok({ fastForwarded: false });
+  }
+
+  logger.info("Fast-forwarded project to workspace tip", { projectRemote, sha: workspaceTip });
+  return ok({ fastForwarded: true, commit: workspaceTip });
+}
+
+export interface BatchWorkspace {
+  changeId: string;
+  remote: string;
+  token: string;
+}
+
+export interface BatchMergeTimings {
+  cloneMs: number;
+  fetchMs: number;
+  mergeMs: number;
+  pushMs: number;
+  totalMs: number;
+}
+
+export interface BatchMergeResult {
+  commit: string;
+  landed: string[];
+  conflicted: string[];
+  timings: BatchMergeTimings;
+}
+
+/**
+ * Real-flow throughput spike (ADR 004 Task 1 gate): clone the project ONCE, fetch
+ * N workspace tips CONCURRENTLY (overlapping I/O — the read-side question), then
+ * sequentially 3-way merge each onto main, then ONE push. Measures whether the
+ * read side parallelizes and what the batched real-flow commits/sec actually is.
+ *
+ * Distinct-file (non-conflicting) workspaces merge cleanly; a conflicting one is
+ * recorded and skipped (checkpoint/restore of the dirty FS is Task 3 — not needed
+ * for the non-conflicting throughput measurement).
+ */
+export async function batchMergeWorkspaces(
+  projectRemote: string,
+  projectToken: string,
+  workspaces: BatchWorkspace[],
+  logger: Logger,
+): Promise<Result<BatchMergeResult, AppError>> {
+  const startedAt = Date.now();
+  const cloneStart = Date.now();
+  const cloneResult = await cloneRepo(projectRemote, projectToken, logger);
+  if (!cloneResult.success) return err(cloneResult.error);
+  const { fs, dir } = cloneResult.data;
+  const cloneMs = Date.now() - cloneStart;
+
+  // Register each workspace as its own remote, then fetch them all concurrently.
+  for (let i = 0; i < workspaces.length; i++) {
+    const addResult = await fromPromise(
+      git.addRemote({ fs, dir, remote: `ws${i}`, url: workspaces[i]?.remote ?? "" }),
+    );
+    if (!addResult.success) {
+      return err(
+        new ExternalServiceError("Git", "Failed to add workspace remote", addResult.error),
+      );
+    }
+  }
+
+  const fetchStart = Date.now();
+  const fetched = await Promise.all(
+    workspaces.map((ws, i) =>
+      fromPromise(
+        git.fetch({
+          fs,
+          http,
+          dir,
+          remote: `ws${i}`,
+          ref: "main",
+          singleBranch: true,
+          onAuth: makeAuth(ws.token),
+        }),
+      ),
+    ),
+  );
+  const fetchMs = Date.now() - fetchStart;
+  for (const f of fetched) {
+    if (!f.success) {
+      return err(new ExternalServiceError("Git", "Concurrent workspace fetch failed", f.error));
+    }
+  }
+
+  const landed: string[] = [];
+  const conflicted: string[] = [];
+  const mergeStart = Date.now();
+  for (let i = 0; i < workspaces.length; i++) {
+    const ws = workspaces[i];
+    if (!ws) continue;
+    const tipResult = await fromPromise(
+      git.resolveRef({ fs, dir, ref: `refs/remotes/ws${i}/main` }),
+    );
+    if (!tipResult.success) {
+      conflicted.push(ws.changeId);
+      continue;
+    }
+    const mergeResult = await fromPromise(
+      git.merge({
+        fs,
+        dir,
+        ours: "main",
+        theirs: tipResult.data,
+        author: SYSTEM_AUTHOR,
+        message: `Merge change ${ws.changeId}`,
+      }),
+    );
+    if (mergeResult.success) {
+      landed.push(ws.changeId);
+    } else {
+      conflicted.push(ws.changeId);
+    }
+  }
+  const mergeMs = Date.now() - mergeStart;
+
+  const headResult = await fromPromise(git.resolveRef({ fs, dir, ref: "main" }));
+  if (!headResult.success) {
+    return err(
+      new ExternalServiceError("Git", "Failed to resolve head after merges", headResult.error),
+    );
+  }
+
+  const pushStart = Date.now();
+  const pushResult = await fromPromise(
+    git.push({ fs, dir, http, url: projectRemote, ref: "main", onAuth: makeAuth(projectToken) }),
+  );
+  const pushMs = Date.now() - pushStart;
+  if (!pushResult.success) {
+    return err(new ExternalServiceError("Git", "Batch push failed", pushResult.error));
+  }
+
+  return ok({
+    commit: headResult.data,
+    landed,
+    conflicted,
+    timings: { cloneMs, fetchMs, mergeMs, pushMs, totalMs: Date.now() - startedAt },
+  });
+}
+
+/**
+ * Collect every object reachable from a tree (the tree, its subtrees, and the
+ * blobs) as loose-object ("wrapped") bytes — the inverse of placeLooseObject, used
+ * to stage a workspace's tip tree to R2 so the merge needs no fork fetch. Returns
+ * `[{oid, bytes}]` where bytes are `<type> <len>\0<content>` (oid = git SHA-1).
+ */
+export async function extractTreeObjects(
+  fs: NodeFS,
+  dir: string,
+  treeOid: string,
+): Promise<{ oid: string; bytes: Uint8Array }[]> {
+  const out: { oid: string; bytes: Uint8Array }[] = [];
+  const seen = new Set<string>();
+
+  const wrapped = async (oid: string): Promise<Uint8Array> => {
+    const r = await git.readObject({ fs, dir, oid, format: "wrapped" });
+    return r.object as Uint8Array;
+  };
+
+  const visit = async (oid: string): Promise<void> => {
+    if (seen.has(oid)) return;
+    seen.add(oid);
+    out.push({ oid, bytes: await wrapped(oid) });
+    const tree = await git.readTree({ fs, dir, oid });
+    for (const entry of tree.tree) {
+      if (entry.type === "tree") {
+        await visit(entry.oid);
+      } else if (entry.type === "blob" && !seen.has(entry.oid)) {
+        seen.add(entry.oid);
+        out.push({ oid: entry.oid, bytes: await wrapped(entry.oid) });
+      }
+    }
+  };
+
+  await visit(treeOid);
+  return out;
+}
+
+export interface StagedMergeResult {
+  commit: string;
+  landed: string[];
+  conflicted: string[];
+  timings: { cloneMs: number; loadMs: number; mergeMs: number; pushMs: number; totalMs: number };
+}
+
+/**
+ * Real-flow R2 path (ADR 004 Task 1c): clone the project ONCE, let `loadStaged`
+ * place the batch's staged objects into the warm FS (the caller reads them from
+ * R2 — the read side that avoids the connection-capped fork fetch), then
+ * sequentially 3-way merge each staged commit onto main, then ONE push. Measures
+ * whether the R2-fed real flow clears the throughput target.
+ */
+export async function mergeStagedCommits(
+  projectRemote: string,
+  projectToken: string,
+  commitOids: string[],
+  loadStaged: (fs: NodeFS, gitdir: string) => Promise<void>,
+  logger: Logger,
+): Promise<Result<StagedMergeResult, AppError>> {
+  const startedAt = Date.now();
+  const cloneStart = Date.now();
+  const cloneResult = await cloneRepo(projectRemote, projectToken, logger);
+  if (!cloneResult.success) return err(cloneResult.error);
+  const { fs, dir } = cloneResult.data;
+  const cloneMs = Date.now() - cloneStart;
+
+  const loadStart = Date.now();
+  await loadStaged(fs, `${dir === "/" ? "" : dir}/.git`);
+  const loadMs = Date.now() - loadStart;
+
+  const landed: string[] = [];
+  const conflicted: string[] = [];
+  const mergeStart = Date.now();
+  for (const oid of commitOids) {
+    const merged = await fromPromise(
+      git.merge({
+        fs,
+        dir,
+        ours: "main",
+        theirs: oid,
+        author: SYSTEM_AUTHOR,
+        message: `merge ${oid.slice(0, 7)}`,
+      }),
+    );
+    if (!merged.success) {
+      conflicted.push(oid);
+      continue;
+    }
+    landed.push(oid);
+    await fromPromise(git.checkout({ fs, dir, ref: "main" }));
+  }
+  const mergeMs = Date.now() - mergeStart;
+
+  const headResult = await fromPromise(git.resolveRef({ fs, dir, ref: "main" }));
+  if (!headResult.success) {
+    return err(new ExternalServiceError("Git", "Failed to resolve head", headResult.error));
+  }
+  const pushStart = Date.now();
+  const pushResult = await fromPromise(
+    git.push({ fs, dir, http, url: projectRemote, ref: "main", onAuth: makeAuth(projectToken) }),
+  );
+  const pushMs = Date.now() - pushStart;
+  if (!pushResult.success) {
+    return err(new ExternalServiceError("Git", "Staged batch push failed", pushResult.error));
+  }
+
+  return ok({
+    commit: headResult.data,
+    landed,
+    conflicted,
+    timings: { cloneMs, loadMs, mergeMs, pushMs, totalMs: Date.now() - startedAt },
+  });
+}
+
+const TREE_OID_HEX_LEN = 40;
+
+/**
+ * Stage a workspace's tip TREE to R2 (ADR 004 Task 3): one value =
+ * `[40-byte tipTreeOid][packed tree objects]`. Recomputed on every commit so the
+ * merge always sees the LIVE tip (no stale snapshot) without fetching the fork.
+ */
+export async function stageWorkspaceTree(
+  bucket: R2Bucket,
+  key: string,
+  fs: NodeFS,
+  dir: string,
+  commitSha: string,
+  logger: Logger,
+): Promise<Result<{ treeOid: string; objectCount: number }, AppError>> {
+  const commit = await fromPromise(git.readCommit({ fs, dir, oid: commitSha }));
+  if (!commit.success) {
+    return err(new ExternalServiceError("Git", "Failed to read commit for staging", commit.error));
+  }
+  const treeOid = commit.data.commit.tree;
+  const objects = await extractTreeObjects(fs, dir, treeOid);
+  const pack = packObjects(objects);
+  const header = new TextEncoder().encode(treeOid);
+  const value = new Uint8Array(header.length + pack.length);
+  value.set(header);
+  value.set(pack, header.length);
+  const put = await fromPromise(bucket.put(key, value));
+  if (!put.success) {
+    logger.error(
+      "Failed to stage workspace tree",
+      put.error instanceof Error ? put.error : undefined,
+    );
+    return err(new AppError("Failed to stage workspace tree", "STORAGE_ERROR", 500));
+  }
+  return ok({ treeOid, objectCount: objects.length });
+}
+
+export interface StagedTree {
+  treeOid: string;
+  objects: { oid: string; bytes: Uint8Array }[];
+}
+
+/** Load a workspace's staged tip tree from R2 (see stageWorkspaceTree). */
+export async function loadStagedTree(bucket: R2Bucket, key: string): Promise<StagedTree | null> {
+  const obj = await bucket.get(key);
+  if (!obj) return null;
+  const value = new Uint8Array(await obj.arrayBuffer());
+  const treeOid = new TextDecoder().decode(value.subarray(0, TREE_OID_HEX_LEN));
+  const objects = unpackObjects(value.subarray(TREE_OID_HEX_LEN));
+  return { treeOid, objects };
+}
+
+export interface StagedTreeItem {
+  changeId: string;
+  baseSha: string;
+  staged: StagedTree;
+}
+
+export interface StagedItemResult {
+  changeId: string;
+  merged: boolean;
+  commit?: string;
+}
+
+/**
+ * Group-commit batch over R2-staged workspace trees (ADR 004 Task 5): operates on
+ * a caller-provided WARM fs/dir (clone reused across batches), placing each item's
+ * staged objects, synthesizing a commit
+ * `{tree: tipTree, parent: baseSha}`, and 3-way `git.merge` it onto the head —
+ * checkpoint/restore the FS around each so a conflict can't dirty the next — then
+ * ONE push. Per-item result (merged | conflicted); a clone/push failure throws
+ * (the coordinator rejects the whole batch).
+ */
+export async function batchMergeStagedTrees(
+  fs: NodeFS,
+  dir: string,
+  projectRemote: string,
+  projectToken: string,
+  items: StagedTreeItem[],
+  _logger: Logger,
+): Promise<Result<StagedItemResult[], AppError>> {
+  const gitdir = `${dir === "/" ? "" : dir}/.git`;
+
+  // Phase 1 (off the merge critical path): place every item's objects, then build
+  // the synthetic commits. The synth SHA-1 (`commitObject`) is async crypto with real
+  // per-call overhead — running them sequentially inside the merge loop was the
+  // dominant cost; `Promise.all` lets the crypto overlap. (Placement stays sequential:
+  // concurrent writes race on MemoryFS object-dir creation.)
+  for (const item of items) {
+    for (const o of item.staged.objects) await placeLooseObject(fs, gitdir, o.oid, o.bytes);
+  }
+  const synths = await Promise.all(
+    items.map((item) =>
+      commitObject({
+        tree: item.staged.treeOid,
+        parents: [item.baseSha],
+        message: `change ${item.changeId}`,
+        timestamp: Math.floor(Date.now() / 1000),
+      }),
+    ),
+  );
+  for (const synth of synths) await placeLooseObject(fs, gitdir, synth.oid, synth.bytes);
+
+  // Phase 2: serial merge loop (the ref advance must be serialized). Checkpoint/
+  // restore around each so a conflict can't dirty the next.
+  const results: StagedItemResult[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const synthOid = synths[i]?.oid;
+    if (!item || !synthOid) continue;
+    const checkpoint = await fromPromise(git.resolveRef({ fs, dir, ref: "main" }));
+    if (!checkpoint.success) {
+      results.push({ changeId: item.changeId, merged: false });
+      continue;
+    }
+    const attempt = await fromPromise(
+      (async () => {
+        const merged = await git.merge({
+          fs,
+          dir,
+          ours: "main",
+          theirs: synthOid,
+          author: SYSTEM_AUTHOR,
+          message: `Merge change ${item.changeId}`,
+        });
+        await git.checkout({ fs, dir, ref: "main" });
+        // git.merge omits `oid` when already up to date (the change's tree is already
+        // in main) — that's a successful no-op merge, not a conflict. Fall back to the
+        // current head so it's reported merged.
+        return merged.oid ?? (await git.resolveRef({ fs, dir, ref: "main" }));
+      })(),
+    );
+    if (attempt.success && attempt.data) {
+      results.push({ changeId: item.changeId, merged: true, commit: attempt.data });
+    } else {
+      // Conflict/error: restore main to the checkpoint so the next merge is clean.
+      await fromPromise(
+        git.writeRef({ fs, dir, ref: "main", value: checkpoint.data, force: true }),
+      );
+      await fromPromise(git.checkout({ fs, dir, ref: "main" }));
+      results.push({ changeId: item.changeId, merged: false });
+    }
+  }
+
+  if (results.some((r) => r.merged)) {
+    const pushResult = await fromPromise(
+      git.push({ fs, dir, http, url: projectRemote, ref: "main", onAuth: makeAuth(projectToken) }),
+    );
+    if (!pushResult.success) {
+      return err(new ExternalServiceError("Git", "Batch push failed", pushResult.error));
+    }
+  }
+  return ok(results);
 }
 
 async function squashMerge(

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -775,7 +775,10 @@ export async function mergeStagedCommits(
   const cloneMs = Date.now() - cloneStart;
 
   const loadStart = Date.now();
-  await loadStaged(fs, `${dir === "/" ? "" : dir}/.git`);
+  const loaded = await fromPromise(loadStaged(fs, `${dir === "/" ? "" : dir}/.git`));
+  if (!loaded.success) {
+    return err(new ExternalServiceError("Git", "Failed to load staged objects", loaded.error));
+  }
   const loadMs = Date.now() - loadStart;
 
   const landed: string[] = [];
@@ -796,8 +799,13 @@ export async function mergeStagedCommits(
       conflicted.push(oid);
       continue;
     }
+    const checkout = await fromPromise(git.checkout({ fs, dir, ref: "main" }));
+    if (!checkout.success) {
+      return err(
+        new ExternalServiceError("Git", "Failed to checkout main after merge", checkout.error),
+      );
+    }
     landed.push(oid);
-    await fromPromise(git.checkout({ fs, dir, ref: "main" }));
   }
   const mergeMs = Date.now() - mergeStart;
 
@@ -842,7 +850,11 @@ export async function stageWorkspaceTree(
     return err(new ExternalServiceError("Git", "Failed to read commit for staging", commit.error));
   }
   const treeOid = commit.data.commit.tree;
-  const objects = await extractTreeObjects(fs, dir, treeOid);
+  const extracted = await fromPromise(extractTreeObjects(fs, dir, treeOid));
+  if (!extracted.success) {
+    return err(new ExternalServiceError("Git", "Failed to extract tree objects", extracted.error));
+  }
+  const objects = extracted.data;
   const pack = packObjects(objects);
   const header = new TextEncoder().encode(treeOid);
   const value = new Uint8Array(header.length + pack.length);
@@ -958,10 +970,26 @@ export async function batchMergeStagedTrees(
       results.push({ changeId: item.changeId, merged: true, commit: attempt.data });
     } else {
       // Conflict/error: restore main to the checkpoint so the next merge is clean.
-      await fromPromise(
+      // If restoration itself fails the FS is corrupt — abort the whole batch
+      // rather than merge subsequent items against a dirty state.
+      const restoreRef = await fromPromise(
         git.writeRef({ fs, dir, ref: "main", value: checkpoint.data, force: true }),
       );
-      await fromPromise(git.checkout({ fs, dir, ref: "main" }));
+      if (!restoreRef.success) {
+        return err(
+          new ExternalServiceError("Git", "Failed to restore ref after conflict", restoreRef.error),
+        );
+      }
+      const restoreCheckout = await fromPromise(git.checkout({ fs, dir, ref: "main" }));
+      if (!restoreCheckout.success) {
+        return err(
+          new ExternalServiceError(
+            "Git",
+            "Failed to checkout after conflict restore",
+            restoreCheckout.error,
+          ),
+        );
+      }
       results.push({ changeId: item.changeId, merged: false });
     }
   }

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -844,7 +844,7 @@ export async function stageWorkspaceTree(
   dir: string,
   commitSha: string,
   logger: Logger,
-): Promise<Result<{ treeOid: string; objectCount: number }, AppError>> {
+): Promise<Result<{ treeOid: string; objectCount: number; value: Uint8Array }, AppError>> {
   const commit = await fromPromise(git.readCommit({ fs, dir, oid: commitSha }));
   if (!commit.success) {
     return err(new ExternalServiceError("Git", "Failed to read commit for staging", commit.error));
@@ -868,7 +868,7 @@ export async function stageWorkspaceTree(
     );
     return err(new AppError("Failed to stage workspace tree", "STORAGE_ERROR", 500));
   }
-  return ok({ treeOid, objectCount: objects.length });
+  return ok({ treeOid, objectCount: objects.length, value });
 }
 
 export interface StagedTree {
@@ -876,14 +876,18 @@ export interface StagedTree {
   objects: { oid: string; bytes: Uint8Array }[];
 }
 
+/** Parse the `[40-byte tipTreeOid][packed objects]` staged-tree value. */
+export function parseStagedTree(value: Uint8Array): StagedTree {
+  const treeOid = new TextDecoder().decode(value.subarray(0, TREE_OID_HEX_LEN));
+  const objects = unpackObjects(value.subarray(TREE_OID_HEX_LEN));
+  return { treeOid, objects };
+}
+
 /** Load a workspace's staged tip tree from R2 (see stageWorkspaceTree). */
 export async function loadStagedTree(bucket: R2Bucket, key: string): Promise<StagedTree | null> {
   const obj = await bucket.get(key);
   if (!obj) return null;
-  const value = new Uint8Array(await obj.arrayBuffer());
-  const treeOid = new TextDecoder().decode(value.subarray(0, TREE_OID_HEX_LEN));
-  const objects = unpackObjects(value.subarray(TREE_OID_HEX_LEN));
-  return { treeOid, objects };
+  return parseStagedTree(new Uint8Array(await obj.arrayBuffer()));
 }
 
 export interface StagedTreeItem {

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -878,7 +878,15 @@ export interface StagedTree {
 
 /** Parse the `[40-byte tipTreeOid][packed objects]` staged-tree value. */
 export function parseStagedTree(value: Uint8Array): StagedTree {
+  // Fail fast at the parser boundary on a truncated/corrupt payload (40-byte oid
+  // header + at least the 4-byte pack count) rather than deeper in object unpacking.
+  if (value.byteLength < TREE_OID_HEX_LEN + 4) {
+    throw new Error("Invalid staged tree: truncated header");
+  }
   const treeOid = new TextDecoder().decode(value.subarray(0, TREE_OID_HEX_LEN));
+  if (!/^[0-9a-f]{40}$/i.test(treeOid)) {
+    throw new Error("Invalid staged tree: malformed tree oid");
+  }
   const objects = unpackObjects(value.subarray(TREE_OID_HEX_LEN));
   return { treeOid, objects };
 }

--- a/src/storage/metrics.ts
+++ b/src/storage/metrics.ts
@@ -486,7 +486,7 @@ export async function getCommitMetrics(
         `SELECT outcome, total_ms, token_mint_ms, project_clone_ms, workspace_fetch_ms,
                 merge_ms, push_ms, ref_advance_ms, d1_update_ms, provenance_ms
          FROM commit_metrics
-         ORDER BY recorded_at DESC
+         ORDER BY recorded_at DESC, id DESC
          LIMIT ?`,
       )
       .bind(limit)

--- a/src/storage/metrics.ts
+++ b/src/storage/metrics.ts
@@ -328,6 +328,202 @@ export async function getMetricsSummary(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Commit/merge hot-path metrics (ADR 004, Phase 0)
+// ---------------------------------------------------------------------------
+
+export type CommitOutcome = "fast_forward" | "cold_fallback" | "squash";
+
+/** Per-phase wall-clock spans (ms). Undefined when a phase did not run. */
+export interface CommitPhaseSpans {
+  tokenMintMs?: number;
+  projectCloneMs?: number;
+  workspaceFetchMs?: number;
+  mergeMs?: number;
+  pushMs?: number;
+  refAdvanceMs?: number;
+  d1UpdateMs?: number;
+  provenanceMs?: number;
+}
+
+export interface CommitMetricInput {
+  project: string;
+  changeId: string;
+  outcome: CommitOutcome;
+  /** Benchmark context; omit outside the load harness. */
+  conflictMode?: "none" | "same";
+  concurrencyN?: number;
+  phases: CommitPhaseSpans;
+  totalMs: number;
+}
+
+export interface PhaseStat {
+  avg: number;
+  p50: number;
+  p95: number;
+  count: number;
+}
+
+export interface CommitMetricsSummary {
+  count: number;
+  outcomes: Record<CommitOutcome, number>;
+  total: PhaseStat;
+  phases: Record<keyof CommitPhaseSpans, PhaseStat>;
+}
+
+const COMMIT_PHASE_COLUMNS: Array<[keyof CommitPhaseSpans, string]> = [
+  ["tokenMintMs", "token_mint_ms"],
+  ["projectCloneMs", "project_clone_ms"],
+  ["workspaceFetchMs", "workspace_fetch_ms"],
+  ["mergeMs", "merge_ms"],
+  ["pushMs", "push_ms"],
+  ["refAdvanceMs", "ref_advance_ms"],
+  ["d1UpdateMs", "d1_update_ms"],
+  ["provenanceMs", "provenance_ms"],
+];
+
+/** Map a PhaseTimer's raw spans to the typed phase fields (drops unknown keys). */
+export function commitPhasesFromSpans(spans: Record<string, number>): CommitPhaseSpans {
+  const out: CommitPhaseSpans = {};
+  for (const [key] of COMMIT_PHASE_COLUMNS) {
+    const value = spans[key];
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Record one row of commit/merge phase timings. A single batched INSERT (not
+ * one row per phase) keeps D1 write pressure to one statement per merge — D1 is
+ * a single writer, so the hot path must not fan out writes.
+ */
+export async function recordCommitMetrics(
+  db: D1Database,
+  metric: CommitMetricInput,
+  logger: Logger,
+): Promise<Result<void, AppError>> {
+  try {
+    await db
+      .prepare(
+        `INSERT INTO commit_metrics (
+          project, change_id, outcome, conflict_mode, concurrency_n,
+          token_mint_ms, project_clone_ms, workspace_fetch_ms, merge_ms,
+          push_ms, ref_advance_ms, d1_update_ms, provenance_ms, total_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        metric.project,
+        metric.changeId,
+        metric.outcome,
+        metric.conflictMode ?? null,
+        metric.concurrencyN ?? null,
+        metric.phases.tokenMintMs ?? null,
+        metric.phases.projectCloneMs ?? null,
+        metric.phases.workspaceFetchMs ?? null,
+        metric.phases.mergeMs ?? null,
+        metric.phases.pushMs ?? null,
+        metric.phases.refAdvanceMs ?? null,
+        metric.phases.d1UpdateMs ?? null,
+        metric.phases.provenanceMs ?? null,
+        metric.totalMs,
+      )
+      .run();
+
+    return ok(undefined);
+  } catch (error) {
+    logger.error("Failed to record commit metric", error instanceof Error ? error : undefined);
+    return err(new AppError("Failed to record commit metric", "STORAGE_ERROR", 500));
+  }
+}
+
+function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return 0;
+  const rank = Math.ceil((p / 100) * sortedAsc.length) - 1;
+  const idx = Math.min(Math.max(rank, 0), sortedAsc.length - 1);
+  return sortedAsc[idx] ?? 0;
+}
+
+function statOf(values: number[]): PhaseStat {
+  const present = values.filter((v): v is number => typeof v === "number" && !Number.isNaN(v));
+  if (present.length === 0) return { avg: 0, p50: 0, p95: 0, count: 0 };
+  const sorted = [...present].sort((a, b) => a - b);
+  const sum = present.reduce((acc, v) => acc + v, 0);
+  return {
+    avg: Math.round((sum / present.length) * 100) / 100,
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    count: present.length,
+  };
+}
+
+interface CommitMetricRow {
+  outcome: CommitOutcome;
+  total_ms: number;
+  token_mint_ms: number | null;
+  project_clone_ms: number | null;
+  workspace_fetch_ms: number | null;
+  merge_ms: number | null;
+  push_ms: number | null;
+  ref_advance_ms: number | null;
+  d1_update_ms: number | null;
+  provenance_ms: number | null;
+}
+
+/**
+ * Summarize recent commit metrics: per-phase avg/p50/p95 + outcome counts.
+ * Percentiles are computed in JS over a bounded recent window rather than in
+ * SQL (D1/SQLite has no native percentile and an unbounded scan would grow with
+ * commit volume — exactly the high-frequency workload this measures).
+ */
+export async function getCommitMetrics(
+  db: D1Database,
+  logger: Logger,
+  limit = 5000,
+): Promise<Result<CommitMetricsSummary, AppError>> {
+  try {
+    const result = await db
+      .prepare(
+        `SELECT outcome, total_ms, token_mint_ms, project_clone_ms, workspace_fetch_ms,
+                merge_ms, push_ms, ref_advance_ms, d1_update_ms, provenance_ms
+         FROM commit_metrics
+         ORDER BY recorded_at DESC
+         LIMIT ?`,
+      )
+      .bind(limit)
+      .all<CommitMetricRow>();
+
+    const rows = result.results ?? [];
+
+    const outcomes: Record<CommitOutcome, number> = {
+      fast_forward: 0,
+      cold_fallback: 0,
+      squash: 0,
+    };
+    for (const row of rows) {
+      if (row.outcome in outcomes) outcomes[row.outcome] += 1;
+    }
+
+    const phases = {} as Record<keyof CommitPhaseSpans, PhaseStat>;
+    for (const [key, column] of COMMIT_PHASE_COLUMNS) {
+      phases[key] = statOf(
+        rows
+          .map((r) => r[column as keyof CommitMetricRow] as number | null)
+          .filter((v): v is number => v !== null),
+      );
+    }
+
+    return ok({
+      count: rows.length,
+      outcomes,
+      total: statOf(rows.map((r) => r.total_ms)),
+      phases,
+    });
+  } catch (error) {
+    logger.error("Failed to get commit metrics", error instanceof Error ? error : undefined);
+    return err(new AppError("Failed to get commit metrics", "STORAGE_ERROR", 500));
+  }
+}
+
 /**
  * Get current queue depth (active imports)
  */

--- a/src/storage/object-loader.ts
+++ b/src/storage/object-loader.ts
@@ -66,16 +66,21 @@ export function packObjects(objs: { oid: string; bytes: Uint8Array }[]): Uint8Ar
 }
 
 export function unpackObjects(buf: Uint8Array): { oid: string; bytes: Uint8Array }[] {
+  // Validate the framing as we go — a truncated/corrupt payload must fail loudly,
+  // not read out of bounds and crash the merge path.
+  if (buf.byteLength < 4) throw new Error("Invalid object pack: missing count header");
   const dec = new TextDecoder();
   const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
   const count = view.getUint32(0, true);
   const out: { oid: string; bytes: Uint8Array }[] = [];
   let off = 4;
   for (let i = 0; i < count; i++) {
+    if (off + 44 > buf.byteLength) throw new Error("Invalid object pack: truncated entry header");
     const oid = dec.decode(buf.subarray(off, off + 40));
     off += 40;
     const len = view.getUint32(off, true);
     off += 4;
+    if (off + len > buf.byteLength) throw new Error("Invalid object pack: truncated object bytes");
     out.push({ oid, bytes: buf.subarray(off, off + len) });
     off += len;
   }

--- a/src/storage/object-loader.ts
+++ b/src/storage/object-loader.ts
@@ -1,0 +1,99 @@
+/**
+ * Loads R2-staged git objects (ADR 004 Option A) into a MemoryFS so isomorphic-git
+ * can read them. Our object plane stores loose objects UNCOMPRESSED
+ * (`<type> <len>\0<content>`), but git reads loose objects from
+ * `.git/objects/xx/yyyy` as **zlib-deflated** bytes — so each staged object must be
+ * deflated and placed at its fanned-out path. The oid is computed over the
+ * inflated content, so any valid zlib stream works (compression level is free).
+ */
+
+interface FsLike {
+  promises: {
+    writeFile(path: string, data: Uint8Array): Promise<void>;
+    mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
+  };
+}
+
+async function deflate(input: Uint8Array): Promise<Uint8Array> {
+  const cs = new CompressionStream("deflate"); // zlib (RFC 1950), matches git loose objects
+  const writer = cs.writable.getWriter();
+  void writer.write(input);
+  void writer.close();
+  const chunks: Uint8Array[] = [];
+  const reader = cs.readable.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.length;
+  }
+  return out;
+}
+
+/**
+ * Frame several git objects into one value so a change's objects stage + load
+ * with ONE R2 op instead of one per object (R2 GET count, not deflate, is the
+ * load bottleneck — measured ~20ms/get, non-overlapping). Format:
+ * `[count u32 LE]` then per object `[40-byte ascii oid][u32 LE len][bytes]`.
+ */
+export function packObjects(objs: { oid: string; bytes: Uint8Array }[]): Uint8Array {
+  const enc = new TextEncoder();
+  const parts: Uint8Array[] = [];
+  const count = new Uint8Array(4);
+  new DataView(count.buffer).setUint32(0, objs.length, true);
+  parts.push(count);
+  for (const o of objs) {
+    parts.push(enc.encode(o.oid));
+    const lenBuf = new Uint8Array(4);
+    new DataView(lenBuf.buffer).setUint32(0, o.bytes.length, true);
+    parts.push(lenBuf);
+    parts.push(o.bytes);
+  }
+  const total = parts.reduce((nn, p) => nn + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+export function unpackObjects(buf: Uint8Array): { oid: string; bytes: Uint8Array }[] {
+  const dec = new TextDecoder();
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  const count = view.getUint32(0, true);
+  const out: { oid: string; bytes: Uint8Array }[] = [];
+  let off = 4;
+  for (let i = 0; i < count; i++) {
+    const oid = dec.decode(buf.subarray(off, off + 40));
+    off += 40;
+    const len = view.getUint32(off, true);
+    off += 4;
+    out.push({ oid, bytes: buf.subarray(off, off + len) });
+    off += len;
+  }
+  return out;
+}
+
+/**
+ * Place one staged loose object into the repo so `git` can read it.
+ * `gitdir` is the `.git` directory (e.g. `${dir}/.git`).
+ */
+export async function placeLooseObject(
+  fs: FsLike,
+  gitdir: string,
+  oid: string,
+  looseBytes: Uint8Array,
+): Promise<void> {
+  const deflated = await deflate(looseBytes);
+  const objDir = `${gitdir}/objects/${oid.slice(0, 2)}`;
+  await fs.promises.mkdir(objDir, { recursive: true });
+  await fs.promises.writeFile(`${objDir}/${oid.slice(2)}`, deflated);
+}

--- a/src/storage/object-store.ts
+++ b/src/storage/object-store.ts
@@ -1,0 +1,49 @@
+import { AppError } from "../utils/errors";
+import type { Logger } from "../utils/logger";
+import { type Result, err, fromPromise, ok } from "../utils/result";
+
+/**
+ * Content-addressed git object plane on R2 (ADR 004 Phase 2). Objects are keyed
+ * by their oid under `objects/<oid>`, so writes are idempotent and need zero
+ * coordination — any number of writers can store objects in parallel and never
+ * collide. This is the "infinite fan-out" plane the ref CAS is decoupled from.
+ */
+export async function putObject(
+  bucket: R2Bucket,
+  oid: string,
+  bytes: Uint8Array,
+  logger: Logger,
+): Promise<Result<void, AppError>> {
+  const res = await fromPromise(bucket.put(`objects/${oid}`, bytes));
+  if (!res.success) {
+    logger.error(
+      "Failed to write object to R2",
+      res.error instanceof Error ? res.error : undefined,
+      { oid },
+    );
+    return err(new AppError("Failed to write object to object store", "STORAGE_ERROR", 500));
+  }
+  return ok(undefined);
+}
+
+/** Read a content-addressed object from R2. Returns null if absent. */
+export async function getObject(
+  bucket: R2Bucket,
+  oid: string,
+  logger: Logger,
+): Promise<Result<Uint8Array | null, AppError>> {
+  const res = await fromPromise(bucket.get(`objects/${oid}`));
+  if (!res.success) {
+    logger.error(
+      "Failed to read object from R2",
+      res.error instanceof Error ? res.error : undefined,
+      {
+        oid,
+      },
+    );
+    return err(new AppError("Failed to read object from object store", "STORAGE_ERROR", 500));
+  }
+  if (!res.data) return ok(null);
+  const buf = await res.data.arrayBuffer();
+  return ok(new Uint8Array(buf));
+}

--- a/src/storage/object-store.ts
+++ b/src/storage/object-store.ts
@@ -44,6 +44,14 @@ export async function getObject(
     return err(new AppError("Failed to read object from object store", "STORAGE_ERROR", 500));
   }
   if (!res.data) return ok(null);
-  const buf = await res.data.arrayBuffer();
-  return ok(new Uint8Array(buf));
+  const bufRes = await fromPromise(res.data.arrayBuffer());
+  if (!bufRes.success) {
+    logger.error(
+      "Failed to decode object body from R2",
+      bufRes.error instanceof Error ? bufRes.error : undefined,
+      { oid },
+    );
+    return err(new AppError("Failed to decode object from object store", "STORAGE_ERROR", 500));
+  }
+  return ok(new Uint8Array(bufRes.data));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,11 @@ export interface Env {
   SANDBOX?: SandboxBinding;
   AI?: AiBinding;
   MERGE_QUEUE?: DurableObjectNamespace;
+  REPO_DO?: DurableObjectNamespace;
+  /** Content-addressed git object plane (ADR 004 Phase 2). */
+  REPO_OBJECTS?: R2Bucket;
+  /** Gates the RepoDO fast-forward path (ADR 004). Off -> classic cold merge. */
+  REPO_DO_ENABLED?: string;
   EVENTS_QUEUE?: Queue;
   IMPORT_QUEUE?: Queue<ImportJobMessage | SyncJobMessage>;
 }

--- a/src/utils/phase-timer.ts
+++ b/src/utils/phase-timer.ts
@@ -1,0 +1,43 @@
+/**
+ * Accumulates named wall-clock spans for the commit/merge hot path (ADR 004,
+ * Phase 0 instrumentation).
+ *
+ * IMPORTANT measurement caveats — do not over-read the numbers:
+ *  - Cloudflare Workers freeze `Date.now()` between I/O for timing-attack
+ *    mitigation: the clock advances only across `await`s that perform I/O. A
+ *    pure-CPU span (e.g. an in-memory three-way merge) may therefore read ~0 ms,
+ *    and the cost can surface in an adjacent I/O-bound span instead.
+ *  - The custom git HTTP client buffers the full request body before `fetch()`
+ *    and streams the response lazily, so push/fetch CPU can interleave with
+ *    later isomorphic-git pack processing.
+ * Consequently spans are independent diagnostics and MUST NOT be summed into a
+ * synthetic total — record an end-to-end `total_ms` separately. Network-bound
+ * spans (clone/fetch/push) are the trustworthy signal for "where do the seconds
+ * go"; treat CPU-span values as lower bounds.
+ */
+export class PhaseTimer {
+  private readonly spans = new Map<string, number>();
+
+  /** Time an async phase, accumulating into the named span (summed if repeated). */
+  async measure<T>(name: string, fn: () => Promise<T>): Promise<T> {
+    const start = Date.now();
+    try {
+      return await fn();
+    } finally {
+      this.add(name, Date.now() - start);
+    }
+  }
+
+  /** Manually add milliseconds to a span (e.g. an isolated network leg). */
+  add(name: string, ms: number): void {
+    this.spans.set(name, (this.spans.get(name) ?? 0) + ms);
+  }
+
+  get(name: string): number | undefined {
+    return this.spans.get(name);
+  }
+
+  toObject(): Record<string, number> {
+    return Object.fromEntries(this.spans);
+  }
+}

--- a/tests/bench-harness.test.ts
+++ b/tests/bench-harness.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertSafeTarget,
+  formatReport,
+  isProductionHost,
+  parseArgs,
+  percentile,
+  summarizeRun,
+} from "../scripts/bench-commit-throughput";
+
+describe("parseArgs", () => {
+  it("parses concurrency list, conflict mode, and repeat", () => {
+    const args = parseArgs(["--n=1,5,25", "--conflict=same", "--repeat=3", "--url=http://x:8787"]);
+    expect(args.concurrencies).toEqual([1, 5, 25]);
+    expect(args.conflict).toBe("same");
+    expect(args.repeat).toBe(3);
+    expect(args.baseUrl).toBe("http://x:8787");
+  });
+
+  it("defaults to localhost and conflict=none", () => {
+    const args = parseArgs([]);
+    expect(args.conflict).toBe("none");
+    expect(args.allowProd).toBe(false);
+    expect(args.concurrencies).toEqual([1, 5, 25, 100]);
+  });
+
+  it("rejects an invalid conflict mode", () => {
+    expect(() => parseArgs(["--conflict=weird"])).toThrow();
+  });
+});
+
+describe("isProductionHost / assertSafeTarget", () => {
+  it("flags production hosts", () => {
+    expect(isProductionHost("https://app.usestratum.dev")).toBe(true);
+    expect(isProductionHost("https://usestratum.dev")).toBe(true);
+  });
+
+  it("does not flag localhost or staging preview hosts", () => {
+    expect(isProductionHost("http://localhost:8787")).toBe(false);
+    expect(isProductionHost("https://pr-45.staging.app.workers.dev")).toBe(false);
+  });
+
+  it("refuses production without the opt-in flag", () => {
+    const args = parseArgs(["--url=https://app.usestratum.dev"]);
+    expect(() => assertSafeTarget(args)).toThrow(/production/i);
+  });
+
+  it("allows production with the opt-in flag", () => {
+    const args = parseArgs([
+      "--url=https://app.usestratum.dev",
+      "--i-understand-this-writes-real-commits",
+    ]);
+    expect(() => assertSafeTarget(args)).not.toThrow();
+  });
+});
+
+describe("summarizeRun / percentile / formatReport", () => {
+  it("computes commits/sec and suppresses percentiles at high N", () => {
+    const lowN = summarizeRun(5, "none", [10, 20, 30, 40, 50], 0, 1000);
+    expect(lowN.commitsPerSec).toBe(5);
+    expect(lowN.latency).toBeDefined();
+
+    const highN = summarizeRun(25, "same", new Array(25).fill(100), 0, 1000);
+    expect(highN.latency).toBeUndefined();
+    expect(highN.commitsPerSec).toBe(25);
+  });
+
+  it("nearest-rank percentile", () => {
+    expect(percentile([10, 20, 30, 40], 50)).toBe(20);
+    expect(percentile([10, 20, 30, 40], 95)).toBe(40);
+    expect(percentile([], 50)).toBe(0);
+  });
+
+  it("formats a report including the suppression note at high N", () => {
+    const report = formatReport([summarizeRun(25, "same", new Array(25).fill(100), 1, 1000)]);
+    expect(report).toContain("suppressed");
+    expect(report).toContain("commits/sec");
+  });
+});

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -1402,11 +1402,10 @@ describe("POST /api/projects/:name/changes/merge-batch", () => {
           }
         : { success: false, error: new NotFoundError("User", token) },
     );
-    // biome-ignore lint/suspicious/noExplicitAny: minimal stub
     vi.mocked(getAgentByToken).mockResolvedValue({
       success: false,
       error: new NotFoundError("Agent", "x"),
-    } as any);
+    });
     // biome-ignore lint/suspicious/noExplicitAny: minimal stub
     vi.mocked(getProject).mockResolvedValue({ success: true, data: mockProject } as any);
     vi.mocked(loadPolicy).mockResolvedValue(mockPolicy);

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -7,8 +7,9 @@ import type { Change, Env } from "../src/types";
 vi.mock("../src/storage/changes", () => ({
   createChange: vi.fn(),
   getChange: vi.fn(),
+  getChangesByIds: vi.fn(),
   listChanges: vi.fn(),
-  updateChangeStatus: vi.fn(),
+  updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
 }));
 
 vi.mock("../src/storage/git-ops", async (importActual) => {
@@ -19,6 +20,8 @@ vi.mock("../src/storage/git-ops", async (importActual) => {
     mergeWorkspaceIntoProject: vi.fn(),
     getCommitLog: vi.fn(),
     freshRepoToken: vi.fn(async () => ({ success: true, data: "test-token" })),
+    cloneRepo: vi.fn(async () => ({ success: true, data: { fs: {}, dir: "/" } })),
+    batchMergeStagedTrees: vi.fn(),
   };
 });
 
@@ -125,14 +128,22 @@ vi.mock("../src/storage/agents", () => ({
 
 import { CompositeEvaluator, SecretScanEvaluator, loadPolicy } from "../src/evaluation";
 import { getAgentByToken } from "../src/storage/agents";
-import { createChange, getChange, listChanges, updateChangeStatus } from "../src/storage/changes";
+import {
+  createChange,
+  getChange,
+  getChangesByIds,
+  listChanges,
+  updateChangeStatus,
+} from "../src/storage/changes";
 import { listEvalRuns, recordEvalRuns } from "../src/storage/eval-runs";
 import {
+  batchMergeStagedTrees,
   freshRepoToken,
   getCommitLog,
   getDiffBetweenRepos,
   mergeWorkspaceIntoProject,
 } from "../src/storage/git-ops";
+import { packObjects } from "../src/storage/object-loader";
 import { getProject, getWorkspace } from "../src/storage/state";
 import { getUserByToken } from "../src/storage/users";
 
@@ -1344,5 +1355,161 @@ describe("POST /api/changes/:id/reject", () => {
       env,
     );
     expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/projects/:name/changes/merge-batch", () => {
+  let app: ReturnType<typeof makeApp>;
+  let env: Env;
+  let gcCalls: string[][];
+  let waitUntils: Promise<unknown>[];
+
+  // Minimal valid staged-tree value: [40-byte oid][packObjects([])].
+  const stagedValue = (() => {
+    const oid = "a".repeat(40);
+    const pack = packObjects([]);
+    const v = new Uint8Array(40 + pack.length);
+    v.set(new TextEncoder().encode(oid));
+    v.set(pack, 40);
+    return v;
+  })();
+
+  const exec = () => ({
+    waitUntil: (p: Promise<unknown>) => {
+      waitUntils.push(p);
+    },
+    passThroughOnException: () => {},
+  });
+
+  beforeEach(() => {
+    app = makeApp();
+    env = makeEnv();
+    vi.clearAllMocks();
+    gcCalls = [];
+    waitUntils = [];
+
+    vi.mocked(getUserByToken).mockImplementation(async (_db, token) =>
+      token === "stratum_user_testtoken00000000000000000"
+        ? {
+            success: true,
+            data: {
+              id: "user_test",
+              email: "test@example.com",
+              username: "test",
+              tokenHash: "hash",
+              createdAt: "2026-01-01T00:00:00.000Z",
+            },
+          }
+        : { success: false, error: new NotFoundError("User", token) },
+    );
+    // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+    vi.mocked(getAgentByToken).mockResolvedValue({
+      success: false,
+      error: new NotFoundError("Agent", "x"),
+    } as any);
+    // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+    vi.mocked(getProject).mockResolvedValue({ success: true, data: mockProject } as any);
+    vi.mocked(loadPolicy).mockResolvedValue(mockPolicy);
+    vi.mocked(getChangesByIds).mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: "chg_b1",
+          project: "my-project",
+          workspace: "fix-bug",
+          status: "approved",
+          baseSha: "base1",
+        },
+        {
+          id: "chg_b2",
+          project: "my-project",
+          workspace: "feat-x",
+          status: "approved",
+          baseSha: "base1",
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal Change stubs
+    } as any);
+    vi.mocked(batchMergeStagedTrees).mockResolvedValue({
+      success: true,
+      data: [
+        { changeId: "chg_b1", merged: true, commit: "merge-1" },
+        { changeId: "chg_b2", merged: false },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal result stub
+    } as any);
+
+    const stub = {
+      getStagedTrees: vi.fn(async (ws: string[]) =>
+        ws.map((w) => ({ workspace: w, value: stagedValue })),
+      ),
+      gcStagedTrees: vi.fn(async (ws: string[]) => {
+        gcCalls.push(ws);
+      }),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: minimal DO + D1 stubs
+    env.REPO_DO = { idFromName: (n: string) => n, get: () => stub } as any;
+    // biome-ignore lint/suspicious/noExplicitAny: minimal D1 stub
+    env.DB = { prepare: () => ({ bind: () => ({}) }), batch: vi.fn(async () => []) } as any;
+  });
+
+  it("merges eligible changes via the DO hot index, dedupes ids, reports per-change outcomes", async () => {
+    const res = await app.fetch(
+      request(
+        "POST",
+        "/api/projects/my-project/changes/merge-batch",
+        { changeIds: ["chg_b1", "chg_b2", "chg_b1"], force: true },
+        USER_AUTH,
+      ),
+      env,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal ExecutionContext
+      exec() as any,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { merged: string[]; conflicted: string[] };
+    expect(body.merged).toEqual(["chg_b1"]);
+    expect(body.conflicted).toEqual(["chg_b2"]);
+
+    // Dedupe: chg_b1 supplied twice but merged once (two distinct items total).
+    const items = vi.mocked(batchMergeStagedTrees).mock.calls[0]?.[4] as { changeId: string }[];
+    expect(items.map((i) => i.changeId).sort()).toEqual(["chg_b1", "chg_b2"]);
+
+    // Deferred bookkeeping GCs only the landed workspace from the hot index.
+    await Promise.all(waitUntils);
+    expect(gcCalls).toEqual([["fix-bug"]]);
+  });
+
+  it("rejects a batch above the size cap", async () => {
+    const ids = Array.from({ length: 81 }, (_u, i) => `c${i}`);
+    const res = await app.fetch(
+      request(
+        "POST",
+        "/api/projects/my-project/changes/merge-batch",
+        { changeIds: ids, force: true },
+        USER_AUTH,
+      ),
+      env,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal ExecutionContext
+      exec() as any,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("skips changes whose tree is absent from the hot index", async () => {
+    const stub = { getStagedTrees: vi.fn(async () => []), gcStagedTrees: vi.fn(async () => {}) };
+    // biome-ignore lint/suspicious/noExplicitAny: minimal DO stub
+    env.REPO_DO = { idFromName: (n: string) => n, get: () => stub } as any;
+    const res = await app.fetch(
+      request(
+        "POST",
+        "/api/projects/my-project/changes/merge-batch",
+        { changeIds: ["chg_b1"], force: true },
+        USER_AUTH,
+      ),
+      env,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal ExecutionContext
+      exec() as any,
+    );
+    expect(res.status).toBe(400);
   });
 });

--- a/tests/commit-metrics.test.ts
+++ b/tests/commit-metrics.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CommitMetricInput,
+  getCommitMetrics,
+  recordCommitMetrics,
+} from "../src/storage/metrics";
+import type { Logger } from "../src/utils/logger";
+
+const noopLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+} as unknown as Logger;
+
+interface StoredRow {
+  outcome: string;
+  total_ms: number;
+  token_mint_ms: number | null;
+  project_clone_ms: number | null;
+  workspace_fetch_ms: number | null;
+  merge_ms: number | null;
+  push_ms: number | null;
+  ref_advance_ms: number | null;
+  d1_update_ms: number | null;
+  provenance_ms: number | null;
+  recorded_seq: number;
+}
+
+/** Minimal stateful D1 stub for the commit_metrics table. */
+function makeCommitMetricsD1(opts: { failAll?: boolean } = {}): {
+  db: D1Database;
+  rows: StoredRow[];
+} {
+  const rows: StoredRow[] = [];
+  let seq = 0;
+
+  function makeStmt(sql: string, bindings: unknown[]) {
+    const upper = sql.trim().toUpperCase();
+    return {
+      bind: (...args: unknown[]) => makeStmt(sql, args),
+      run: async () => {
+        if (upper.startsWith("INSERT INTO COMMIT_METRICS")) {
+          rows.push({
+            outcome: bindings[2] as string,
+            token_mint_ms: bindings[5] as number | null,
+            project_clone_ms: bindings[6] as number | null,
+            workspace_fetch_ms: bindings[7] as number | null,
+            merge_ms: bindings[8] as number | null,
+            push_ms: bindings[9] as number | null,
+            ref_advance_ms: bindings[10] as number | null,
+            d1_update_ms: bindings[11] as number | null,
+            provenance_ms: bindings[12] as number | null,
+            total_ms: bindings[13] as number,
+            recorded_seq: seq++,
+          });
+        }
+        return { success: true, meta: {} };
+      },
+      first: async () => null,
+      all: async <T>() => {
+        if (opts.failAll) throw new Error("simulated D1 read failure");
+        const limit = (bindings[0] as number) ?? rows.length;
+        const results = [...rows].sort((a, b) => b.recorded_seq - a.recorded_seq).slice(0, limit);
+        return { results: results as unknown as T[], success: true, meta: {} };
+      },
+    };
+  }
+
+  const db = { prepare: (sql: string) => makeStmt(sql, []) } as unknown as D1Database;
+  return { db, rows };
+}
+
+const ffMetric: CommitMetricInput = {
+  project: "acme/web",
+  changeId: "chg_1",
+  outcome: "fast_forward",
+  conflictMode: "none",
+  concurrencyN: 25,
+  phases: { tokenMintMs: 5, workspaceFetchMs: 40, pushMs: 60, refAdvanceMs: 2 },
+  totalMs: 110,
+};
+
+describe("recordCommitMetrics", () => {
+  it("writes exactly one row per merge", async () => {
+    const { db, rows } = makeCommitMetricsD1();
+    const res = await recordCommitMetrics(db, ffMetric, noopLogger);
+    expect(res.success).toBe(true);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.outcome).toBe("fast_forward");
+    expect(rows[0]?.project_clone_ms).toBeNull(); // skipped on fast-forward
+    expect(rows[0]?.push_ms).toBe(60);
+    expect(rows[0]?.total_ms).toBe(110);
+  });
+
+  it("returns an err Result (never throws) when the insert fails", async () => {
+    const throwingDb = {
+      prepare: () => ({
+        bind: () => ({
+          run: async () => {
+            throw new Error("boom");
+          },
+        }),
+      }),
+    } as unknown as D1Database;
+    const res = await recordCommitMetrics(throwingDb, ffMetric, noopLogger);
+    expect(res.success).toBe(false);
+  });
+});
+
+describe("getCommitMetrics", () => {
+  it("aggregates outcome counts and per-phase percentiles", async () => {
+    const { db } = makeCommitMetricsD1();
+    // 3 fast-forwards with push spans 10,20,30 and one cold fallback with a clone.
+    await recordCommitMetrics(
+      db,
+      { ...ffMetric, changeId: "a", phases: { pushMs: 10 }, totalMs: 10 },
+      noopLogger,
+    );
+    await recordCommitMetrics(
+      db,
+      { ...ffMetric, changeId: "b", phases: { pushMs: 20 }, totalMs: 20 },
+      noopLogger,
+    );
+    await recordCommitMetrics(
+      db,
+      { ...ffMetric, changeId: "c", phases: { pushMs: 30 }, totalMs: 30 },
+      noopLogger,
+    );
+    await recordCommitMetrics(
+      db,
+      {
+        ...ffMetric,
+        changeId: "d",
+        outcome: "cold_fallback",
+        phases: { projectCloneMs: 500, pushMs: 40 },
+        totalMs: 600,
+      },
+      noopLogger,
+    );
+
+    const res = await getCommitMetrics(db, noopLogger);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    const s = res.data;
+    expect(s.count).toBe(4);
+    expect(s.outcomes.fast_forward).toBe(3);
+    expect(s.outcomes.cold_fallback).toBe(1);
+    // push present on all 4 rows.
+    expect(s.phases.pushMs.count).toBe(4);
+    // nearest-rank p50 of [10,20,30,40] -> index ceil(0.5*4)-1 = 1 -> 20
+    expect(s.phases.pushMs.p50).toBe(20);
+    expect(s.phases.pushMs.p95).toBe(40);
+    // project clone only on the cold fallback.
+    expect(s.phases.projectCloneMs.count).toBe(1);
+    expect(s.phases.projectCloneMs.avg).toBe(500);
+  });
+
+  it("returns an err Result when the read fails", async () => {
+    const { db } = makeCommitMetricsD1({ failAll: true });
+    const res = await getCommitMetrics(db, noopLogger);
+    expect(res.success).toBe(false);
+  });
+});

--- a/tests/git-merge-staged.test.ts
+++ b/tests/git-merge-staged.test.ts
@@ -1,0 +1,86 @@
+import git from "isomorphic-git";
+import { describe, expect, it } from "vitest";
+import { blobObject, commitObject, treeObject } from "../src/storage/git-objects";
+import { MemoryFS } from "../src/storage/memory-fs";
+import { placeLooseObject } from "../src/storage/object-loader";
+
+const enc = (s: string) => new TextEncoder().encode(s);
+const author = { name: "Stratum", email: "system@usestratum.dev" };
+
+// Task 1b gate: prove isomorphic-git git.merge can consume R2-staged objects
+// (built by git-objects.ts, placed via the deflate/fanout loader) and 3-way merge.
+describe("git.merge over R2-staged objects (Task 1b gate)", () => {
+  it("loads staged objects and merges two disjoint changes onto a shared base", async () => {
+    const fs = new MemoryFS().toNodeFS() as unknown as Parameters<typeof git.init>[0]["fs"];
+    const dir = "/repo";
+    const gitdir = `${dir}/.git`;
+    await git.init({ fs, dir, defaultBranch: "main" });
+
+    const place = async (...objs: { oid: string; bytes: Uint8Array }[]) => {
+      for (const o of objs) await placeLooseObject(fs as never, gitdir, o.oid, o.bytes);
+    };
+
+    // Base commit B: { file.txt }
+    const baseBlob = await blobObject(enc("base\n"));
+    const baseTree = await treeObject([{ mode: "100644", name: "file.txt", oid: baseBlob.oid }]);
+    const base = await commitObject({
+      tree: baseTree.oid,
+      parents: [],
+      message: "base",
+      timestamp: 1700000000,
+    });
+    await place(baseBlob, baseTree, base);
+    await git.writeRef({ fs, dir, ref: "refs/heads/main", value: base.oid, force: true });
+    await git.checkout({ fs, dir, ref: "main" });
+
+    // Change 1 (from B): add a.txt
+    const aBlob = await blobObject(enc("a\n"));
+    const t1 = await treeObject([
+      { mode: "100644", name: "a.txt", oid: aBlob.oid },
+      { mode: "100644", name: "file.txt", oid: baseBlob.oid },
+    ]);
+    const c1 = await commitObject({
+      tree: t1.oid,
+      parents: [base.oid],
+      message: "c1",
+      timestamp: 1700000001,
+    });
+    await place(aBlob, t1, c1);
+
+    // Change 2 (from B): add b.txt
+    const bBlob = await blobObject(enc("b\n"));
+    const t2 = await treeObject([
+      { mode: "100644", name: "b.txt", oid: bBlob.oid },
+      { mode: "100644", name: "file.txt", oid: baseBlob.oid },
+    ]);
+    const c2 = await commitObject({
+      tree: t2.oid,
+      parents: [base.oid],
+      message: "c2",
+      timestamp: 1700000002,
+    });
+    await place(bBlob, t2, c2);
+
+    // isomorphic-git must be able to read a staged object back.
+    const readBack = await git.readCommit({ fs, dir, oid: c1.oid });
+    expect(readBack.commit.tree).toBe(t1.oid);
+
+    // Merge c1 (fast-forward), then 3-way merge c2 onto it.
+    await git.merge({ fs, dir, ours: "main", theirs: c1.oid, author });
+    await git.checkout({ fs, dir, ref: "main" });
+    const merged = await git.merge({
+      fs,
+      dir,
+      ours: "main",
+      theirs: c2.oid,
+      author,
+      message: "merge c2",
+    });
+    expect(merged.oid).toBeDefined();
+    await git.checkout({ fs, dir, ref: "main" });
+
+    // The merged tree must contain all three files — no data lost.
+    const files = await git.listFiles({ fs, dir, ref: "main" });
+    expect(files.sort()).toEqual(["a.txt", "b.txt", "file.txt"]);
+  });
+});

--- a/tests/git-objects.test.ts
+++ b/tests/git-objects.test.ts
@@ -64,4 +64,10 @@ describe("git-objects (real git SHA-1 oids)", () => {
     const { bytes } = await hashObject("blob", new TextEncoder().encode("hi"));
     expect(new TextDecoder().decode(bytes.slice(0, 7))).toBe("blob 2\0");
   });
+
+  it("rejects a malformed entry oid instead of silently corrupting the tree", () => {
+    expect(() => treeObject([{ mode: "100644", name: "f", oid: "not-a-valid-oid" }])).toThrow(
+      /invalid git oid/i,
+    );
+  });
 });

--- a/tests/git-objects.test.ts
+++ b/tests/git-objects.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { blobObject, commitObject, hashObject, treeObject } from "../src/storage/git-objects";
+
+describe("git-objects (real git SHA-1 oids)", () => {
+  it("computes git's canonical empty-blob oid", async () => {
+    const { oid } = await blobObject(new Uint8Array(0));
+    expect(oid).toBe("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391");
+  });
+
+  it("computes git's canonical oid for blob 'hello\\n'", async () => {
+    // `printf 'hello\n' | git hash-object --stdin` => ce013625030ba8dba906f756967f9e9ca394464a
+    const { oid } = await blobObject(new TextEncoder().encode("hello\n"));
+    expect(oid).toBe("ce013625030ba8dba906f756967f9e9ca394464a");
+  });
+
+  it("is content-addressed and stable", async () => {
+    const a = await blobObject(new TextEncoder().encode("x"));
+    const b = await blobObject(new TextEncoder().encode("x"));
+    const c = await blobObject(new TextEncoder().encode("y"));
+    expect(a.oid).toBe(b.oid);
+    expect(a.oid).not.toBe(c.oid);
+  });
+
+  it("encodes a tree whose oid is sorted-order independent of input order", async () => {
+    const blob = await blobObject(new TextEncoder().encode("data"));
+    const t1 = await treeObject([
+      { mode: "100644", name: "a.txt", oid: blob.oid },
+      { mode: "100644", name: "b.txt", oid: blob.oid },
+    ]);
+    const t2 = await treeObject([
+      { mode: "100644", name: "b.txt", oid: blob.oid },
+      { mode: "100644", name: "a.txt", oid: blob.oid },
+    ]);
+    expect(t1.oid).toBe(t2.oid);
+    expect(t1.oid).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("builds a commit object referencing tree + parent deterministically", async () => {
+    const tree = await treeObject([]);
+    const c1 = await commitObject({
+      tree: tree.oid,
+      parents: [],
+      message: "init",
+      timestamp: 1700000000,
+    });
+    const c2 = await commitObject({
+      tree: tree.oid,
+      parents: [],
+      message: "init",
+      timestamp: 1700000000,
+    });
+    expect(c1.oid).toBe(c2.oid); // deterministic given fixed timestamp
+    expect(c1.oid).toMatch(/^[0-9a-f]{40}$/);
+    const withParent = await commitObject({
+      tree: tree.oid,
+      parents: [c1.oid],
+      message: "init",
+      timestamp: 1700000000,
+    });
+    expect(withParent.oid).not.toBe(c1.oid);
+  });
+
+  it("hashObject prefixes the loose-object header", async () => {
+    const { bytes } = await hashObject("blob", new TextEncoder().encode("hi"));
+    expect(new TextDecoder().decode(bytes.slice(0, 7))).toBe("blob 2\0");
+  });
+});

--- a/tests/group-commit.test.ts
+++ b/tests/group-commit.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { GroupCommitCoordinator, type ItemOutcome } from "../src/queue/group-commit";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const allOk = <T>(batch: T[]): ItemOutcome<void>[] =>
+  batch.map(() => ({ ok: true, value: undefined }));
+
+describe("GroupCommitCoordinator correctness", () => {
+  it("resolves a single submission after its durable write", async () => {
+    const writes: number[] = [];
+    const coord = new GroupCommitCoordinator<string>({
+      maxBatchSize: 16,
+      durableWrite: async (batch) => {
+        writes.push(batch.length);
+        return allOk(batch);
+      },
+    });
+    await coord.submit("a");
+    expect(writes).toEqual([1]);
+  });
+
+  it("folds a burst of concurrent advances into far fewer durable writes", async () => {
+    const batchSizes: number[] = [];
+    const coord = new GroupCommitCoordinator<number>({
+      maxBatchSize: 64,
+      durableWrite: async (batch) => {
+        batchSizes.push(batch.length);
+        await sleep(20); // hold the window open so concurrent submits coalesce
+        return allOk(batch);
+      },
+    });
+    await Promise.all(Array.from({ length: 50 }, (_u, i) => coord.submit(i)));
+    expect(coord.stats.items).toBe(50);
+    expect(batchSizes.length).toBeLessThan(50);
+    expect(coord.stats.avgBatchSize).toBeGreaterThan(1);
+  });
+
+  it("rejects only the conflicting item; others in the batch still resolve", async () => {
+    const coord = new GroupCommitCoordinator<string>({
+      maxBatchSize: 64,
+      durableWrite: async (batch) => {
+        await sleep(10);
+        // Item "bad" conflicts; everyone else lands.
+        return batch.map((item) =>
+          item === "bad"
+            ? { ok: false as const, error: new Error("conflict") }
+            : { ok: true as const, value: undefined },
+        );
+      },
+    });
+    const results = await Promise.allSettled([
+      coord.submit("a"),
+      coord.submit("bad"),
+      coord.submit("b"),
+    ]);
+    expect(results[0]?.status).toBe("fulfilled");
+    expect(results[1]?.status).toBe("rejected");
+    expect(results[2]?.status).toBe("fulfilled");
+  });
+
+  it("rejects the whole batch when durableWrite throws (catastrophic, e.g. push failed)", async () => {
+    let first = true;
+    const coord = new GroupCommitCoordinator<string>({
+      maxBatchSize: 1,
+      durableWrite: async (batch) => {
+        if (first) {
+          first = false;
+          throw new Error("push failed");
+        }
+        return allOk(batch);
+      },
+    });
+    await expect(coord.submit("x")).rejects.toThrow("push failed");
+    await expect(coord.submit("y")).resolves.toBeUndefined();
+  });
+
+  it("rejects the batch if durableWrite returns a wrong-length outcome list", async () => {
+    const coord = new GroupCommitCoordinator<string>({
+      maxBatchSize: 64,
+      durableWrite: async () => [], // contract violation
+    });
+    await expect(coord.submit("x")).rejects.toThrow(/outcomes/);
+  });
+});
+
+describe("GroupCommitCoordinator throughput (local model of the ref plane)", () => {
+  const DURABLE_WRITE_MS = 50;
+  const TARGET_CPS = 22.6;
+
+  async function measure(maxBatchSize: number, concurrency: number, durationMs: number) {
+    const coord = new GroupCommitCoordinator<number>({
+      maxBatchSize,
+      durableWrite: async (batch) => {
+        await sleep(DURABLE_WRITE_MS);
+        return allOk(batch);
+      },
+    });
+    let completed = 0;
+    let stop = false;
+    const start = Date.now();
+    const submitters = Array.from({ length: concurrency }, async () => {
+      while (!stop) {
+        await coord.submit(completed);
+        completed += 1;
+      }
+    });
+    await sleep(durationMs);
+    stop = true;
+    const counted = completed;
+    const elapsedMs = Date.now() - start;
+    await Promise.all(submitters);
+    return { commitsPerSec: counted / (elapsedMs / 1000), stats: coord.stats };
+  }
+
+  it("group commit sustains >> 22.6 commits/sec into one repo; serial does not", async () => {
+    const grouped = await measure(64, 24, 500);
+    const serial = await measure(1, 24, 500);
+
+    console.log(
+      `\n[group-commit benchmark] durableWrite=${DURABLE_WRITE_MS}ms, 24 concurrent writers, single repo:`,
+    );
+    console.log(
+      `  group-commit (batch<=64): ${grouped.commitsPerSec.toFixed(1)} commits/sec ` +
+        `(avg batch ${grouped.stats.avgBatchSize.toFixed(1)}, max ${grouped.stats.maxBatchSize})`,
+    );
+    console.log(
+      `  serial      (batch=1):    ${serial.commitsPerSec.toFixed(1)} commits/sec ` +
+        `(avg batch ${serial.stats.avgBatchSize.toFixed(1)})`,
+    );
+    console.log(`  target: ${TARGET_CPS} commits/sec\n`);
+
+    expect(grouped.commitsPerSec).toBeGreaterThan(TARGET_CPS);
+    expect(grouped.commitsPerSec).toBeGreaterThan(serial.commitsPerSec * 5);
+    expect(grouped.stats.avgBatchSize).toBeGreaterThan(1);
+  }, 15000);
+});

--- a/tests/group-commit.test.ts
+++ b/tests/group-commit.test.ts
@@ -74,6 +74,16 @@ describe("GroupCommitCoordinator correctness", () => {
     await expect(coord.submit("y")).resolves.toBeUndefined();
   });
 
+  it("rejects a non-positive maxBatchSize at construction (would never drain)", () => {
+    expect(
+      () =>
+        new GroupCommitCoordinator<string>({
+          maxBatchSize: 0,
+          durableWrite: async (batch) => batch.map(() => ({ ok: true, value: undefined })),
+        }),
+    ).toThrow(/maxBatchSize/);
+  });
+
   it("rejects the batch if durableWrite returns a wrong-length outcome list", async () => {
     const coord = new GroupCommitCoordinator<string>({
       maxBatchSize: 64,

--- a/tests/merge-queue-metrics.test.ts
+++ b/tests/merge-queue-metrics.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/storage/changes", () => ({
+  getChange: vi.fn(),
+  updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
+}));
+vi.mock("../src/storage/state", () => ({
+  getProject: vi.fn(),
+  getWorkspace: vi.fn(),
+}));
+vi.mock("../src/storage/git-ops", () => ({
+  freshRepoToken: vi.fn(async () => ({ success: true, data: "tok" })),
+  mergeWorkspaceIntoProject: vi.fn(async () => ({ success: true, data: "deadbeef" })),
+}));
+vi.mock("../src/storage/provenance", () => ({
+  recordProvenance: vi.fn(async () => ({ success: true, data: undefined })),
+}));
+vi.mock("../src/storage/metrics", () => ({
+  recordCommitMetrics: vi.fn(async () => ({ success: true, data: undefined })),
+  commitPhasesFromSpans: (spans: Record<string, number>) => spans,
+}));
+
+import { MergeQueue } from "../src/queue/merge-queue";
+import { getChange } from "../src/storage/changes";
+import { recordCommitMetrics } from "../src/storage/metrics";
+import { getProject, getWorkspace } from "../src/storage/state";
+import type { Env } from "../src/types";
+
+const env = { DB: {}, STATE: {}, ARTIFACTS: {} } as unknown as Env;
+const ctx = {} as unknown as DurableObjectState;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getChange).mockResolvedValue({
+    success: true,
+    data: {
+      id: "chg_1",
+      project: "acme/web",
+      workspace: "ws_1",
+      status: "approved",
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: minimal Change stub for the test
+  } as any);
+  vi.mocked(getProject).mockResolvedValue({
+    success: true,
+    data: { id: "proj_1", remote: "https://artifacts/acme-web.git" },
+    // biome-ignore lint/suspicious/noExplicitAny: minimal Project stub
+  } as any);
+  vi.mocked(getWorkspace).mockResolvedValue({
+    success: true,
+    data: { remote: "https://artifacts/acme-web-ws1.git" },
+    // biome-ignore lint/suspicious/noExplicitAny: minimal Workspace stub
+  } as any);
+});
+
+describe("MergeQueue records commit metrics", () => {
+  it("writes exactly one cold_fallback row on a successful merge", async () => {
+    const queue = new MergeQueue(ctx, env);
+    const result = await queue.merge("chg_1");
+
+    expect(result.success).toBe(true);
+    expect(recordCommitMetrics).toHaveBeenCalledTimes(1);
+    const arg = vi.mocked(recordCommitMetrics).mock.calls[0]?.[1];
+    expect(arg?.outcome).toBe("cold_fallback");
+    expect(arg?.project).toBe("acme/web");
+    expect(arg?.changeId).toBe("chg_1");
+    expect(typeof arg?.totalMs).toBe("number");
+  });
+
+  it("does not fail the merge when metrics recording fails", async () => {
+    vi.mocked(recordCommitMetrics).mockResolvedValueOnce({
+      success: false,
+      // biome-ignore lint/suspicious/noExplicitAny: error shape not under test
+      error: { message: "db down" } as any,
+    });
+    const queue = new MergeQueue(ctx, env);
+    const result = await queue.merge("chg_1");
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/metrics-route.test.ts
+++ b/tests/metrics-route.test.ts
@@ -1,0 +1,82 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/utils/admin", () => ({ isAdminRequest: vi.fn() }));
+vi.mock("../src/storage/metrics", () => ({
+  getMetricsSummary: vi.fn(),
+  getQueueDepth: vi.fn(),
+  getCommitMetrics: vi.fn(),
+}));
+
+import { metricsRouter } from "../src/routes/metrics";
+import { getCommitMetrics, getMetricsSummary, getQueueDepth } from "../src/storage/metrics";
+import type { Env } from "../src/types";
+import { isAdminRequest } from "../src/utils/admin";
+
+const env = { DB: {} } as unknown as Env;
+
+function app() {
+  const a = new Hono<{ Bindings: Env }>();
+  a.route("/", metricsRouter);
+  return a;
+}
+
+const summary = {
+  totalStarted: 0,
+  totalCompleted: 0,
+  totalFailed: 0,
+  totalCancelled: 0,
+  successRate: 0,
+  failureRate: 0,
+  averageDurationMs: 0,
+  last24h: { started: 0, completed: 0, failed: 0, cancelled: 0 },
+  last7d: { started: 0, completed: 0, failed: 0, cancelled: 0 },
+  last30d: { started: 0, completed: 0, failed: 0, cancelled: 0 },
+  errorTypes: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getMetricsSummary).mockResolvedValue({ success: true, data: summary });
+  vi.mocked(getQueueDepth).mockResolvedValue({ success: true, data: 0 });
+});
+
+describe("GET /api/admin/metrics commits block", () => {
+  it("returns 401 without admin access", async () => {
+    vi.mocked(isAdminRequest).mockResolvedValue(false);
+    const res = await app().request("/", {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("includes the commits block when commit metrics are available", async () => {
+    vi.mocked(isAdminRequest).mockResolvedValue(true);
+    vi.mocked(getCommitMetrics).mockResolvedValue({
+      success: true,
+      data: {
+        count: 3,
+        outcomes: { fast_forward: 2, cold_fallback: 1, squash: 0 },
+        // biome-ignore lint/suspicious/noExplicitAny: stat shape not under test
+        total: { avg: 100, p50: 90, p95: 200, count: 3 } as any,
+        // biome-ignore lint/suspicious/noExplicitAny: phases shape not under test
+        phases: {} as any,
+      },
+    });
+    const res = await app().request("/", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { commits?: { count: number } };
+    expect(body.commits?.count).toBe(3);
+  });
+
+  it("still returns 200 (omitting commits) when commit metrics fail", async () => {
+    vi.mocked(isAdminRequest).mockResolvedValue(true);
+    vi.mocked(getCommitMetrics).mockResolvedValue({
+      success: false,
+      // biome-ignore lint/suspicious/noExplicitAny: error shape not under test
+      error: { message: "db down" } as any,
+    });
+    const res = await app().request("/", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { commits?: unknown };
+    expect(body.commits).toBeUndefined();
+  });
+});

--- a/tests/object-loader.test.ts
+++ b/tests/object-loader.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { packObjects, unpackObjects } from "../src/storage/object-loader";
+
+describe("object pack framing", () => {
+  it("round-trips packed objects", () => {
+    const objs = [
+      { oid: "a".repeat(40), bytes: new Uint8Array([1, 2, 3]) },
+      { oid: "b".repeat(40), bytes: new Uint8Array([]) },
+      { oid: "c".repeat(40), bytes: new Uint8Array([9, 8, 7, 6, 5]) },
+    ];
+    const out = unpackObjects(packObjects(objs));
+    expect(out.map((o) => o.oid)).toEqual(objs.map((o) => o.oid));
+    expect([...(out[0]?.bytes ?? [])]).toEqual([1, 2, 3]);
+    expect([...(out[2]?.bytes ?? [])]).toEqual([9, 8, 7, 6, 5]);
+  });
+
+  it("fails loudly on a truncated pack instead of reading out of bounds", () => {
+    const packed = packObjects([{ oid: "a".repeat(40), bytes: new Uint8Array([1, 2, 3]) }]);
+    expect(() => unpackObjects(packed.subarray(0, packed.length - 2))).toThrow(/truncated/i);
+    expect(() => unpackObjects(new Uint8Array(2))).toThrow(/count header/i);
+  });
+});

--- a/tests/object-store.test.ts
+++ b/tests/object-store.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { putObject } from "../src/storage/object-store";
+import type { Logger } from "../src/utils/logger";
+
+const noopLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+} as unknown as Logger;
+
+describe("putObject", () => {
+  it("writes under objects/<oid> and returns ok", async () => {
+    const writes: string[] = [];
+    const bucket = {
+      put: async (key: string) => {
+        writes.push(key);
+      },
+    } as unknown as R2Bucket;
+    const res = await putObject(bucket, "abc123", new Uint8Array([1]), noopLogger);
+    expect(res.success).toBe(true);
+    expect(writes).toEqual(["objects/abc123"]);
+  });
+
+  it("returns an err Result when R2 put throws", async () => {
+    const bucket = {
+      put: async () => {
+        throw new Error("R2 down");
+      },
+    } as unknown as R2Bucket;
+    const res = await putObject(bucket, "abc", new Uint8Array([1]), noopLogger);
+    expect(res.success).toBe(false);
+  });
+});

--- a/tests/phase-timer.test.ts
+++ b/tests/phase-timer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { PhaseTimer } from "../src/utils/phase-timer";
+
+describe("PhaseTimer", () => {
+  it("records a span around a measured async phase", async () => {
+    const timer = new PhaseTimer();
+    await timer.measure("push", async () => {
+      await new Promise((r) => setTimeout(r, 5));
+    });
+    expect(timer.get("push")).toBeGreaterThanOrEqual(0);
+    expect(timer.toObject()).toHaveProperty("push");
+  });
+
+  it("accumulates repeated measures of the same span", async () => {
+    const timer = new PhaseTimer();
+    timer.add("net", 10);
+    timer.add("net", 15);
+    expect(timer.get("net")).toBe(25);
+  });
+
+  it("records the span even when the measured fn throws", async () => {
+    const timer = new PhaseTimer();
+    await expect(
+      timer.measure("clone", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(timer.toObject()).toHaveProperty("clone");
+  });
+
+  it("returns undefined for an unmeasured span and an empty object initially", () => {
+    const timer = new PhaseTimer();
+    expect(timer.get("missing")).toBeUndefined();
+    expect(timer.toObject()).toEqual({});
+  });
+});

--- a/tests/r2-merge-flow.test.ts
+++ b/tests/r2-merge-flow.test.ts
@@ -1,0 +1,68 @@
+import git from "isomorphic-git";
+import { describe, expect, it } from "vitest";
+import { commitObject } from "../src/storage/git-objects";
+import { extractTreeObjects } from "../src/storage/git-ops";
+import { MemoryFS } from "../src/storage/memory-fs";
+import { packObjects, placeLooseObject, unpackObjects } from "../src/storage/object-loader";
+
+const author = { name: "Stratum", email: "system@usestratum.dev" };
+
+// Task 3+5 core: extract a workspace tip TREE's objects, round-trip through the
+// R2 pack format, then merge it onto a divergent project head via a SYNTHETIC
+// commit (tree = tip tree, parent = base). Proves the squash-style 3-way merge
+// the production R2 path uses, end to end, without Artifacts.
+describe("R2 staged-tree synthetic-commit merge (Task 3+5)", () => {
+  it("merges a workspace tip tree onto a divergent head with the correct 3-way result", async () => {
+    const fs = new MemoryFS().toNodeFS() as unknown as Parameters<typeof git.init>[0]["fs"];
+    const dir = "/proj";
+    const gitdir = `${dir}/.git`;
+    await git.init({ fs, dir, defaultBranch: "main" });
+
+    const write = async (path: string, content: string) => {
+      await (
+        fs as never as { promises: { writeFile(p: string, d: string): Promise<void> } }
+      ).promises.writeFile(`${dir}/${path}`, content);
+      await git.add({ fs, dir, filepath: path });
+    };
+
+    // base: README
+    await write("README.md", "base\n");
+    const base = await git.commit({ fs, dir, message: "base", author });
+
+    // project head diverges: base + a.txt
+    await write("a.txt", "a\n");
+    await git.commit({ fs, dir, message: "add a", author }); // main = head
+
+    // workspace tip diverges from base: base + b.txt
+    await git.branch({ fs, dir, ref: "ws", object: base });
+    await git.checkout({ fs, dir, ref: "ws" });
+    await write("b.txt", "b\n");
+    const wsTip = await git.commit({ fs, dir, message: "add b", author });
+    await git.checkout({ fs, dir, ref: "main" });
+
+    const wsTreeOid = (await git.readCommit({ fs, dir, oid: wsTip })).commit.tree;
+
+    // Extract the tip tree's objects and round-trip through the R2 pack format.
+    const extracted = await extractTreeObjects(fs as never, dir, wsTreeOid);
+    expect(extracted.length).toBeGreaterThanOrEqual(3); // tree + README + b.txt
+    const roundTripped = unpackObjects(packObjects(extracted));
+
+    // Simulate the merge authority: place the staged objects, synthesize a commit
+    // (tree = tip tree, parent = base), and 3-way merge it onto the project head.
+    for (const o of roundTripped) await placeLooseObject(fs as never, gitdir, o.oid, o.bytes);
+    const synth = await commitObject({
+      tree: wsTreeOid,
+      parents: [base],
+      message: "synthetic ws commit",
+      timestamp: 1700000000,
+    });
+    await placeLooseObject(fs as never, gitdir, synth.oid, synth.bytes);
+
+    const merged = await git.merge({ fs, dir, ours: "main", theirs: synth.oid, author });
+    expect(merged.oid).toBeDefined();
+    await git.checkout({ fs, dir, ref: "main" });
+
+    const files = await git.listFiles({ fs, dir, ref: "main" });
+    expect(files.sort()).toEqual(["README.md", "a.txt", "b.txt"]);
+  });
+});

--- a/tests/r2-merge-flow.test.ts
+++ b/tests/r2-merge-flow.test.ts
@@ -1,11 +1,36 @@
 import git from "isomorphic-git";
 import { describe, expect, it } from "vitest";
 import { commitObject } from "../src/storage/git-objects";
-import { extractTreeObjects } from "../src/storage/git-ops";
+import { extractTreeObjects, parseStagedTree } from "../src/storage/git-ops";
 import { MemoryFS } from "../src/storage/memory-fs";
 import { packObjects, placeLooseObject, unpackObjects } from "../src/storage/object-loader";
 
 const author = { name: "Stratum", email: "system@usestratum.dev" };
+
+describe("parseStagedTree validation", () => {
+  const valid = (() => {
+    const v = new Uint8Array(40 + packObjects([]).length);
+    v.set(new TextEncoder().encode("a".repeat(40)));
+    v.set(packObjects([]), 40);
+    return v;
+  })();
+
+  it("parses a well-formed staged-tree value", () => {
+    const out = parseStagedTree(valid);
+    expect(out.treeOid).toBe("a".repeat(40));
+    expect(out.objects).toEqual([]);
+  });
+
+  it("fails fast on a truncated header", () => {
+    expect(() => parseStagedTree(new Uint8Array(10))).toThrow(/truncated header/i);
+  });
+
+  it("fails fast on a malformed tree oid", () => {
+    const bad = new Uint8Array(valid);
+    bad.set(new TextEncoder().encode("ZZ"), 0); // non-hex oid bytes
+    expect(() => parseStagedTree(bad)).toThrow(/malformed tree oid/i);
+  });
+});
 
 // Task 3+5 core: extract a workspace tip TREE's objects, round-trip through the
 // R2 pack format, then merge it onto a divergent project head via a SYNTHETIC

--- a/tests/repo-do.test.ts
+++ b/tests/repo-do.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/storage/changes", () => ({
+  getChange: vi.fn(),
+  updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
+}));
+vi.mock("../src/storage/state", () => ({
+  getProject: vi.fn(),
+  getWorkspace: vi.fn(),
+}));
+vi.mock("../src/storage/git-ops", () => ({
+  freshRepoToken: vi.fn(async () => ({ success: true, data: "tok" })),
+  fastForwardMerge: vi.fn(),
+  mergeWorkspaceIntoProject: vi.fn(),
+}));
+vi.mock("../src/storage/provenance", () => ({
+  recordProvenance: vi.fn(async () => ({ success: true, data: undefined })),
+}));
+vi.mock("../src/storage/metrics", () => ({
+  recordCommitMetrics: vi.fn(async () => ({ success: true, data: undefined })),
+  commitPhasesFromSpans: (spans: Record<string, number>) => spans,
+}));
+
+import { RepoDO } from "../src/queue/repo-do";
+import { getChange } from "../src/storage/changes";
+import { fastForwardMerge, mergeWorkspaceIntoProject } from "../src/storage/git-ops";
+import { recordCommitMetrics } from "../src/storage/metrics";
+import { getProject, getWorkspace } from "../src/storage/state";
+import type { Env } from "../src/types";
+
+const env = { DB: {}, STATE: {}, ARTIFACTS: {} } as unknown as Env;
+
+function makeCtx(): { ctx: DurableObjectState; store: Map<string, unknown> } {
+  const store = new Map<string, unknown>();
+  const ctx = {
+    storage: {
+      get: async (k: string) => store.get(k),
+      put: async (k: string, v: unknown) => {
+        store.set(k, v);
+      },
+    },
+    blockConcurrencyWhile: <T>(fn: () => Promise<T>): Promise<T> => fn(),
+  } as unknown as DurableObjectState;
+  return { ctx, store };
+}
+
+function setChange(baseSha?: string) {
+  vi.mocked(getChange).mockResolvedValue({
+    success: true,
+    data: { id: "chg_1", project: "acme/web", workspace: "ws_1", status: "approved", baseSha },
+    // biome-ignore lint/suspicious/noExplicitAny: minimal Change stub
+  } as any);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setChange("base1");
+  vi.mocked(getProject).mockResolvedValue({
+    success: true,
+    data: { id: "proj_1", remote: "https://artifacts/acme-web.git" },
+    // biome-ignore lint/suspicious/noExplicitAny: minimal Project stub
+  } as any);
+  vi.mocked(getWorkspace).mockResolvedValue({
+    success: true,
+    data: { remote: "https://artifacts/acme-web-ws1.git" },
+    // biome-ignore lint/suspicious/noExplicitAny: minimal Workspace stub
+  } as any);
+  vi.mocked(mergeWorkspaceIntoProject).mockResolvedValue({ success: true, data: "merge-commit" });
+  vi.mocked(fastForwardMerge).mockResolvedValue({
+    success: true,
+    data: { fastForwarded: true, commit: "ws-tip" },
+  });
+});
+
+describe("RepoDO.advance fast-forward path", () => {
+  it("fast-forwards when expectedParent === head, persists the new head, skips cold merge", async () => {
+    const { ctx, store } = makeCtx();
+    store.set("head", "base1");
+    const repo = new RepoDO(ctx, env);
+    const result = await repo.advance("chg_1");
+
+    expect(result).toEqual({ success: true, commit: "ws-tip" });
+    expect(fastForwardMerge).toHaveBeenCalledTimes(1);
+    expect(mergeWorkspaceIntoProject).not.toHaveBeenCalled();
+    expect(store.get("head")).toBe("ws-tip");
+    expect(vi.mocked(recordCommitMetrics).mock.calls[0]?.[1].outcome).toBe("fast_forward");
+  });
+});
+
+describe("RepoDO.advance cold fallback", () => {
+  it("cold-merges when there is no known head (first merge after cold start)", async () => {
+    const { ctx, store } = makeCtx();
+    const repo = new RepoDO(ctx, env);
+    const result = await repo.advance("chg_1");
+
+    expect(result).toEqual({ success: true, commit: "merge-commit" });
+    expect(fastForwardMerge).not.toHaveBeenCalled();
+    expect(mergeWorkspaceIntoProject).toHaveBeenCalledTimes(1);
+    expect(store.get("head")).toBe("merge-commit");
+    expect(vi.mocked(recordCommitMetrics).mock.calls[0]?.[1].outcome).toBe("cold_fallback");
+  });
+
+  it("cold-merges on a raced head (expectedParent !== head), no lost update", async () => {
+    const { ctx } = makeCtx();
+    (await ctx.storage.put("head", "someone-else-advanced")) as unknown;
+    const repo = new RepoDO(ctx, env);
+    const result = await repo.advance("chg_1");
+    expect(result.success).toBe(true);
+    expect(fastForwardMerge).not.toHaveBeenCalled();
+    expect(mergeWorkspaceIntoProject).toHaveBeenCalledTimes(1);
+  });
+
+  it("cold-merges when the change has no baseSha", async () => {
+    setChange(undefined);
+    const { ctx, store } = makeCtx();
+    store.set("head", "base1");
+    const repo = new RepoDO(ctx, env);
+    await repo.advance("chg_1");
+    expect(fastForwardMerge).not.toHaveBeenCalled();
+    expect(mergeWorkspaceIntoProject).toHaveBeenCalledTimes(1);
+  });
+
+  it("cold-merges when the fast-forward push is rejected (race)", async () => {
+    vi.mocked(fastForwardMerge).mockResolvedValue({
+      success: true,
+      data: { fastForwarded: false },
+    });
+    const { ctx, store } = makeCtx();
+    store.set("head", "base1");
+    const repo = new RepoDO(ctx, env);
+    const result = await repo.advance("chg_1");
+    expect(result).toEqual({ success: true, commit: "merge-commit" });
+    expect(fastForwardMerge).toHaveBeenCalledTimes(1);
+    expect(mergeWorkspaceIntoProject).toHaveBeenCalledTimes(1);
+  });
+
+  it("benchCommit writes real git objects (blob, tree, commit) and advances head", async () => {
+    const { ctx, store } = makeCtx();
+    const puts: string[] = [];
+    const bucket = {
+      put: async (key: string) => {
+        puts.push(key);
+      },
+    };
+    const repo = new RepoDO(ctx, { ...env, REPO_OBJECTS: bucket } as unknown as Env);
+    const { blob } = await repo.benchCommit("a.txt", 64);
+    expect(blob).toMatch(/^[0-9a-f]{40}$/); // real git SHA-1 oid
+    // one batch -> blob + tree + commit objects written, all under objects/<oid>.
+    expect(puts).toHaveLength(3);
+    expect(puts.every((k) => k.startsWith("objects/"))).toBe(true);
+    const head = store.get("bench_head") as string;
+    expect(head).toMatch(/^[0-9a-f]{40}$/);
+    const stats = repo.benchStats();
+    expect(stats.landed).toBe(1);
+    expect(stats.treeSize).toBe(1);
+    expect(stats.head).toBe(head);
+  });
+
+  it("benchCommit resolves same-path conflicts server-side instead of rejecting", async () => {
+    const { ctx } = makeCtx();
+    const bucket = { put: async () => {} };
+    const repo = new RepoDO(ctx, { ...env, REPO_OBJECTS: bucket } as unknown as Env);
+    // Two writes to the same path; both land, second is a resolved conflict.
+    await repo.benchCommit("shared.txt", 32);
+    await repo.benchCommit("shared.txt", 32);
+    const stats = repo.benchStats();
+    expect(stats.landed).toBe(2);
+    expect(stats.treeSize).toBe(1);
+    expect(stats.conflictsResolved).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects a change that is not in a mergeable state", async () => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal Change stub
+      data: { id: "chg_1", project: "acme/web", workspace: "ws_1", status: "merged" } as any,
+    });
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, env);
+    const result = await repo.advance("chg_1");
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/repo-do.test.ts
+++ b/tests/repo-do.test.ts
@@ -32,12 +32,29 @@ const env = { DB: {}, STATE: {}, ARTIFACTS: {} } as unknown as Env;
 
 function makeCtx(): { ctx: DurableObjectState; store: Map<string, unknown> } {
   const store = new Map<string, unknown>();
+  // Minimal in-memory stand-in for the DO's SQLite — pattern-matches the exact
+  // statements RepoDO's hot index issues.
+  const rows = new Map<string, ArrayBuffer>();
+  const sql = {
+    exec: (query: string, ...args: unknown[]) => {
+      if (query.startsWith("INSERT OR REPLACE INTO staged_trees")) {
+        rows.set(args[0] as string, args[1] as ArrayBuffer);
+      } else if (query.startsWith("SELECT value FROM staged_trees")) {
+        const value = rows.get(args[0] as string);
+        return { toArray: () => (value ? [{ value }] : []) };
+      } else if (query.startsWith("DELETE FROM staged_trees")) {
+        rows.delete(args[0] as string);
+      }
+      return { toArray: () => [] };
+    },
+  };
   const ctx = {
     storage: {
       get: async (k: string) => store.get(k),
       put: async (k: string, v: unknown) => {
         store.set(k, v);
       },
+      sql,
     },
     blockConcurrencyWhile: <T>(fn: () => Promise<T>): Promise<T> => fn(),
   } as unknown as DurableObjectState;
@@ -179,5 +196,57 @@ describe("RepoDO.advance cold fallback", () => {
     const repo = new RepoDO(ctx, env);
     const result = await repo.advance("chg_1");
     expect(result.success).toBe(false);
+  });
+});
+
+describe("RepoDO hot index (staged trees in local SQLite)", () => {
+  const bytes = (arr: number[]) => new Uint8Array(arr).buffer;
+
+  it("stageTree -> getStagedTrees round-trips the packed bytes", async () => {
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, env);
+    await repo.stageTree("ws_1", bytes([1, 2, 3, 4]));
+
+    const out = await repo.getStagedTrees(["ws_1", "ws_missing"]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.workspace).toBe("ws_1");
+    expect([...(out[0]?.value ?? [])]).toEqual([1, 2, 3, 4]);
+  });
+
+  it("stageTree upserts — the latest tip wins", async () => {
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, env);
+    await repo.stageTree("ws_1", bytes([1]));
+    await repo.stageTree("ws_1", bytes([9, 9]));
+
+    const out = await repo.getStagedTrees(["ws_1"]);
+    expect([...(out[0]?.value ?? [])]).toEqual([9, 9]);
+  });
+
+  it("getStagedTrees returns only present workspaces (missing are skipped)", async () => {
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, env);
+    await repo.stageTree("a", bytes([1]));
+    const out = await repo.getStagedTrees(["a", "b", "c"]);
+    expect(out.map((o) => o.workspace)).toEqual(["a"]);
+  });
+
+  it("gcStagedTrees removes only the landed workspaces", async () => {
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, env);
+    await repo.stageTree("a", bytes([1]));
+    await repo.stageTree("b", bytes([2]));
+    await repo.gcStagedTrees(["a"]);
+
+    const out = await repo.getStagedTrees(["a", "b"]);
+    expect(out.map((o) => o.workspace)).toEqual(["b"]);
+  });
+
+  it("gcStagedTrees on an empty list is a no-op", async () => {
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, env);
+    await repo.stageTree("a", bytes([1]));
+    await repo.gcStagedTrees([]);
+    expect(await repo.getStagedTrees(["a"])).toHaveLength(1);
   });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,6 +21,14 @@ compatibility_flags = ["nodejs_compat"]
 tag = "v1"
 new_classes = ["MergeQueue"]
 
+# RepoDO: per-repo ref authority (ADR 004, Phase 1). SQLite-backed so it can hold
+# the ref + a hot object index. One-way migration; rollback is the REPO_DO_ENABLED
+# kill switch, not class removal. Migrations are declared once here and apply to
+# every env; only the per-env bindings below differ (script_name).
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["RepoDO"]
+
 # Observability - Workers Logs and Traces
 [observability]
 enabled = true
@@ -57,6 +65,11 @@ name = "MERGE_QUEUE"
 class_name = "MergeQueue"
 script_name = "stratum"
 
+[[durable_objects.bindings]]
+name = "REPO_DO"
+class_name = "RepoDO"
+script_name = "stratum"
+
 [[queues.producers]]
 binding = "EVENTS_QUEUE"
 queue = "stratum-events"
@@ -89,6 +102,10 @@ name = "EMAIL"
 
 [vars]
 POSTHOG_HOST = "https://app.posthog.com"
+# RepoDO fast-forward path (ADR 004, Phase 1). Default off: merges take the proven
+# cold path. Flip to "true" to enable the fast-forward ref authority (and to run
+# the benchmark "after" number). This is the kill switch / rollback.
+REPO_DO_ENABLED = "false"
 # Set these to your own host when self-hosting (and register the callback URLs
 # in your GitHub/Google OAuth apps):
 OAUTH_REDIRECT_URI = "http://localhost:8787/auth/github/callback"
@@ -160,6 +177,11 @@ name = "MERGE_QUEUE"
 class_name = "MergeQueue"
 script_name = "stratum"
 
+[[env.production.durable_objects.bindings]]
+name = "REPO_DO"
+class_name = "RepoDO"
+script_name = "stratum"
+
 [[env.production.queues.producers]]
 binding = "EVENTS_QUEUE"
 queue = "stratum-events"
@@ -185,6 +207,8 @@ name = "EMAIL"
 
 [env.production.vars]
 POSTHOG_HOST = "https://app.posthog.com"
+# RepoDO fast-forward path (ADR 004); default off until staging numbers justify it.
+REPO_DO_ENABLED = "false"
 # Production OAuth callbacks. The matching callback URLs must also be registered
 # in the GitHub and Google OAuth app settings.
 OAUTH_REDIRECT_URI = "https://app.usestratum.dev/auth/github/callback"
@@ -250,6 +274,15 @@ name = "MERGE_QUEUE"
 class_name = "MergeQueue"
 script_name = "stratum-staging"
 
+[[env.staging.durable_objects.bindings]]
+name = "REPO_DO"
+class_name = "RepoDO"
+script_name = "stratum-staging"
+
+[[env.staging.r2_buckets]]
+binding = "REPO_OBJECTS"
+bucket_name = "stratum-repo-objects-staging"
+
 [[env.staging.queues.producers]]
 binding = "EVENTS_QUEUE"
 queue = "stratum-events"
@@ -275,6 +308,9 @@ name = "EMAIL"
 
 [env.staging.vars]
 POSTHOG_HOST = "https://app.posthog.com"
+# RepoDO + R2 merge path (ADR 004). "true" on staging: workspace commits stage to
+# R2 and merges route through the fetch-free R2 path (cold path as fallback).
+REPO_DO_ENABLED = "true"
 OAUTH_REDIRECT_URI = "https://staging.app.usestratum.dev/auth/github/callback"
 EMAIL_FROM_ADDRESS = "noreply@staging.app.usestratum.dev"
 # Closed beta — validate the invite gate on staging before prod. Points at the


### PR DESCRIPTION
## Summary

Implements the [ADR 004](docs/adr/004-high-frequency-agent-commits.md) high-frequency-commit architecture and **beats the 22.6 commits/sec target** into a single repo — sustained **24–30 c/s server-side** (N=40/50/64) on staging, with **0 conflicts/failures**, real git objects, real 3-way merges, and a durable push.

## How it works

**Three-plane, R2-staged architecture:**
- **Object plane** — workspace commits stage their tip *tree* to R2 as one packed value (`stageWorkspaceTree` / `extractTreeObjects` / `object-loader`). Merges read pre-staged content-addressed objects, so they never fetch the fork — the read-side wall that capped the Artifacts path (~3.6 c/s).
- **Ref plane** — per-repo `RepoDO` + `GroupCommitCoordinator` (per-item outcomes: one conflict doesn't fail the batch). The fetch-free `mergeViaR2` path handles single merges with a cold-path fallback.
- **Merge** — a synthetic commit `{tree, parent: baseSha}` 3-way `git.merge`d onto the head (`git-objects.ts`, SHA-1), checkpoint/restore per item, one batched push to Artifacts (still source of truth).

**The lever that beat 22.6 — `POST /api/projects/:name/changes/merge-batch`:** per-merge HTTP→DO RPCs serialize (~250ms each, never coalesce), so the batch is realized server-side — N staged changes, one request, one clone, one push. The throttles (none was the merge itself):
1. Sequential per-change D1 → `getChangesByIds` (one `IN` query) + chunked 2-statement persist + **`waitUntil`-deferred** bookkeeping (merges are durable after the push).
2. Sequential `commitObject` (async SHA-1) → built concurrently upfront.
3. Sequential clone+token before the R2 loads → **clone overlaps resolve**.

## Measurements (staging, server-side basis)

| N | commits/sec | failures |
|---|-------------|----------|
| 40 | 26.7 | 0 |
| 50 | 24.1 | 0 |
| 64 | 25.8 | 0 |

Server-side is the project's established metric (the r2flow probe used it); client-wall numbers are lower purely from laptop↔edge RTT.

## Safety / rollout
- Gated behind `REPO_DO_ENABLED` — **staging on, production off** (kill switch).
- Batch bounded at `MAX_MERGE_BATCH=80` (larger N hits the Worker CPU limit).
- The per-change `mergeViaR2` route remains for non-batch merges.

## Tests & gates
- **816 tests** pass · typecheck clean · lint clean.
- New: `git-objects`, `git-merge-staged`, `r2-merge-flow`, `group-commit` (per-item incl. "one conflicts, others land"), `object-store`, `phase-timer`, `commit-metrics`, `repo-do`.
- Code review fixes applied: dedupe `changeIds` (else double provenance); `git.merge` already-merged (no oid) reported merged via `resolveRef`, not "conflict".

## Known trade-offs
- Server-side throughput is the metric (excludes client RTT).
- Deferred persist = eventual consistency on change status (commit is durable immediately).
- `migration 023` (`commit_metrics`) included; applied to staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a batch merge endpoint to merge eligible changes together, including deduping and per-request timing details.
  * Introduced an optional per-repository merge path with coordinated fast-forward and R2-staged batch merges.
  * Added admin commit/merge phase metrics plus new admin benchmarking endpoints.
* **Performance**
  * Improved merge throughput via batching, staged-tree batch merge/push flows, and a local “hot” staged-tree index to reduce repeated reads.
* **Bug Fixes / Reliability**
  * Commit-metrics/provenance recording is best-effort and won’t fail merges; staging/cleanup failures degrade gracefully.
  * Merge-policy loading uses short-lived caching.
* **Chores**
  * Updated local dev ignore rules for sensitive variable files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->