### PR TITLE
chore: point repo references at canonical stratum-eng/stratum

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security report
-    url: https://github.com/jlamoreaux/stratum/security/advisories/new
+    url: https://github.com/stratum-eng/stratum/security/advisories/new
     about: Please report security issues privately, not as public issues. See SECURITY.md.
   - name: Question or discussion
-    url: https://github.com/jlamoreaux/stratum/discussions
+    url: https://github.com/stratum-eng/stratum/discussions
     about: Ask questions and discuss ideas with the community.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes, GitHub import/sync, server-rendered web UI, email and GitHub OAuth authentication,
   API tokens, agent identities, and provenance tracking.
 
-[Unreleased]: https://github.com/jlamoreaux/stratum/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/jlamoreaux/stratum/releases/tag/v0.1.0
+[Unreleased]: https://github.com/stratum-eng/stratum/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/stratum-eng/stratum/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,7 +12,7 @@ interact respectfully and in good faith.
 ## Reporting
 
 If you experience or witness a concern, report it privately to the project maintainers by
-[opening a confidential advisory](https://github.com/jlamoreaux/stratum/security/advisories/new) or
+[opening a confidential advisory](https://github.com/stratum-eng/stratum/security/advisories/new) or
 contacting a maintainer directly through GitHub. All reports will be reviewed and handled
 confidentially, and maintainers will respect the privacy of the reporter.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ to uphold it. Report unacceptable behavior per the contact in that file.
 **Prerequisites:** Node.js 20+ and a Cloudflare account (for full local dev against bindings).
 
 ```bash
-git clone https://github.com/jlamoreaux/stratum.git
+git clone https://github.com/stratum-eng/stratum.git
 cd stratum
 npm install
 npm run dev        # local dev server at http://localhost:8787

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stratum
 
-[![CI Status](https://github.com/jlamoreaux/stratum/actions/workflows/ci.yml/badge.svg)](https://github.com/jlamoreaux/stratum/actions)
+[![CI Status](https://github.com/stratum-eng/stratum/actions/workflows/ci.yml/badge.svg)](https://github.com/stratum-eng/stratum/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A code collaboration platform for the AI engineering era. Built on Cloudflare Workers with Artifacts, D1, KV, and Queues.
@@ -73,7 +73,7 @@ Stratum is a GitHub alternative where both humans and AI agents are first-class 
 
 ```bash
 # Clone the repository
-git clone https://github.com/jlamoreaux/stratum.git
+git clone https://github.com/stratum-eng/stratum.git
 cd stratum
 
 # Install dependencies

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ and the deployed instances. There is no long-term-support branch yet.
 discussions.**
 
 Instead, report privately through **GitHub Security Advisories** —
-[open a private advisory](https://github.com/jlamoreaux/stratum/security/advisories/new). This keeps
+[open a private advisory](https://github.com/stratum-eng/stratum/security/advisories/new). This keeps
 the report confidential and lets us collaborate on a fix before disclosure.
 
 Please include:

--- a/agent/package.json
+++ b/agent/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Reference agent for Stratum — fork, edit with an LLM, commit, open a Change",
   "license": "MIT",
-  "repository": { "type": "git", "url": "https://github.com/jlamoreaux/stratum.git", "directory": "agent" },
+  "repository": { "type": "git", "url": "https://github.com/stratum-eng/stratum.git", "directory": "agent" },
   "type": "module",
   "bin": { "stratum-agent": "./dist/index.js" },
   "files": ["dist"],

--- a/cli/package.json
+++ b/cli/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "CLI for Stratum — code hosting for the AI engineering era",
   "license": "MIT",
-  "repository": { "type": "git", "url": "https://github.com/jlamoreaux/stratum.git", "directory": "cli" },
+  "repository": { "type": "git", "url": "https://github.com/stratum-eng/stratum.git", "directory": "cli" },
   "type": "module",
   "bin": { "stratum": "./dist/index.js" },
   "files": ["dist"],

--- a/docs/developer/local-setup.md
+++ b/docs/developer/local-setup.md
@@ -9,7 +9,7 @@
 ## Setup
 
 ```bash
-git clone https://github.com/jlamoreaux/stratum.git
+git clone https://github.com/stratum-eng/stratum.git
 cd stratum
 npm install
 npx wrangler login

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "description": "A code collaboration platform for the AI engineering era, built on Cloudflare Workers.",
-  "repository": { "type": "git", "url": "https://github.com/jlamoreaux/stratum.git" },
+  "repository": { "type": "git", "url": "https://github.com/stratum-eng/stratum.git" },
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",


### PR DESCRIPTION
Follow-up to #111. Updates all in-repo GitHub URLs from `jlamoreaux/stratum` to the new canonical org `stratum-eng/stratum`.

### Changed (13 refs / 10 files)
- `README.md` — CI badge + `git clone` URL
- `package.json`, `cli/package.json`, `agent/package.json` — `repository.url`
- `CONTRIBUTING.md`, `docs/developer/local-setup.md` — `git clone` URL
- `SECURITY.md`, `CODE_OF_CONDUCT.md` — security-advisory link
- `.github/ISSUE_TEMPLATE/config.yml` — advisory + discussions links
- `CHANGELOG.md` — compare/release link refs

### Notes
- These resolve once the repo transfer to `stratum-eng` lands; GitHub's automatic redirects cover the interim window.
- Workflow files need no change — they use `context.payload.repository.html_url` (dynamic).
- No `src/` or `scripts/` references existed.

### Still owner-only (outside this PR)
Re-verify on the new org after transfer: Actions secrets & environments, branch protection, CodeRabbit (and other GitHub Apps), the Cloudflare↔GitHub connection, webhooks/deploy keys, and that Discussions + Security Advisories are enabled. Update the local git remote with `git remote set-url origin git@github.com:stratum-eng/stratum.git`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository references and URLs across documentation, configuration files, and package metadata to reflect organizational updates. Changes include setup instructions, CI status configuration, package information, and security reporting links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->