### PR TITLE
ci: stop opening an issue on every successful production deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
           npx vitest run tests/smoke/ --reporter=verbose || true
           echo "✓ Smoke tests completed"
 
-      - name: Create deployment notification
+      - name: Record deployment summary
         if: success()
         uses: actions/github-script@v7
         with:
@@ -209,26 +209,19 @@ jobs:
             const commitSha = context.sha.substring(0, 7);
             const commitMessage = context.payload.head_commit?.message || 'No message';
 
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `✅ Production Deployment Successful - ${commitSha}`,
-              body: `## Production Deployment Complete
-
-            **Commit:** ${commitSha}
-            **Message:** ${commitMessage}
-            **URL:** ${deploymentUrl}
-
-            ### Deployment Checklist
-            - [x] D1 migrations applied
-            - [x] Build successful
-            - [x] Health checks passed
-            - [x] Smoke tests completed
-            - [x] Deployment verified
-
-            [View Workflow Run](${context.payload.repository.html_url}/actions/runs/${context.runId})`,
-              labels: ['deployment', 'production']
-            });
+            await core.summary
+              .addHeading('✅ Production Deployment Complete')
+              .addRaw(`**Commit:** ${commitSha}\n\n`)
+              .addRaw(`**Message:** ${commitMessage}\n\n`)
+              .addRaw(`**URL:** ${deploymentUrl}\n`)
+              .addList([
+                'D1 migrations applied',
+                'Build successful',
+                'Health checks passed',
+                'Smoke tests completed',
+                'Deployment verified',
+              ])
+              .write();
 
       - name: Notify on failure
         if: failure()


### PR DESCRIPTION
### Problem
The `deploy-production` job in `ci.yml` had a **"Create deployment notification"** step (`if: success()`) that called `github.rest.issues.create(...)` on every successful production deploy — so each deploy filed a new **"✅ Production Deployment Successful"** issue. That's unwanted noise in the Issues tab.

### Fix
Replace the issue creation with a write to the **GitHub Actions run summary** (`core.summary`). The same deployment record (commit, message, URL, checklist) still shows up — on the workflow run's summary page instead of as an issue.

- The `Notify on failure` step (`if: failure()`) is **unchanged** — real failures still notify.
- This is the only `issues.create` guarded by `success()`; all others across the workflows are `failure()`-gated.

### Verified
- `ci.yml` parses as valid YAML.

### Note
This doesn't retroactively close the issues already created by past deploys. Happy to bulk-close any open `✅ Production Deployment Successful` issues (label `deployment`/`production`) in a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)