### PR TITLE
fix(cli): correct workspace endpoint path to /api/workspaces

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -159,7 +159,7 @@ export class StratumClient {
   async createWorkspace(ref: ProjectRef, name?: string) {
     return this.request<{ workspace: string; remote: string; path: string }>(
       "POST",
-      `/api/projects/${encodeURIComponent(ref.namespace)}/${encodeURIComponent(ref.slug)}/workspaces`,
+      `/api/workspaces/${encodeURIComponent(ref.namespace)}/${encodeURIComponent(ref.slug)}/workspaces`,
       { ...(name ? { name } : {}) },
     );
   }
@@ -167,7 +167,7 @@ export class StratumClient {
   async listWorkspaces(ref: ProjectRef) {
     return this.request<{ workspaces: Array<{ name: string; createdAt: string; path: string }> }>(
       "GET",
-      `/api/projects/${encodeURIComponent(ref.namespace)}/${encodeURIComponent(ref.slug)}/workspaces`,
+      `/api/workspaces/${encodeURIComponent(ref.namespace)}/${encodeURIComponent(ref.slug)}/workspaces`,
     );
   }
 

--- a/cli/tests/client.test.ts
+++ b/cli/tests/client.test.ts
@@ -46,13 +46,13 @@ describe("StratumClient", () => {
     const ref = parseProjectRef("@user/repo");
     await client.createWorkspace(ref, "ws-1");
     expect(lastCall().url).toBe(
-      "https://stratum.example.com/api/projects/%40user/repo/workspaces",
+      "https://stratum.example.com/api/workspaces/%40user/repo/workspaces",
     );
     expect(lastCall().init.method).toBe("POST");
 
     await client.listWorkspaces(ref);
     expect(lastCall().url).toBe(
-      "https://stratum.example.com/api/projects/%40user/repo/workspaces",
+      "https://stratum.example.com/api/workspaces/%40user/repo/workspaces",
     );
 
     await client.deleteWorkspace("ws-1", "proj_123");


### PR DESCRIPTION
## Problem

`stratum workspace create` and `stratum workspace list` **404 against a real instance**. The CLI client targeted `/api/projects/:ns/:slug/workspaces`, but the Worker mounts those routes under `/api/workspaces/:ns/:slug/workspaces` (`src/index.ts`, `src/routes/workspaces.ts:29,106`).

The client's own unit test pinned the wrong URL — it mocks `fetch`, so it asserted the buggy path and never caught the mismatch. CI stayed green while the command was unusable.

## Fix

- `cli/src/client.ts` — `createWorkspace` / `listWorkspaces` now hit `/api/workspaces/...`.
- `cli/tests/client.test.ts` — assertions updated to the path the server actually serves.

The workspace-scoped routes (`commit`, `delete`) were already correct and are unchanged.

## Verification

Exercised end-to-end against the production instance (`app.usestratum.dev`):

- `stratum init` → project created
- `stratum workspace create` / `list` → ✅ (were 404 before)
- `stratum commit` → real server-side commit SHA returned

`npm run build` clean, `npm test` 9/9 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
