### PR TITLE
feat(git-http): native git clone/fetch via smart-HTTP proxy (ADR 005 slice 1)

### DIFF
--- a/docs/adr/005-git-smart-http-proxy.md
+++ b/docs/adr/005-git-smart-http-proxy.md
@@ -2,7 +2,18 @@
 
 ## Status
 
-Proposed
+Partially accepted — **slice 1 (clone/fetch) implemented**; push (`receive-pack`)
+remains proposed/deferred.
+
+Slice 1 ships the authenticated `git-upload-pack` proxy: a Stratum project can be
+used as a git remote for `git clone` / `git fetch` (`src/routes/git-http.ts`,
+mounted in `src/index.ts`; middlewares exempt git paths via `isGitHttpPath`).
+`git-receive-pack` (push) is refused with HTTP 403 pointing at `stratum commit`
+and is the subject of the still-deferred slice below. Two corrections surfaced
+during implementation and are reflected here: the global `authMiddleware` is
+Bearer-only and had to step aside for git's Basic-auth challenge, and outbound
+request bodies must be **buffered** (Workers drop streamed outbound bodies), so
+the proxy buffers the request and streams only the response.
 
 ## Context
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { authRouter } from "./routes/auth";
 import { bulkImportRouter } from "./routes/bulk-import";
 import { changesRouter } from "./routes/changes";
 import { emailAuthRouter } from "./routes/email-auth";
+import { gitHttpRouter } from "./routes/git-http";
 import { healthRouter } from "./routes/health";
 import { issuesRouter } from "./routes/issues";
 import { loginRouter } from "./routes/login";
@@ -154,6 +155,10 @@ app.route("/api", syncRouter);
 app.route("/api", syncManagementRouter);
 app.route("/api/bulk-import", bulkImportRouter);
 app.route("/api/webhooks/github", githubWebhookRouter);
+// Git smart-HTTP proxy (clone/fetch). Mount before the UI catch-all so its
+// /@ns/slug/{info/refs,git-upload-pack,git-receive-pack} paths resolve here.
+app.route("/", gitHttpRouter);
+
 // Mount the UI router last: its /:namespace/:slug catch-all would otherwise
 // shadow two-segment API paths like GET /api/projects.
 app.route("/", uiRouter);

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from "hono";
 import { getCookie } from "hono/cookie";
+import { isGitHttpPath } from "../routes/git-http";
 import { getAgentByToken } from "../storage/agents";
 import { deleteSession, getSession } from "../storage/sessions";
 import { getUser, getUserByToken } from "../storage/users";
@@ -33,6 +34,13 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
   });
 
   c.set("logger", logger);
+
+  // The git smart-HTTP router authenticates over HTTP Basic itself; let it own
+  // the challenge instead of rejecting the non-Bearer header here.
+  if (isGitHttpPath(c.req.path)) {
+    await next();
+    return;
+  }
 
   const authHeader = c.req.header("Authorization");
 

--- a/src/middleware/csrf.ts
+++ b/src/middleware/csrf.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from "hono";
+import { isGitHttpPath } from "../routes/git-http";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
 
@@ -16,6 +17,12 @@ const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
  */
 export const csrfMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
   if (!STATE_CHANGING_METHODS.has(c.req.method)) {
+    await next();
+    return;
+  }
+  // Git smart-HTTP is Basic/token-authenticated (not session cookies) and owns
+  // its own access checks — exempt by path to be robust to future changes.
+  if (isGitHttpPath(c.req.path)) {
     await next();
     return;
   }

--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from "hono";
+import { isGitHttpPath } from "../routes/git-http";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
 
@@ -24,6 +25,13 @@ export function rateLimitMiddleware(opts?: RateLimitOptions): MiddlewareHandler<
 }> {
   return async (c, next) => {
     if (c.req.path === "/health") {
+      await next();
+      return;
+    }
+
+    // Git clone/fetch is one long request (or many subrequests); a 429 mid-clone
+    // corrupts it. The git router governs its own access — skip the limiter.
+    if (isGitHttpPath(c.req.path)) {
       await next();
       return;
     }

--- a/src/routes/git-http.ts
+++ b/src/routes/git-http.ts
@@ -1,0 +1,292 @@
+import { Hono } from "hono";
+import { getAgentByToken } from "../storage/agents";
+import {
+  artifactsRepoNameFromRemote,
+  extractTokenSecret,
+  freshRepoToken,
+} from "../storage/git-ops";
+import { getProjectByPath } from "../storage/state";
+import { getUserByToken } from "../storage/users";
+import type { Env, ProjectEntry } from "../types";
+import { canReadProject } from "../utils/authz";
+import { createLogger } from "../utils/logger";
+
+/**
+ * Git smart-HTTP proxy (ADR 005, slice 1: clone/fetch only).
+ *
+ * Lets a Stratum project be used as a git remote: `git clone <host>/@ns/slug.git`.
+ * The router authenticates with the existing API-key system over HTTP Basic,
+ * authorizes the caller, mints a short-lived Cloudflare Artifacts token, and
+ * proxies the smart-HTTP request to the backing Artifacts remote. The Artifacts
+ * token never leaves the Worker.
+ *
+ * Push (`git-receive-pack`) is intentionally refused — see `pushNotSupported`.
+ */
+
+/**
+ * Whether a request path belongs to the git smart-HTTP surface. The global
+ * `authMiddleware` (Bearer-only) would otherwise reject git's Basic-auth
+ * requests before this router runs, so the middlewares consult this to step
+ * aside and let the router own auth.
+ *
+ * Anchored to the exact `/<namespace>/<slug>/<git-suffix>` shape — a bare
+ * `endsWith` would also exempt unrelated routes whose path merely ends in the
+ * suffix (e.g. the UI `…/blob/<file>/info/refs`), stripping auth/CSRF/rate-limit
+ * from them.
+ */
+const GIT_HTTP_PATH = /^\/[^/]+\/[^/]+\/(?:info\/refs|git-upload-pack|git-receive-pack)$/;
+
+export function isGitHttpPath(path: string): boolean {
+  return GIT_HTTP_PATH.test(path);
+}
+
+const UPLOAD_PACK = "git-upload-pack";
+const RECEIVE_PACK = "git-receive-pack";
+
+// Response headers git expects on a smart-HTTP reply. We forward these verbatim
+// from Artifacts and deliberately drop framing headers (Content-Length /
+// Transfer-Encoding) so the runtime re-frames the re-streamed body, and never
+// copy anything auth-related.
+const FORWARDED_RESPONSE_HEADERS = [
+  "content-type",
+  "content-encoding",
+  "cache-control",
+  "pragma",
+  "expires",
+];
+
+function authChallenge(): Response {
+  return new Response("Authentication required\n", {
+    status: 401,
+    headers: {
+      "WWW-Authenticate": 'Basic realm="Stratum"',
+      "Content-Type": "text/plain",
+    },
+  });
+}
+
+// Identical response for "not found" and "found but unauthorized" so an
+// authenticated caller cannot probe private-repo existence.
+function gitNotFound(): Response {
+  return new Response("Not found\n", { status: 404, headers: { "Content-Type": "text/plain" } });
+}
+
+function upstreamError(): Response {
+  return new Response("Upstream git error\n", {
+    status: 502,
+    headers: { "Content-Type": "text/plain" },
+  });
+}
+
+function serverError(): Response {
+  return new Response("Internal error\n", {
+    status: 500,
+    headers: { "Content-Type": "text/plain" },
+  });
+}
+
+/**
+ * Extract a Stratum API key from an HTTP Basic header. git clients place the
+ * credential in either field (`https://TOKEN@host` lands it in the username
+ * with an empty password), so accept whichever field carries a recognized
+ * prefix, preferring the password.
+ */
+function parseBasicToken(header: string | undefined): string | null {
+  if (!header || !header.startsWith("Basic ")) return null;
+  let decoded: string;
+  try {
+    decoded = atob(header.slice("Basic ".length));
+  } catch {
+    return null;
+  }
+  const sep = decoded.indexOf(":");
+  const username = sep >= 0 ? decoded.slice(0, sep) : decoded;
+  const password = sep >= 0 ? decoded.slice(sep + 1) : "";
+  for (const candidate of [password, username]) {
+    if (candidate.startsWith("stratum_user_") || candidate.startsWith("stratum_agent_")) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+interface Identity {
+  userId?: string;
+  agentOwnerId?: string;
+}
+
+/**
+ * Resolve the caller's identity from Basic credentials. Returns `null` for
+ * anonymous *or* unrecognized/invalid credentials — both collapse to "no
+ * identity" for the access truth table, never a 500.
+ */
+async function authenticate(
+  c: { req: { header(name: string): string | undefined }; env: Env },
+  logger: ReturnType<typeof createLogger>,
+): Promise<Identity | null> {
+  const token = parseBasicToken(c.req.header("Authorization"));
+  if (!token) return null;
+
+  if (token.startsWith("stratum_user_")) {
+    const result = await getUserByToken(c.env.DB, token, logger);
+    return result.success ? { userId: result.data.id } : null;
+  }
+  const result = await getAgentByToken(c.env.DB, token, logger);
+  return result.success ? { agentOwnerId: result.data.ownerId } : null;
+}
+
+function basicAuthHeader(artifactsToken: string): string {
+  return `Basic ${btoa(`x:${extractTokenSecret(artifactsToken)}`)}`;
+}
+
+/**
+ * Proxy a smart-HTTP request to the project's Artifacts remote with a freshly
+ * minted read token. Buffers the request body (Workers silently drop streamed
+ * outbound bodies — see `git-ops.ts`) and streams the response body back.
+ */
+async function proxyUpstream(
+  c: { req: { header(name: string): string | undefined }; env: Env },
+  project: ProjectEntry,
+  upstreamUrl: string,
+  method: "GET" | "POST",
+  body: ArrayBuffer | undefined,
+  logger: ReturnType<typeof createLogger>,
+): Promise<Response> {
+  const tokenResult = await freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger);
+  if (!tokenResult.success) {
+    logger.error("Failed to mint Artifacts token for git proxy", tokenResult.error);
+    return upstreamError();
+  }
+
+  const headers: Record<string, string> = { Authorization: basicAuthHeader(tokenResult.data) };
+  // Forward the bits of the request that affect protocol negotiation. Never
+  // forward the inbound Authorization — it is replaced by the Artifacts token.
+  for (const name of ["Git-Protocol", "Content-Type", "Content-Encoding"]) {
+    const value = c.req.header(name);
+    if (value) headers[name] = value;
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(upstreamUrl, { method, headers, body, redirect: "manual" });
+  } catch (error) {
+    logger.error("Git upstream fetch failed", error instanceof Error ? error : undefined, {
+      upstreamUrl,
+      method,
+    });
+    return upstreamError();
+  }
+
+  // Only a clean 2xx is streamed through. A redirect (manual) or upstream error
+  // is failed closed — never follow a redirect carrying the Artifacts token.
+  if (upstream.status < 200 || upstream.status >= 300) {
+    logger.error("Git upstream returned non-2xx", undefined, {
+      upstreamUrl,
+      status: upstream.status,
+    });
+    return upstreamError();
+  }
+
+  const responseHeaders = new Headers();
+  for (const name of FORWARDED_RESPONSE_HEADERS) {
+    const value = upstream.headers.get(name);
+    if (value) responseHeaders.set(name, value);
+  }
+  return new Response(upstream.body, { status: 200, headers: responseHeaders });
+}
+
+function pushNotSupported(): Response {
+  return new Response(
+    "push over git is not yet supported — use 'stratum commit' or the change flow\n",
+    { status: 403, headers: { "Content-Type": "text/plain" } },
+  );
+}
+
+/** Strip a trailing `.git` so both `/@ns/slug.git` and `/@ns/slug` resolve. */
+function normalizeSlug(slug: string): string {
+  return slug.endsWith(".git") ? slug.slice(0, -".git".length) : slug;
+}
+
+/**
+ * Resolve + authorize a project for a read, applying the no-leak truth table.
+ * Returns the project on success, or a `Response` to return as-is.
+ */
+async function authorizeRead(
+  c: { req: { header(name: string): string | undefined; param(name: string): string }; env: Env },
+  logger: ReturnType<typeof createLogger>,
+): Promise<ProjectEntry | Response> {
+  const namespace = c.req.param("namespace");
+  const slug = normalizeSlug(c.req.param("slug"));
+
+  const identity = await authenticate(c, logger);
+  const isAnonymous = identity === null;
+
+  const projectResult = await getProjectByPath(c.env.STATE, namespace, slug, logger);
+  if (!projectResult.success) {
+    // Only a genuine miss enters the truth table. A KV outage or corrupt entry
+    // (5xx) must surface as an error, not a bogus auth/404 that loops the client
+    // through credential retries.
+    if (projectResult.error.code !== "NOT_FOUND") {
+      logger.error("Project lookup failed for git request", projectResult.error);
+      return serverError();
+    }
+    // Missing repo: challenge the anonymous caller (so git retries with creds),
+    // 404 the authenticated one — neither path reveals existence.
+    return isAnonymous ? authChallenge() : gitNotFound();
+  }
+
+  const project = projectResult.data;
+  const canRead = await canReadProject(c.env.DB, project, identity?.userId, identity?.agentOwnerId);
+  if (!canRead) {
+    return isAnonymous ? authChallenge() : gitNotFound();
+  }
+
+  if (!artifactsRepoNameFromRemote(project.remote)) {
+    logger.warn("Git proxy requested for non-Artifacts remote", {
+      namespace,
+      slug,
+      project: project.id,
+    });
+    return new Response("git protocol is not available for this project\n", {
+      status: 501,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+
+  return project;
+}
+
+export const gitHttpRouter = new Hono<{ Bindings: Env }>();
+
+// GET /@:namespace/:slug.git/info/refs?service=git-(upload|receive)-pack
+gitHttpRouter.get("/:namespace/:slug/info/refs", async (c) => {
+  const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path, method: "GET" });
+  const service = c.req.query("service");
+  if (service === RECEIVE_PACK) return pushNotSupported();
+  if (service !== UPLOAD_PACK) {
+    return new Response("only the smart-HTTP git-upload-pack service is supported\n", {
+      status: 400,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+
+  const result = await authorizeRead(c, logger);
+  if (result instanceof Response) return result;
+
+  const upstreamUrl = `${result.remote}/info/refs?service=${UPLOAD_PACK}`;
+  return proxyUpstream(c, result, upstreamUrl, "GET", undefined, logger);
+});
+
+// POST /@:namespace/:slug.git/git-upload-pack — clone/fetch RPC
+gitHttpRouter.post("/:namespace/:slug/git-upload-pack", async (c) => {
+  const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path, method: "POST" });
+  const result = await authorizeRead(c, logger);
+  if (result instanceof Response) return result;
+
+  const body = await c.req.arrayBuffer();
+  const upstreamUrl = `${result.remote}/${UPLOAD_PACK}`;
+  return proxyUpstream(c, result, upstreamUrl, "POST", body, logger);
+});
+
+// POST /@:namespace/:slug.git/git-receive-pack — push (refused, slice 1)
+gitHttpRouter.post("/:namespace/:slug/git-receive-pack", () => pushNotSupported());

--- a/tests/git-http.test.ts
+++ b/tests/git-http.test.ts
@@ -1,0 +1,384 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../src/index";
+import { isGitHttpPath } from "../src/routes/git-http";
+import type { Env, ProjectEntry } from "../src/types";
+
+// Real `artifactsRepoNameFromRemote` + `extractTokenSecret` (pure) are kept so
+// the tests exercise the genuine URL validation; only `freshRepoToken` (which
+// needs the ARTIFACTS binding) is stubbed.
+vi.mock("../src/storage/git-ops", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/git-ops")>();
+  return {
+    ...actual,
+    freshRepoToken: vi.fn(async () => ({ success: true, data: "secret?expires=9999999999" })),
+  };
+});
+
+const OWNER_TOKEN = "stratum_user_owner000000000000000000";
+const OTHER_TOKEN = "stratum_user_other000000000000000000";
+const AGENT_TOKEN = "stratum_agent_agent00000000000000000";
+const INVALID_TOKEN = "stratum_user_invalid0000000000000000";
+
+vi.mock("../src/storage/users", () => ({
+  getUserByToken: vi.fn(async (_db: unknown, token: string) => {
+    if (token === OWNER_TOKEN)
+      return { success: true, data: { id: "user_owner", email: "o@x.io", username: "owner" } };
+    if (token === OTHER_TOKEN)
+      return { success: true, data: { id: "user_other", email: "t@x.io", username: "other" } };
+    return { success: false, error: { message: "not found" } };
+  }),
+  getUser: vi.fn(async () => ({ success: false, error: { message: "not found" } })),
+}));
+
+vi.mock("../src/storage/agents", () => ({
+  getAgentByToken: vi.fn(async (_db: unknown, token: string) => {
+    if (token === AGENT_TOKEN)
+      return { success: true, data: { id: "agent_1", ownerId: "user_owner" } };
+    return { success: false, error: { message: "not found" } };
+  }),
+}));
+
+const ARTIFACTS_REMOTE = "https://acct.artifacts.cloudflare.net/git/@owner/repo.git";
+
+function makeKV(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+  } as unknown as KVNamespace;
+}
+
+function makeEnv(): Env {
+  return {
+    ARTIFACTS: {} as unknown as Env["ARTIFACTS"],
+    STATE: makeKV(),
+    DB: {} as D1Database,
+  } as Env;
+}
+
+async function seedProject(env: Env, overrides: Partial<ProjectEntry> = {}): Promise<ProjectEntry> {
+  const project: ProjectEntry = {
+    id: "proj_1",
+    name: "repo",
+    slug: "repo",
+    namespace: "@owner",
+    ownerId: "user_owner",
+    ownerType: "user",
+    remote: ARTIFACTS_REMOTE,
+    createdAt: new Date().toISOString(),
+    visibility: "private",
+    ...overrides,
+  };
+  await env.STATE.put(`project:${project.namespace}:${project.slug}`, JSON.stringify(project));
+  return project;
+}
+
+function req(path: string, init: RequestInit = {}): Request {
+  return new Request(`http://localhost${path}`, init);
+}
+
+function basic(token: string, inUsername = false): Record<string, string> {
+  const pair = inUsername ? `${token}:` : `x:${token}`;
+  return { Authorization: `Basic ${btoa(pair)}` };
+}
+
+const ADVERTISE = "/@owner/repo.git/info/refs?service=git-upload-pack";
+
+let originalFetch: typeof fetch;
+
+function stubFetch(impl: (url: string, init: RequestInit) => Response): ReturnType<typeof vi.fn> {
+  const mock = vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) =>
+    impl(String(input), init),
+  );
+  globalThis.fetch = mock as unknown as typeof fetch;
+  return mock;
+}
+
+function okUpstream(): Response {
+  return new Response("PACKDATA", {
+    status: 200,
+    headers: { "Content-Type": "application/x-git-upload-pack-advertisement" },
+  });
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("isGitHttpPath — matches only the git route shape", () => {
+  it("matches real git endpoints", () => {
+    expect(isGitHttpPath("/@owner/repo.git/info/refs")).toBe(true);
+    expect(isGitHttpPath("/@owner/repo/git-upload-pack")).toBe(true);
+    expect(isGitHttpPath("/org-slug/repo.git/git-receive-pack")).toBe(true);
+  });
+
+  it("does NOT match routes that merely end in a git suffix", () => {
+    // The UI blob route would otherwise lose auth/CSRF/rate-limit.
+    expect(isGitHttpPath("/@owner/repo.git/blob/x/info/refs")).toBe(false);
+    expect(isGitHttpPath("/@owner/repo/blob/dir/git-upload-pack")).toBe(false);
+    expect(isGitHttpPath("/info/refs")).toBe(false);
+    expect(isGitHttpPath("/api/projects")).toBe(false);
+  });
+});
+
+describe("git smart-HTTP proxy — routing & middleware exemption (Task 1)", () => {
+  it("a Basic-auth git request reaches the router, not authMiddleware's JSON 401", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    const res = await app.fetch(req(ADVERTISE, { headers: basic(INVALID_TOKEN) }), env);
+    // authMiddleware would have returned {"error":"Invalid token"} with no challenge.
+    expect(res.status).toBe(401);
+    expect(res.headers.get("WWW-Authenticate")).toBe('Basic realm="Stratum"');
+    expect(await res.text()).not.toContain("Invalid token");
+  });
+
+  it("dispatches GET info/refs on the service param: 400 when absent", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    const res = await app.fetch(req("/@owner/repo.git/info/refs"), env);
+    expect(res.status).toBe(400);
+  });
+
+  it("git path does not fall through to the UI catch-all", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    stubFetch(() => okUpstream());
+    const res = await app.fetch(req(ADVERTISE), env);
+    expect(res.headers.get("Content-Type")).toBe("application/x-git-upload-pack-advertisement");
+  });
+});
+
+describe("git smart-HTTP proxy — auth & authorization truth table (Task 2)", () => {
+  it("anonymous + public → proxied (200)", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    const fetchMock = stubFetch(() => okUpstream());
+    const res = await app.fetch(req(ADVERTISE), env);
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("anonymous + private → 401 challenge, no upstream call", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "private" });
+    const fetchMock = stubFetch(() => okUpstream());
+    const res = await app.fetch(req(ADVERTISE), env);
+    expect(res.status).toBe(401);
+    expect(res.headers.get("WWW-Authenticate")).toBe('Basic realm="Stratum"');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("anonymous + missing → 401 challenge, byte-identical to private-exists", async () => {
+    const env = makeEnv();
+    // no project seeded
+    const res = await app.fetch(req("/@owner/missing.git/info/refs?service=git-upload-pack"), env);
+    expect(res.status).toBe(401);
+    expect(res.headers.get("WWW-Authenticate")).toBe('Basic realm="Stratum"');
+
+    const env2 = makeEnv();
+    await seedProject(env2, { visibility: "private" });
+    const privateRes = await app.fetch(req(ADVERTISE), env2);
+    expect(await res.text()).toBe(await privateRes.text());
+  });
+
+  it("owner token + private → proxied (200)", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "private" });
+    const fetchMock = stubFetch(() => okUpstream());
+    const res = await app.fetch(req(ADVERTISE, { headers: basic(OWNER_TOKEN) }), env);
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("agent owned by the user + private → proxied (200)", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "private" });
+    stubFetch(() => okUpstream());
+    const res = await app.fetch(req(ADVERTISE, { headers: basic(AGENT_TOKEN) }), env);
+    expect(res.status).toBe(200);
+  });
+
+  it("non-owner token + private → 404, byte-identical to authed+missing", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "private" });
+    const res = await app.fetch(req(ADVERTISE, { headers: basic(OTHER_TOKEN) }), env);
+    expect(res.status).toBe(404);
+
+    const env2 = makeEnv();
+    const missingRes = await app.fetch(
+      req("/@owner/missing.git/info/refs?service=git-upload-pack", {
+        headers: basic(OTHER_TOKEN),
+      }),
+      env2,
+    );
+    expect(missingRes.status).toBe(404);
+    expect(await res.text()).toBe(await missingRes.text());
+  });
+
+  it("invalid token + private → treated as anonymous (401)", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "private" });
+    const res = await app.fetch(req(ADVERTISE, { headers: basic(INVALID_TOKEN) }), env);
+    expect(res.status).toBe(401);
+  });
+
+  it("token in the username field is accepted", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "private" });
+    stubFetch(() => okUpstream());
+    const res = await app.fetch(
+      req(ADVERTISE, { headers: basic(OWNER_TOKEN, /* inUsername */ true) }),
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("non-Artifacts remote → 501 (post-authorization)", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public", remote: "https://github.com/foo/bar.git" });
+    const res = await app.fetch(req(ADVERTISE), env);
+    expect(res.status).toBe(501);
+  });
+
+  it("non-Artifacts remote + private + anonymous → 401, never 501 (no leak)", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "private", remote: "https://github.com/foo/bar.git" });
+    const res = await app.fetch(req(ADVERTISE), env);
+    expect(res.status).toBe(401);
+  });
+
+  it.each([
+    ["empty payload", "Basic "],
+    ["non-base64", "Basic !!!notbase64"],
+    ["no colon", `Basic ${btoa("nocolon")}`],
+    ["empty token", `Basic ${btoa(":")}`],
+  ])(
+    "malformed Authorization (%s) is treated as anonymous → 401 on private",
+    async (_label, header) => {
+      const env = makeEnv();
+      await seedProject(env, { visibility: "private" });
+      const res = await app.fetch(req(ADVERTISE, { headers: { Authorization: header } }), env);
+      expect(res.status).toBe(401);
+    },
+  );
+});
+
+describe("git smart-HTTP proxy — upstream proxy (Task 3)", () => {
+  it("builds the upstream URL and Artifacts Basic auth; never forwards the client token", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    const fetchMock = stubFetch(() => okUpstream());
+
+    await app.fetch(req(ADVERTISE, { headers: { "Git-Protocol": "version=2" } }), env);
+
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe(`${ARTIFACTS_REMOTE}/info/refs?service=git-upload-pack`);
+    const headers = init.headers as Record<string, string>;
+    // x:<extractTokenSecret("secret?expires=...")> = x:secret
+    expect(headers.Authorization).toBe(`Basic ${btoa("x:secret")}`);
+    expect(headers["Git-Protocol"]).toBe("version=2");
+    expect(init.redirect).toBe("manual");
+  });
+
+  it("does not leak the Artifacts token in any response header", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    stubFetch(
+      () =>
+        new Response("PACK", {
+          status: 200,
+          headers: { "Content-Type": "application/x-git-upload-pack-advertisement" },
+        }),
+    );
+    const res = await app.fetch(req(ADVERTISE), env);
+    for (const [, value] of res.headers) {
+      expect(value).not.toContain("secret");
+    }
+  });
+
+  it("POST git-upload-pack buffers and forwards the request body", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    const fetchMock = stubFetch(
+      () =>
+        new Response("PACK", {
+          status: 200,
+          headers: { "Content-Type": "application/x-git-upload-pack-result" },
+        }),
+    );
+
+    await app.fetch(
+      req("/@owner/repo.git/git-upload-pack", {
+        method: "POST",
+        body: "0032want abc\n",
+        headers: { "Content-Type": "application/x-git-upload-pack-request" },
+      }),
+      env,
+    );
+
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe(`${ARTIFACTS_REMOTE}/git-upload-pack`);
+    expect(new TextDecoder().decode(init.body as ArrayBuffer)).toBe("0032want abc\n");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/x-git-upload-pack-request",
+    );
+  });
+
+  it("POST git-upload-pack with an empty body still proxies (0-length buffer)", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    const fetchMock = stubFetch(() => new Response("PACK", { status: 200 }));
+    const res = await app.fetch(req("/@owner/repo.git/git-upload-pack", { method: "POST" }), env);
+    expect(res.status).toBe(200);
+    const body = fetchMock.mock.calls[0]?.[1]?.body as ArrayBuffer;
+    expect(body.byteLength).toBe(0);
+  });
+
+  it("maps an upstream 5xx to 502", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    stubFetch(() => new Response("boom", { status: 500 }));
+    const res = await app.fetch(req(ADVERTISE), env);
+    expect(res.status).toBe(502);
+  });
+
+  it("fails closed on an upstream redirect (no token-bearing follow)", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    stubFetch(
+      () => new Response(null, { status: 302, headers: { Location: "https://evil.test" } }),
+    );
+    const res = await app.fetch(req(ADVERTISE), env);
+    expect(res.status).toBe(502);
+  });
+});
+
+describe("git smart-HTTP proxy — receive-pack rejection (Task 4)", () => {
+  it("POST git-receive-pack → 403 naming stratum commit, no upstream call", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    const fetchMock = stubFetch(() => okUpstream());
+    const res = await app.fetch(req("/@owner/repo.git/git-receive-pack", { method: "POST" }), env);
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain("stratum commit");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("info/refs?service=git-receive-pack → 403", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    const res = await app.fetch(req("/@owner/repo.git/info/refs?service=git-receive-pack"), env);
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/smoke/git-clone.test.ts
+++ b/tests/smoke/git-clone.test.ts
@@ -1,0 +1,93 @@
+// @ts-nocheck
+/**
+ * Smoke Tests — Git smart-HTTP clone/fetch (ADR 005, slice 1)
+ *
+ * These hit a LIVE deployed Worker backed by real Cloudflare Artifacts — the
+ * only place the proxy's pkt-line framing, gzip, protocol-v2 negotiation, and
+ * redirect handling are actually exercised. Offline unit tests (stubbed fetch)
+ * cannot prove a real `git clone` works; this is the gate that does.
+ *
+ * Run with:
+ *   STAGING_URL=https://staging.app.usestratum.dev \
+ *   GIT_SMOKE_REPO=@someuser/some-public-repo \
+ *   [TEST_AUTH_TOKEN=stratum_user_…] \
+ *   npm run test:smoke
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const TARGET_URL = process.env.STAGING_URL || process.env.PRODUCTION_URL || "";
+const REPO = process.env.GIT_SMOKE_REPO || ""; // e.g. "@alice/my-public-repo"
+const TOKEN = process.env.TEST_AUTH_TOKEN || "";
+
+const configured = Boolean(TARGET_URL && REPO);
+let reachable = false;
+
+beforeAll(async () => {
+  if (!configured) return;
+  try {
+    const response = await fetch(`${TARGET_URL}/health`, { timeout: 5000 } as RequestInit);
+    reachable = response.status === 200;
+  } catch {
+    reachable = false;
+  }
+});
+
+const cloneBase = `${TARGET_URL.replace(/\/$/, "")}/${REPO}.git`;
+const authedBase = TOKEN
+  ? cloneBase.replace("://", `://x:${encodeURIComponent(TOKEN)}@`)
+  : cloneBase;
+
+const tmpDirs: string[] = [];
+afterAll(() => {
+  for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+describe.skipIf(!configured || !reachable)(`Git clone smoke — ${cloneBase}`, () => {
+  it("advertises git-upload-pack with the correct content-type and pkt-line preamble", async () => {
+    const res = await fetch(`${cloneBase}/info/refs?service=git-upload-pack`, {
+      headers: TOKEN ? { Authorization: `Basic ${btoa(`x:${TOKEN}`)}` } : {},
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/x-git-upload-pack-advertisement");
+    const body = await res.text();
+    // Smart-HTTP advertisement starts with the service pkt-line.
+    expect(body).toContain("# service=git-upload-pack");
+  });
+
+  it("refuses git-receive-pack (push) with 403", async () => {
+    const res = await fetch(`${cloneBase}/info/refs?service=git-receive-pack`, {
+      headers: TOKEN ? { Authorization: `Basic ${btoa(`x:${TOKEN}`)}` } : {},
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("clones the repo end-to-end with stock git", () => {
+    const dir = mkdtempSync(join(tmpdir(), "stratum-clone-"));
+    tmpDirs.push(dir);
+    execFileSync("git", ["clone", "--depth", "1", authedBase, dir], {
+      stdio: "pipe",
+      timeout: 60_000,
+    });
+    const entries = readdirSync(dir);
+    expect(entries).toContain(".git");
+    expect(entries.length).toBeGreaterThan(1);
+  });
+
+  it("fetches again without error", () => {
+    const dir = mkdtempSync(join(tmpdir(), "stratum-fetch-"));
+    tmpDirs.push(dir);
+    execFileSync("git", ["clone", "--depth", "1", authedBase, dir], {
+      stdio: "pipe",
+      timeout: 60_000,
+    });
+    execFileSync("git", ["-C", dir, "fetch", "--depth", "1", "origin"], {
+      stdio: "pipe",
+      timeout: 60_000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **slice 1 of ADR 005**: a git smart-HTTP proxy so a Stratum project can be used as a git remote. `git clone https://<host>/@ns/slug.git` and `git fetch` now work with stock git. Push (`git-receive-pack`) is intentionally refused and deferred to a follow-up.

New router `src/routes/git-http.ts` proxies the `git-upload-pack` service to the project's Cloudflare Artifacts backing repo: authenticate (existing API key over HTTP Basic) → authorize (`canReadProject`) → mint a short-lived Artifacts token → broker the request. The Artifacts token never leaves the Worker.

## Key decisions

- **No-existence-leak truth table:** anon+public proxies; anon+private/missing → `401` + `WWW-Authenticate`; authed+readable proxies; authed+unauthorized/missing → `404` (byte-identical no-leak pairs).
- **Middleware exemption:** the global Bearer-only `authMiddleware` (and csrf/rate-limit) step aside for git's Basic-auth requests via a **shape-anchored** `isGitHttpPath` — anchored to `/<ns>/<slug>/<git-suffix>` rather than `endsWith`, so it can't strip auth from routes like the UI `…/blob/<file>/info/refs`.
- **Workers streaming constraint:** request bodies are buffered (Workers drop streamed outbound bodies — see `git-ops.ts`), responses streamed; `redirect: "manual"` fails closed so the token can't leak across a redirect.
- **Push refused:** `git-receive-pack` → `403` pointing at `stratum commit`.

## Two corrections vs. the original ADR design (both verified in source)

- Global `app.use("*", authMiddleware)` would have 401'd every git request before the router ran → middleware exemption added.
- `duplex: "half"` outbound streaming is silently dropped on Workers → buffer request, stream response.

## Testing

- **27 unit tests** (`tests/git-http.test.ts`): truth table + byte-identical no-leak pairs, malformed-Basic variants → anonymous, token-in-username, agent identity, non-Artifacts remote → 501 (and 401 when private+anon), header hygiene (no inbound `Authorization` upstream, no token in responses, `Git-Protocol` forwarded), request-body buffering incl. empty body, upstream 5xx → 502, redirect → fail-closed, receive-pack 403, and an `isGitHttpPath` bypass regression.
- **Staging-gated smoke** (`tests/smoke/git-clone.test.ts`): a real `git clone`/`fetch` + advertisement assertions, gated on `STAGING_URL`/`GIT_SMOKE_REPO`.
- Gates: typecheck clean · full suite 858 passed / 25 skipped · Biome clean.
- A 3-agent code review found and fixed 2 issues (the `isGitHttpPath` bypass; a KV-500 conflated with not-found).

## ⚠️ Not yet done

**Live staging verification** (ADR 005 Task 5.2). Offline tests prove logic/headers/truth-table but **cannot** prove pkt-line framing, gzip, protocol-v2 negotiation, or redirect handling against real Artifacts. Run the gated smoke test against staging before treating this as production-proven.

Design: `docs/adr/005-git-smart-http-proxy.md` (status updated to slice-1-implemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
