### PR TITLE
fix(users): remove unauthenticated POST /api/users (email → token) route

### DIFF
--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,42 +1,19 @@
 import { Hono } from "hono";
 import { recordAudit } from "../storage/audit";
-import { createUser, getUser, getUserByUsername, rotateUserToken } from "../storage/users";
+import { getUser, getUserByUsername, rotateUserToken } from "../storage/users";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
-import { badRequest, created, ok } from "../utils/response";
+import { ok } from "../utils/response";
 import { validateUsername } from "../utils/username-validation";
-import { isValidEmail } from "../utils/validation";
 
 const app = new Hono<{ Bindings: Env }>();
 
-app.post("/", async (c) => {
-  const logger = createLogger({
-    requestId: crypto.randomUUID(),
-    path: c.req.path,
-    method: c.req.method,
-  });
-
-  const body = await c.req.json<{ email?: unknown }>();
-  if (!isValidEmail(body.email)) {
-    logger.warn("Invalid email in create user request");
-    return badRequest("email must be a valid email address");
-  }
-
-  const result = await createUser(c.env.DB, body.email, logger);
-
-  if (!result.success) {
-    logger.error("Failed to create user", result.error);
-    return c.json({ error: "Failed to create user" }, 500);
-  }
-
-  const { user, plaintext } = result.data;
-  logger.info("User created via API", { userId: user.id });
-
-  return created({
-    user: { id: user.id, email: user.email, createdAt: user.createdAt },
-    token: plaintext,
-  });
-});
+// NOTE: user creation has no API route. Accounts are bootstrapped only through
+// verified flows (`/auth/github`, `/auth/google`, `/auth/email` magic link, and
+// the localhost-gated `/dev-login`). API tokens are issued only to an
+// authenticated caller — see `POST /me/rotate-token` below and `POST /api/agents`.
+// An unauthenticated `email → token` endpoint previously lived here; it let
+// anyone mint a working token, bypass the closed beta, and squat emails.
 
 app.get("/me", async (c) => {
   const logger = createLogger({

--- a/tests/users.test.ts
+++ b/tests/users.test.ts
@@ -6,7 +6,6 @@ import type { Env } from "../src/types";
 import { NotFoundError } from "../src/utils/errors";
 
 vi.mock("../src/storage/users", () => ({
-  createUser: vi.fn(),
   getUser: vi.fn(),
   getUserByToken: vi.fn(),
 }));
@@ -15,7 +14,7 @@ vi.mock("../src/storage/agents", () => ({
   getAgentByToken: vi.fn(),
 }));
 
-import { createUser, getUser, getUserByToken } from "../src/storage/users";
+import { getUser, getUserByToken } from "../src/storage/users";
 
 function makeApp() {
   const app = new Hono<{ Bindings: Env }>();
@@ -57,53 +56,17 @@ const mockUser = {
   createdAt: "2026-01-01T00:00:00.000Z",
 };
 
-describe("POST /api/users", () => {
-  let app: ReturnType<typeof makeApp>;
-  let env: Env;
-
-  beforeEach(() => {
-    app = makeApp();
-    env = makeEnv();
-    vi.clearAllMocks();
-    vi.mocked(createUser).mockResolvedValue({
-      success: true,
-      data: {
-        user: mockUser,
-        plaintext: "stratum_user_deadbeef",
-      },
-    });
-  });
-
-  it("creates user with valid email and returns 201", async () => {
-    const res = await app.fetch(request("POST", "/api/users", { email: "test@example.com" }), env);
-    expect(res.status).toBe(201);
-    const body = (await res.json()) as {
-      user: { id: string; email: string; createdAt: string };
-      token: string;
-    };
-    expect(body.user.id).toBe("usr_abc123");
-    expect(body.user.email).toBe("test@example.com");
-    expect(body.token).toBe("stratum_user_deadbeef");
-    expect(body.user).not.toHaveProperty("tokenHash");
-    expect(createUser).toHaveBeenCalledWith(env.DB, "test@example.com", expect.any(Object));
-  });
-
-  it("returns 400 for invalid email", async () => {
-    const res = await app.fetch(request("POST", "/api/users", { email: "not-an-email" }), env);
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toContain("email");
-  });
-
-  it("returns 400 for missing email", async () => {
-    const res = await app.fetch(request("POST", "/api/users", {}), env);
-    expect(res.status).toBe(400);
-  });
-
-  it("propagates D1 unique constraint error as 500", async () => {
-    vi.mocked(createUser).mockRejectedValue(new Error("UNIQUE constraint failed: users.email"));
-    const res = await app.fetch(request("POST", "/api/users", { email: "dupe@example.com" }), env);
-    expect(res.status).toBe(500);
+describe("POST /api/users — removed", () => {
+  // Unauthenticated user/token creation was removed: accounts are bootstrapped
+  // only through verified flows (OAuth, magic link, dev-login). The route must
+  // not exist.
+  it("no longer mints a user+token from an email", async () => {
+    const app = makeApp();
+    const res = await app.fetch(
+      request("POST", "/api/users", { email: "attacker@example.com" }),
+      makeEnv(),
+    );
+    expect(res.status).toBe(404);
   });
 });
 


### PR DESCRIPTION
## Problem

`POST /api/users {email}` minted a working `stratum_user_` API token from **just an email** — no authentication, no email verification, no beta gate (`BETA_GATE` only guards the signup UI/referral flow, not this API route). Confirmed reachable unauthenticated on production (invalid email → `400`, not `401`).

Impact:
- **Closed-beta bypass** — anyone can self-serve a full account + API token, no invite.
- **Email / namespace squatting** — `email` is `UNIQUE NOT NULL`, so claiming `someone@company.com` first locks the real owner out of signup (denial-of-registration).
- **Spam accounts** — only throttled by the anon rate limit.

Mitigating factor (not a fix): because email is `UNIQUE`, you can't mint a second token over an *existing* account — so this is unauthenticated creation for *unclaimed* emails, not takeover of established ones.

## Fix

Remove the route entirely. Nothing in the frontend, CLI, or agent calls it (verified by grep) — it was a seed/dev convenience that was never locked down.

Account creation already happens **only through verified flows**:
- GitHub / Google OAuth (`src/routes/auth.ts`)
- email magic link (`src/routes/email-auth.tsx`)
- localhost-gated `/dev-login` (`src/index.ts`)

…and API tokens are issued **only to an authenticated caller** — `POST /api/users/me/rotate-token` and `POST /api/agents` both start with `if (!userId) return unauthorized(...)`. This change aligns `/api/users` with that convention. The `createUser` storage helper is untouched; only its unauthenticated HTTP entrypoint is gone.

## Tests

Replaced the route's test suite with a guard asserting `POST /api/users` now returns `404`. Typecheck ✅ · full suite 828 passed ✅ · Biome ✅.

## Note on seeding

`scripts/seed-preview.ts` documented using this endpoint to obtain a token. Seeding should now use `/dev-login` locally (already what the script's `STRATUM_SESSION` path supports) or a token from an authenticated session. No code depends on the removed route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
