### PR TITLE
fix(merge): merge the evaluated commit, not the workspace's live tip (#115)

### DIFF
--- a/migrations/024_change_workspace_head_sha.sql
+++ b/migrations/024_change_workspace_head_sha.sql
@@ -1,0 +1,5 @@
+-- The exact workspace commit sha that a change was evaluated against. The merge
+-- gate must merge *this* commit, not the workspace branch's current tip — pinning
+-- it closes a TOCTOU where a re-push between evaluation and merge could land
+-- unevaluated content on the project's default branch (ADR 005 / #115).
+ALTER TABLE changes ADD COLUMN workspace_head_sha TEXT;

--- a/src/queue/merge-queue.ts
+++ b/src/queue/merge-queue.ts
@@ -64,7 +64,12 @@ export class MergeQueue extends DurableObject<Env> {
         workspace.remote,
         workspaceToken.data,
         log,
-        { strategy: "merge", timer },
+        // Merge the exact evaluated commit, not the workspace's live tip (#115).
+        {
+          strategy: "merge",
+          timer,
+          ...(change.workspaceHeadSha ? { workspaceSha: change.workspaceHeadSha } : {}),
+        },
       );
 
       if (!commitResult.success) {

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -279,7 +279,9 @@ app.post("/projects/:name/changes", async (c) => {
     logger.error("Failed to get diff between repos", diffResult.error);
     return badRequest(diffResult.error.message);
   }
-  const diff = diffResult.data;
+  // Pin the exact commit the diff was computed from, so the merge consumes this
+  // sha rather than a later re-pushed tip (gate soundness — #115).
+  const { diff, workspaceSha: workspaceHeadSha } = diffResult.data;
 
   const evaluators: Array<{ type: string; evaluator: Evaluator }> = [
     { type: "secret_scan", evaluator: new SecretScanEvaluator() },
@@ -378,6 +380,7 @@ app.post("/projects/:name/changes", async (c) => {
     evalScore: evalResult.score,
     evalPassed: evalResult.passed,
     evalReason: evalResult.reason,
+    ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
   });
   if (!updateResult.success) {
     logger.error("Failed to update change status", updateResult.error);
@@ -404,6 +407,7 @@ app.post("/projects/:name/changes", async (c) => {
     evalScore: evalResult.score,
     evalPassed: evalResult.passed,
     evalReason: evalResult.reason,
+    ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
   };
 
   logger.info("Change created and evaluated", {
@@ -708,7 +712,8 @@ app.post("/changes/:id/merge", async (c) => {
     workspace.remote,
     workspaceMergeToken.data,
     logger,
-    { strategy },
+    // Merge the exact evaluated commit, not the workspace's live tip (#115).
+    { strategy, ...(change.workspaceHeadSha ? { workspaceSha: change.workspaceHeadSha } : {}) },
   );
   if (!mergeResult.success) {
     if (mergeResult.error instanceof MergeConflictError) {
@@ -1204,7 +1209,9 @@ app.post("/changes/:id/evaluate", async (c) => {
     logger.error("Failed to get diff between repos", diffResult.error);
     return badRequest(diffResult.error.message);
   }
-  const diff = diffResult.data;
+  // Pin the exact commit the diff was computed from, so the merge consumes this
+  // sha rather than a later re-pushed tip (gate soundness — #115).
+  const { diff, workspaceSha: workspaceHeadSha } = diffResult.data;
 
   const evaluators: Array<{ type: string; evaluator: Evaluator }> = [
     { type: "secret_scan", evaluator: new SecretScanEvaluator() },
@@ -1301,6 +1308,8 @@ app.post("/changes/:id/evaluate", async (c) => {
       evalScore: evalResult.score,
       evalPassed: evalResult.passed,
       evalReason: evalResult.reason,
+      // Re-pin to the commit this re-evaluation actually ran against (#115).
+      ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
     },
   );
   if (!updateResult.success) {

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -570,7 +570,7 @@ app.get("/changes/:id", async (c) => {
           logger,
         );
         if (diffResult.success) {
-          diffFiles = parseUnifiedDiff(diffResult.data);
+          diffFiles = parseUnifiedDiff(diffResult.data.diff);
         } else {
           logger.warn("Failed to load change diff", { changeId: change.id });
         }

--- a/src/storage/changes.ts
+++ b/src/storage/changes.ts
@@ -14,6 +14,7 @@ interface ChangeRow {
   eval_passed: number | null;
   eval_reason: string | null;
   base_sha: string | null;
+  workspace_head_sha: string | null;
   created_at: string;
   merged_at: string | null;
   github_owner: string | null;
@@ -41,6 +42,7 @@ function rowToChange(row: ChangeRow): Change {
   if (row.eval_passed !== null) change.evalPassed = row.eval_passed === 1;
   if (row.eval_reason !== null) change.evalReason = row.eval_reason;
   if (row.base_sha !== null) change.baseSha = row.base_sha;
+  if (row.workspace_head_sha !== null) change.workspaceHeadSha = row.workspace_head_sha;
   if (row.merged_at !== null) change.mergedAt = row.merged_at;
   if (row.github_owner !== null) change.githubOwner = row.github_owner;
   if (row.github_repo !== null) change.githubRepo = row.github_repo;
@@ -248,6 +250,7 @@ export async function updateChangeStatus(
     evalScore?: number;
     evalPassed?: boolean;
     evalReason?: string;
+    workspaceHeadSha?: string;
     mergedAt?: string;
     githubOwner?: string;
     githubRepo?: string;
@@ -287,6 +290,7 @@ export async function updateChangeStatus(
       opts?.evalPassed !== undefined ? (opts.evalPassed ? 1 : 0) : undefined,
     );
     addOptional("eval_reason", opts?.evalReason);
+    addOptional("workspace_head_sha", opts?.workspaceHeadSha);
     addOptional("merged_at", opts?.mergedAt);
     addOptional("github_owner", opts?.githubOwner);
     addOptional("github_repo", opts?.githubRepo);

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -114,6 +114,15 @@ export interface MergeWorkspaceOptions {
   strategy?: MergeStrategy;
   /** Optional Phase 0 instrumentation; populates per-phase spans when present. */
   timer?: PhaseTimer;
+  /**
+   * The exact workspace commit to merge (the sha the change was evaluated
+   * against). When set, the merge uses this commit instead of the workspace's
+   * live `main` tip — closing the TOCTOU where a re-push between evaluation and
+   * merge would otherwise land unevaluated content. Omit to merge the live tip
+   * (legacy behavior, unchanged). The sha must be reachable in the fetched
+   * workspace history, else the merge fails closed.
+   */
+  workspaceSha?: string;
 }
 
 export class MergeConflictError extends AppError {
@@ -413,26 +422,47 @@ export async function mergeWorkspaceIntoProject(
   }
 
   let workspaceSha: string;
-  const resolveFetchResult = await fromPromise(git.resolveRef({ fs, dir, ref: "FETCH_HEAD" }));
-  if (resolveFetchResult.success) {
-    workspaceSha = resolveFetchResult.data;
-  } else {
-    const resolveRemoteResult = await fromPromise(
-      git.resolveRef({ fs, dir, ref: "refs/remotes/workspace/main" }),
-    );
-    if (!resolveRemoteResult.success) {
-      logger.error("Failed to resolve workspace ref", resolveRemoteResult.error, {
+  if (options.workspaceSha) {
+    // Pin to the evaluated commit. It must be reachable in the just-fetched
+    // history; if a re-push rewound past it, readCommit throws and we fail
+    // closed rather than merge a different (unevaluated) tip.
+    const pinnedResult = await fromPromise(git.readCommit({ fs, dir, oid: options.workspaceSha }));
+    if (!pinnedResult.success) {
+      logger.error("Pinned workspace sha not reachable in workspace", pinnedResult.error, {
         workspaceRemote,
+        workspaceSha: options.workspaceSha,
       });
       return err(
         new ExternalServiceError(
           "Git",
-          "Failed to resolve workspace ref",
-          resolveRemoteResult.error,
+          "Evaluated workspace commit is no longer present in the workspace",
+          pinnedResult.error,
         ),
       );
     }
-    workspaceSha = resolveRemoteResult.data;
+    workspaceSha = options.workspaceSha;
+  } else {
+    const resolveFetchResult = await fromPromise(git.resolveRef({ fs, dir, ref: "FETCH_HEAD" }));
+    if (resolveFetchResult.success) {
+      workspaceSha = resolveFetchResult.data;
+    } else {
+      const resolveRemoteResult = await fromPromise(
+        git.resolveRef({ fs, dir, ref: "refs/remotes/workspace/main" }),
+      );
+      if (!resolveRemoteResult.success) {
+        logger.error("Failed to resolve workspace ref", resolveRemoteResult.error, {
+          workspaceRemote,
+        });
+        return err(
+          new ExternalServiceError(
+            "Git",
+            "Failed to resolve workspace ref",
+            resolveRemoteResult.error,
+          ),
+        );
+      }
+      workspaceSha = resolveRemoteResult.data;
+    }
   }
 
   if (options.strategy === "squash") {
@@ -1782,7 +1812,7 @@ export async function getDiffBetweenRepos(
   workspaceRemote: string,
   workspaceToken: string,
   logger: Logger,
-): Promise<Result<string, AppError>> {
+): Promise<Result<{ diff: string; workspaceSha: string }, AppError>> {
   logger.debug("Getting diff between repos", { baseRemote, workspaceRemote });
 
   const [workspaceCloneResult, baseCloneResult] = await Promise.all([
@@ -1793,8 +1823,24 @@ export async function getDiffBetweenRepos(
   if (!workspaceCloneResult.success) return err(workspaceCloneResult.error);
   if (!baseCloneResult.success) return err(baseCloneResult.error);
 
-  const { fs: workspaceFs } = workspaceCloneResult.data;
+  const { fs: workspaceFs, dir: workspaceDir } = workspaceCloneResult.data;
   const { fs: baseFs } = baseCloneResult.data;
+
+  // Resolve the workspace tip from this very clone, so the sha we pin for the
+  // merge is provably the same content we are about to evaluate (no second
+  // clone / re-push window — gate soundness, #115).
+  const workspaceShaResult = await fromPromise(
+    git.resolveRef({ fs: workspaceFs, dir: workspaceDir, ref: "main" }),
+  );
+  if (!workspaceShaResult.success) {
+    logger.error("Failed to resolve workspace head for diff", workspaceShaResult.error, {
+      workspaceRemote,
+    });
+    return err(
+      new ExternalServiceError("Git", "Failed to resolve workspace head", workspaceShaResult.error),
+    );
+  }
+  const workspaceSha = workspaceShaResult.data;
 
   const [workspaceFilesResult, baseFilesResult] = await Promise.all([
     listFilesAtCommit(workspaceFs, "main", logger),
@@ -1827,7 +1873,7 @@ export async function getDiffBetweenRepos(
 
   const diff = buildUnifiedDiff(baseContent, workspaceContent);
   logger.info("Successfully generated diff between repos", { baseRemote, workspaceRemote });
-  return ok(diff);
+  return ok({ diff, workspaceSha });
 }
 
 export function buildUnifiedDiff(

--- a/src/types.ts
+++ b/src/types.ts
@@ -347,6 +347,12 @@ export interface Change {
   evalReason?: string;
   /** Project HEAD at change creation — the base the evaluation ran against. */
   baseSha?: string;
+  /**
+   * The workspace commit sha the evaluation ran against. The merge gate merges
+   * *this* sha (not the workspace's live tip), so a re-push between eval and
+   * merge cannot land unevaluated content on the default branch.
+   */
+  workspaceHeadSha?: string;
   createdAt: string;
   mergedAt?: string;
   githubOwner?: string;

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -304,7 +304,7 @@ describe("POST /api/projects/:name/changes", () => {
     });
     vi.mocked(getDiffBetweenRepos).mockResolvedValue({
       success: true,
-      data: "diff --git a/src/index.ts b/src/index.ts\n+new line",
+      data: { diff: "diff --git a/src/index.ts b/src/index.ts\n+new line", workspaceSha: "sha_ws" },
     });
     vi.mocked(updateChangeStatus).mockResolvedValue({
       success: true,
@@ -349,7 +349,8 @@ describe("POST /api/projects/:name/changes", () => {
       expect.any(Object),
       "chg_abc123",
       "accepted",
-      expect.objectContaining({ evalPassed: true }),
+      // Pins the evaluated workspace commit (from the diff's own clone) for a sound merge.
+      expect.objectContaining({ evalPassed: true, workspaceHeadSha: "sha_ws" }),
     );
     expect(recordEvalRuns).toHaveBeenCalledWith(
       env.DB,
@@ -897,6 +898,29 @@ describe("POST /api/changes/:id/merge", () => {
       "chg_abc123",
       "merged",
       expect.objectContaining({ mergedAt: expect.any(String) }),
+    );
+  });
+
+  it("merges the pinned evaluated sha, not the workspace's live tip", async () => {
+    const pinnedChange: Change = {
+      ...mockChange,
+      status: "accepted",
+      workspaceHeadSha: "sha_evaluated",
+    };
+    vi.mocked(getChange).mockResolvedValue({ success: true, data: pinnedChange });
+
+    const res = await app.fetch(
+      request("POST", "/api/changes/chg_abc123/merge", undefined, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(mergeWorkspaceIntoProject).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({ workspaceSha: "sha_evaluated" }),
     );
   });
 


### PR DESCRIPTION
## Problem (gate soundness / TOCTOU)

The merge gate evaluates a change against the workspace tip, then merges whatever the workspace's `main` points at **at merge time**. A re-push between evaluation and merge lands **unevaluated content** on the project default branch — defeating the gate, for any change source (CLI `stratum commit`, REST, or git push). This is PR B1 of completing #115 (gated `git push`), but it's an independent correctness fix.

## Fix — pin and merge the evaluated commit

- **Migration 024**: `changes.workspace_head_sha` records the commit a change was evaluated against.
- **`getDiffBetweenRepos`** now returns `{ diff, workspaceSha }`, resolving the sha from the **same clone** it diffs — so the pinned sha is provably the evaluated content. (Also removes a redundant second clone that an earlier draft used, which had a cross-clone race — caught in review.)
- **`mergeWorkspaceIntoProject`** gains an optional `workspaceSha`: when set it `readCommit`-verifies the sha is reachable in the freshly-fetched workspace and merges **that** commit (3-way **and** squash). If a re-push rewound past it, the merge **fails closed** rather than merging a different tip. Omitted ⇒ legacy live-tip behavior (NULL on pre-migration changes — backward compatible).
- Threaded through the **production** merge paths: the cold `POST /changes/:id/merge` path and `MergeQueue.merge`.

## Scope / performance

Production runs `REPO_DO_ENABLED=false`, so **every production merge now goes through the pinned path**. The staging-only R2/group-commit fast path (`mergeViaR2`/`fastForwardMerge`/`batchMergeStagedTrees`) still resolves the live tip — it must be pinned **before `REPO_DO_ENABLED=true` ships to prod** (follow-up). That path is **untouched here**, so the throughput benchmark is unchanged:

```
group-commit: 431.1 c/s   (baseline 431.1; target 22.6) — no regression
```

## Tests / review

- Unit: change-create persists the pinned sha (from the diff clone); merge threads `workspaceSha` into `mergeWorkspaceIntoProject`; the no-pin (legacy) path still passes `{strategy}` only.
- Typecheck ✅ · full suite 856 ✅ · Biome ✅ · throughput benchmark ✅.
- A focused security review confirmed fail-closed behavior, squash pinning, reachability, production routing, backward-compat, and that the cross-clone capture race is closed.

⚠️ Follow-up (blocking for R2-in-prod): pin the R2/group-commit fast path to the evaluated sha/tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace commit SHA is now captured during change evaluation and pinned to each change record, ensuring merges execute against the exact evaluated workspace state rather than the workspace's current live tip.

* **Tests**
  * Added test coverage to verify merged changes use the pinned evaluated workspace commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->