### PR TITLE
docs(api): document project & account deletion endpoints (deletion PR-3)

### DIFF
--- a/docs/api/endpoints/projects.md
+++ b/docs/api/endpoints/projects.md
@@ -11,3 +11,18 @@
 
 ## Import from GitHub
 `POST /api/projects/{namespace}/{slug}/import`
+
+## Delete Project
+`DELETE /api/projects/{namespace}/{slug}`
+
+Permanently deletes a project and **all** associated data (repo + workspace
+forks, changes, issues, events, metrics, webhooks). **Owner-only.** The request
+body must confirm the exact path:
+
+```json
+{ "confirm": "@namespace/slug" }
+```
+
+Returns `202 Accepted` with `{ "status": "deleting", "jobId": "del_…" }` — the
+cascade runs asynchronously and is idempotent/resumable. A mismatched `confirm`
+returns `400`; a non-owner returns `404`.

--- a/docs/api/endpoints/users.md
+++ b/docs/api/endpoints/users.md
@@ -4,3 +4,22 @@
 `GET /api/users`
 
 Returns the authenticated user's profile.
+
+## Delete Account
+`DELETE /api/users/me`
+
+GDPR-grade account erasure. Deletes the caller's account and **all** owned
+projects, revokes all tokens/sessions (and the user's agents), and **anonymizes**
+the user's contributions to *other* people's projects (author set to a
+`deleted-user` tombstone — the contribution stays, the identity is removed).
+Requires confirmation with the caller's own username:
+
+```json
+{ "confirm": "<your-username>" }
+```
+
+Setting deletion **immediately invalidates the caller's credentials** (subsequent
+requests return `401`). Returns `202 Accepted` with
+`{ "status": "deleting", "jobId": "del_…" }`; the cascade runs asynchronously and
+always completes (org sole-ownership is auto-resolved, never blocking erasure). A
+mismatched `confirm` returns `400`.

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -57,13 +57,26 @@ paths:
           application/json:
             schema:
               type: object
+              required: [confirm]
               properties:
                 confirm:
                   type: string
                   description: Must exactly equal "@namespace/slug".
       responses:
         '202':
-          description: Deletion enqueued (jobId returned)
+          description: Deletion enqueued
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status, jobId]
+                properties:
+                  status:
+                    type: string
+                    example: deleting
+                  jobId:
+                    type: string
+                    example: del_abc123
         '400':
           description: Confirmation mismatch
         '404':
@@ -78,12 +91,25 @@ paths:
           application/json:
             schema:
               type: object
+              required: [confirm]
               properties:
                 confirm:
                   type: string
                   description: Must exactly equal the caller's username.
       responses:
         '202':
-          description: Erasure enqueued; credentials invalidated immediately
+          description: Erasure enqueued (jobId returned); credentials invalidated immediately
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status, jobId]
+                properties:
+                  status:
+                    type: string
+                    example: deleting
+                  jobId:
+                    type: string
+                    example: del_abc123
         '400':
           description: Confirmation mismatch

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -36,3 +36,54 @@ paths:
       responses:
         '201':
           description: Project created
+
+  /api/projects/{namespace}/{slug}:
+    delete:
+      summary: Delete project (owner-only, cascading, async)
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                confirm:
+                  type: string
+                  description: Must exactly equal "@namespace/slug".
+      responses:
+        '202':
+          description: Deletion enqueued (jobId returned)
+        '400':
+          description: Confirmation mismatch
+        '404':
+          description: Not found or not the owner
+
+  /api/users/me:
+    delete:
+      summary: Delete account (GDPR erasure, self-only, async)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                confirm:
+                  type: string
+                  description: Must exactly equal the caller's username.
+      responses:
+        '202':
+          description: Erasure enqueued; credentials invalidated immediately
+        '400':
+          description: Confirmation mismatch


### PR DESCRIPTION
Documents the DELETE endpoints shipped by the deletion feature (Task 7). Stacks on [PR-2 #127](https://github.com/stratum-eng/stratum/pull/127).

- `docs/api/endpoints/projects.md` — `DELETE /api/projects/{ns}/{slug}` (owner-only, exact `@ns/slug` confirm, 202 + async cascade)
- `docs/api/endpoints/users.md` — `DELETE /api/users/me` (GDPR erasure, username confirm, immediate credential revocation, anonymized cross-project contributions)
- `docs/api/openapi.yml` — both paths with confirm-token request bodies + response codes

Doc-only; no code. The sweep found these enumerations were the only stale docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented permanent project deletion, including required confirmation, owner authorization, asynchronous processing, and response codes.
  - Documented account deletion with credential revocation, data erasure, contribution anonymization, and required confirmation.
  - Updated the OpenAPI specification with both deletion endpoints, request formats, and documented responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->