### PR TITLE
Stop capturing scanner noise in analytics middleware

### DIFF
--- a/src/middleware/analytics.ts
+++ b/src/middleware/analytics.ts
@@ -10,6 +10,9 @@ export const analyticsMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (
   await next();
   const path = c.req.path;
   if (path === "/health") return;
+  // Unmatched routes are overwhelmingly internet scanners probing for
+  // /.env, /.git/config, and the like — noise, not product traffic.
+  if (c.res.status === 404) return;
 
   const latency = Date.now() - start;
   const userId = c.get("userId");
@@ -24,15 +27,19 @@ export const analyticsMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (
     agentId,
   });
 
+  const distinctId = userId ?? agentId ?? "server";
   const client = createPostHogClient(c.env);
   const capture = client.capture({
     event: "api_request",
-    distinctId: "server",
+    distinctId,
     properties: {
       method: c.req.method,
       path,
       status: c.res.status,
       latency_ms: latency,
+      // Unattributed events would otherwise accrete on a shared "server"
+      // person profile; capture them personless instead.
+      ...(distinctId === "server" ? { $process_person_profile: false } : {}),
     },
   });
   try {

--- a/tests/analytics-middleware.test.ts
+++ b/tests/analytics-middleware.test.ts
@@ -1,0 +1,111 @@
+import { Hono } from "hono";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { analyticsMiddleware } from "../src/middleware/analytics";
+import type { Env } from "../src/types";
+
+interface CapturedEvent {
+  event: string;
+  distinct_id: string;
+  properties: Record<string, string | number | boolean>;
+}
+
+function makeApp(vars: { userId?: string; agentId?: string } = {}) {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", async (c, next) => {
+    if (vars.userId) c.set("userId", vars.userId);
+    if (vars.agentId) c.set("agentId", vars.agentId);
+    await next();
+  });
+  app.use("*", analyticsMiddleware);
+  app.get("/api/changes", (c) => c.json({ ok: true }));
+  app.get("/health", (c) => c.json({ ok: true }));
+  return app;
+}
+
+const env = { POSTHOG_API_KEY: "phc_test", POSTHOG_HOST: "https://ph.example.com" } as Env;
+
+function stubCapture(): CapturedEvent[] {
+  const captured: CapturedEvent[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init?: RequestInit) => {
+      captured.push(JSON.parse(init?.body as string) as CapturedEvent);
+      return new Response("ok");
+    }),
+  );
+  return captured;
+}
+
+async function flushCapture() {
+  // The middleware fires capture without awaiting it (waitUntil outside
+  // workers falls back to a floating promise); let it settle.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("analyticsMiddleware", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("captures matched requests with method, path, status, and latency", async () => {
+    const captured = stubCapture();
+    const res = await makeApp().fetch(new Request("https://api.example.com/api/changes"), env);
+    await flushCapture();
+
+    expect(res.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.event).toBe("api_request");
+    expect(captured[0]?.properties.method).toBe("GET");
+    expect(captured[0]?.properties.path).toBe("/api/changes");
+    expect(captured[0]?.properties.status).toBe(200);
+  });
+
+  it("does not capture 404s (scanner probes on unmatched routes)", async () => {
+    const captured = stubCapture();
+    const res = await makeApp().fetch(new Request("https://api.example.com/.env"), env);
+    await flushCapture();
+
+    expect(res.status).toBe(404);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("does not capture /health", async () => {
+    const captured = stubCapture();
+    await makeApp().fetch(new Request("https://api.example.com/health"), env);
+    await flushCapture();
+
+    expect(captured).toHaveLength(0);
+  });
+
+  it("attributes events to the authenticated user", async () => {
+    const captured = stubCapture();
+    await makeApp({ userId: "user-123" }).fetch(
+      new Request("https://api.example.com/api/changes"),
+      env,
+    );
+    await flushCapture();
+
+    expect(captured[0]?.distinct_id).toBe("user-123");
+    expect(captured[0]?.properties.$process_person_profile).toBeUndefined();
+  });
+
+  it("attributes events to the agent when no user is set", async () => {
+    const captured = stubCapture();
+    await makeApp({ agentId: "agent-42" }).fetch(
+      new Request("https://api.example.com/api/changes"),
+      env,
+    );
+    await flushCapture();
+
+    expect(captured[0]?.distinct_id).toBe("agent-42");
+  });
+
+  it("captures unattributed events personless under the server id", async () => {
+    const captured = stubCapture();
+    await makeApp().fetch(new Request("https://api.example.com/api/changes"), env);
+    await flushCapture();
+
+    expect(captured[0]?.distinct_id).toBe("server");
+    expect(captured[0]?.properties.$process_person_profile).toBe(false);
+  });
+});

--- a/tests/analytics-middleware.test.ts
+++ b/tests/analytics-middleware.test.ts
@@ -89,6 +89,17 @@ describe("analyticsMiddleware", () => {
     expect(captured[0]?.properties.$process_person_profile).toBeUndefined();
   });
 
+  it("prefers the user over the agent when both are set", async () => {
+    const captured = stubCapture();
+    await makeApp({ userId: "user-123", agentId: "agent-42" }).fetch(
+      new Request("https://api.example.com/api/changes"),
+      env,
+    );
+    await flushCapture();
+
+    expect(captured[0]?.distinct_id).toBe("user-123");
+  });
+
   it("attributes events to the agent when no user is set", async () => {
     const captured = stubCapture();
     await makeApp({ agentId: "agent-42" }).fetch(


### PR DESCRIPTION
## Summary
`analyticsMiddleware` captured every incoming request as an `api_request` event with a hardcoded `distinctId: "server"` — **48,633 events across 10,778 distinct paths in the last 30 days**, the vast majority being vulnerability scanners probing `/.env`, `/.git/config`, `/.aws/credentials`, etc., all accreting on one mega-person named "server" in PostHog.

Changes:
- **Skip 404 responses** — unmatched routes are overwhelmingly scanner probes, not product traffic. This kills virtually all the noise.
- **Attribute events to the real actor**: `userId ?? agentId ?? "server"`.
- **Capture the unattributed remainder personless** (`$process_person_profile: false`) so anonymous server events stop building a person profile.

## Testing
- New `tests/analytics-middleware.test.ts` covers: capture shape on matched routes, 404 and `/health` skips, user/agent attribution, and the personless fallback.
- Full suite: 861 passed, 25 skipped. `typecheck` and `lint` clean.

Fixes STR-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics now ignores 404 responses and other unmatched/scanner traffic, reducing noisy events.
  * Event attribution now uses the most specific available identity, falling back from user to agent to server.
  * Server-originated events no longer get attached to a shared person profile.

* **Tests**
  * Added coverage for route matching, 404 handling, health checks, and analytics attribution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->