### PR TITLE
fix(audit): tranche 1 — safe high-value remediation

### DIFF
--- a/src/merge/protection.ts
+++ b/src/merge/protection.ts
@@ -65,6 +65,9 @@ export async function checkMergeProtection(
 
   const requiredApprovals = merge.requiredApprovals ?? 0;
   if (requiredApprovals > 0) {
+    // NOTE: self-approval exclusion (countApprovals' excludeUserId arg) is wired in a
+    // follow-up — the `changes` table records no creating-user id yet (only agentId),
+    // so excluding the author requires a schema addition. Tracked in TASKS.md.
     const approvalsResult = await countApprovals(db, logger, change.id);
     if (!approvalsResult.success) return err(approvalsResult.error);
     if (approvalsResult.data < requiredApprovals) {

--- a/src/routes/bulk-import.ts
+++ b/src/routes/bulk-import.ts
@@ -192,7 +192,6 @@ export async function processRepoImport(
       return { success: false, error: setResult.error.message, repo: url };
     }
 
-    // Mark as successful (actual import happens in background)
     await updateImportStatus(
       env.DB,
       namespace,
@@ -201,6 +200,19 @@ export async function processRepoImport(
       logger,
       `Bulk import job ${index + 1}/${total} queued`,
     );
+
+    // Actually enqueue the clone — without this the job stays "queued" forever and
+    // the repo is never imported (the single-import path in projects.ts does this).
+    const { queueImportJob } = await import("../queue/import-queue");
+    await queueImportJob(env.IMPORT_QUEUE, {
+      importId,
+      projectId,
+      namespace,
+      slug,
+      githubUrl: url,
+      branch,
+      depth: 10,
+    });
 
     job && job.successfulRepos++;
     return { success: true, repo: url };

--- a/src/routes/bulk-import.ts
+++ b/src/routes/bulk-import.ts
@@ -192,6 +192,32 @@ export async function processRepoImport(
       return { success: false, error: setResult.error.message, repo: url };
     }
 
+    // Enqueue the clone FIRST, then mark "queued" only once it's accepted — so a
+    // queue outage surfaces as a "failed" repo, not a row stuck at "queued" forever.
+    // (Without this enqueue the repo would never actually be imported.)
+    try {
+      const { queueImportJob } = await import("../queue/import-queue");
+      await queueImportJob(env.IMPORT_QUEUE, {
+        importId,
+        projectId,
+        namespace,
+        slug,
+        githubUrl: url,
+        branch,
+        depth: 10,
+      });
+    } catch (queueError) {
+      const msg = queueError instanceof Error ? queueError.message : String(queueError);
+      logger.error(
+        "Failed to enqueue bulk import job",
+        queueError instanceof Error ? queueError : undefined,
+        { namespace, slug },
+      );
+      await updateImportStatus(env.DB, namespace, slug, "failed", logger, `Enqueue failed: ${msg}`);
+      job && job.failedRepos++;
+      return { success: false, error: `Failed to enqueue import: ${msg}`, repo: url };
+    }
+
     await updateImportStatus(
       env.DB,
       namespace,
@@ -200,19 +226,6 @@ export async function processRepoImport(
       logger,
       `Bulk import job ${index + 1}/${total} queued`,
     );
-
-    // Actually enqueue the clone — without this the job stays "queued" forever and
-    // the repo is never imported (the single-import path in projects.ts does this).
-    const { queueImportJob } = await import("../queue/import-queue");
-    await queueImportJob(env.IMPORT_QUEUE, {
-      importId,
-      projectId,
-      namespace,
-      slug,
-      githubUrl: url,
-      branch,
-      depth: 10,
-    });
 
     job && job.successfulRepos++;
     return { success: true, repo: url };

--- a/src/routes/sync-management.ts
+++ b/src/routes/sync-management.ts
@@ -508,6 +508,13 @@ app.post("/projects/conflicts/:id/resolve", async (c) => {
   }
   const project = projectResult.data;
 
+  // Resolving a conflict mints a write token and pushes a merge into the project
+  // repo, so it requires project write access — not merely knowing the (unguessable
+  // but leakable) conflict id. Collapse to 404 to avoid leaking existence.
+  if (!(await canWriteProject(c.env.DB, project, userId))) {
+    return c.json({ error: "Project not found" }, 404);
+  }
+
   const workspaceResult = await getWorkspace(
     c.env.STATE,
     project.id,

--- a/src/storage/change-reviews.ts
+++ b/src/storage/change-reviews.ts
@@ -188,14 +188,18 @@ export async function countApprovals(
   db: D1Database,
   logger: Logger,
   changeId: string,
+  /** The change author (createdByUserId): their own approval must not count
+   * toward requiredApprovals — otherwise a lone writer self-approves and merges. */
+  excludeUserId?: string,
 ): Promise<Result<number, AppError>> {
   try {
-    const row = await db
-      .prepare(
-        "SELECT COUNT(*) AS approvals FROM change_reviews WHERE change_id = ? AND verdict = 'approve'",
-      )
-      .bind(changeId)
-      .first<{ approvals: number }>();
+    const sql = excludeUserId
+      ? "SELECT COUNT(*) AS approvals FROM change_reviews WHERE change_id = ? AND verdict = 'approve' AND NOT (author_type = 'user' AND author_id = ?)"
+      : "SELECT COUNT(*) AS approvals FROM change_reviews WHERE change_id = ? AND verdict = 'approve'";
+    const stmt = excludeUserId
+      ? db.prepare(sql).bind(changeId, excludeUserId)
+      : db.prepare(sql).bind(changeId);
+    const row = await stmt.first<{ approvals: number }>();
     return ok(row?.approvals ?? 0);
   } catch (error) {
     const appError = toAppError(error, "countApprovals", { changeId });

--- a/src/storage/change-reviews.ts
+++ b/src/storage/change-reviews.ts
@@ -193,8 +193,10 @@ export async function countApprovals(
   excludeUserId?: string,
 ): Promise<Result<number, AppError>> {
   try {
+    // change_reviews keys the approver on reviewer_id (author_type/author_id are on
+    // change_comments, a different table) — filter on the column that actually exists.
     const sql = excludeUserId
-      ? "SELECT COUNT(*) AS approvals FROM change_reviews WHERE change_id = ? AND verdict = 'approve' AND NOT (author_type = 'user' AND author_id = ?)"
+      ? "SELECT COUNT(*) AS approvals FROM change_reviews WHERE change_id = ? AND verdict = 'approve' AND reviewer_id != ?"
       : "SELECT COUNT(*) AS approvals FROM change_reviews WHERE change_id = ? AND verdict = 'approve'";
     const stmt = excludeUserId
       ? db.prepare(sql).bind(changeId, excludeUserId)

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -187,9 +187,11 @@ export function isStringRecord(value: unknown): value is Record<string, string> 
 }
 
 // Multi-provider URL patterns
-const GITHUB_REPO_RE = /^https?:\/\/github\.com\/[^/]+\/[^/\s]+/i;
-const GITLAB_REPO_RE = /^https?:\/\/gitlab\.com\/.+\/[^/\s]+/i;
-const BITBUCKET_REPO_RE = /^https?:\/\/bitbucket\.org\/[^/]+\/[^/\s]+/i;
+// https only: an http:// clone exposes the fetch to MITM (the host is still
+// pinned to the three providers below, so this is downgrade protection).
+const GITHUB_REPO_RE = /^https:\/\/github\.com\/[^/]+\/[^/\s]+/i;
+const GITLAB_REPO_RE = /^https:\/\/gitlab\.com\/.+\/[^/\s]+/i;
+const BITBUCKET_REPO_RE = /^https:\/\/bitbucket\.org\/[^/]+\/[^/\s]+/i;
 
 /**
  * Validates a repository URL from any supported provider (GitHub, GitLab, Bitbucket).

--- a/tests/change-reviews.test.ts
+++ b/tests/change-reviews.test.ts
@@ -79,7 +79,7 @@ function makeReviewsD1(): { db: D1Database; comments: CommentRow[]; reviews: Rev
       first: async <T>() => {
         if (upper.includes("COUNT(*)")) {
           // Honor the optional author-exclusion clause (bindings[1] = excludeUserId).
-          const excludeUserId = upper.includes("NOT (AUTHOR_TYPE")
+          const excludeUserId = upper.includes("REVIEWER_ID !=")
             ? (bindings[1] as string)
             : undefined;
           const approvals = reviews.filter(

--- a/tests/change-reviews.test.ts
+++ b/tests/change-reviews.test.ts
@@ -78,8 +78,15 @@ function makeReviewsD1(): { db: D1Database; comments: CommentRow[]; reviews: Rev
       },
       first: async <T>() => {
         if (upper.includes("COUNT(*)")) {
+          // Honor the optional author-exclusion clause (bindings[1] = excludeUserId).
+          const excludeUserId = upper.includes("NOT (AUTHOR_TYPE")
+            ? (bindings[1] as string)
+            : undefined;
           const approvals = reviews.filter(
-            (r) => r.change_id === bindings[0] && r.verdict === "approve",
+            (r) =>
+              r.change_id === bindings[0] &&
+              r.verdict === "approve" &&
+              r.reviewer_id !== excludeUserId,
           ).length;
           return { approvals } as T;
         }
@@ -196,5 +203,28 @@ describe("change reviews", () => {
     expect(count.success).toBe(true);
     if (!count.success) return;
     expect(count.data).toBe(2);
+  });
+
+  it("excludes the change author's own approval from the count", async () => {
+    const { db } = makeReviewsD1();
+    // The author (user_1) approves their own change, plus one independent approval.
+    await submitReview(db, mockLogger, {
+      changeId: "chg_2",
+      reviewerId: "user_1",
+      verdict: "approve",
+    });
+    await submitReview(db, mockLogger, {
+      changeId: "chg_2",
+      reviewerId: "user_2",
+      verdict: "approve",
+    });
+
+    const withAuthor = await countApprovals(db, mockLogger, "chg_2");
+    expect(withAuthor.success && withAuthor.data).toBe(2);
+
+    // Excluding the author leaves only the independent approval — a lone writer
+    // can no longer self-approve past requiredApprovals: 1.
+    const excluded = await countApprovals(db, mockLogger, "chg_2", "user_1");
+    expect(excluded.success && excluded.data).toBe(1);
   });
 });

--- a/tests/conflict-resolution.test.ts
+++ b/tests/conflict-resolution.test.ts
@@ -279,9 +279,10 @@ describe("POST /api/projects/conflicts/:id/resolve (route)", () => {
   it("resolves successfully and deletes the conflict KV key", async () => {
     const kv = makeKv();
 
+    // The caller (user_test) owns the project → passes the new write-access check.
     vi.mocked(getProjectByPath).mockResolvedValue({
       success: true,
-      data: PROJECT,
+      data: { ...PROJECT, ownerId: "user_test" },
     } as Awaited<ReturnType<typeof getProjectByPath>>);
     vi.mocked(getWorkspace).mockResolvedValue({
       success: true,
@@ -306,6 +307,28 @@ describe("POST /api/projects/conflicts/:id/resolve (route)", () => {
     expect(body.status).toBe("resolved");
     expect(body.commitSha).toBe("resolved-sha");
     expect(vi.mocked(kv.delete)).toHaveBeenCalledWith("conflict:conflict-abc");
+  });
+
+  it("404s a caller without project write access (never mints a token or pushes)", async () => {
+    const kv = makeKv();
+    vi.mocked(resolveConflict).mockClear();
+    // Project owned by someone else, caller has no org write → write check fails.
+    vi.mocked(getProjectByPath).mockResolvedValue({
+      success: true,
+      data: { ...PROJECT, ownerId: "someone_else" },
+    } as Awaited<ReturnType<typeof getProjectByPath>>);
+
+    const res = await app.fetch(
+      new Request("http://localhost/api/projects/conflicts/conflict-abc/resolve", {
+        method: "POST",
+        headers: { ...AUTH_HEADER, "Content-Type": "application/json" },
+        body: JSON.stringify({ strategy: "accept-project" }),
+      }),
+      { STATE: kv, DB: makeDb() },
+    );
+
+    expect(res.status).toBe(404);
+    expect(vi.mocked(resolveConflict)).not.toHaveBeenCalled();
   });
 
   it("conflict context stored by changes route contains no token fields", () => {

--- a/tests/repo-url-https.test.ts
+++ b/tests/repo-url-https.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isValidRepoUrl } from "../src/utils/validation";
+
+describe("isValidRepoUrl — https only (downgrade protection)", () => {
+  it("accepts https provider URLs", () => {
+    expect(isValidRepoUrl("https://github.com/owner/repo")).toBe(true);
+    expect(isValidRepoUrl("https://gitlab.com/group/repo")).toBe(true);
+    expect(isValidRepoUrl("https://bitbucket.org/owner/repo")).toBe(true);
+  });
+
+  it("rejects cleartext http:// (MITM exposure)", () => {
+    expect(isValidRepoUrl("http://github.com/owner/repo")).toBe(false);
+    expect(isValidRepoUrl("http://gitlab.com/group/repo")).toBe(false);
+    expect(isValidRepoUrl("http://bitbucket.org/owner/repo")).toBe(false);
+  });
+
+  it("still rejects non-provider hosts", () => {
+    expect(isValidRepoUrl("https://evil.example.com/owner/repo")).toBe(false);
+  });
+});


### PR DESCRIPTION
First tranche of the principal-eng re-audit remediation (`/ship` methodology). Scoped to **localized, no-migration, no-data** fixes so it shares no revert surface with the riskier tranches.

## Findings closed
- **Functional bug (High):** bulk-import created the job and set status `queued` but **never called `queueImportJob`** — bulk-imported repos were never cloned. Now enqueues, mirroring the single-import path.
- **Security (conflict-resolve BFLA, Medium):** `POST /projects/conflicts/:id/resolve` minted a write token and pushed a merge into the project repo with only an *authenticated* check — no `canWriteProject`. Any authed caller holding a (leakable) conflict id could write into another tenant's repo. Now requires project write; collapses to 404 (no existence leak).
- **Security (downgrade, Low):** repo-URL validators accepted `http://`; now `https://` only (host still pinned to the 3 providers).
- **Self-approval (Low), partial:** `countApprovals` gains an `excludeUserId` so a change author's own approval won't satisfy `requiredApprovals`. *Call-site wiring deferred* — the `changes` table has no creating-user column yet (only `agentId`); tracked in `.claude/ship/TASKS.md`.

## Tests
Self-approval exclusion, https-only URLs, conflict-resolve authz denial. **Full suite green (1050 pass), typecheck + lint clean.**

## What's staged for later tranches
Sessions/CSRF + account-enumeration · merge-CAS de-dup · deletion enforcement + re-drive · backup restore/health/all-refs · KV→D1 canonical identity · LIMIT/pagination.

## ⚠️ Gated — need operator input, deliberately NOT in this PR
- **CI `--remote` migration fix:** flipping `--remote` today would apply an unknown accumulated backlog to prod in one shot (staging shares the bug, so isn't a faithful rehearsal). Needs the real remote `d1_migrations` ledger state + reconciliation first.
- **Live `POST /api/admin/restore`:** total-data-loss blast radius behind one shared admin key — shipping `scripts/restore.ts` (dry-run default) instead; a live route needs a break-glass decision.
- **Removing the T5 name-fallback:** gated on verified zero-NULL `project_id` after backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Repository imports now begin processing automatically after being queued.
  - Conflict resolution now requires project write access.

- **Bug Fixes**
  - Approval counts can exclude approvals from the change author.
  - Repository validation now requires secure HTTPS URLs for supported providers.
  - Unauthorized conflict-resolution requests return a generic not-found response.

- **Tests**
  - Added coverage for approval exclusions, access control, and HTTPS-only repository validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->