### PR TITLE
fix(audit): tranche 2 — auth/session hardening (hash sessions, login-CSRF)

### DIFF
--- a/src/middleware/csrf.ts
+++ b/src/middleware/csrf.ts
@@ -1,9 +1,56 @@
-import type { MiddlewareHandler } from "hono";
+import type { Context, MiddlewareHandler } from "hono";
 import { isGitHttpPath } from "../routes/git-http";
 import type { Env } from "../types";
-import { createLogger } from "../utils/logger";
+import { type Logger, createLogger } from "../utils/logger";
 
 const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * Reject a state-changing request whose Origin/Referer doesn't match the request
+ * host (or is absent). Returns a 403 Response to return as-is, or `null` when the
+ * request is same-origin and may proceed. Exported so unauthenticated endpoints
+ * that `csrfMiddleware` skips (it only guards session-cookie auth) can enforce
+ * same-origin themselves — e.g. the magic-link verify POST, which has no session
+ * yet but must not be forgeable cross-site (login CSRF).
+ */
+export function enforceSameOrigin(c: Context<{ Bindings: Env }>, logger: Logger): Response | null {
+  const requestHost = new URL(c.req.url).host;
+
+  const origin = c.req.header("Origin");
+  if (origin) {
+    let originHost: string;
+    try {
+      originHost = new URL(origin).host;
+    } catch {
+      logger.warn("CSRF rejected - malformed Origin header", { origin });
+      return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
+    }
+    if (originHost !== requestHost) {
+      logger.warn("CSRF rejected - Origin mismatch", { origin, requestHost });
+      return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
+    }
+    return null;
+  }
+
+  const referer = c.req.header("Referer");
+  if (referer) {
+    let refererHost: string;
+    try {
+      refererHost = new URL(referer).host;
+    } catch {
+      logger.warn("CSRF rejected - malformed Referer header", {});
+      return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
+    }
+    if (refererHost !== requestHost) {
+      logger.warn("CSRF rejected - Referer mismatch", { requestHost });
+      return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
+    }
+    return null;
+  }
+
+  logger.warn("CSRF rejected - no Origin or Referer on state-changing request", {});
+  return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
+}
 
 /**
  * CSRF protection for cookie-authenticated requests.
@@ -32,43 +79,8 @@ export const csrfMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
     return;
   }
 
-  const requestHost = new URL(c.req.url).host;
   const logger = c.get("logger") ?? createLogger({ path: c.req.path, method: c.req.method });
-
-  const origin = c.req.header("Origin");
-  if (origin) {
-    let originHost: string;
-    try {
-      originHost = new URL(origin).host;
-    } catch {
-      logger.warn("CSRF rejected - malformed Origin header", { origin });
-      return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
-    }
-    if (originHost !== requestHost) {
-      logger.warn("CSRF rejected - Origin mismatch", { origin, requestHost });
-      return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
-    }
-    await next();
-    return;
-  }
-
-  const referer = c.req.header("Referer");
-  if (referer) {
-    let refererHost: string;
-    try {
-      refererHost = new URL(referer).host;
-    } catch {
-      logger.warn("CSRF rejected - malformed Referer header", {});
-      return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
-    }
-    if (refererHost !== requestHost) {
-      logger.warn("CSRF rejected - Referer mismatch", { requestHost });
-      return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
-    }
-    await next();
-    return;
-  }
-
-  logger.warn("CSRF rejected - no Origin or Referer on session-authenticated mutation", {});
-  return c.json({ error: "Cross-site request rejected", code: "CSRF" }, 403);
+  const rejected = enforceSameOrigin(c, logger);
+  if (rejected) return rejected;
+  await next();
 };

--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { admitUser, betaGateEnabled, validateInviteCode } from "../beta/gate";
 import { getInviteCodesEmail, getMagicLinkEmail } from "../email/templates";
+import { enforceSameOrigin } from "../middleware/csrf";
 import { recordAudit } from "../storage/audit";
 import { consumeMagicLink, createMagicLink } from "../storage/magic-links";
 import { createSession } from "../storage/sessions";
@@ -650,6 +651,15 @@ app.post("/verify", async (c) => {
     path: c.req.path,
     method: c.req.method,
   });
+
+  // This endpoint is unauthenticated (it MINTS the session), so csrfMiddleware —
+  // which only guards session-cookie auth — skips it. Enforce same-origin here,
+  // BEFORE consuming the token, so a cross-site auto-submitting form can't POST an
+  // attacker's magic-link token and log a victim into the attacker's account
+  // (login CSRF). Rejecting before consume leaves the token usable for the real
+  // same-origin flow.
+  const csrf = enforceSameOrigin(c, logger);
+  if (csrf) return csrf;
 
   const form = await c.req.parseBody();
   const token = typeof form.token === "string" ? form.token : undefined;

--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -8,6 +8,7 @@ import { consumeMagicLink, createMagicLink } from "../storage/magic-links";
 import { createSession } from "../storage/sessions";
 import { createUser, getUserByEmail, getUserByUsername } from "../storage/users";
 import type { Env } from "../types";
+import { escapeHtml } from "../utils/html";
 import { type Logger, createLogger } from "../utils/logger";
 import { validateUsername } from "../utils/username-validation";
 import { validateEmail } from "../utils/validation";
@@ -617,15 +618,41 @@ app.post("/send", async (c) => {
   }
 });
 
-// GET /auth/email/verify - Verify magic link and handle signup/login
-app.get("/verify", async (c) => {
+// GET /auth/email/verify — render a same-origin confirm page rather than logging
+// in on the GET itself. A raw GET verify is login-CSRF: an attacker embeds their
+// own magic link in an <img>/<a> and the victim's browser silently gets a session
+// for the ATTACKER's account. Requiring an explicit same-origin POST (below) means
+// the sign-in is a deliberate action, not a drive-by, and cross-site auto-submits
+// are blocked by the CSRF middleware's Origin check.
+app.get("/verify", (c) => {
+  const token = c.req.query("token");
+  if (!token) {
+    return emailAuthRedirect(c, "error", "invalid_link");
+  }
+  const safeToken = escapeHtml(token);
+  return c.html(
+    `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Complete sign-in</title></head>
+<body style="font-family:system-ui,sans-serif;max-width:28rem;margin:4rem auto;padding:0 1rem;text-align:center">
+<h1 style="font-size:1.25rem">Complete your sign-in</h1>
+<p style="color:#555">Click below to finish signing in to Stratum.</p>
+<form method="POST" action="/auth/email/verify">
+<input type="hidden" name="token" value="${safeToken}">
+<button type="submit" style="padding:0.6rem 1.4rem;font-size:1rem;border:0;border-radius:0.5rem;background:#111;color:#fff;cursor:pointer">Continue</button>
+</form>
+</body></html>`,
+  );
+});
+
+// POST /auth/email/verify - consume the magic link and handle signup/login
+app.post("/verify", async (c) => {
   const logger = createLogger({
     requestId: crypto.randomUUID(),
     path: c.req.path,
     method: c.req.method,
   });
 
-  const token = c.req.query("token");
+  const form = await c.req.parseBody();
+  const token = typeof form.token === "string" ? form.token : undefined;
 
   if (!token) {
     logger.warn("Missing token in verify request");

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -3,11 +3,12 @@ import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { authMiddleware } from "../middleware/auth";
 import {
   deleteAllUserSessions,
-  deleteSession,
+  deleteSessionByStoredId,
   getUserSessions,
   refreshSession,
 } from "../storage/sessions";
 import type { Env } from "../types";
+import { hashToken } from "../utils/crypto";
 import { createLogger } from "../utils/logger";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -146,6 +147,8 @@ app.get("/", async (c) => {
   }
 
   const currentSessionId = getCookie(c, "stratum_session");
+  // session.id is the stored hash; the cookie is raw, so compare against its hash.
+  const currentHashed = currentSessionId ? await hashToken(currentSessionId) : undefined;
 
   // Mark current session and filter out expired ones
   const now = new Date();
@@ -154,7 +157,7 @@ app.get("/", async (c) => {
     .map((session) => ({
       id: session.id,
       expiresAt: session.expiresAt,
-      isCurrent: session.id === currentSessionId,
+      isCurrent: session.id === currentHashed,
     }));
 
   return c.json({
@@ -184,9 +187,11 @@ app.delete("/:id", async (c) => {
     userId,
   });
 
-  logger.debug("Deleting specific session", { sessionId: sessionIdToDelete });
+  logger.debug("Deleting specific session");
 
-  const result = await deleteSession(c.env.DB, sessionIdToDelete, userId, logger);
+  // The :id comes from the list endpoint, which exposes the STORED (hashed) id —
+  // delete by it directly (do not re-hash).
+  const result = await deleteSessionByStoredId(c.env.DB, sessionIdToDelete, userId, logger);
 
   if (!result.success) {
     return c.json({ error: "Failed to delete session" }, 500);
@@ -197,8 +202,10 @@ app.delete("/:id", async (c) => {
     return c.json({ error: "Session not found" }, 404);
   }
 
-  // If deleting current session, clear the cookie
-  if (sessionIdToDelete === currentSessionId) {
+  // If deleting the current session, clear the cookie. The listed id is the hash,
+  // so compare against the hashed cookie.
+  const currentHashed = currentSessionId ? await hashToken(currentSessionId) : undefined;
+  if (sessionIdToDelete === currentHashed) {
     deleteCookie(c, "stratum_session", { path: "/" });
     logger.info("Current session deleted, user logged out");
   }

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -66,20 +66,29 @@ export async function getSession(
   db: D1Database,
   id: string,
   logger: Logger,
-): Promise<Result<Session, NotFoundError>> {
+): Promise<Result<Session, NotFoundError | AppError>> {
   logger.debug("Fetching session");
-  const row = await db
-    .prepare("SELECT id, user_id, expires_at FROM sessions WHERE id = ?")
-    .bind(await hashToken(id))
-    .first<SessionRow>();
+  try {
+    const row = await db
+      .prepare("SELECT id, user_id, expires_at FROM sessions WHERE id = ?")
+      .bind(await hashToken(id))
+      .first<SessionRow>();
 
-  if (!row) {
-    return err(new NotFoundError("Session", id));
+    // A missing row is expected (invalid/expired cookie); return NotFound without
+    // the raw id so an unauthenticated bearer value never lands in a log.
+    if (!row) {
+      return err(new NotFoundError("Session", "(hashed)"));
+    }
+
+    // Return the caller's raw id (the row's id is the hash) so downstream refresh/
+    // isCurrent comparisons against the cookie keep working.
+    return ok({ id, userId: row.user_id, expiresAt: row.expires_at });
+  } catch (error) {
+    // hashToken or the D1 read can reject; surface it as a Result so callers never
+    // get a thrown error instead of Result<Session, …>.
+    logger.error("Failed to fetch session", error instanceof Error ? error : undefined);
+    return err(new AppError("Failed to fetch session", "STORAGE_ERROR", 500));
   }
-
-  // Return the caller's raw id (the row's id is the hash) so downstream refresh/
-  // isCurrent comparisons against the cookie keep working.
-  return ok({ id, userId: row.user_id, expiresAt: row.expires_at });
 }
 
 export async function deleteSession(
@@ -97,21 +106,19 @@ export async function deleteSession(
 
     const deleted = (result.meta?.changes ?? 0) > 0;
 
+    // Never log the raw id — it is the bearer cookie; userId is enough to trace.
     if (deleted) {
-      logger.info("Session deleted", { sessionId: id, userId });
+      logger.info("Session deleted", { userId });
     } else {
-      logger.warn("Session not found or not owned by user", { sessionId: id, userId });
+      logger.warn("Session not found or not owned by user", { userId });
     }
 
     return ok(deleted);
   } catch (error) {
     logger.error("Failed to delete session", error instanceof Error ? error : undefined, {
-      id,
       userId,
     });
-    return err(
-      new AppError(`Failed to delete session '${id}'`, "STORAGE_ERROR", 500, { sessionId: id }),
-    );
+    return err(new AppError("Failed to delete session", "STORAGE_ERROR", 500, { userId }));
   }
 }
 
@@ -154,7 +161,8 @@ export async function refreshSession(
   rememberMe: boolean,
   logger: Logger,
 ): Promise<Result<Session, AppError | NotFoundError>> {
-  logger.debug("Refreshing session", { id, rememberMe });
+  // Never log the raw id (the bearer cookie).
+  logger.debug("Refreshing session", { rememberMe });
 
   // First check if session exists and is valid
   const sessionResult = await getSession(db, id, logger);
@@ -168,8 +176,10 @@ export async function refreshSession(
 
   // Don't refresh expired sessions
   if (expiresAt < now) {
-    logger.warn("Attempted to refresh expired session", { sessionId: id });
-    return err(new AppError("Session has expired", "SESSION_EXPIRED", 401, { sessionId: id }));
+    logger.warn("Attempted to refresh expired session", { userId: session.userId });
+    return err(
+      new AppError("Session has expired", "SESSION_EXPIRED", 401, { userId: session.userId }),
+    );
   }
 
   try {
@@ -185,9 +195,11 @@ export async function refreshSession(
     logger.info("Session refreshed", { newExpiresAt, rememberMe });
     return ok({ ...session, expiresAt: newExpiresAt });
   } catch (error) {
-    logger.error("Failed to refresh session", error instanceof Error ? error : undefined, { id });
+    logger.error("Failed to refresh session", error instanceof Error ? error : undefined, {
+      userId: session.userId,
+    });
     return err(
-      new AppError(`Failed to refresh session '${id}'`, "STORAGE_ERROR", 500, { sessionId: id }),
+      new AppError("Failed to refresh session", "STORAGE_ERROR", 500, { userId: session.userId }),
     );
   }
 }

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -1,7 +1,13 @@
+import { hashToken } from "../utils/crypto";
 import { AppError, NotFoundError } from "../utils/errors";
 import { newId } from "../utils/ids";
 import type { Logger } from "../utils/logger";
 import { type Result, err, ok } from "../utils/result";
+
+// Sessions are stored HASHED at rest: the `id` column holds hashToken(rawId), and
+// the raw id is only ever held by the client cookie. A read-only leak of the
+// sessions table (SQLi read, a backup, logs) therefore yields no replayable
+// credential — matching how user/agent/magic-link tokens are stored.
 
 export interface Session {
   id: string;
@@ -38,10 +44,11 @@ export async function createSession(
 
     await db
       .prepare("INSERT INTO sessions (id, user_id, expires_at) VALUES (?, ?, ?)")
-      .bind(id, userId, expiresAt)
+      .bind(await hashToken(id), userId, expiresAt)
       .run();
 
-    logger.info("Session created", { sessionId: id, userId, rememberMe });
+    logger.info("Session created", { userId, rememberMe });
+    // Return the RAW id — it becomes the cookie; only its hash is persisted.
     return ok({ id, userId, expiresAt });
   } catch (error) {
     logger.error("Failed to create session", error instanceof Error ? error : undefined, {
@@ -60,17 +67,19 @@ export async function getSession(
   id: string,
   logger: Logger,
 ): Promise<Result<Session, NotFoundError>> {
-  logger.debug("Fetching session", { id });
+  logger.debug("Fetching session");
   const row = await db
     .prepare("SELECT id, user_id, expires_at FROM sessions WHERE id = ?")
-    .bind(id)
+    .bind(await hashToken(id))
     .first<SessionRow>();
 
   if (!row) {
     return err(new NotFoundError("Session", id));
   }
 
-  return ok(rowToSession(row));
+  // Return the caller's raw id (the row's id is the hash) so downstream refresh/
+  // isCurrent comparisons against the cookie keep working.
+  return ok({ id, userId: row.user_id, expiresAt: row.expires_at });
 }
 
 export async function deleteSession(
@@ -79,11 +88,11 @@ export async function deleteSession(
   userId: string,
   logger: Logger,
 ): Promise<Result<boolean, AppError>> {
-  logger.debug("Deleting session", { id, userId });
+  logger.debug("Deleting session", { userId });
   try {
     const result = await db
       .prepare("DELETE FROM sessions WHERE id = ? AND user_id = ?")
-      .bind(id, userId)
+      .bind(await hashToken(id), userId)
       .run();
 
     const deleted = (result.meta?.changes ?? 0) > 0;
@@ -103,6 +112,35 @@ export async function deleteSession(
     return err(
       new AppError(`Failed to delete session '${id}'`, "STORAGE_ERROR", 500, { sessionId: id }),
     );
+  }
+}
+
+/**
+ * Revoke a session by its STORED id (the hash surfaced by getUserSessions), NOT a
+ * raw cookie value — so it must not be re-hashed. Used by the "log out of this
+ * device" list UI, where the client only ever sees the opaque hashed handle.
+ */
+export async function deleteSessionByStoredId(
+  db: D1Database,
+  storedId: string,
+  userId: string,
+  logger: Logger,
+): Promise<Result<boolean, AppError>> {
+  try {
+    const result = await db
+      .prepare("DELETE FROM sessions WHERE id = ? AND user_id = ?")
+      .bind(storedId, userId)
+      .run();
+    return ok((result.meta?.changes ?? 0) > 0);
+  } catch (error) {
+    logger.error(
+      "Failed to delete session by stored id",
+      error instanceof Error ? error : undefined,
+      {
+        userId,
+      },
+    );
+    return err(new AppError("Failed to delete session", "STORAGE_ERROR", 500, { userId }));
   }
 }
 
@@ -141,10 +179,10 @@ export async function refreshSession(
 
     await db
       .prepare("UPDATE sessions SET expires_at = ? WHERE id = ?")
-      .bind(newExpiresAt, id)
+      .bind(newExpiresAt, await hashToken(id))
       .run();
 
-    logger.info("Session refreshed", { sessionId: id, newExpiresAt, rememberMe });
+    logger.info("Session refreshed", { newExpiresAt, rememberMe });
     return ok({ ...session, expiresAt: newExpiresAt });
   } catch (error) {
     logger.error("Failed to refresh session", error instanceof Error ? error : undefined, { id });

--- a/tests/auth-signup-login.test.ts
+++ b/tests/auth-signup-login.test.ts
@@ -235,8 +235,14 @@ function createFormData(data: Record<string, string>): FormData {
 
 // Magic-link verification is now a same-origin POST (the GET only renders a
 // confirm page — login-CSRF protection), so consume/login goes through here.
-function verifyReq(token: string): Request {
-  return request("/auth/email/verify", { method: "POST", body: createFormData({ token }) });
+// A real browser sends Origin on the form POST; default to same-origin so the
+// endpoint's CSRF guard admits it. Pass a foreign origin to exercise rejection.
+function verifyReq(token: string, origin: string | null = "http://localhost"): Request {
+  return request("/auth/email/verify", {
+    method: "POST",
+    body: createFormData({ token }),
+    ...(origin ? { headers: { Origin: origin } } : {}),
+  });
 }
 
 async function extractMagicLinkToken(_env: Env): Promise<string | null> {
@@ -929,6 +935,31 @@ describe("Auth Signup/Login Integration Tests", () => {
         // Verify session cookie was set
         const setCookieHeader = res.headers.get("set-cookie");
         expect(setCookieHeader).toContain("stratum_session");
+      });
+
+      it("rejects a cross-site (foreign Origin) verify POST and preserves the token (login CSRF)", async () => {
+        const { createUser } = await import("../src/storage/users");
+        await createUser(env.DB, "victim@example.com", {} as unknown as Logger, "victimuser");
+        const token = "valid-login-token-csrf";
+        magicStore.set(token, {
+          email: "victim@example.com",
+          intent: "login",
+          createdAt: Date.now(),
+          rememberMe: false,
+        });
+
+        // An attacker's auto-submitting form on another origin must be rejected
+        // BEFORE the token is consumed — otherwise it logs the victim into the
+        // attacker's account.
+        const attack = await app.fetch(verifyReq(token, "https://evil.example"), env);
+        expect(attack.status).toBe(403);
+        expect(attack.headers.get("set-cookie")).toBeNull();
+        // Token untouched, so the real same-origin flow still works.
+        expect(magicStore.has(token)).toBe(true);
+
+        const legit = await app.fetch(verifyReq(token), env);
+        expect(legit.status).toBe(302);
+        expect(magicStore.has(token)).toBe(false);
       });
 
       it("rejects missing token", async () => {

--- a/tests/auth-signup-login.test.ts
+++ b/tests/auth-signup-login.test.ts
@@ -233,6 +233,12 @@ function createFormData(data: Record<string, string>): FormData {
   return formData;
 }
 
+// Magic-link verification is now a same-origin POST (the GET only renders a
+// confirm page — login-CSRF protection), so consume/login goes through here.
+function verifyReq(token: string): Request {
+  return request("/auth/email/verify", { method: "POST", body: createFormData({ token }) });
+}
+
 async function extractMagicLinkToken(_env: Env): Promise<string | null> {
   const first = magicStore.keys().next();
   return first.done ? null : (first.value as string);
@@ -873,7 +879,7 @@ describe("Auth Signup/Login Integration Tests", () => {
 
         magicStore.set(token, tokenData);
 
-        const res = await app.fetch(request(`/auth/email/verify?token=${token}`), env);
+        const res = await app.fetch(verifyReq(token), env);
 
         expect(res.status).toBe(302);
         expect(res.headers.get("location")).toBe("/welcome");
@@ -912,7 +918,7 @@ describe("Auth Signup/Login Integration Tests", () => {
 
         magicStore.set(token, tokenData);
 
-        const res = await app.fetch(request(`/auth/email/verify?token=${token}`), env);
+        const res = await app.fetch(verifyReq(token), env);
 
         expect(res.status).toBe(302);
         expect(res.headers.get("location")).toBe("/");
@@ -933,10 +939,29 @@ describe("Auth Signup/Login Integration Tests", () => {
       });
 
       it("rejects invalid token", async () => {
-        const res = await app.fetch(request("/auth/email/verify?token=invalid-token"), env);
+        const res = await app.fetch(verifyReq("invalid-token"), env);
 
         expect(res.status).toBe(302);
         expect(res.headers.get("location")).toContain("error=link_expired");
+      });
+
+      it("GET renders a confirm page and does NOT consume the token (login-CSRF guard)", async () => {
+        const token = "get-should-not-consume";
+        magicStore.set(token, {
+          email: "x@example.com",
+          intent: "login",
+          createdAt: Date.now(),
+        });
+
+        const res = await app.fetch(request(`/auth/email/verify?token=${token}`), env);
+
+        // A raw GET must not log anyone in: 200 confirm page, no session, token intact.
+        expect(res.status).toBe(200);
+        expect(res.headers.get("set-cookie")).toBeNull();
+        const html = await res.text();
+        expect(html).toContain('method="POST"');
+        expect(html).toContain(token);
+        expect(magicStore.has(token)).toBe(true);
       });
 
       it("rejects expired token", async () => {
@@ -953,7 +978,7 @@ describe("Auth Signup/Login Integration Tests", () => {
         // consume finds nothing and reports the link expired.
         void tokenData;
 
-        const res = await app.fetch(request(`/auth/email/verify?token=${token}`), env);
+        const res = await app.fetch(verifyReq(token), env);
 
         expect(res.status).toBe(302);
         expect(res.headers.get("location")).toContain("error=link_expired");
@@ -974,12 +999,12 @@ describe("Auth Signup/Login Integration Tests", () => {
         magicStore.set(token, tokenData);
 
         // First use - should succeed
-        const res1 = await app.fetch(request(`/auth/email/verify?token=${token}`), env);
+        const res1 = await app.fetch(verifyReq(token), env);
         expect(res1.status).toBe(302);
         expect(res1.headers.get("location")).toBe("/");
 
         // Second use - should fail (token deleted)
-        const res2 = await app.fetch(request(`/auth/email/verify?token=${token}`), env);
+        const res2 = await app.fetch(verifyReq(token), env);
         expect(res2.status).toBe(302);
         expect(res2.headers.get("location")).toContain("error=link_expired");
       });
@@ -1000,7 +1025,7 @@ describe("Auth Signup/Login Integration Tests", () => {
         const { createUser } = await import("../src/storage/users");
         await createUser(env.DB, "other@example.com", {} as unknown as Logger, "raceuser");
 
-        const res = await app.fetch(request(`/auth/email/verify?token=${token}`), env);
+        const res = await app.fetch(verifyReq(token), env);
 
         expect(res.status).toBe(302);
         expect(res.headers.get("location")).toContain("error=username_taken");
@@ -1022,7 +1047,7 @@ describe("Auth Signup/Login Integration Tests", () => {
         const { createUser } = await import("../src/storage/users");
         await createUser(env.DB, "raceemail@example.com", {} as unknown as Logger, "otheruser");
 
-        const res = await app.fetch(request(`/auth/email/verify?token=${token}`), env);
+        const res = await app.fetch(verifyReq(token), env);
 
         expect(res.status).toBe(302);
         // Should redirect to home since user now exists (treats as login)
@@ -1040,7 +1065,7 @@ describe("Auth Signup/Login Integration Tests", () => {
 
         magicStore.set(token, tokenData);
 
-        const res = await app.fetch(request(`/auth/email/verify?token=${token}`), env);
+        const res = await app.fetch(verifyReq(token), env);
 
         expect(res.status).toBe(302);
         expect(res.headers.get("location")).toContain("error=invalid_link");

--- a/tests/magic-link.test.ts
+++ b/tests/magic-link.test.ts
@@ -236,8 +236,11 @@ describe("Magic Link Authentication", () => {
     });
 
     it("should reject invalid token", async () => {
-      // No token stored in KV, so it will return null
-      const res = await emailAuthRouter.fetch(request("/verify?token=invalid-token"), env);
+      // No token stored, so consume returns null. Verify is now a POST (the GET
+      // only renders a same-origin confirm page — login-CSRF protection).
+      const body = new FormData();
+      body.append("token", "invalid-token");
+      const res = await emailAuthRouter.fetch(request("/verify", { method: "POST", body }), env);
 
       expect(res.status).toBe(302);
       expect(res.headers.get("location")).toContain("error=link_expired");
@@ -251,7 +254,9 @@ describe("Magic Link Authentication", () => {
         createdAt: Date.now(),
       });
 
-      const res = await emailAuthRouter.fetch(request("/verify?token=valid-token-123"), env);
+      const body = new FormData();
+      body.append("token", "valid-token-123");
+      const res = await emailAuthRouter.fetch(request("/verify", { method: "POST", body }), env);
 
       // The test will fail because user doesn't exist in mocked DB
       // But it validates the token was found and processed

--- a/tests/magic-link.test.ts
+++ b/tests/magic-link.test.ts
@@ -240,7 +240,10 @@ describe("Magic Link Authentication", () => {
       // only renders a same-origin confirm page — login-CSRF protection).
       const body = new FormData();
       body.append("token", "invalid-token");
-      const res = await emailAuthRouter.fetch(request("/verify", { method: "POST", body }), env);
+      const res = await emailAuthRouter.fetch(
+        request("/verify", { method: "POST", body, headers: { Origin: "http://localhost" } }),
+        env,
+      );
 
       expect(res.status).toBe(302);
       expect(res.headers.get("location")).toContain("error=link_expired");
@@ -256,7 +259,10 @@ describe("Magic Link Authentication", () => {
 
       const body = new FormData();
       body.append("token", "valid-token-123");
-      const res = await emailAuthRouter.fetch(request("/verify", { method: "POST", body }), env);
+      const res = await emailAuthRouter.fetch(
+        request("/verify", { method: "POST", body, headers: { Origin: "http://localhost" } }),
+        env,
+      );
 
       // The test will fail because user doesn't exist in mocked DB
       // But it validates the token was found and processed

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -69,9 +69,13 @@ describe("session hashing at rest", () => {
     expect(got.success && got.data.userId).toBe("user_1");
     expect(got.success && got.data.id).toBe(rawId);
 
-    // A stale plaintext id (as if read from an old backup) does NOT resolve as-is.
-    const asIfPlaintextLeak = await getSession(db, await hashToken(rawId), log);
-    expect(asIfPlaintextLeak.success).toBe(false);
+    // Migration behavior: a LEGACY row keyed by the raw plaintext id (as written
+    // before hashing-at-rest) must no longer resolve — getSession hashes the
+    // incoming id, so the plaintext-keyed row is unreachable.
+    const legacyRawId = "sess_legacy_plaintext_0000000000";
+    rows.set(legacyRawId, { user_id: "user_legacy", expires_at: "2099-01-01T00:00:00.000Z" });
+    const legacyLookup = await getSession(db, legacyRawId, log);
+    expect(legacyLookup.success).toBe(false);
   });
 });
 

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -1,11 +1,79 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createSession,
   deleteAllUserSessions,
   deleteSession,
+  getSession,
   getUserSessions,
   refreshSession,
 } from "../src/storage/sessions";
+import { hashToken } from "../src/utils/crypto";
+import type { Logger } from "../src/utils/logger";
+
+const log = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => log),
+} as unknown as Logger;
+
+/** In-memory sessions table keyed by the stored `id` (which should be a hash). */
+function makeSessionsD1(): {
+  db: D1Database;
+  rows: Map<string, { user_id: string; expires_at: string }>;
+} {
+  const rows = new Map<string, { user_id: string; expires_at: string }>();
+  function stmt(sql: string, binds: unknown[] = []) {
+    return {
+      bind: (...args: unknown[]) => stmt(sql, args),
+      run: async () => {
+        if (/^INSERT INTO sessions/i.test(sql)) {
+          rows.set(binds[0] as string, {
+            user_id: binds[1] as string,
+            expires_at: binds[2] as string,
+          });
+        }
+        return { success: true, meta: { changes: 1 } };
+      },
+      first: async <T>() => {
+        const m = sql.match(/WHERE id = \?/i);
+        if (m) {
+          const r = rows.get(binds[0] as string);
+          return r ? ({ id: binds[0], user_id: r.user_id, expires_at: r.expires_at } as T) : null;
+        }
+        return null;
+      },
+      all: async <T>() => ({ results: [] as T[], success: true, meta: {} }),
+    };
+  }
+  return { db: { prepare: (sql: string) => stmt(sql) } as unknown as D1Database, rows };
+}
+
+describe("session hashing at rest", () => {
+  it("stores the hash of the id (not the raw id) and resolves by the raw cookie", async () => {
+    const { db, rows } = makeSessionsD1();
+    const created = await createSession(db, "user_1", log);
+    expect(created.success).toBe(true);
+    if (!created.success) return;
+
+    const rawId = created.data.id;
+    // The stored key is the hash, never the raw id that goes in the cookie.
+    expect(rows.has(rawId)).toBe(false);
+    expect(rows.has(await hashToken(rawId))).toBe(true);
+
+    // getSession resolves the raw cookie id (hashes internally) and returns it.
+    const got = await getSession(db, rawId, log);
+    expect(got.success && got.data.userId).toBe("user_1");
+    expect(got.success && got.data.id).toBe(rawId);
+
+    // A stale plaintext id (as if read from an old backup) does NOT resolve as-is.
+    const asIfPlaintextLeak = await getSession(db, await hashToken(rawId), log);
+    expect(asIfPlaintextLeak.success).toBe(false);
+  });
+});
 
 describe("Session Storage Functions", () => {
   // Note: These are unit tests for the storage functions


### PR DESCRIPTION
Second tranche of the re-audit remediation. Self-contained security fix.

**Finding (Low, but sharp):** session IDs were stored **plaintext** in D1 while every other secret is SHA-256 hashed. Any read-only leak of the `sessions` table (SQLi read, a leaked backup, logs) yielded directly replayable session cookies. Now hashed at rest — the raw id lives only in the cookie.

**Done correctly across all 5 call sites + the list/revoke contract** (the part the PRD critique flagged as easy to get wrong):
- `createSession` stores `hashToken(rawId)`, returns the raw id for the cookie
- `getSession`/`deleteSession`/`refreshSession` hash the raw cookie input
- `getUserSessions` surfaces the stored hash as an opaque handle; list `isCurrent` compares the **hashed** cookie
- revoke-from-list uses a new `deleteSessionByStoredId` (no double-hash)

**Cutover:** existing plaintext sessions stop resolving (forces re-login) — and a restored old backup can no longer reintroduce live session credentials.

Test added; full suite green (1046), typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explicit confirmation step for email magic-link verification before signing users in.
  * Magic-link verification now uses a secure same-origin form submission.

* **Bug Fixes**
  * Improved session tracking and revocation, including reliably identifying and deleting the current session.
  * Session identifiers are now protected when stored, while existing sign-in sessions continue to work normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->