### PR TITLE
fix(audit): bound KV get fan-out + follow the list cursor (no truncation)

### DIFF
--- a/src/storage/state.ts
+++ b/src/storage/state.ts
@@ -6,6 +6,28 @@ import { type Result, err, ok } from "../utils/result";
 const PROJECT_PREFIX = "project:";
 const WORKSPACE_PREFIX = "workspace:";
 
+// KV get-per-key fan-out must stay well under the Workers ~1000-subrequest cap.
+// An unbounded `Promise.all(keys.map(get))` throws once an instance passes ~1000
+// projects/workspaces, taking the whole write path down; bound it to a pool.
+const KV_FANOUT_LIMIT = 25;
+
+async function mapBounded<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const out = new Array<R>(items.length);
+  let next = 0;
+  const worker = async () => {
+    while (next < items.length) {
+      const idx = next++;
+      out[idx] = await fn(items[idx] as T);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return out;
+}
+
 function parseEntry<T>(raw: string, key: string, logger: Logger): Result<T, AppError> {
   try {
     const parsed = JSON.parse(raw) as T;
@@ -224,14 +246,12 @@ export async function listProjects(
       cursor = page.cursor;
       if (!cursor) break;
     }
-    const entries = await Promise.all(
-      keyNames.map(async (name) => {
-        const raw = await kv.get(name);
-        if (!raw) return null;
-        const parsed = parseEntry<ProjectEntry>(raw, name, logger);
-        return parsed.success ? parsed.data : null;
-      }),
-    );
+    const entries = await mapBounded(keyNames, KV_FANOUT_LIMIT, async (name) => {
+      const raw = await kv.get(name);
+      if (!raw) return null;
+      const parsed = parseEntry<ProjectEntry>(raw, name, logger);
+      return parsed.success ? parsed.data : null;
+    });
     return ok(entries.filter((e): e is ProjectEntry => e !== null));
   } catch (error) {
     logger.error("Failed to list projects", error instanceof Error ? error : undefined);
@@ -248,14 +268,12 @@ export async function listProjectsByNamespace(
   logger.debug("Listing projects by namespace", { namespace });
   try {
     const result = await kv.list({ prefix: `${PROJECT_PREFIX}${namespace}:` });
-    const entries = await Promise.all(
-      result.keys.map(async ({ name }) => {
-        const raw = await kv.get(name);
-        if (!raw) return null;
-        const parsed = parseEntry<ProjectEntry>(raw, name, logger);
-        return parsed.success ? parsed.data : null;
-      }),
-    );
+    const entries = await mapBounded(result.keys, KV_FANOUT_LIMIT, async ({ name }) => {
+      const raw = await kv.get(name);
+      if (!raw) return null;
+      const parsed = parseEntry<ProjectEntry>(raw, name, logger);
+      return parsed.success ? parsed.data : null;
+    });
     return ok(entries.filter((e): e is ProjectEntry => e !== null));
   } catch (error) {
     logger.error(
@@ -366,14 +384,12 @@ export async function listWorkspaces(
   logger.debug("Listing workspaces", { projectId });
   try {
     const result = await kv.list({ prefix: `${WORKSPACE_PREFIX}${projectId}:` });
-    const entries = await Promise.all(
-      result.keys.map(async ({ name }) => {
-        const raw = await kv.get(name);
-        if (!raw) return null;
-        const parsed = parseEntry<WorkspaceEntry>(raw, name, logger);
-        return parsed.success ? parsed.data : null;
-      }),
-    );
+    const entries = await mapBounded(result.keys, KV_FANOUT_LIMIT, async ({ name }) => {
+      const raw = await kv.get(name);
+      if (!raw) return null;
+      const parsed = parseEntry<WorkspaceEntry>(raw, name, logger);
+      return parsed.success ? parsed.data : null;
+    });
     return ok(entries.filter((e): e is WorkspaceEntry => e !== null));
   } catch (error) {
     logger.error("Failed to list workspaces", error instanceof Error ? error : undefined, {

--- a/src/storage/state.ts
+++ b/src/storage/state.ts
@@ -28,6 +28,25 @@ async function mapBounded<T, R>(
   return out;
 }
 
+/**
+ * Every KV key name under a prefix, following the `list` cursor to exhaustion.
+ * KV `list` returns at most one page (~1000 keys); without the loop a namespace
+ * or project with more entries would silently drop everything past the first
+ * page. Callers then map over the full key set with a bounded fan-out.
+ */
+async function listAllKeyNames(kv: KVNamespace, prefix: string): Promise<string[]> {
+  const names: string[] = [];
+  let cursor: string | undefined;
+  for (;;) {
+    const page = await kv.list(cursor ? { prefix, cursor } : { prefix });
+    for (const key of page.keys) names.push(key.name);
+    if (page.list_complete) break;
+    cursor = page.cursor;
+    if (!cursor) break;
+  }
+  return names;
+}
+
 function parseEntry<T>(raw: string, key: string, logger: Logger): Result<T, AppError> {
   try {
     const parsed = JSON.parse(raw) as T;
@@ -232,20 +251,9 @@ export async function listProjects(
 ): Promise<Result<ProjectEntry[], AppError>> {
   logger.debug("Listing all projects");
   try {
-    // KV `list` returns at most one page (~1000 keys); loop the cursor to
-    // exhaustion so callers (getProjectById → authz, account deletion) never
-    // miss a project.
-    const keyNames: string[] = [];
-    let cursor: string | undefined;
-    for (;;) {
-      const page = await kv.list(
-        cursor ? { prefix: PROJECT_PREFIX, cursor } : { prefix: PROJECT_PREFIX },
-      );
-      for (const key of page.keys) keyNames.push(key.name);
-      if (page.list_complete) break;
-      cursor = page.cursor;
-      if (!cursor) break;
-    }
+    // Loop the list cursor to exhaustion so callers (getProjectById → authz,
+    // account deletion) never miss a project past the first ~1000-key page.
+    const keyNames = await listAllKeyNames(kv, PROJECT_PREFIX);
     const entries = await mapBounded(keyNames, KV_FANOUT_LIMIT, async (name) => {
       const raw = await kv.get(name);
       if (!raw) return null;
@@ -267,8 +275,9 @@ export async function listProjectsByNamespace(
 ): Promise<Result<ProjectEntry[], AppError>> {
   logger.debug("Listing projects by namespace", { namespace });
   try {
-    const result = await kv.list({ prefix: `${PROJECT_PREFIX}${namespace}:` });
-    const entries = await mapBounded(result.keys, KV_FANOUT_LIMIT, async ({ name }) => {
+    // Loop the cursor so a namespace with >1 page of projects isn't truncated.
+    const keyNames = await listAllKeyNames(kv, `${PROJECT_PREFIX}${namespace}:`);
+    const entries = await mapBounded(keyNames, KV_FANOUT_LIMIT, async (name) => {
       const raw = await kv.get(name);
       if (!raw) return null;
       const parsed = parseEntry<ProjectEntry>(raw, name, logger);
@@ -383,8 +392,9 @@ export async function listWorkspaces(
 ): Promise<Result<WorkspaceEntry[], AppError>> {
   logger.debug("Listing workspaces", { projectId });
   try {
-    const result = await kv.list({ prefix: `${WORKSPACE_PREFIX}${projectId}:` });
-    const entries = await mapBounded(result.keys, KV_FANOUT_LIMIT, async ({ name }) => {
+    // Loop the cursor so a project with >1 page of workspaces isn't truncated.
+    const keyNames = await listAllKeyNames(kv, `${WORKSPACE_PREFIX}${projectId}:`);
+    const entries = await mapBounded(keyNames, KV_FANOUT_LIMIT, async (name) => {
       const raw = await kv.get(name);
       if (!raw) return null;
       const parsed = parseEntry<WorkspaceEntry>(raw, name, logger);

--- a/tests/state-fanout.test.ts
+++ b/tests/state-fanout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { listProjects } from "../src/storage/state";
+import { listProjects, listProjectsByNamespace, listWorkspaces } from "../src/storage/state";
 import type { Logger } from "../src/utils/logger";
 
 const log = {
@@ -50,5 +50,64 @@ describe("listProjects KV fan-out is bounded", () => {
     expect(result.data).toHaveLength(60); // all projects, none dropped
     // The unbounded version would peak at 60 concurrent gets; bounded stays ≤ 25.
     expect(peak()).toBeLessThanOrEqual(25);
+  });
+});
+
+/** Fake KV with REAL cursor pagination + prefix filtering (small pages). */
+function makePaginatedKV(entries: Record<string, string>, pageSize: number): KVNamespace {
+  return {
+    list: async (opts?: { prefix?: string; cursor?: string }) => {
+      const prefix = opts?.prefix ?? "";
+      const all = Object.keys(entries)
+        .filter((k) => k.startsWith(prefix))
+        .sort();
+      const start = opts?.cursor ? Number(opts.cursor) : 0;
+      const page = all.slice(start, start + pageSize);
+      const complete = start + pageSize >= all.length;
+      return {
+        keys: page.map((name) => ({ name })),
+        list_complete: complete,
+        cursor: complete ? "" : String(start + pageSize),
+      };
+    },
+    get: async (key: string) => entries[key] ?? null,
+  } as unknown as KVNamespace;
+}
+
+describe("KV list cursor is followed to exhaustion (no page-1 truncation)", () => {
+  it("listProjectsByNamespace returns projects spanning multiple KV pages", async () => {
+    const entries: Record<string, string> = {};
+    for (let i = 0; i < 7; i++) {
+      entries[`project:@ns:p${i}`] = JSON.stringify({
+        id: `proj_${i}`,
+        name: `p${i}`,
+        slug: `p${i}`,
+        namespace: "@ns",
+      });
+    }
+    // A project in another namespace must NOT leak in (prefix filtering).
+    entries["project:@other:x"] = JSON.stringify({ id: "x", name: "x", slug: "x" });
+    const kv = makePaginatedKV(entries, 3); // 3 per page → @ns spans 3 pages
+
+    const result = await listProjectsByNamespace(kv, "@ns", log);
+
+    expect(result.success && result.data).toHaveLength(7);
+  });
+
+  it("listWorkspaces returns workspaces spanning multiple KV pages", async () => {
+    const entries: Record<string, string> = {};
+    for (let i = 0; i < 5; i++) {
+      entries[`workspace:proj_1:w${i}`] = JSON.stringify({
+        name: `w${i}`,
+        parent: "proj_1",
+        remote: "r",
+        createdAt: "t",
+      });
+    }
+    const kv = makePaginatedKV(entries, 2); // 2 per page → 3 pages
+
+    const result = await listWorkspaces(kv, "proj_1", log);
+
+    expect(result.success && result.data).toHaveLength(5);
   });
 });

--- a/tests/state-fanout.test.ts
+++ b/tests/state-fanout.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { listProjects } from "../src/storage/state";
+import type { Logger } from "../src/utils/logger";
+
+const log = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => log),
+} as unknown as Logger;
+
+/** Fake KV that records the peak number of concurrent get() calls. */
+function makeCountingKV(projectCount: number): { kv: KVNamespace; peak: () => number } {
+  const store = new Map<string, string>();
+  for (let i = 0; i < projectCount; i++) {
+    store.set(
+      `project:@o:p${i}`,
+      JSON.stringify({ id: `proj_${i}`, name: `p${i}`, slug: `p${i}` }),
+    );
+  }
+  let inFlight = 0;
+  let peak = 0;
+  const kv = {
+    list: async (_opts?: { prefix?: string; cursor?: string }) => ({
+      keys: [...store.keys()].map((name) => ({ name })),
+      list_complete: true,
+      cursor: "",
+    }),
+    get: async (key: string) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 1)); // force overlap
+      inFlight--;
+      return store.get(key) ?? null;
+    },
+  } as unknown as KVNamespace;
+  return { kv, peak: () => peak };
+}
+
+describe("listProjects KV fan-out is bounded", () => {
+  it("returns every project but never exceeds the concurrency cap", async () => {
+    const { kv, peak } = makeCountingKV(60);
+    const result = await listProjects(kv, log);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toHaveLength(60); // all projects, none dropped
+    // The unbounded version would peak at 60 concurrent gets; bounded stays ≤ 25.
+    expect(peak()).toBeLessThanOrEqual(25);
+  });
+});


### PR DESCRIPTION
Third remediation PR. Addresses the **Critical scale cliff** the audit's performance pass found.

**Problem:** `listProjects`/`listProjectsByNamespace`/`listWorkspaces` each did an **unbounded** `Promise.all(keys.map(kv.get))` — one KV subrequest per entry, no concurrency limit. Past ~1000 projects/workspaces this exceeds the Workers **1000-subrequest-per-invocation cap and throws**. Because merge, dashboard, backup, and sync all route through `listProjects`, the **entire write path fails instance-wide** at that threshold.

**Fix:** bound the fan-out to a pool of 25 (`mapBounded`). All entries still returned; only concurrency is capped. Removes the hard crash.

**Not** the whole story: the deeper issue is needing a full-instance *scan* at all (every merge resolves identity via `listProjects`). That's the KV→D1 identity tranche (T5) — this PR just removes the cap-exceeded crash in the meantime.

Test: 60 projects list fully with peak concurrency ≤ 25. Full suite green (1046).

🤖 Generated with [Claude Code](https://claude.com/claude-code)