### PR TITLE
fix(audit): tranche 3a — unique provenance per merge commit

### DIFF
--- a/migrations/033_provenance_unique.sql
+++ b/migrations/033_provenance_unique.sql
@@ -1,0 +1,17 @@
+-- Prevent duplicate provenance rows for a single merge commit. A concurrent
+-- double-merge of the same change (the merge path is not wrapped in a CAS on
+-- every backend) could reach recordProvenance twice and write two rows for one
+-- commit, corrupting the audit trail.
+--
+-- Scope is (change_id, commit_sha), NOT change_id alone: a legitimate re-merge of
+-- a change after a revert produces a DIFFERENT commit sha and must still record.
+
+-- First remove any existing duplicates (from before this constraint), keeping the
+-- earliest row per (change_id, commit_sha).
+DELETE FROM provenance
+ WHERE rowid NOT IN (
+   SELECT MIN(rowid) FROM provenance GROUP BY change_id, commit_sha
+ );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_provenance_change_commit
+  ON provenance(change_id, commit_sha);

--- a/src/storage/provenance.ts
+++ b/src/storage/provenance.ts
@@ -70,9 +70,13 @@ export async function recordProvenance(
     const id = newId("prv");
     const mergedAt = new Date().toISOString();
 
-    await db
+    // OR IGNORE tolerates the (change_id, commit_sha) unique index (migration 033):
+    // a concurrent duplicate merge that both reach recordProvenance can't write two
+    // rows for one merge commit. A legitimate re-merge after a revert produces a
+    // different commit_sha, so it is NOT deduped.
+    const result = await db
       .prepare(
-        "INSERT INTO provenance (id, commit_sha, project, project_id, workspace, change_id, agent_id, eval_score, model, prompt_hash, merged_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT OR IGNORE INTO provenance (id, commit_sha, project, project_id, workspace, change_id, agent_id, eval_score, model, prompt_hash, merged_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
       )
       .bind(
         id,
@@ -88,6 +92,13 @@ export async function recordProvenance(
         mergedAt,
       )
       .run();
+
+    if ((result.meta?.changes ?? 0) === 0) {
+      logger.info("Provenance already recorded for this merge; skipped duplicate", {
+        changeId: opts.changeId,
+        commitSha: opts.commitSha,
+      });
+    }
 
     const record: ProvenanceRecord = {
       id,

--- a/tests/project-id-dual-write.test.ts
+++ b/tests/project-id-dual-write.test.ts
@@ -37,16 +37,16 @@ function makeCapturingD1(): { db: D1Database; captures: Capture[] } {
   const captures: Capture[] = [];
 
   function parseColumns(sql: string): string[] {
-    const match = sql.match(/INSERT INTO \w+\s*\(([^)]*)\)/i);
-    if (!match?.[1]) return [];
-    return match[1].split(",").map((c) => c.trim());
+    const match = sql.match(/INSERT( OR IGNORE)? INTO \w+\s*\(([^)]*)\)/i);
+    if (!match?.[2]) return [];
+    return match[2].split(",").map((c) => c.trim());
   }
 
   function makeStmt(sql: string, bindings: unknown[]) {
     return {
       bind: (...args: unknown[]) => makeStmt(sql, args),
       run: async () => {
-        if (/^\s*INSERT INTO/i.test(sql)) {
+        if (/^\s*INSERT( OR IGNORE)? INTO/i.test(sql)) {
           captures.push({ columns: parseColumns(sql), bindings });
         }
         return { success: true, meta: {} };

--- a/tests/provenance.test.ts
+++ b/tests/provenance.test.ts
@@ -30,8 +30,12 @@ function makeD1() {
           return this;
         },
         async run() {
-          if (this._sql.startsWith("INSERT INTO provenance")) {
+          if (/^INSERT( OR IGNORE)? INTO provenance/i.test(this._sql)) {
             const b = this._binds;
+            // Model the (change_id, commit_sha) unique index: OR IGNORE is a no-op
+            // when a row already exists for the same merge commit.
+            const dupe = rows.some((r) => r.change_id === b[5] && r.commit_sha === b[1]);
+            if (dupe) return { success: true, meta: { changes: 0 } };
             rows.push({
               id: b[0],
               commit_sha: b[1],
@@ -45,8 +49,9 @@ function makeD1() {
               prompt_hash: b[9] ?? null,
               merged_at: b[10],
             });
+            return { success: true, meta: { changes: 1 } };
           }
-          return { success: true };
+          return { success: true, meta: { changes: 0 } };
         },
         async all() {
           const project = this._binds[0];
@@ -86,6 +91,29 @@ describe("provenance model + prompt hash", () => {
       expect(read.data[0]?.model).toBe("claude-fable-5");
       expect(read.data[0]?.promptHash).toBe("sha256:digest");
     }
+  });
+
+  it("dedups a duplicate merge: two records for one (change, commit) → one row", async () => {
+    const db = makeD1();
+    const opts = {
+      commitSha: "same_commit",
+      project: "proj-3",
+      workspace: "ws",
+      changeId: "chg_dupe",
+    };
+    // Two concurrent mergers both reach recordProvenance for the same merge commit.
+    const first = await recordProvenance(db, logger, opts);
+    const second = await recordProvenance(db, logger, opts);
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true); // the loser is tolerated, not an error
+
+    const read = await listProvenance(db, logger, "proj-3");
+    expect(read.success && read.data).toHaveLength(1); // exactly one provenance row
+
+    // A re-merge after a revert has a DIFFERENT commit sha → still recorded.
+    await recordProvenance(db, logger, { ...opts, commitSha: "remerge_commit" });
+    const after = await listProvenance(db, logger, "proj-3");
+    expect(after.success && after.data).toHaveLength(2);
   });
 
   it("leaves model and prompt hash undefined for a user-authored merge", async () => {


### PR DESCRIPTION
Part of the merge de-dup finding (High). A concurrent double-merge could write **two provenance rows for one merge commit**, corrupting the audit trail.

This is the **DB-level, path-independent** backstop (holds regardless of which of the three merge paths runs):
- **migration 033** — dedupe existing `(change_id, commit_sha)` rows, then a UNIQUE INDEX on `(change_id, commit_sha)`. Scope includes `commit_sha` so a legitimate re-merge after a revert (different sha) still records.
- `recordProvenance` → `INSERT OR IGNORE`: the losing concurrent writer is tolerated (logged), not an error.

**Remaining T3 piece** (separate PR): the status-transition CAS across the three merge paths to also de-dup the `change.merged` **event** (double webhooks / post-merge). Filed as follow-up.

Test: two records for one (change, commit) → one row; re-merge with a new commit still records. Full suite green (1046).

🤖 Generated with [Claude Code](https://claude.com/claude-code)