### PR TITLE
fix(audit): tranche 4a — backup health signal + cron audit

### DIFF
--- a/src/backup/run-backup.ts
+++ b/src/backup/run-backup.ts
@@ -1,3 +1,4 @@
+import { recordAudit } from "../storage/audit";
 import { RUN_MANIFEST_KEY, pruneRuns, putBlob } from "../storage/backup-store";
 import { BACKUP_TABLES, exportTable } from "../storage/d1-backup";
 import { exportKvIdentity } from "../storage/kv-backup";
@@ -41,6 +42,10 @@ export interface BackupRunSummary {
   };
   bytes: number;
   prunedRuns: number;
+  /** True only when EVERY D1 table exported ok, KV identity is whole, and no repo
+   * failed. `_manifest.json` presence merely means "not crashed"; `healthy` means
+   * "actually restorable". A reader/alert should key on this, not on completeness. */
+  healthy: boolean;
 }
 
 /** Injectable so the orchestration is testable without a real Artifacts clone. */
@@ -104,6 +109,7 @@ export async function runBackup(
     repos: { total: 0, backedUp: 0, skipped: [], failed: [], deferred: 0 },
     bytes: 0,
     prunedRuns: 0,
+    healthy: true,
   };
 
   if (!bucket) {
@@ -255,11 +261,41 @@ async function runBackupLocked(
   const pruned = await pruneRuns(bucket, retention, logger);
   if (pruned.success) summary.prunedRuns = pruned.data.prunedRuns;
 
+  // A run is healthy only if everything landed — completeness (manifest present)
+  // is NOT the same as success; without this a run where every export failed still
+  // reads as complete and retention evicts the last good one.
+  summary.healthy =
+    summary.d1.every((t) => t.ok) && summary.kv.ok && summary.repos.failed.length === 0;
+  if (!summary.healthy) {
+    logger.error("Backup run UNHEALTHY — an export failed; this run is not restorable", undefined, {
+      runTs,
+      d1Failed: summary.d1.filter((t) => !t.ok).map((t) => t.table),
+      kvOk: summary.kv.ok,
+      reposFailed: summary.repos.failed.length,
+    });
+  }
+
   // --- Run manifest LAST: its presence marks the run complete ---
   await put(RUN_MANIFEST_KEY, new TextEncoder().encode(JSON.stringify(summary)));
 
+  // Durable signal for an operator/alert — the cron path previously left no
+  // audit trail at all (only the manual route did).
+  await recordAudit(env.DB, logger, {
+    action: "backup.run",
+    actorType: "system",
+    subject: runTs,
+    detail: {
+      trigger: "auto",
+      healthy: summary.healthy,
+      repos: summary.repos.backedUp,
+      failed: summary.repos.failed.length,
+      bytes: summary.bytes,
+    },
+  });
+
   logger.info("Backup run complete", {
     runTs,
+    healthy: summary.healthy,
     repos: summary.repos.backedUp,
     deferred: summary.repos.deferred,
     bytes: summary.bytes,

--- a/tests/backup-route.test.ts
+++ b/tests/backup-route.test.ts
@@ -38,6 +38,7 @@ const summary = {
   repos: { total: 0, backedUp: 2, skipped: [], failed: [], deferred: 0 },
   bytes: 100,
   prunedRuns: 0,
+  healthy: true,
 };
 
 beforeEach(() => {

--- a/tests/run-backup.test.ts
+++ b/tests/run-backup.test.ts
@@ -81,6 +81,7 @@ describe("runBackup orchestrator", () => {
     expect(keys[keys.length - 1]).toBe(`2026-07-19T06:00:00Z/${RUN_MANIFEST_KEY}`);
 
     expect(summary.repos.backedUp).toBe(1);
+    expect(summary.healthy).toBe(true);
     expect(summary.kv.projects).toBe(1);
     expect(summary.d1.find((t) => t.table === "users")?.rowCount).toBe(1);
   });
@@ -128,7 +129,9 @@ describe("runBackup orchestrator", () => {
 
     expect(summary.repos.backedUp).toBe(1);
     expect(summary.repos.failed.map((f) => f.projectId)).toEqual(["bad"]);
-    // Run still completed: manifest was written.
+    // Run still completed (manifest written) BUT is flagged unhealthy — a reader
+    // must not treat this as restorable just because it's "complete".
+    expect(summary.healthy).toBe(false);
     const bucket = env.BACKUPS as unknown as { store: Map<string, Uint8Array> };
     expect([...bucket.store.keys()]).toContain(`2026-07-19T06:00:00Z/${RUN_MANIFEST_KEY}`);
   });


### PR DESCRIPTION
Addresses the **silent backup rot** finding (High). Backups could degrade to useless while still reading as `complete: true` — `_manifest.json` is written unconditionally even if every export failed, and retention then evicts the last good run.

- **`healthy` flag** in the run summary/manifest: true only when every D1 table exported ok, KV is whole, and zero repos failed. Completeness (manifest present) ≠ success.
- **Error log** when a run is unhealthy — the actionable operator signal.
- **Cron audit row** (`backup.run`) with the healthy flag — the scheduled path previously left no audit trail at all (only the manual route did).

Follow-ups noted in the commit: retention should prefer healthy runs; an external alert transport; full-depth/all-refs capture.

Test: healthy=true on a clean run, healthy=false when a repo export fails. Full suite green (1045).

🤖 Generated with [Claude Code](https://claude.com/claude-code)