### PR TITLE
fix(audit): tranche 4b — backup captures full history (not depth-50 shallow)

### DIFF
--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -138,7 +138,11 @@ export async function snapshotRepo(
   const token = await freshRepoToken(env.ARTIFACTS, project.remote, "read", logger);
   if (!token.success) return err(token.error);
 
-  const clone = await cloneRepo(project.remote, token.data, logger);
+  // Full history: a shallow clone would drop ancestors past depth 50, yielding a
+  // pack that can't restore the repo to its true tip.
+  const clone = await cloneRepo(project.remote, token.data, logger, undefined, {
+    fullHistory: true,
+  });
   if (!clone.success) return err(clone.error);
 
   const walk = await walkRepoObjects(clone.data.fs, clone.data.dir, maxBytes, logger);

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -140,6 +140,15 @@ export async function snapshotRepo(
 
   // Full history: a shallow clone would drop ancestors past depth 50, yielding a
   // pack that can't restore the repo to its true tip.
+  //
+  // Known trade-off: `maxBytes` is enforced by walkRepoObjects AFTER the clone,
+  // so an over-cap repo is loaded into MemoryFS before it is skipped. This is
+  // inherent to full-history backup — restorability requires the whole history,
+  // and the smart-HTTP fetch (isomorphic-git) gives no way to know a repo's size
+  // before fetching it, so there is no correctness-preserving pre-clone guard. A
+  // bounded/streaming fetch that aborts mid-clone would be the real fix (tracked
+  // as a follow-up); for now MAX_BACKUP_BYTES should be set well under the
+  // Worker's memory budget so a normal repo never approaches it.
   const clone = await cloneRepo(project.remote, token.data, logger, undefined, {
     fullHistory: true,
   });

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -318,8 +318,9 @@ export async function cloneRepo(
   token: string,
   logger: Logger,
   httpClient: HttpClient = http,
+  opts: { fullHistory?: boolean } = {},
 ): Promise<Result<{ fs: NodeFS; dir: string }, AppError>> {
-  logger.debug("Cloning repository", { remote });
+  logger.debug("Cloning repository", { remote, fullHistory: opts.fullHistory ?? false });
 
   const fs = new MemoryFS().toNodeFS();
   const cloneResult = await fromPromise(
@@ -330,7 +331,11 @@ export async function cloneRepo(
       url: remote,
       ref: "main",
       singleBranch: true,
-      depth: 50,
+      // Merges only need recent history (fast shallow clone). Backup needs the FULL
+      // reachable history so the resulting pack is reachability-closed and restores
+      // to the true tip — a 50-commit shallow clone silently drops older ancestors,
+      // producing a snapshot that can't be restored past commit 50.
+      ...(opts.fullHistory ? {} : { depth: 50 }),
       onAuth: makeAuth(token),
     }),
   );


### PR DESCRIPTION
Fixes a real **correctness bug** in the backup feature: `snapshotRepo` clones via `cloneRepo`, which hardcodes `depth: 50`. So a repo with >50 commits was snapshotted with its **older ancestors missing** — the pack isn't reachability-closed and **can't restore the repo past commit 50**. The "full reachable history" backup silently wasn't.

- `cloneRepo` gains a `fullHistory` option: **merges keep the fast shallow clone**, **backup clones the complete history**. `MAX_BACKUP_BYTES` still bounds it (oversize repos skip + mark the run unhealthy, per #139).

**Follow-up** (noted in commit): all-refs capture (non-`main` branches/tags) needs manifest + reconstruct + restore changes — larger, tracked separately.

The git-clone depth flag isn't unit-testable without a git server; the reachability-closure it feeds is covered by the existing repo-snapshot walk test. Full suite green (1045).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository snapshots now preserve the complete reachable Git history instead of limiting it to a shallow history.
  * Restoring from a snapshot can now reliably return the repository to its exact latest commit.
  * Existing snapshot handling remains unchanged, including skipping empty or oversized repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->