### PR TITLE
fix(audit): deletion enforcement on synchronous write routes

### DIFF
--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -24,6 +24,7 @@ import {
   updateChangeStatus,
 } from "../storage/changes";
 import { type CostSample, getChangeCostSummary, recordCosts } from "../storage/costs";
+import { isTargetDeleting } from "../storage/deletion";
 import { listEvalRuns, recordEvalRuns } from "../storage/eval-runs";
 import {
   MergeConflictError,
@@ -223,6 +224,13 @@ app.post("/projects/:name/changes", async (c) => {
 
   if (!(await canWriteProject(c.env.DB, project, userId, agentOwnerId)))
     return forbidden("Project access denied");
+
+  // Refuse writes while the project (or its owner) is being deleted — otherwise a
+  // new change resurrects rows the cascade is removing and wedges the job as
+  // `incomplete`. Best-effort (TOCTOU); the verifier re-run is the durable backstop.
+  if (await isTargetDeleting(c.env, project, logger)) {
+    return c.json({ error: "Project is being deleted", code: "TARGET_DELETING" }, 409);
+  }
 
   const body = await c.req.json<{ workspace?: unknown }>().catch(() => ({ workspace: undefined }));
   if (typeof body.workspace !== "string" || !body.workspace.trim()) {

--- a/src/routes/issues.ts
+++ b/src/routes/issues.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { type EventActor, emitEvent } from "../queue/events";
 import { getChange } from "../storage/changes";
+import { isTargetDeleting } from "../storage/deletion";
 import {
   type IssueStatus,
   createIssue,
@@ -78,6 +79,12 @@ app.post("/:namespace/:slug/issues", async (c) => {
   // Anyone who can read the project can open issues against it.
   if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
     return notFound("Project", `${project.namespace}/${project.slug}`);
+  }
+
+  // Refuse opening an issue while the project is being deleted — it resurrects a
+  // row the cascade removed and wedges the job. Best-effort; verifier re-run backs it.
+  if (await isTargetDeleting(c.env, project, logger)) {
+    return c.json({ error: "Project is being deleted", code: "TARGET_DELETING" }, 409);
   }
 
   let body: { title?: unknown; body?: unknown; linkedChangeId?: unknown };

--- a/src/routes/reviews.ts
+++ b/src/routes/reviews.ts
@@ -8,6 +8,7 @@ import {
   submitReview,
 } from "../storage/change-reviews";
 import { getChange, updateChangeStatus } from "../storage/changes";
+import { isTargetDeleting } from "../storage/deletion";
 import { getProject } from "../storage/state";
 import type { Change, Env, ProjectEntry } from "../types";
 import { canReadProject, canWriteProject } from "../utils/authz";
@@ -167,6 +168,12 @@ app.post("/changes/:id/reviews", async (c) => {
 
   if (!(await canWriteProject(c.env.DB, project, userId)))
     return forbidden("Project access denied");
+
+  // Refuse a review verdict while the project is being deleted (it resurrects
+  // change_reviews rows and wedges the cascade). Best-effort; verifier re-run backs it.
+  if (await isTargetDeleting(c.env, project, logger)) {
+    return c.json({ error: "Project is being deleted", code: "TARGET_DELETING" }, 409);
+  }
 
   if (!REVIEWABLE_STATUSES.includes(change.status)) {
     return badRequest(`Cannot review a ${change.status} change`);

--- a/src/routes/workspaces.ts
+++ b/src/routes/workspaces.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { type EventActor, emitEvent } from "../queue/events";
+import { isTargetDeleting } from "../storage/deletion";
 import {
   artifactsRepoNameFromRemote,
   cloneRepo,
@@ -64,6 +65,12 @@ app.post("/:namespace/:slug/workspaces", async (c) => {
 
   if (!(await canWriteProject(c.env.DB, project, userId, agentOwnerId)))
     return forbidden("Project access denied");
+
+  // Refuse creating a workspace/fork while the project is being deleted — a new
+  // fork the cascade never captured leaks as an orphan and wedges the job.
+  if (await isTargetDeleting(c.env, project, logger)) {
+    return c.json({ error: "Project is being deleted", code: "TARGET_DELETING" }, 409);
+  }
 
   const body = await c.req.json<{ name?: unknown }>().catch(() => ({ name: undefined }));
   const workspaceName = isValidSlug(body.name) ? body.name : `ws-${Date.now()}`;

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -34,6 +34,10 @@ vi.mock("../src/storage/state", () => ({
   getWorkspace: vi.fn(),
 }));
 
+vi.mock("../src/storage/deletion", () => ({
+  isTargetDeleting: vi.fn().mockResolvedValue(false),
+}));
+
 vi.mock("../src/evaluation", () => ({
   loadPolicy: vi.fn(),
   DiffEvaluator: vi.fn().mockImplementation(() => ({
@@ -137,6 +141,7 @@ import {
   listChanges,
   updateChangeStatus,
 } from "../src/storage/changes";
+import { isTargetDeleting } from "../src/storage/deletion";
 import { listEvalRuns, recordEvalRuns } from "../src/storage/eval-runs";
 import {
   batchMergeStagedTrees,
@@ -348,6 +353,18 @@ describe("POST /api/projects/:name/changes", () => {
           aggregate: vi.fn().mockReturnValue(passingEvalResult),
         }) as unknown as CompositeEvaluator,
     );
+  });
+
+  it("409s when the project is being deleted (no change created)", async () => {
+    vi.mocked(isTargetDeleting).mockResolvedValueOnce(true);
+    const res = await app.fetch(
+      request("POST", "/api/projects/my-project/changes", { workspace: "fix-bug" }, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("TARGET_DELETING");
+    expect(vi.mocked(createChange)).not.toHaveBeenCalled();
   });
 
   it("creates a change, runs evaluators, and returns accepted status when eval passes", async () => {


### PR DESCRIPTION
Addresses the deletion-enforcement gap (High). `isTargetDeleting` guarded the **async** queue consumers (merge/import/sync) but **not** the synchronous write **routes** — so during a project's deletion cascade a caller could still create a change, commit a workspace/fork, submit a review, or open an issue, **resurrecting rows/forks** the verifier then flags and **wedging the job as terminal `incomplete`** (and blocking GDPR account erasure).

Guards the four write routes after project-resolution + authz → **409 `TARGET_DELETING`**:
- `createChange` (changes.ts) · workspace create/fork (workspaces.ts) · `submitReview` (reviews.ts) · `createIssue` (issues.ts)

**Best-effort by design** (TOCTOU — a write already past the check can still land); the durable backstop is the cascade's idempotent verifier re-run. The remaining half — making `incomplete` **re-drivable** so a lost race self-heals — needs a retryable-error taxonomy + attempts cap and is tracked separately.

Test: createChange 409s (code `TARGET_DELETING`) and never creates the change when deleting. Full suite green (1046).

🤖 Generated with [Claude Code](https://claude.com/claude-code)