### PR TITLE
fix(audit): deliver webhooks by project_id (close cross-tenant leak)

### DIFF
--- a/src/queue/webhook-delivery.ts
+++ b/src/queue/webhook-delivery.ts
@@ -116,7 +116,12 @@ export async function deliverEventToWebhooks(
   event: EventRecord,
   logger: Logger,
 ): Promise<void> {
-  const webhooksResult = await listWebhooks(env.DB, logger, event.project, { activeOnly: true });
+  // Scope delivery by the canonical project_id when the event carries one, so a
+  // same-named project in another namespace never receives these events.
+  const webhooksResult = await listWebhooks(env.DB, logger, event.project, {
+    activeOnly: true,
+    ...(event.projectId !== undefined ? { projectId: event.projectId } : {}),
+  });
   if (!webhooksResult.success) return;
 
   const matching = webhooksResult.data.filter((webhook) =>

--- a/src/storage/webhooks.ts
+++ b/src/storage/webhooks.ts
@@ -177,16 +177,23 @@ export async function listWebhooks(
   db: D1Database,
   logger: Logger,
   project: string,
-  opts?: { activeOnly?: boolean },
+  opts?: { activeOnly?: boolean; projectId?: string },
 ): Promise<Result<Webhook[], AppError>> {
   try {
-    const result = opts?.activeOnly
+    const activeClause = opts?.activeOnly ? " AND active = 1" : "";
+    // When a canonical project_id is known (delivery path), match on it and fall
+    // back to the name only for legacy webhooks whose project_id wasn't backfilled.
+    // Matching purely on the free-form `project` name would deliver one tenant's
+    // events to a same-named project in ANOTHER namespace (cross-tenant leak).
+    const result = opts?.projectId
       ? await db
-          .prepare("SELECT * FROM webhooks WHERE project = ? AND active = 1")
-          .bind(project)
+          .prepare(
+            `SELECT * FROM webhooks WHERE (project_id = ? OR (project_id IS NULL AND project = ?))${activeClause}`,
+          )
+          .bind(opts.projectId, project)
           .all<WebhookRow>()
       : await db
-          .prepare("SELECT * FROM webhooks WHERE project = ?")
+          .prepare(`SELECT * FROM webhooks WHERE project = ?${activeClause}`)
           .bind(project)
           .all<WebhookRow>();
     return ok(result.results.map(rowToWebhook));

--- a/tests/helpers/webhooks-d1.ts
+++ b/tests/helpers/webhooks-d1.ts
@@ -83,6 +83,16 @@ export function makeWebhooksD1(): {
             .filter((d) => d.webhook_id === bindings[0])
             .sort((a, b) => b.created_at.localeCompare(a.created_at))
             .slice(0, bindings[1] as number);
+        } else if (upper.includes("PROJECT_ID = ?")) {
+          // project_id-first with legacy name fallback: (project_id = ? OR (project_id IS NULL AND project = ?))
+          const projectId = bindings[0] as string;
+          const project = bindings[1] as string;
+          const activeReq = upper.includes("ACTIVE = 1");
+          results = webhooks.filter(
+            (w) =>
+              (w.project_id === projectId || (w.project_id === null && w.project === project)) &&
+              (!activeReq || w.active === 1),
+          );
         } else if (upper.includes("AND ACTIVE = 1")) {
           results = webhooks.filter((w) => w.project === bindings[0] && w.active === 1);
         } else {

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -55,6 +55,33 @@ describe("webhook storage", () => {
     expect(result.data.active).toBe(true);
   });
 
+  it("scopes delivery lookup by project_id — no cross-tenant leak on a name collision", async () => {
+    const { db } = makeWebhooksD1();
+    // Two projects both named "api" in different namespaces, with distinct ids.
+    await createWebhook(db, mockLogger, {
+      project: "api",
+      projectId: "proj_alice",
+      url: "https://alice.example.com/hook",
+      createdBy: "alice",
+    });
+    await createWebhook(db, mockLogger, {
+      project: "api",
+      projectId: "proj_bob",
+      url: "https://bob.example.com/hook",
+      createdBy: "bob",
+    });
+
+    // Delivery for alice's project must only find alice's webhook.
+    const forAlice = await listWebhooks(db, mockLogger, "api", {
+      activeOnly: true,
+      projectId: "proj_alice",
+    });
+    expect(forAlice.success).toBe(true);
+    if (!forAlice.success) return;
+    expect(forAlice.data).toHaveLength(1);
+    expect(forAlice.data[0]?.url).toBe("https://alice.example.com/hook");
+  });
+
   it("lists, toggles, and deletes webhooks", async () => {
     const { db, deliveries } = makeWebhooksD1();
     const created = await createWebhook(db, mockLogger, {


### PR DESCRIPTION
Addresses the **cross-tenant webhook leak** (High) from the data-model audit. Delivery matched subscribers by the free-form `project` **name** — and names are only unique per-namespace, so under a collision **`@bob/api`'s endpoint received `@alice/api`'s event payloads** (event type, actor ids, change/PR metadata). The `webhooks.project_id` column (already dual-written on create) was ignored.

- `listWebhooks` now takes a `projectId`; delivery passes `event.projectId`. Query: `(project_id = ? OR (project_id IS NULL AND project = ?))` — **project_id first**, name only as a fallback for legacy un-backfilled webhooks.

**Known gap (transitional, per the /ship PRD):** legacy rows with NULL `project_id` still fall back to name matching; the residual closes once the T5 backfill runs and the name fallback is removed (gated on verified zero-NULL). New webhooks + events are correctly scoped now.

Test: two same-named projects in different namespaces → delivery lookup for one returns only its own webhook. Full suite green (1046).

🤖 Generated with [Claude Code](https://claude.com/claude-code)