### PR TITLE
fix(audit): make incomplete deletion jobs re-drivable (bounded auto-retry + admin route)

### DIFF
--- a/migrations/034_deletion_job_attempts.sql
+++ b/migrations/034_deletion_job_attempts.sql
@@ -1,0 +1,7 @@
+-- Re-drivable incomplete deletions: bound auto-retry with an attempt counter.
+-- `incomplete` used to be a hard-terminal state (the sweep excluded it) so a
+-- permanently-failing target could never loop forever. With a capped attempt
+-- count the sweep can safely re-drive TRANSIENT failures, while genuinely stuck
+-- jobs (attempts exhausted, or a terminal residual) stay `incomplete` for an
+-- operator to re-drive explicitly via the admin route.
+ALTER TABLE deletion_jobs ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { authRouter } from "./routes/auth";
 import { backupRouter } from "./routes/backup";
 import { bulkImportRouter } from "./routes/bulk-import";
 import { changesRouter } from "./routes/changes";
+import { deletionJobsRouter } from "./routes/deletion-jobs";
 import { emailAuthRouter } from "./routes/email-auth";
 import { gitHttpRouter } from "./routes/git-http";
 import { healthRouter } from "./routes/health";
@@ -125,6 +126,7 @@ app.route("/api/admin/metrics", metricsRouter);
 // Admin audit trail endpoint
 app.route("/api/admin/audit", auditRouter);
 app.route("/api/admin/backup", backupRouter);
+app.route("/api/admin/deletion-jobs", deletionJobsRouter);
 
 // Redirects from old /ui/* URLs to new paths (backward compatibility)
 app.get("/ui", (c) => c.redirect("/", 301));

--- a/src/queue/deletion-runner.ts
+++ b/src/queue/deletion-runner.ts
@@ -10,7 +10,9 @@ import {
   finishJob,
   getDeletionJob,
   heartbeat,
+  listRetryableIncompleteJobs,
   listUnfinishedJobs,
+  reopenIncompleteJob,
   setJobState,
 } from "../storage/deletion-jobs";
 import type { Env } from "../types";
@@ -26,6 +28,29 @@ const LEASE_TTL_MS = 15 * 60 * 1000;
 
 /** A job with no heartbeat progress for this long counts as stuck. */
 const STALE_HEARTBEAT_MS = 10 * 60 * 1000;
+
+/**
+ * How many times the sweep will auto-re-drive an `incomplete` job before
+ * leaving it for an operator. Bounds the retry so a permanently-failing target
+ * can't loop forever, while transient faults (a momentary Artifacts/D1 hiccup)
+ * still self-heal.
+ */
+const MAX_DELETION_ATTEMPTS = 3;
+
+/**
+ * Residual markers that can never clear on a retry — re-driving a job carrying
+ * one is pointless, so the sweep leaves it `incomplete` for an operator even
+ * while attempts remain. A malformed target is the canonical case: no amount of
+ * re-driving repairs unparseable job JSON.
+ */
+const TERMINAL_RESIDUAL_PREFIXES = ["target:unparseable"] as const;
+
+/** Whether an `incomplete` job's residuals could plausibly clear on a re-drive. */
+function residualsAreRetryable(residuals: string[]): boolean {
+  return !residuals.some((residual) =>
+    TERMINAL_RESIDUAL_PREFIXES.some((prefix) => residual.startsWith(prefix)),
+  );
+}
 
 function parseProjectTarget(raw: string): DeletionTarget | null {
   let parsed: unknown;
@@ -202,11 +227,12 @@ export async function runDeletionJob(
  * job with a stale (or missing) heartbeat. The initial enqueue after a delete
  * request is only an optimization — this sweep is what guarantees completion.
  *
- * `incomplete` is intentionally TERMINAL here: `listUnfinishedJobs` excludes it,
- * so the sweep never auto-retries. A permanently-failing Artifacts repo would
- * otherwise loop forever; instead the residuals are recorded + audited for an
- * operator, who recovers by enqueueing a FRESH job for the same target once the
- * underlying fault clears (the cascade is idempotent, so it converges).
+ * `incomplete` jobs are re-driven too, but only up to `MAX_DELETION_ATTEMPTS`
+ * and only when their residuals could plausibly clear (a terminal residual such
+ * as an unparseable target is never retried). A job that exhausts its budget or
+ * carries a terminal residual stays `incomplete` for an operator, who re-drives
+ * it explicitly via the admin route once the underlying fault is fixed. The
+ * cascade is idempotent, so every re-drive converges rather than double-deleting.
  */
 export async function sweepDeletionJobs(env: Env, logger: Logger): Promise<void> {
   const log = logger.child({ component: "deletion-sweep" });
@@ -218,10 +244,63 @@ export async function sweepDeletionJobs(env: Env, logger: Logger): Promise<void>
   }
   // Sequential on purpose: one Worker invocation driving many cascades in
   // parallel would compound subrequest limits and D1 write contention.
+  const drivenThisSweep = new Set<string>();
   for (const job of jobsResult.data) {
+    drivenThisSweep.add(job.id);
     const result = await runDeletionJob(env, job.id, log);
     if (!result.success) {
       log.error("Failed to drive deletion job", result.error, { jobId: job.id });
     }
   }
+
+  const retryableResult = await listRetryableIncompleteJobs(env.DB, log, MAX_DELETION_ATTEMPTS);
+  if (!retryableResult.success) {
+    log.error("Failed to list retryable incomplete deletion jobs", retryableResult.error);
+    return;
+  }
+  for (const job of retryableResult.data) {
+    // A job the stale-heartbeat pass already drove to `incomplete` this sweep
+    // must wait for the NEXT sweep — otherwise a single fault would burn two
+    // attempts per cycle instead of the one `MAX_DELETION_ATTEMPTS` implies.
+    if (drivenThisSweep.has(job.id)) continue;
+    if (!residualsAreRetryable(job.residuals)) continue;
+    const reopened = await reopenIncompleteJob(env.DB, log, job.id);
+    if (!reopened.success) {
+      log.error("Failed to reopen incomplete deletion job", reopened.error, { jobId: job.id });
+      continue;
+    }
+    // A concurrent driver already reopened or finished it; leave it be.
+    if (!reopened.data) continue;
+    log.info("Re-driving incomplete deletion job", { jobId: job.id, attempts: job.attempts });
+    const result = await runDeletionJob(env, job.id, log);
+    if (!result.success) {
+      log.error("Failed to re-drive incomplete deletion job", result.error, { jobId: job.id });
+    }
+  }
+}
+
+/**
+ * Operator-initiated re-drive of an `incomplete` job (admin route): clears the
+ * attempt budget and drives once. Returns `reopened: false` — for the route to
+ * map to 404/409 — when the job is missing or not `incomplete` (already
+ * completed, still running, or reopened by a racing driver). The cascade is
+ * idempotent, so re-driving an already-cleaned target simply verifies clean.
+ */
+export async function redriveDeletionJob(
+  env: Env,
+  jobId: string,
+  logger: Logger,
+): Promise<Result<{ reopened: boolean }, AppError>> {
+  const log = logger.child({ component: "deletion-redrive", jobId });
+  const jobResult = await getDeletionJob(env.DB, log, jobId);
+  if (!jobResult.success) return err(jobResult.error);
+  if (!jobResult.data || jobResult.data.state !== "incomplete") {
+    return ok({ reopened: false });
+  }
+  const reopened = await reopenIncompleteJob(env.DB, log, jobId, { resetAttempts: true });
+  if (!reopened.success) return err(reopened.error);
+  if (!reopened.data) return ok({ reopened: false });
+  const driven = await runDeletionJob(env, jobId, log);
+  if (!driven.success) return err(driven.error);
+  return ok({ reopened: true });
 }

--- a/src/routes/deletion-jobs.ts
+++ b/src/routes/deletion-jobs.ts
@@ -1,0 +1,68 @@
+import { Hono } from "hono";
+import { redriveDeletionJob } from "../queue/deletion-runner";
+import { recordAudit } from "../storage/audit";
+import { getDeletionJob } from "../storage/deletion-jobs";
+import type { Env } from "../types";
+import { isAdminRequest } from "../utils/admin";
+import { createLogger } from "../utils/logger";
+import { forbidden, internalError, notFound, ok } from "../utils/response";
+
+const app = new Hono<{ Bindings: Env }>();
+
+async function requireAdmin(c: {
+  env: Env;
+  req: { header: (n: string) => string | undefined; path: string; method: string };
+  get: (k: "userId") => string | undefined;
+}): Promise<{ ok: true; logger: ReturnType<typeof createLogger> } | { ok: false }> {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+  const isAdmin = await isAdminRequest(
+    c.env,
+    {
+      ...(c.req.header("X-Admin-API-Key") !== undefined
+        ? { adminApiKeyHeader: c.req.header("X-Admin-API-Key") }
+        : {}),
+      ...(c.get("userId") !== undefined ? { userId: c.get("userId") } : {}),
+    },
+    logger,
+  );
+  return isAdmin ? { ok: true, logger } : { ok: false };
+}
+
+// POST /api/admin/deletion-jobs/:id/redrive — operator re-drive of a deletion
+// job that finished `incomplete` (transient fault, or a fault the operator has
+// since fixed). Resets the attempt budget and drives once; idempotent.
+app.post("/:id/redrive", async (c) => {
+  const auth = await requireAdmin(c);
+  if (!auth.ok) return forbidden("Administrator access required");
+  const { logger } = auth;
+  const id = c.req.param("id");
+
+  const result = await redriveDeletionJob(c.env, id, logger);
+  if (!result.success) return internalError(result.error.message);
+
+  if (!result.data.reopened) {
+    const existing = await getDeletionJob(c.env.DB, logger, id);
+    if (existing.success && !existing.data) return notFound("Deletion job", id);
+    return c.json(
+      { error: "Deletion job is not in the incomplete state", code: "NOT_REDRIVABLE" },
+      409,
+    );
+  }
+
+  await recordAudit(c.env.DB, logger, {
+    action: "deletion.redrive",
+    actorType: c.get("userId") ? "user" : "system",
+    ...(c.get("userId") !== undefined ? { actorId: c.get("userId") } : {}),
+    subject: id,
+  });
+
+  const refreshed = await getDeletionJob(c.env.DB, logger, id);
+  return ok({ job: refreshed.success ? refreshed.data : null });
+});
+
+export { app as deletionJobsRouter };

--- a/src/storage/audit.ts
+++ b/src/storage/audit.ts
@@ -17,7 +17,8 @@ export type AuditAction =
   | "deletion.requested"
   | "deletion.started"
   | "deletion.completed"
-  | "deletion.incomplete";
+  | "deletion.incomplete"
+  | "deletion.redrive";
 
 export interface AuditEntry {
   id: string;

--- a/src/storage/deletion-jobs.ts
+++ b/src/storage/deletion-jobs.ts
@@ -18,6 +18,8 @@ export interface DeletionJob {
   leaseOwner: string | null;
   leaseExpiresAt: string | null;
   residuals: string[];
+  /** Count of drives that ended `incomplete`; caps auto-retry in the sweep. */
+  attempts: number;
   createdAt: string;
   startedAt: string | null;
   finishedAt: string | null;
@@ -33,6 +35,7 @@ interface DeletionJobRow {
   lease_owner: string | null;
   lease_expires_at: string | null;
   residuals: string | null;
+  attempts: number | null;
   created_at: string;
   started_at: string | null;
   finished_at: string | null;
@@ -66,6 +69,7 @@ function rowToJob(row: DeletionJobRow, logger: Logger): DeletionJob {
     leaseOwner: row.lease_owner,
     leaseExpiresAt: row.lease_expires_at,
     residuals,
+    attempts: row.attempts ?? 0,
     createdAt: row.created_at,
     startedAt: row.started_at,
     finishedAt: row.finished_at,
@@ -109,6 +113,7 @@ export async function createDeletionJob(
     leaseOwner: null,
     leaseExpiresAt: null,
     residuals: [],
+    attempts: 0,
     createdAt: now,
     startedAt: null,
     finishedAt: null,
@@ -282,16 +287,70 @@ export async function finishJob(
   residuals: string[],
 ): Promise<Result<boolean, AppError>> {
   try {
+    // Only a failed drive counts against the retry budget; a `completed` drive
+    // is terminal-success and leaves the counter untouched.
+    const attemptIncrement = state === "incomplete" ? 1 : 0;
     const result = await db
       .prepare(
         "UPDATE deletion_jobs SET state = ?, residuals = ?, finished_at = ?, " +
-          "lease_owner = NULL, lease_expires_at = NULL WHERE id = ? AND lease_owner = ?",
+          "attempts = attempts + ?, lease_owner = NULL, lease_expires_at = NULL " +
+          "WHERE id = ? AND lease_owner = ?",
       )
-      .bind(state, JSON.stringify(residuals), new Date().toISOString(), id, owner)
+      .bind(state, JSON.stringify(residuals), new Date().toISOString(), attemptIncrement, id, owner)
       .run();
     return ok((result.meta?.changes ?? 0) > 0);
   } catch (error) {
     return err(toDbError(error, "finish", logger, id));
+  }
+}
+
+/**
+ * `incomplete` jobs still within the retry budget. The sweep filters these
+ * further by residual class (a terminal residual can never clear) before
+ * re-driving; this query only bounds the SQL scan by attempt count.
+ */
+export async function listRetryableIncompleteJobs(
+  db: D1Database,
+  logger: Logger,
+  maxAttempts: number,
+): Promise<Result<DeletionJob[], AppError>> {
+  try {
+    const result = await db
+      .prepare("SELECT * FROM deletion_jobs WHERE state = 'incomplete' AND attempts < ?")
+      .bind(maxAttempts)
+      .all<DeletionJobRow>();
+    return ok(result.results.map((row) => rowToJob(row, logger)));
+  } catch (error) {
+    return err(toDbError(error, "list retryable", logger));
+  }
+}
+
+/**
+ * Move an `incomplete` job back to `pending` so a driver re-drives it. Guarded
+ * on `state = 'incomplete'` so it can never disturb an active or completed job
+ * (returns `false` when nothing matched — e.g. a concurrent driver already
+ * reopened it). `checkpoint` is preserved: the `deletion.started` audit already
+ * landed and the cascade is idempotent, so a re-drive must not re-audit the
+ * start. `resetAttempts` clears the budget for an operator-initiated re-drive
+ * after the underlying fault has been fixed.
+ */
+export async function reopenIncompleteJob(
+  db: D1Database,
+  logger: Logger,
+  id: string,
+  opts?: { resetAttempts?: boolean },
+): Promise<Result<boolean, AppError>> {
+  try {
+    const attemptsReset = opts?.resetAttempts ? ", attempts = 0" : "";
+    const result = await db
+      .prepare(
+        `UPDATE deletion_jobs SET state = 'pending', finished_at = NULL, heartbeat_at = NULL, lease_owner = NULL, lease_expires_at = NULL${attemptsReset} WHERE id = ? AND state = 'incomplete'`,
+      )
+      .bind(id)
+      .run();
+    return ok((result.meta?.changes ?? 0) > 0);
+  } catch (error) {
+    return err(toDbError(error, "reopen", logger, id));
   }
 }
 

--- a/tests/deletion-jobs.test.ts
+++ b/tests/deletion-jobs.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { runDeletionJob, sweepDeletionJobs } from "../src/queue/deletion-runner";
+import {
+  redriveDeletionJob,
+  runDeletionJob,
+  sweepDeletionJobs,
+} from "../src/queue/deletion-runner";
 import type { DeletionTarget } from "../src/storage/deletion";
 import {
   acquireLease,
@@ -7,7 +11,9 @@ import {
   finishJob,
   getDeletionJob,
   heartbeat,
+  listRetryableIncompleteJobs,
   listUnfinishedJobs,
+  reopenIncompleteJob,
 } from "../src/storage/deletion-jobs";
 import type { Env } from "../src/types";
 import type { Logger } from "../src/utils/logger";
@@ -302,6 +308,114 @@ describe("runDeletionJob", () => {
   });
 });
 
+describe("attempt budget", () => {
+  it("finishJob increments attempts only when the drive ends incomplete", async () => {
+    const stub = makeJobsD1();
+    const badId = await createProjectJob(stub, "proj_bad");
+    const goodId = await createProjectJob(stub, "proj_good");
+    await acquireLease(stub.db, mockLogger, badId, "d", 600_000);
+    await acquireLease(stub.db, mockLogger, goodId, "d", 600_000);
+
+    await finishJob(stub.db, mockLogger, badId, "d", "incomplete", ["artifacts:x"]);
+    await finishJob(stub.db, mockLogger, goodId, "d", "completed", []);
+
+    expect(stub.jobs.get(badId)?.attempts).toBe(1);
+    expect(stub.jobs.get(goodId)?.attempts).toBe(0);
+  });
+
+  it("listRetryableIncompleteJobs returns incomplete jobs under the cap only", async () => {
+    const stub = makeJobsD1();
+    const underId = await createProjectJob(stub, "proj_under");
+    const atCapId = await createProjectJob(stub, "proj_cap");
+    const pendingId = await createProjectJob(stub, "proj_pending");
+    const under = stub.jobs.get(underId);
+    const atCap = stub.jobs.get(atCapId);
+    if (under) {
+      under.state = "incomplete";
+      under.attempts = 1;
+    }
+    if (atCap) {
+      atCap.state = "incomplete";
+      atCap.attempts = 3;
+    }
+
+    const listed = await listRetryableIncompleteJobs(stub.db, mockLogger, 3);
+    expect(listed.success).toBe(true);
+    if (!listed.success) return;
+    // atCap (attempts == cap) and the still-pending job are both excluded.
+    expect(listed.data.map((job) => job.id)).toEqual([underId]);
+    expect(pendingId).toBeDefined();
+  });
+
+  it("reopenIncompleteJob only reopens incomplete jobs and can clear attempts", async () => {
+    const stub = makeJobsD1();
+    const jobId = await createProjectJob(stub);
+
+    // Pending, not incomplete: nothing to reopen.
+    const noop = await reopenIncompleteJob(stub.db, mockLogger, jobId);
+    expect(noop.success && noop.data).toBe(false);
+    expect(stub.jobs.get(jobId)?.state).toBe("pending");
+
+    const row = stub.jobs.get(jobId);
+    if (row) {
+      row.state = "incomplete";
+      row.attempts = 2;
+      row.finished_at = PAST;
+      row.lease_owner = "stale";
+    }
+    const reopened = await reopenIncompleteJob(stub.db, mockLogger, jobId, { resetAttempts: true });
+    expect(reopened.success && reopened.data).toBe(true);
+    const after = stub.jobs.get(jobId);
+    expect(after?.state).toBe("pending");
+    expect(after?.attempts).toBe(0);
+    expect(after?.finished_at).toBeNull();
+    expect(after?.lease_owner).toBeNull();
+  });
+});
+
+describe("redriveDeletionJob (operator)", () => {
+  it("reopens an incomplete job, resets the budget, and drives it to completed", async () => {
+    const stub = makeJobsD1();
+    const jobId = await createProjectJob(stub);
+    const row = stub.jobs.get(jobId);
+    if (row) {
+      // Budget exhausted by the auto-sweep; operator forces one more drive.
+      row.state = "incomplete";
+      row.residuals = JSON.stringify(["artifacts:x"]);
+      row.attempts = 3;
+      row.checkpoint = "cascade";
+      row.finished_at = PAST;
+    }
+
+    const result = await redriveDeletionJob(makeEnv(stub), jobId, mockLogger);
+
+    expect(result.success && result.data.reopened).toBe(true);
+    const after = stub.jobs.get(jobId);
+    expect(after?.state).toBe("completed");
+    expect(after?.attempts).toBe(0);
+    // checkpoint was already set, so the re-drive must not re-audit the start.
+    expect(stub.audits.map((a) => a.action)).toEqual(["deletion.completed"]);
+  });
+
+  it("returns reopened:false for a job that is not incomplete", async () => {
+    const stub = makeJobsD1();
+    const jobId = await createProjectJob(stub); // pending
+
+    const result = await redriveDeletionJob(makeEnv(stub), jobId, mockLogger);
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.reopened).toBe(false);
+    expect(stub.jobs.get(jobId)?.state).toBe("pending");
+  });
+
+  it("returns reopened:false for a missing job", async () => {
+    const stub = makeJobsD1();
+    const result = await redriveDeletionJob(makeEnv(stub), "del_missing", mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.reopened).toBe(false);
+  });
+});
+
 describe("sweepDeletionJobs", () => {
   it("re-drives stale jobs and leaves fresh ones alone", async () => {
     const stub = makeJobsD1();
@@ -325,5 +439,83 @@ describe("sweepDeletionJobs", () => {
 
     expect(stub.jobs.get(staleId)?.state).toBe("completed");
     expect(stub.jobs.get(freshId)?.state).toBe("running");
+  });
+
+  it("auto-re-drives a transiently-incomplete job to completed within the cap", async () => {
+    const stub = makeJobsD1();
+    const jobId = await createProjectJob(stub);
+    const failing = makeArtifactsStub(() => {
+      throw new Error("upstream 500");
+    });
+    // First drive fails on Artifacts, landing the job incomplete with attempts=1.
+    await runDeletionJob(makeEnv(stub, failing.artifacts), jobId, mockLogger);
+    expect(stub.jobs.get(jobId)?.state).toBe("incomplete");
+    expect(stub.jobs.get(jobId)?.attempts).toBe(1);
+
+    // Sweep with healthy Artifacts: incomplete jobs are swept by state (not
+    // heartbeat staleness), so it reopens and re-drives to completion.
+    await sweepDeletionJobs(makeEnv(stub), mockLogger);
+
+    expect(stub.jobs.get(jobId)?.state).toBe("completed");
+  });
+
+  it("does not auto-retry a job whose residual can never clear", async () => {
+    const stub = makeJobsD1();
+    const jobId = await createProjectJob(stub);
+    const row = stub.jobs.get(jobId);
+    if (row) {
+      row.state = "incomplete";
+      row.residuals = JSON.stringify(["target:unparseable"]);
+      row.attempts = 1;
+      row.finished_at = PAST;
+    }
+
+    await sweepDeletionJobs(makeEnv(stub), mockLogger);
+
+    // A terminal residual is skipped even with budget remaining.
+    expect(stub.jobs.get(jobId)?.state).toBe("incomplete");
+    expect(stub.jobs.get(jobId)?.attempts).toBe(1);
+  });
+
+  it("does not re-drive a job in the same sweep that just drove it incomplete", async () => {
+    const stub = makeJobsD1();
+    const jobId = await createProjectJob(stub);
+    // Stale, crashed running job: the stale-heartbeat pass drives it first.
+    const row = stub.jobs.get(jobId);
+    if (row) {
+      row.state = "running";
+      row.heartbeat_at = PAST;
+      row.lease_owner = "dead-driver";
+      row.lease_expires_at = PAST;
+      row.checkpoint = "started";
+    }
+    const failing = makeArtifactsStub(() => {
+      throw new Error("upstream 500");
+    });
+
+    await sweepDeletionJobs(makeEnv(stub, failing.artifacts), mockLogger);
+
+    const after = stub.jobs.get(jobId);
+    expect(after?.state).toBe("incomplete");
+    // Phase 1 drove it (attempts=1); the retry pass must skip it this sweep so a
+    // single fault costs one attempt per cycle, not two.
+    expect(after?.attempts).toBe(1);
+  });
+
+  it("stops auto-retrying once the attempt cap is reached", async () => {
+    const stub = makeJobsD1();
+    const jobId = await createProjectJob(stub);
+    const row = stub.jobs.get(jobId);
+    if (row) {
+      row.state = "incomplete";
+      row.residuals = JSON.stringify(["artifacts:x"]);
+      row.attempts = 3;
+      row.finished_at = PAST;
+    }
+
+    await sweepDeletionJobs(makeEnv(stub), mockLogger);
+
+    expect(stub.jobs.get(jobId)?.state).toBe("incomplete");
+    expect(stub.jobs.get(jobId)?.attempts).toBe(3);
   });
 });

--- a/tests/deletion-redrive-route.test.ts
+++ b/tests/deletion-redrive-route.test.ts
@@ -1,0 +1,94 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../src/types";
+
+vi.mock("../src/queue/deletion-runner", () => ({ redriveDeletionJob: vi.fn() }));
+vi.mock("../src/storage/deletion-jobs", () => ({ getDeletionJob: vi.fn() }));
+vi.mock("../src/storage/audit", () => ({ recordAudit: vi.fn(async () => ({ success: true })) }));
+
+import { redriveDeletionJob } from "../src/queue/deletion-runner";
+import { deletionJobsRouter } from "../src/routes/deletion-jobs";
+import { recordAudit } from "../src/storage/audit";
+import { getDeletionJob } from "../src/storage/deletion-jobs";
+
+const ADMIN_KEY = "admin-secret";
+
+function makeApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.route("/api/admin/deletion-jobs", deletionJobsRouter);
+  return app;
+}
+
+const env = { DB: {}, ADMIN_API_KEY: ADMIN_KEY } as unknown as Env;
+const ctx = {
+  waitUntil: () => {},
+  passThroughOnException: () => {},
+} as unknown as ExecutionContext;
+
+function req(headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/admin/deletion-jobs/del_1/redrive", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("POST /api/admin/deletion-jobs/:id/redrive", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("403 without admin credentials", async () => {
+    const res = await makeApp().fetch(req(), env, ctx);
+    expect(res.status).toBe(403);
+    expect(redriveDeletionJob).not.toHaveBeenCalled();
+  });
+
+  it("re-drives and 200s for an admin on an incomplete job", async () => {
+    vi.mocked(redriveDeletionJob).mockResolvedValue({
+      success: true,
+      data: { reopened: true },
+    } as never);
+    vi.mocked(getDeletionJob).mockResolvedValue({
+      success: true,
+      data: { id: "del_1", state: "pending" },
+    } as never);
+
+    const res = await makeApp().fetch(req({ "X-Admin-API-Key": ADMIN_KEY }), env, ctx);
+
+    expect(res.status).toBe(200);
+    expect(redriveDeletionJob).toHaveBeenCalledWith(env, "del_1", expect.any(Object));
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({ action: "deletion.redrive", subject: "del_1" }),
+    );
+  });
+
+  it("409 (NOT_REDRIVABLE) when the job exists but is not incomplete", async () => {
+    vi.mocked(redriveDeletionJob).mockResolvedValue({
+      success: true,
+      data: { reopened: false },
+    } as never);
+    vi.mocked(getDeletionJob).mockResolvedValue({
+      success: true,
+      data: { id: "del_1", state: "completed" },
+    } as never);
+
+    const res = await makeApp().fetch(req({ "X-Admin-API-Key": ADMIN_KEY }), env, ctx);
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("NOT_REDRIVABLE");
+    expect(recordAudit).not.toHaveBeenCalled();
+  });
+
+  it("404 when the job does not exist", async () => {
+    vi.mocked(redriveDeletionJob).mockResolvedValue({
+      success: true,
+      data: { reopened: false },
+    } as never);
+    vi.mocked(getDeletionJob).mockResolvedValue({ success: true, data: null } as never);
+
+    const res = await makeApp().fetch(req({ "X-Admin-API-Key": ADMIN_KEY }), env, ctx);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/helpers/deletion-stubs.ts
+++ b/tests/helpers/deletion-stubs.ts
@@ -146,6 +146,7 @@ export interface DeletionJobRowStub {
   lease_owner: string | null;
   lease_expires_at: string | null;
   residuals: string | null;
+  attempts: number;
   created_at: string;
   started_at: string | null;
   finished_at: string | null;
@@ -206,6 +207,7 @@ export function makeJobsD1(
         lease_owner: null,
         lease_expires_at: null,
         residuals: null,
+        attempts: 0,
         created_at: createdAt,
         started_at: null,
         finished_at: null,
@@ -278,10 +280,11 @@ export function makeJobsD1(
     }
 
     if (norm.startsWith("UPDATE deletion_jobs SET state = ?, residuals = ?")) {
-      const [state, residuals, finishedAt, id, owner] = bindings as [
+      const [state, residuals, finishedAt, attemptIncrement, id, owner] = bindings as [
         string,
         string,
         string,
+        number,
         string,
         string,
       ];
@@ -290,9 +293,33 @@ export function makeJobsD1(
       job.state = state;
       job.residuals = residuals;
       job.finished_at = finishedAt;
+      job.attempts += attemptIncrement;
       job.lease_owner = null;
       job.lease_expires_at = null;
       return { rows: [], changes: 1 };
+    }
+
+    // reopenIncompleteJob: incomplete -> pending, optionally clearing attempts.
+    if (norm.startsWith("UPDATE deletion_jobs SET state = 'pending'")) {
+      const id = bindings[0] as string;
+      const job = jobs.get(id);
+      if (!job || job.state !== "incomplete") return { rows: [], changes: 0 };
+      job.state = "pending";
+      job.finished_at = null;
+      job.heartbeat_at = null;
+      job.lease_owner = null;
+      job.lease_expires_at = null;
+      if (norm.includes("attempts = 0")) job.attempts = 0;
+      return { rows: [], changes: 1 };
+    }
+
+    // listRetryableIncompleteJobs: incomplete jobs still within the attempt cap.
+    if (norm.startsWith("SELECT * FROM deletion_jobs WHERE state = 'incomplete'")) {
+      const maxAttempts = bindings[0] as number;
+      const rows = [...jobs.values()]
+        .filter((job) => job.state === "incomplete" && job.attempts < maxAttempts)
+        .map((job) => ({ ...job }));
+      return { rows, changes: 0 };
     }
 
     if (norm.startsWith("SELECT * FROM deletion_jobs WHERE state IN")) {


### PR DESCRIPTION
## What & why

Closes the re-audit finding that a deletion job which finishes **`incomplete`** (crash mid-cascade, or a transient Artifacts/D1 fault) had no re-drive path — `incomplete` was hard-terminal (the sweep excluded it), and recovery was a manual "operator enqueues a fresh job." This adds a bounded, self-healing retry plus an explicit operator escape hatch.

## Changes

- **`migrations/034_deletion_job_attempts.sql`** — additive `attempts INTEGER NOT NULL DEFAULT 0` on `deletion_jobs`. Existing rows backfill to 0.
- **`finishJob`** increments `attempts` only when a drive ends `incomplete` (a `completed` drive leaves it untouched). The increment is atomic in SQL.
- **`sweepDeletionJobs`** now re-drives `incomplete` jobs, bounded three ways:
  - `attempts < MAX_DELETION_ATTEMPTS` (3) — a permanently-failing target can't loop forever;
  - residuals must be retryable — a **terminal** residual (`target:unparseable`) is never retried, since re-driving can't repair it;
  - a job already driven **this sweep** by the stale-heartbeat pass is skipped, so one fault costs one attempt per cycle, not two.
- **`reopenIncompleteJob`** is a compare-and-swap (`WHERE state='incomplete'`) so exactly one concurrent driver re-drives; it **preserves `checkpoint`**, so a re-drive never re-writes the `deletion.started` audit. The cascade is idempotent → every re-drive converges rather than double-deleting.
- **`POST /api/admin/deletion-jobs/:id/redrive`** (admin-only, mirrors the `backup` route's `requireAdmin`) — operator escape hatch after the auto-budget is exhausted or a fault is fixed: resets the budget and drives once. Maps to `404` (missing) / `409 NOT_REDRIVABLE` (exists but not incomplete) / `200` with the refreshed job. Adds a `deletion.redrive` audit action.

## Tests

- storage: attempts increments on incomplete only; `listRetryableIncompleteJobs` respects the cap; `reopenIncompleteJob` guard + attempt reset.
- runner: sweep auto-re-drives a transient failure to `completed`; leaves a terminal-residual job `incomplete`; stops at the cap; does not double-drive within one sweep.
- operator: `redriveDeletionJob` reopens+drives+resets, and returns `reopened:false` for non-incomplete/missing jobs.
- route: 403 without admin creds; 200 + audit on success; 409 `NOT_REDRIVABLE`; 404 missing.

Full suite: **1059 passed** / 27 skipped. Typecheck + biome clean.

## Notes for reviewer

- Uses migration **034** to avoid colliding with `033_provenance_unique.sql` on the unmerged provenance PR (#138). If #138 doesn't land first there's a harmless numbering gap (033); `wrangler d1 migrations apply` applies un-recorded files regardless of number. Confirm no collision if both merge.
- This deliberately reverses the previous "`incomplete` is terminal" invariant — the cap + terminal-residual skip are what make auto-retry safe (the old comment's loop-forever concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)