### PR TITLE
feat(backup): dry-run restore verification (planRestore + admin route)

### DIFF
--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -82,6 +82,32 @@ bucket for the expected `d1/`, `kv/`, and `repos/` blobs under that prefix.
 Restore is not automated end to end — it is a deliberate operation. Restore into a
 **fresh or staging instance first** and verify before pointing production at it.
 
+### Verify a backup is restorable (dry run)
+
+Before relying on a backup — and as a periodic rot check — confirm a run is
+actually restorable **without writing anything**:
+
+```
+GET /api/admin/restore/<runTs>/plan            # admin only
+```
+
+It reads and **decrypts** every blob under `<runTs>/` and checks each leg against
+the run manifest, returning a `plan`:
+
+- `complete` — the `_manifest.json` is present (the run did not crash partway).
+- `d1[]` — per table, `expectedRows` (from the manifest) vs `parsedRows` (from the
+  dump); `ok` is false on a missing/undecodable dump or a **row-count mismatch**
+  (silent truncation).
+- `kv` — project/workspace counts, cross-checked against the manifest.
+- `repos[]` — per repo, that the manifest parses (has a `tipSha`) and the `.pack`
+  is present and decodes.
+- `restorable` — true only when the run is complete and every leg is `ok`.
+
+A `restorable: false` (or a top-level decode error — usually a wrong
+`BACKUP_ENCRYPTION_SECRET`) means do **not** rely on that run; use an earlier
+complete run. This endpoint never mutates anything; the write/apply steps below
+are the deliberate, separately-run operation.
+
 ### D1
 
 For each `<runTs>/d1/<table>.ndjson`, use `restoreTable` (in `src/storage/d1-backup.ts`).

--- a/src/backup/plan-restore.ts
+++ b/src/backup/plan-restore.ts
@@ -1,0 +1,262 @@
+import { RUN_MANIFEST_KEY, getBlob, listRunObjects } from "../storage/backup-store";
+import { BACKUP_TABLES, verifyTableDump } from "../storage/d1-backup";
+import type { Env } from "../types";
+import { AppError } from "../utils/errors";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+import type { BackupRunSummary } from "./run-backup";
+
+export interface D1LegPlan {
+  table: string;
+  /** Row count the manifest recorded at backup time, or -1 if unknown. */
+  expectedRows: number;
+  parsedRows: number;
+  ok: boolean;
+  error?: string;
+}
+
+export interface KvLegPlan {
+  projects: number;
+  workspaces: number;
+  ok: boolean;
+  error?: string;
+}
+
+export interface RepoLegPlan {
+  projectId: string;
+  tipSha?: string;
+  hasPack: boolean;
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * The result of a DRY-RUN restore check: does every blob a backup run produced
+ * decode, parse, and agree with the run manifest? Nothing is written — this is
+ * the CI-provable "is this backup actually restorable?" gate. `restorable` is
+ * true only when the run is complete and every leg checks out.
+ */
+export interface RestorePlan {
+  runTs: string;
+  complete: boolean;
+  d1: D1LegPlan[];
+  kv: KvLegPlan;
+  repos: RepoLegPlan[];
+  restorable: boolean;
+  errors: string[];
+}
+
+const REPO_MANIFEST_SUFFIX = ".manifest.json";
+
+async function decodeJson<T>(
+  bucket: R2Bucket,
+  key: string,
+  env: Pick<Env, "BACKUP_ENCRYPTION_SECRET">,
+  logger: Logger,
+): Promise<Result<T | null, AppError>> {
+  const blob = await getBlob(bucket, key, env, logger);
+  if (!blob.success) return err(blob.error);
+  if (blob.data === null) return ok(null);
+  try {
+    return ok(JSON.parse(new TextDecoder().decode(blob.data)) as T);
+  } catch {
+    return err(new AppError(`Backup blob ${key} did not parse as JSON`, "BACKUP_ERROR", 500));
+  }
+}
+
+async function planD1(
+  bucket: R2Bucket,
+  runTs: string,
+  env: Env,
+  manifest: BackupRunSummary | null,
+  logger: Logger,
+): Promise<D1LegPlan[]> {
+  // Prefer the manifest's table list + row counts (lets us catch truncation); fall
+  // back to the static schema list when the manifest is missing.
+  const expected =
+    manifest?.d1 ?? BACKUP_TABLES.map((table) => ({ table, rowCount: -1, ok: true }));
+  const legs: D1LegPlan[] = [];
+  for (const entry of expected) {
+    const key = `${runTs}/d1/${entry.table}.ndjson`;
+    const blob = await getBlob(bucket, key, env, logger);
+    if (!blob.success) {
+      legs.push({
+        table: entry.table,
+        expectedRows: entry.rowCount,
+        parsedRows: 0,
+        ok: false,
+        error: blob.error.message,
+      });
+      continue;
+    }
+    if (blob.data === null) {
+      legs.push({
+        table: entry.table,
+        expectedRows: entry.rowCount,
+        parsedRows: 0,
+        ok: false,
+        error: "dump blob is missing",
+      });
+      continue;
+    }
+    const verified = verifyTableDump(entry.table, blob.data);
+    if (!verified.success) {
+      legs.push({
+        table: entry.table,
+        expectedRows: entry.rowCount,
+        parsedRows: 0,
+        ok: false,
+        error: verified.error.message,
+      });
+      continue;
+    }
+    const parsedRows = verified.data.rowCount;
+    const countMatches = entry.rowCount < 0 || parsedRows === entry.rowCount;
+    legs.push({
+      table: entry.table,
+      expectedRows: entry.rowCount,
+      parsedRows,
+      ok: countMatches,
+      ...(countMatches
+        ? {}
+        : { error: `row count mismatch: manifest ${entry.rowCount}, dump ${parsedRows}` }),
+    });
+  }
+  return legs;
+}
+
+async function planKv(
+  bucket: R2Bucket,
+  runTs: string,
+  env: Env,
+  manifest: BackupRunSummary | null,
+  logger: Logger,
+): Promise<KvLegPlan> {
+  const projects = await decodeJson<unknown[]>(bucket, `${runTs}/kv/projects.json`, env, logger);
+  const workspaces = await decodeJson<unknown[]>(
+    bucket,
+    `${runTs}/kv/workspaces.json`,
+    env,
+    logger,
+  );
+  if (!projects.success)
+    return { projects: 0, workspaces: 0, ok: false, error: projects.error.message };
+  if (!workspaces.success)
+    return { projects: 0, workspaces: 0, ok: false, error: workspaces.error.message };
+  if (projects.data === null || workspaces.data === null) {
+    return { projects: 0, workspaces: 0, ok: false, error: "kv identity dump is missing" };
+  }
+  if (!Array.isArray(projects.data) || !Array.isArray(workspaces.data)) {
+    return { projects: 0, workspaces: 0, ok: false, error: "kv identity dump is not an array" };
+  }
+  const projectCount = projects.data.length;
+  const workspaceCount = workspaces.data.length;
+  // The manifest records what was dumped; a mismatch means the blob was truncated.
+  const expected = manifest?.kv;
+  const matches =
+    !expected || (expected.projects === projectCount && expected.workspaces === workspaceCount);
+  return {
+    projects: projectCount,
+    workspaces: workspaceCount,
+    ok: matches,
+    ...(matches
+      ? {}
+      : {
+          error: `kv count mismatch: manifest ${expected?.projects}/${expected?.workspaces}, dump ${projectCount}/${workspaceCount}`,
+        }),
+  };
+}
+
+async function planRepos(
+  bucket: R2Bucket,
+  runTs: string,
+  env: Env,
+  logger: Logger,
+): Promise<RepoLegPlan[]> {
+  const keys = await listRunObjects(bucket, runTs);
+  const prefix = `${runTs}/repos/`;
+  const manifestKeys = keys.filter((k) => k.startsWith(prefix) && k.endsWith(REPO_MANIFEST_SUFFIX));
+  const legs: RepoLegPlan[] = [];
+  for (const manifestKey of manifestKeys) {
+    const projectId = manifestKey.slice(prefix.length, -REPO_MANIFEST_SUFFIX.length);
+    const manifest = await decodeJson<{ tipSha?: string }>(bucket, manifestKey, env, logger);
+    if (!manifest.success) {
+      legs.push({ projectId, hasPack: false, ok: false, error: manifest.error.message });
+      continue;
+    }
+    if (manifest.data === null || typeof manifest.data.tipSha !== "string") {
+      legs.push({ projectId, hasPack: false, ok: false, error: "repo manifest missing tipSha" });
+      continue;
+    }
+    // Fetch (and thus decrypt) the pack to prove it is present and decodable.
+    const pack = await getBlob(bucket, `${prefix}${projectId}.pack`, env, logger);
+    if (!pack.success) {
+      legs.push({
+        projectId,
+        tipSha: manifest.data.tipSha,
+        hasPack: false,
+        ok: false,
+        error: pack.error.message,
+      });
+      continue;
+    }
+    const hasPack = pack.data !== null && pack.data.byteLength > 0;
+    legs.push({
+      projectId,
+      tipSha: manifest.data.tipSha,
+      hasPack,
+      ok: hasPack,
+      ...(hasPack ? {} : { error: "pack blob missing or empty" }),
+    });
+  }
+  return legs;
+}
+
+/**
+ * Dry-run restore verification for a single backup run. Reads every blob under
+ * `<runTs>/`, decrypting via `getBlob`, and checks each leg against the run
+ * manifest. Never writes — safe to run against a production backup bucket. The
+ * actual write/apply restore path (recreating tables, pushing repos) is a
+ * separate, gated break-glass operation.
+ */
+export async function planRestore(
+  env: Env,
+  runTs: string,
+  logger: Logger,
+): Promise<Result<RestorePlan, AppError>> {
+  const bucket = env.BACKUPS;
+  if (!bucket) return err(new AppError("Backups bucket not configured", "STORAGE_ERROR", 500));
+
+  const errors: string[] = [];
+
+  const manifestResult = await decodeJson<BackupRunSummary>(
+    bucket,
+    `${runTs}/${RUN_MANIFEST_KEY}`,
+    env,
+    logger,
+  );
+  if (!manifestResult.success) return err(manifestResult.error);
+  const manifest = manifestResult.data;
+  if (manifest === null) {
+    // _manifest.json is written last; its absence means the run crashed partway.
+    errors.push("run is incomplete: _manifest.json is missing (crashed run)");
+  }
+
+  const d1 = await planD1(bucket, runTs, env, manifest, logger);
+  const kv = await planKv(bucket, runTs, env, manifest, logger);
+  const repos = await planRepos(bucket, runTs, env, logger);
+
+  const d1Ok = d1.every((leg) => leg.ok);
+  const reposOk = repos.every((leg) => leg.ok);
+  const restorable = manifest !== null && errors.length === 0 && d1Ok && kv.ok && reposOk;
+
+  logger.info("Computed restore plan", {
+    runTs,
+    restorable,
+    d1Failed: d1.filter((l) => !l.ok).length,
+    reposFailed: repos.filter((l) => !l.ok).length,
+    kvOk: kv.ok,
+  });
+
+  return ok({ runTs, complete: manifest !== null, d1, kv, repos, restorable, errors });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { loginRouter } from "./routes/login";
 import { metricsRouter } from "./routes/metrics";
 import { orgsRouter } from "./routes/orgs";
 import { projectsRouter } from "./routes/projects";
+import { restoreRouter } from "./routes/restore";
 import { reviewsRouter } from "./routes/reviews";
 import { sessionRouter } from "./routes/sessions";
 import { signupRouter } from "./routes/signup";
@@ -125,6 +126,7 @@ app.route("/api/admin/metrics", metricsRouter);
 // Admin audit trail endpoint
 app.route("/api/admin/audit", auditRouter);
 app.route("/api/admin/backup", backupRouter);
+app.route("/api/admin/restore", restoreRouter);
 
 // Redirects from old /ui/* URLs to new paths (backward compatibility)
 app.get("/ui", (c) => c.redirect("/", 301));

--- a/src/routes/restore.ts
+++ b/src/routes/restore.ts
@@ -1,0 +1,47 @@
+import { Hono } from "hono";
+import { planRestore } from "../backup/plan-restore";
+import type { Env } from "../types";
+import { isAdminRequest } from "../utils/admin";
+import { createLogger } from "../utils/logger";
+import { forbidden, internalError, ok } from "../utils/response";
+
+const app = new Hono<{ Bindings: Env }>();
+
+async function requireAdmin(c: {
+  env: Env;
+  req: { header: (n: string) => string | undefined; path: string; method: string };
+  get: (k: "userId") => string | undefined;
+}): Promise<{ ok: true; logger: ReturnType<typeof createLogger> } | { ok: false }> {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+  const isAdmin = await isAdminRequest(
+    c.env,
+    {
+      ...(c.req.header("X-Admin-API-Key") !== undefined
+        ? { adminApiKeyHeader: c.req.header("X-Admin-API-Key") }
+        : {}),
+      ...(c.get("userId") !== undefined ? { userId: c.get("userId") } : {}),
+    },
+    logger,
+  );
+  return isAdmin ? { ok: true, logger } : { ok: false };
+}
+
+// GET /api/admin/restore/:runTs/plan — dry-run "is this backup restorable?" check.
+// Reads and decrypts every blob in the run and verifies it against the manifest.
+// Read-only: never writes. The actual apply/restore path is a separate gated op.
+app.get("/:runTs/plan", async (c) => {
+  const auth = await requireAdmin(c);
+  if (!auth.ok) return forbidden("Administrator access required");
+  if (!c.env.BACKUPS) return internalError("Backups bucket not configured");
+
+  const plan = await planRestore(c.env, c.req.param("runTs"), auth.logger);
+  if (!plan.success) return internalError(plan.error.message);
+  return ok({ plan: plan.data });
+});
+
+export { app as restoreRouter };

--- a/src/storage/backup-store.ts
+++ b/src/storage/backup-store.ts
@@ -137,6 +137,11 @@ async function listAllKeys(bucket: R2Bucket, prefix: string): Promise<string[]> 
   return keys;
 }
 
+/** Every object key under a single run's prefix (follows R2's paginated cursor). */
+export async function listRunObjects(bucket: R2Bucket, runTs: string): Promise<string[]> {
+  return listAllKeys(bucket, `${runTs}/`);
+}
+
 export interface RunInfo {
   runTs: string;
   complete: boolean;

--- a/src/storage/d1-backup.ts
+++ b/src/storage/d1-backup.ts
@@ -108,6 +108,44 @@ export async function exportTable(
   }
 }
 
+/**
+ * Parse + validate a table dump WITHOUT writing anything — the dry-run half of
+ * `restoreTable`. Confirms the blob decodes to text, the header names the
+ * expected table, and every row line is valid JSON, returning the row count so a
+ * caller can cross-check it against the manifest (catches silent truncation).
+ * A decrypt/decode failure surfaces upstream in `getBlob`; this sees plaintext.
+ */
+export function verifyTableDump(
+  table: string,
+  ndjson: Uint8Array,
+): Result<{ table: string; rowCount: number; columns: string[] }, AppError> {
+  try {
+    const text = new TextDecoder().decode(ndjson).trim();
+    if (text === "") return ok({ table, rowCount: 0, columns: [] });
+    const [headerLine, ...rowLines] = text.split("\n");
+    const header = JSON.parse(headerLine ?? "{}") as { __table?: string; __columns?: string[] };
+    if (header.__table !== table) {
+      return err(
+        new AppError(
+          `Dump table mismatch: expected ${table}, got ${header.__table}`,
+          "BACKUP_ERROR",
+          500,
+        ),
+      );
+    }
+    let rowCount = 0;
+    for (const line of rowLines) {
+      if (line.length === 0) continue;
+      JSON.parse(line); // throws on a corrupt/truncated row line
+      rowCount++;
+    }
+    return ok({ table, rowCount, columns: header.__columns ?? [] });
+  } catch (error) {
+    if (error instanceof AppError) return err(error);
+    return err(new AppError(`Failed to verify dump for ${table}`, "BACKUP_ERROR", 500));
+  }
+}
+
 const MAX_D1_BINDS = 100;
 
 /**

--- a/tests/plan-restore.test.ts
+++ b/tests/plan-restore.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from "vitest";
+import { planRestore } from "../src/backup/plan-restore";
+import type { RepoSnapshot } from "../src/backup/repo-snapshot";
+import type { BackupDeps } from "../src/backup/run-backup";
+import { runBackup } from "../src/backup/run-backup";
+import { RUN_MANIFEST_KEY, putBlob } from "../src/storage/backup-store";
+import { setProject, setWorkspace } from "../src/storage/state";
+import type { Env, ProjectEntry, WorkspaceEntry } from "../src/types";
+import { ok } from "../src/utils/result";
+import { makeFakeD1 } from "./helpers/fake-d1";
+import { makeFakeKV } from "./helpers/fake-kv";
+import { makeFakeR2 } from "./helpers/fake-r2";
+
+const logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+} as unknown as Parameters<typeof planRestore>[2];
+
+const RUN_TS = "2026-07-20T00:00:00.000Z";
+
+function project(id: string): ProjectEntry {
+  return {
+    id,
+    name: id,
+    slug: id,
+    namespace: "@owner",
+    ownerId: "u1",
+    ownerType: "user",
+    remote: `https://acct.artifacts.cloudflare.net/git/@owner/${id}.git`,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function workspace(name: string, parent: string): WorkspaceEntry {
+  return {
+    name,
+    parent,
+    remote: `https://acct.artifacts.cloudflare.net/git/@owner/${parent}#${name}`,
+    createdAt: "2026-01-02T00:00:00.000Z",
+  };
+}
+
+function snapshot(id: string): RepoSnapshot {
+  return {
+    pack: new Uint8Array([1, 2, 3]),
+    manifest: {
+      projectId: id,
+      project: project(id),
+      tipSha: `sha-${id}`,
+      objectCount: 1,
+      byteCount: 3,
+      capturedAt: RUN_TS,
+    },
+  };
+}
+
+const okSnapshots: BackupDeps = {
+  snapshotRepo: async (_env, p) => ok({ status: "ok", snapshot: snapshot(p.id) }),
+};
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    BACKUPS: makeFakeR2(),
+    DB: makeFakeD1(),
+    STATE: makeFakeKV(),
+    ...overrides,
+  } as Env;
+}
+
+/** Seed KV with projects + a workspace, then run a real backup into the env's R2. */
+async function seedAndBackup(env: Env): Promise<void> {
+  await setProject(env.STATE, project("alpha"), logger);
+  await setProject(env.STATE, project("beta"), logger);
+  await setWorkspace(env.STATE, "alpha", workspace("feature-x", "alpha"), logger);
+  await runBackup(env, logger, RUN_TS, okSnapshots);
+}
+
+describe("planRestore", () => {
+  it("reports a clean backup as restorable with correct leg counts", async () => {
+    const env = makeEnv();
+    await seedAndBackup(env);
+
+    const result = await planRestore(env, RUN_TS, logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const plan = result.data;
+
+    expect(plan.complete).toBe(true);
+    expect(plan.restorable).toBe(true);
+    expect(plan.errors).toEqual([]);
+    expect(plan.kv).toMatchObject({ projects: 2, workspaces: 1, ok: true });
+    expect(plan.repos).toHaveLength(2);
+    expect(plan.repos.every((r) => r.ok && r.hasPack)).toBe(true);
+    expect(plan.repos.map((r) => r.tipSha).sort()).toEqual(["sha-alpha", "sha-beta"]);
+    expect(plan.d1.every((t) => t.ok)).toBe(true);
+  });
+
+  it("flags a run with no manifest as incomplete and not restorable", async () => {
+    const env = makeEnv();
+    await seedAndBackup(env);
+    const bucket = env.BACKUPS as R2Bucket & { store: Map<string, Uint8Array> };
+    bucket.store.delete(`${RUN_TS}/${RUN_MANIFEST_KEY}`);
+
+    const result = await planRestore(env, RUN_TS, logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.complete).toBe(false);
+    expect(result.data.restorable).toBe(false);
+    expect(result.data.errors.some((e) => e.includes("_manifest.json"))).toBe(true);
+  });
+
+  it("fails the table leg when a D1 dump blob is missing", async () => {
+    const env = makeEnv();
+    await seedAndBackup(env);
+    const bucket = env.BACKUPS as R2Bucket & { store: Map<string, Uint8Array> };
+    const tableKey = [...bucket.store.keys()].find((k) => k.startsWith(`${RUN_TS}/d1/`));
+    expect(tableKey).toBeDefined();
+    if (tableKey) bucket.store.delete(tableKey);
+
+    const result = await planRestore(env, RUN_TS, logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.restorable).toBe(false);
+    expect(result.data.d1.some((t) => !t.ok && t.error?.includes("missing"))).toBe(true);
+  });
+
+  it("fails a repo leg when its pack blob is gone but the manifest remains", async () => {
+    const env = makeEnv();
+    await seedAndBackup(env);
+    const bucket = env.BACKUPS as R2Bucket & { store: Map<string, Uint8Array> };
+    bucket.store.delete(`${RUN_TS}/repos/alpha.pack`);
+
+    const result = await planRestore(env, RUN_TS, logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.restorable).toBe(false);
+    const alpha = result.data.repos.find((r) => r.projectId === "alpha");
+    expect(alpha).toMatchObject({ hasPack: false, ok: false });
+  });
+
+  it("detects a truncated table dump via the manifest row-count cross-check", async () => {
+    // Seed real rows so the manifest records a non-zero count, then overwrite the
+    // dump with a header-only (zero-row) blob through the same encode path.
+    const db = makeFakeD1();
+    db.seed("events", [{ id: "e1" }, { id: "e2" }, { id: "e3" }]);
+    const env = makeEnv({ DB: db });
+    await seedAndBackup(env);
+    const bucket = env.BACKUPS as R2Bucket & { store: Map<string, Uint8Array> };
+
+    // Confirm the manifest captured 3 rows for `events`, then truncate the dump.
+    const truncated = new TextEncoder().encode(
+      JSON.stringify({ __table: "events", __columns: ["id"] }),
+    );
+    const wrote = await putBlob(bucket, `${RUN_TS}/d1/events.ndjson`, truncated, env, logger);
+    expect(wrote.success).toBe(true);
+
+    const result = await planRestore(env, RUN_TS, logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const events = result.data.d1.find((t) => t.table === "events");
+    expect(events).toMatchObject({ expectedRows: 3, parsedRows: 0, ok: false });
+    expect(result.data.restorable).toBe(false);
+  });
+
+  it("is not restorable when decryption fails (wrong secret)", async () => {
+    const env = makeEnv({ BACKUP_ENCRYPTION_SECRET: "correct-secret" } as Partial<Env>);
+    await seedAndBackup(env);
+
+    // Read the same bucket back with a different secret: every blob fails to decode.
+    const wrongEnv = { ...env, BACKUP_ENCRYPTION_SECRET: "wrong-secret" } as Env;
+    const result = await planRestore(wrongEnv, RUN_TS, logger);
+
+    // getBlob surfaces a decode error for the manifest → planRestore returns err,
+    // or, if the manifest slips through, the legs fail. Either way: not restorable.
+    if (result.success) {
+      expect(result.data.restorable).toBe(false);
+    } else {
+      expect(result.error).toBeDefined();
+    }
+  });
+});

--- a/tests/restore-route.test.ts
+++ b/tests/restore-route.test.ts
@@ -1,0 +1,71 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../src/types";
+
+vi.mock("../src/backup/plan-restore", () => ({ planRestore: vi.fn() }));
+
+import { planRestore } from "../src/backup/plan-restore";
+import { restoreRouter } from "../src/routes/restore";
+
+const ADMIN_KEY = "admin-secret";
+
+function makeApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.route("/api/admin/restore", restoreRouter);
+  return app;
+}
+
+const env = { DB: {}, BACKUPS: {}, ADMIN_API_KEY: ADMIN_KEY } as unknown as Env;
+const ctx = {
+  waitUntil: () => {},
+  passThroughOnException: () => {},
+} as unknown as ExecutionContext;
+
+function req(headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/admin/restore/2026-07-20T00:00:00.000Z/plan", {
+    method: "GET",
+    headers,
+  });
+}
+
+describe("GET /api/admin/restore/:runTs/plan", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("403 without admin credentials", async () => {
+    const res = await makeApp().fetch(req(), env, ctx);
+    expect(res.status).toBe(403);
+    expect(planRestore).not.toHaveBeenCalled();
+  });
+
+  it("200 with the plan for an admin", async () => {
+    vi.mocked(planRestore).mockResolvedValue({
+      success: true,
+      data: {
+        runTs: "2026-07-20T00:00:00.000Z",
+        complete: true,
+        d1: [],
+        kv: { projects: 0, workspaces: 0, ok: true },
+        repos: [],
+        restorable: true,
+        errors: [],
+      },
+    } as never);
+
+    const res = await makeApp().fetch(req({ "X-Admin-API-Key": ADMIN_KEY }), env, ctx);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { plan: { restorable: boolean } };
+    expect(body.plan.restorable).toBe(true);
+    expect(planRestore).toHaveBeenCalledWith(env, "2026-07-20T00:00:00.000Z", expect.any(Object));
+  });
+
+  it("500 when the backups bucket is not configured", async () => {
+    const res = await makeApp().fetch(
+      req({ "X-Admin-API-Key": ADMIN_KEY }),
+      { DB: {}, ADMIN_API_KEY: ADMIN_KEY } as unknown as Env,
+      ctx,
+    );
+    expect(res.status).toBe(500);
+    expect(planRestore).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What & why

The restore **primitives** (`restoreTable`, `restoreKvIdentity`, `restoreProjectRepo`) exist and are CI-tested, but nothing could answer **"is this backup actually restorable?"** without performing a live write. This adds the read-only verifier — the CI-provable "tested restore" half of roadmap #1.

## Changes

- **`planRestore(env, runTs, logger)`** (`src/backup/plan-restore.ts`) — reads and **decrypts** every blob under `<runTs>/` and checks each leg against the run manifest, writing nothing:
  - **D1**: per table, parsed row count vs the manifest's recorded count → catches **silent truncation**; missing/undecodable dumps fail the leg.
  - **KV**: project/workspace counts cross-checked against the manifest.
  - **repos**: each `repos/<id>.manifest.json` parses (has `tipSha`) and its `.pack` is present and decodes.
  - `restorable` is true only when the run is `complete` (manifest present) and every leg is `ok`.
- **`verifyTableDump`** (`d1-backup.ts`) — the parse-only half of `restoreTable` (validates header + every row line, no `INSERT`).
- **`listRunObjects`** (`backup-store.ts`) — enumerate one run's R2 keys.
- **`GET /api/admin/restore/:runTs/plan`** (`src/routes/restore.ts`, admin-only, read-only) — surfaces the plan; mirrors the `backup` router's `requireAdmin`.
- Runbook `backup-restore.md` updated with a "Verify a backup is restorable (dry run)" section.

## Scope / safety

Read-only by construction — safe to run against the production backup bucket. The actual **write/apply** restore path (recreating tables, pushing repos) remains a separate, gated break-glass operation, out of scope here.

## Tests

- backup→verify **round-trip** → `restorable: true` with correct leg counts.
- corruption modes, each correctly reported **not restorable**: missing `_manifest.json`; missing D1 dump; missing repo pack; **manifest row-count truncation**; **wrong `BACKUP_ENCRYPTION_SECRET`** (decrypt failure).
- route: 403 without admin creds; 200 with plan; 500 when no `BACKUPS`.

Full suite **1059 passing**; typecheck + biome clean.

## Note for reviewer

`planRepos` fetches (and decrypts) each `.pack` to prove it decodes, rather than a cheaper `head`. That's deliberate for a verify — it confirms decryptability, not just presence — but it reads packs fully into memory, so this is an on-demand admin op, not something to run in a hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)