### PR TITLE
fix(merge): dedup change.merged via a compare-and-swap transition (T3b)

### DIFF
--- a/src/queue/merge-queue.ts
+++ b/src/queue/merge-queue.ts
@@ -128,7 +128,12 @@ export class MergeQueue extends DurableObject<Env> {
       // Concurrent invocation already merged this change; skip the redundant
       // provenance/metrics writes (the winner recorded them) so one logical merge
       // yields exactly one set of side effects.
-      if (!transitioned) return { success: true, commit, transitioned: false };
+      if (!transitioned) {
+        log.info("Change already merged by a concurrent invocation; skipping provenance/metrics", {
+          changeId,
+        });
+        return { success: true, commit, transitioned: false };
+      }
 
       const provenanceResult = await timer.measure("provenanceMs", () =>
         recordProvenance(this.env.DB, log, {

--- a/src/queue/merge-queue.ts
+++ b/src/queue/merge-queue.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
-import { getChange, markChangeMerged } from "../storage/changes";
+import { getChange, markChangeMerged, mergeTransitionOpts } from "../storage/changes";
 import { isTargetDeleting } from "../storage/deletion";
 import { freshRepoToken, mergeWorkspaceIntoProject } from "../storage/git-ops";
 import { commitPhasesFromSpans, recordCommitMetrics } from "../storage/metrics";
@@ -113,12 +113,12 @@ export class MergeQueue extends DurableObject<Env> {
       const commit = commitResult.data;
 
       const updateResult = await timer.measure("d1UpdateMs", () =>
-        markChangeMerged(this.env.DB, log, changeId, {
-          ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
-          ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
-          ...(change.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
-          mergedAt: new Date().toISOString(),
-        }),
+        markChangeMerged(
+          this.env.DB,
+          log,
+          changeId,
+          mergeTransitionOpts(change, new Date().toISOString()),
+        ),
       );
 
       if (!updateResult.success) {

--- a/src/queue/merge-queue.ts
+++ b/src/queue/merge-queue.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
-import { getChange, updateChangeStatus } from "../storage/changes";
+import { getChange, markChangeMerged } from "../storage/changes";
 import { isTargetDeleting } from "../storage/deletion";
 import { freshRepoToken, mergeWorkspaceIntoProject } from "../storage/git-ops";
 import { commitPhasesFromSpans, recordCommitMetrics } from "../storage/metrics";
@@ -19,6 +19,11 @@ export interface MergeOutcome {
   /** Structured error code (e.g. "STALE_WORKSPACE") so the route can map the
    * failure to the right HTTP status instead of a generic 400. */
   code?: string;
+  /** Whether THIS invocation performed the approved→merged transition. `false`
+   * means a concurrent merger already merged the change (the git merge here was
+   * redundant), so the route must NOT emit a second `change.merged`. Absent on
+   * paths that predate the CAS — treated as "did transition" so the event fires. */
+  transitioned?: boolean;
 }
 
 // Must extend DurableObject: callers invoke merge() over RPC, which the runtime
@@ -108,7 +113,7 @@ export class MergeQueue extends DurableObject<Env> {
       const commit = commitResult.data;
 
       const updateResult = await timer.measure("d1UpdateMs", () =>
-        updateChangeStatus(this.env.DB, log, changeId, "merged", {
+        markChangeMerged(this.env.DB, log, changeId, {
           ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
           ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
           ...(change.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
@@ -119,6 +124,11 @@ export class MergeQueue extends DurableObject<Env> {
       if (!updateResult.success) {
         return { success: false, error: updateResult.error.message };
       }
+      const { transitioned } = updateResult.data;
+      // Concurrent invocation already merged this change; skip the redundant
+      // provenance/metrics writes (the winner recorded them) so one logical merge
+      // yields exactly one set of side effects.
+      if (!transitioned) return { success: true, commit, transitioned: false };
 
       const provenanceResult = await timer.measure("provenanceMs", () =>
         recordProvenance(this.env.DB, log, {
@@ -154,7 +164,7 @@ export class MergeQueue extends DurableObject<Env> {
         log.warn("Failed to record commit metrics", { changeId });
       }
 
-      return { success: true, commit };
+      return { success: true, commit, transitioned };
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       return { success: false, error };

--- a/src/queue/repo-do.ts
+++ b/src/queue/repo-do.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
-import { getChange, updateChangeStatus } from "../storage/changes";
+import { getChange, markChangeMerged } from "../storage/changes";
 import { isTargetDeleting } from "../storage/deletion";
 import { blobObject, commitObject, treeObject } from "../storage/git-objects";
 import {
@@ -261,13 +261,18 @@ export class RepoDO extends DurableObject<Env> {
     // predicts the fast-forward correctly instead of racing on a stale head.
     await this.setHead(result.commit);
 
-    const updateResult = await updateChangeStatus(this.env.DB, log, changeId, "merged", {
+    const updateResult = await markChangeMerged(this.env.DB, log, changeId, {
       ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
       ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
       ...(change.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
       mergedAt: new Date().toISOString(),
     });
     if (!updateResult.success) return { success: false, error: updateResult.error.message };
+    const { transitioned } = updateResult.data;
+    // A concurrent invocation already merged this change (interleaved before our
+    // CAS). The winner recorded provenance and GC'd the staged tree; skip both so
+    // a single logical merge yields exactly one set of side effects.
+    if (!transitioned) return { success: true, commit: result.commit, transitioned: false };
 
     // The commit is already durable; provenance is bookkeeping — log a failure for
     // observability but don't fail the (successful) merge.
@@ -293,7 +298,7 @@ export class RepoDO extends DurableObject<Env> {
         error: error instanceof Error ? error.message : String(error),
       });
     });
-    return { success: true, commit: result.commit };
+    return { success: true, commit: result.commit, transitioned };
   }
 
   // --- Hot object index (ADR 004): staged tip trees in the DO's local SQLite ---
@@ -498,7 +503,7 @@ export class RepoDO extends DurableObject<Env> {
       await timer.measure("refAdvanceMs", () => this.setHead(mergedCommit));
 
       const updateResult = await timer.measure("d1UpdateMs", () =>
-        updateChangeStatus(this.env.DB, log, changeId, "merged", {
+        markChangeMerged(this.env.DB, log, changeId, {
           ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
           ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
           ...(change.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
@@ -507,6 +512,12 @@ export class RepoDO extends DurableObject<Env> {
       );
       if (!updateResult.success) {
         return { success: false, error: updateResult.error.message };
+      }
+      const { transitioned } = updateResult.data;
+      // Concurrent invocation already merged this change; skip the redundant
+      // provenance/metrics writes (the winner recorded them) — see mergeViaR2.
+      if (!transitioned) {
+        return { success: true, commit: mergedCommit, transitioned: false };
       }
 
       const provenanceResult = await timer.measure("provenanceMs", () =>
@@ -542,7 +553,7 @@ export class RepoDO extends DurableObject<Env> {
         log.warn("Failed to record commit metrics", { changeId });
       }
 
-      return { success: true, commit: mergedCommit };
+      return { success: true, commit: mergedCommit, transitioned };
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       return { success: false, error };

--- a/src/queue/repo-do.ts
+++ b/src/queue/repo-do.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
-import { getChange, markChangeMerged } from "../storage/changes";
+import { getChange, markChangeMerged, mergeTransitionOpts } from "../storage/changes";
 import { isTargetDeleting } from "../storage/deletion";
 import { blobObject, commitObject, treeObject } from "../storage/git-objects";
 import {
@@ -261,18 +261,23 @@ export class RepoDO extends DurableObject<Env> {
     // predicts the fast-forward correctly instead of racing on a stale head.
     await this.setHead(result.commit);
 
-    const updateResult = await markChangeMerged(this.env.DB, log, changeId, {
-      ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
-      ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
-      ...(change.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
-      mergedAt: new Date().toISOString(),
-    });
+    const updateResult = await markChangeMerged(
+      this.env.DB,
+      log,
+      changeId,
+      mergeTransitionOpts(change, new Date().toISOString()),
+    );
     if (!updateResult.success) return { success: false, error: updateResult.error.message };
     const { transitioned } = updateResult.data;
     // A concurrent invocation already merged this change (interleaved before our
     // CAS). The winner recorded provenance and GC'd the staged tree; skip both so
     // a single logical merge yields exactly one set of side effects.
-    if (!transitioned) return { success: true, commit: result.commit, transitioned: false };
+    if (!transitioned) {
+      log.info("Change already merged by a concurrent invocation; skipping provenance", {
+        changeId,
+      });
+      return { success: true, commit: result.commit, transitioned: false };
+    }
 
     // The commit is already durable; provenance is bookkeeping — log a failure for
     // observability but don't fail the (successful) merge.
@@ -503,12 +508,12 @@ export class RepoDO extends DurableObject<Env> {
       await timer.measure("refAdvanceMs", () => this.setHead(mergedCommit));
 
       const updateResult = await timer.measure("d1UpdateMs", () =>
-        markChangeMerged(this.env.DB, log, changeId, {
-          ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
-          ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
-          ...(change.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
-          mergedAt: new Date().toISOString(),
-        }),
+        markChangeMerged(
+          this.env.DB,
+          log,
+          changeId,
+          mergeTransitionOpts(change, new Date().toISOString()),
+        ),
       );
       if (!updateResult.success) {
         return { success: false, error: updateResult.error.message };
@@ -517,6 +522,9 @@ export class RepoDO extends DurableObject<Env> {
       // Concurrent invocation already merged this change; skip the redundant
       // provenance/metrics writes (the winner recorded them) — see mergeViaR2.
       if (!transitioned) {
+        log.info("Change already merged by a concurrent invocation; skipping provenance/metrics", {
+          changeId,
+        });
         return { success: true, commit: mergedCommit, transitioned: false };
       }
 

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -21,6 +21,7 @@ import {
   getChange,
   getChangesByIds,
   listChanges,
+  markChangeMerged,
   updateChangeStatus,
 } from "../storage/changes";
 import { type CostSample, getChangeCostSummary, recordCosts } from "../storage/costs";
@@ -747,14 +748,26 @@ app.post("/changes/:id/merge", async (c) => {
       return badRequest(result.error ?? "Merge failed");
     }
 
-    await emitEvent(
-      c.env.DB,
-      c.env.EVENTS_QUEUE,
-      { type: "change.merged", project: change.project, changeId: id, commit: result.commit ?? "" },
-      { type: "user", id: userId },
-      logger,
-      change.projectId ?? project.id,
-    );
+    // Emit only when this request's merge actually performed the transition. A
+    // concurrent request (or interleaved DO invocation) that found the change
+    // already merged returns `transitioned: false`, so we don't double-fire
+    // change.merged (which would double-deliver webhooks and re-run issue
+    // auto-close). Paths predating the CAS leave `transitioned` undefined → emit.
+    if (result.transitioned !== false) {
+      await emitEvent(
+        c.env.DB,
+        c.env.EVENTS_QUEUE,
+        {
+          type: "change.merged",
+          project: change.project,
+          changeId: id,
+          commit: result.commit ?? "",
+        },
+        { type: "user", id: userId },
+        logger,
+        change.projectId ?? project.id,
+      );
+    }
 
     logger.info("Change merged via queue", {
       changeId: id,
@@ -865,7 +878,7 @@ app.post("/changes/:id/merge", async (c) => {
   const commit = mergeResult.data;
 
   const mergedAt = new Date().toISOString();
-  const updateResult = await updateChangeStatus(c.env.DB, logger, id, "merged", {
+  const updateResult = await markChangeMerged(c.env.DB, logger, id, {
     ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
     ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
     ...(change.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
@@ -874,6 +887,21 @@ app.post("/changes/:id/merge", async (c) => {
   if (!updateResult.success) {
     logger.error("Failed to update change status to merged", updateResult.error);
     return badRequest(updateResult.error.message);
+  }
+  if (!updateResult.data.transitioned) {
+    // A concurrent request already merged this change; the git merge we just ran
+    // was redundant. Don't re-record costs/provenance or re-emit change.merged —
+    // just report the change as merged (idempotent).
+    logger.info("Change already merged by a concurrent request; skipping re-emit", {
+      changeId: id,
+    });
+    return okOrFormRedirect(c, id, {
+      merged: true,
+      changeId: id,
+      project: change.project,
+      workspace: change.workspace,
+      commit,
+    });
   }
 
   await recordCosts(

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -22,6 +22,7 @@ import {
   getChangesByIds,
   listChanges,
   markChangeMerged,
+  mergeTransitionOpts,
   updateChangeStatus,
 } from "../storage/changes";
 import { type CostSample, getChangeCostSummary, recordCosts } from "../storage/costs";
@@ -748,26 +749,40 @@ app.post("/changes/:id/merge", async (c) => {
       return badRequest(result.error ?? "Merge failed");
     }
 
-    // Emit only when this request's merge actually performed the transition. A
-    // concurrent request (or interleaved DO invocation) that found the change
-    // already merged returns `transitioned: false`, so we don't double-fire
-    // change.merged (which would double-deliver webhooks and re-run issue
-    // auto-close). Paths predating the CAS leave `transitioned` undefined → emit.
-    if (result.transitioned !== false) {
-      await emitEvent(
-        c.env.DB,
-        c.env.EVENTS_QUEUE,
+    // A concurrent request (or interleaved DO invocation) that found the change
+    // already merged returns `transitioned: false`. Skip ALL post-merge side
+    // effects for it — the change.merged event, the forced-merge audit, and the
+    // post-merge policy check (which can auto-revert) — so a single logical merge
+    // fires exactly one set of side effects. The winning request runs them below.
+    if (result.transitioned === false) {
+      logger.info(
+        "Change already merged by a concurrent request; skipping post-merge side effects",
         {
-          type: "change.merged",
-          project: change.project,
           changeId: id,
-          commit: result.commit ?? "",
         },
-        { type: "user", id: userId },
-        logger,
-        change.projectId ?? project.id,
       );
+      return okOrFormRedirect(c, id, {
+        merged: true,
+        changeId: id,
+        project: change.project,
+        workspace: change.workspace,
+        commit: result.commit,
+      });
     }
+
+    await emitEvent(
+      c.env.DB,
+      c.env.EVENTS_QUEUE,
+      {
+        type: "change.merged",
+        project: change.project,
+        changeId: id,
+        commit: result.commit ?? "",
+      },
+      { type: "user", id: userId },
+      logger,
+      change.projectId ?? project.id,
+    );
 
     logger.info("Change merged via queue", {
       changeId: id,
@@ -878,12 +893,12 @@ app.post("/changes/:id/merge", async (c) => {
   const commit = mergeResult.data;
 
   const mergedAt = new Date().toISOString();
-  const updateResult = await markChangeMerged(c.env.DB, logger, id, {
-    ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
-    ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
-    ...(change.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
-    mergedAt,
-  });
+  const updateResult = await markChangeMerged(
+    c.env.DB,
+    logger,
+    id,
+    mergeTransitionOpts(change, mergedAt),
+  );
   if (!updateResult.success) {
     logger.error("Failed to update change status to merged", updateResult.error);
     return badRequest(updateResult.error.message);

--- a/src/storage/changes.ts
+++ b/src/storage/changes.ts
@@ -353,6 +353,24 @@ export async function updateChangeStatus(
 }
 
 /**
+ * Build the `markChangeMerged` options that carry a change's eval result through
+ * to the merged row. Shared by all four merge call sites (cold route, merge
+ * queue, and both RepoDO paths) so a new eval field is added in exactly one
+ * place, not four.
+ */
+export function mergeTransitionOpts(
+  change: Pick<Change, "evalScore" | "evalPassed" | "evalReason">,
+  mergedAt: string,
+): { evalScore?: number; evalPassed?: boolean; evalReason?: string; mergedAt: string } {
+  return {
+    ...(change.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+    ...(change.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
+    ...(change.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
+    mergedAt,
+  };
+}
+
+/**
  * Transition a change to `merged` as a single atomic compare-and-swap:
  * `UPDATE ... WHERE id = ? AND status != 'merged'`. Returns
  * `{ transitioned: false }` when the row was already `merged` — i.e. a concurrent

--- a/src/storage/changes.ts
+++ b/src/storage/changes.ts
@@ -351,3 +351,66 @@ export async function updateChangeStatus(
     return err(appError);
   }
 }
+
+/**
+ * Transition a change to `merged` as a single atomic compare-and-swap:
+ * `UPDATE ... WHERE id = ? AND status != 'merged'`. Returns
+ * `{ transitioned: false }` when the row was already `merged` — i.e. a concurrent
+ * merger (another request, or an interleaved Durable Object invocation) already
+ * won the transition. Callers emit `change.merged` and record post-merge
+ * bookkeeping ONLY when `transitioned` is true, so exactly one merge of a change
+ * fires exactly one event no matter how many requests race.
+ */
+export async function markChangeMerged(
+  db: D1Database,
+  logger: Logger,
+  id: string,
+  opts?: { evalScore?: number; evalPassed?: boolean; evalReason?: string; mergedAt?: string },
+): Promise<Result<{ transitioned: boolean }, NotFoundError | AppError>> {
+  try {
+    const existingRow = await db
+      .prepare("SELECT id FROM changes WHERE id = ?")
+      .bind(id)
+      .first<{ id: string }>();
+    if (!existingRow) {
+      logger.debug("Change not found for merge transition", { changeId: id });
+      return err(new NotFoundError("Change", id));
+    }
+
+    const assignments = ["status = 'merged'"];
+    const bindings: unknown[] = [];
+    const addOptional = (column: string, value: unknown) => {
+      if (value === undefined) return;
+      assignments.push(`${column} = ?`);
+      bindings.push(value);
+    };
+    addOptional("eval_score", opts?.evalScore);
+    addOptional(
+      "eval_passed",
+      opts?.evalPassed !== undefined ? (opts.evalPassed ? 1 : 0) : undefined,
+    );
+    addOptional("eval_reason", opts?.evalReason);
+    addOptional("merged_at", opts?.mergedAt ?? new Date().toISOString());
+    bindings.push(id);
+
+    const result = await db
+      .prepare(`UPDATE changes SET ${assignments.join(", ")} WHERE id = ? AND status != 'merged'`)
+      .bind(...bindings)
+      .run();
+    const transitioned = (result.meta?.changes ?? 0) > 0;
+    logger.debug("Change merge transition", { changeId: id, transitioned });
+    return ok({ transitioned });
+  } catch (error) {
+    const appError =
+      error instanceof AppError
+        ? error
+        : new AppError(
+            error instanceof Error ? error.message : "Failed to mark change merged",
+            "DATABASE_ERROR",
+            500,
+            { operation: "markChangeMerged", changeId: id },
+          );
+    logger.error("Failed to mark change merged", appError, { changeId: id });
+    return err(appError);
+  }
+}

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -12,6 +12,12 @@ vi.mock("../src/storage/changes", () => ({
   updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
   // Default: this request won the transition, so the merge path emits + records.
   markChangeMerged: vi.fn(async () => ({ success: true, data: { transitioned: true } })),
+  mergeTransitionOpts: (change: { evalScore?: number; evalPassed?: boolean; evalReason?: string }, mergedAt: string) => ({
+    ...(change?.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+    ...(change?.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
+    ...(change?.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
+    mergedAt,
+  }),
 }));
 
 vi.mock("../src/storage/git-ops", async (importActual) => {

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -10,6 +10,8 @@ vi.mock("../src/storage/changes", () => ({
   getChangesByIds: vi.fn(),
   listChanges: vi.fn(),
   updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
+  // Default: this request won the transition, so the merge path emits + records.
+  markChangeMerged: vi.fn(async () => ({ success: true, data: { transitioned: true } })),
 }));
 
 vi.mock("../src/storage/git-ops", async (importActual) => {
@@ -129,12 +131,14 @@ vi.mock("../src/storage/agents", () => ({
 }));
 
 import { CompositeEvaluator, SecretScanEvaluator, loadPolicy } from "../src/evaluation";
+import { emitEvent } from "../src/queue/events";
 import { getAgent, getAgentByToken } from "../src/storage/agents";
 import {
   createChange,
   getChange,
   getChangesByIds,
   listChanges,
+  markChangeMerged,
   updateChangeStatus,
 } from "../src/storage/changes";
 import { listEvalRuns, recordEvalRuns } from "../src/storage/eval-runs";
@@ -947,13 +951,64 @@ describe("POST /api/changes/:id/merge", () => {
       expect.any(Object),
       { strategy: "merge" },
     );
-    expect(updateChangeStatus).toHaveBeenCalledWith(
+    expect(markChangeMerged).toHaveBeenCalledWith(
       env.DB,
       expect.any(Object),
       "chg_abc123",
-      "merged",
       expect.objectContaining({ mergedAt: expect.any(String) }),
     );
+  });
+
+  it("emits change.merged when this request wins the transition (guards the unsafe direction)", async () => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: { ...mockChange, status: "accepted" },
+    });
+    vi.mocked(markChangeMerged).mockResolvedValueOnce({
+      success: true,
+      data: { transitioned: true },
+    });
+
+    const res = await app.fetch(
+      request("POST", "/api/changes/chg_abc123/merge", undefined, USER_AUTH),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(emitEvent).toHaveBeenCalledWith(
+      env.DB,
+      env.EVENTS_QUEUE,
+      expect.objectContaining({ type: "change.merged", changeId: "chg_abc123" }),
+      expect.any(Object),
+      expect.any(Object),
+      expect.anything(),
+    );
+  });
+
+  it("does NOT re-emit change.merged when a concurrent request already merged (dedup)", async () => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: { ...mockChange, status: "accepted" },
+    });
+    // This request's CAS found the change already merged: transitioned = false.
+    vi.mocked(markChangeMerged).mockResolvedValueOnce({
+      success: true,
+      data: { transitioned: false },
+    });
+
+    const res = await app.fetch(
+      request("POST", "/api/changes/chg_abc123/merge", undefined, USER_AUTH),
+      env,
+    );
+
+    // Still reports success (idempotent), but fires no second change.merged event.
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { merged: boolean };
+    expect(body.merged).toBe(true);
+    const mergedEmits = vi
+      .mocked(emitEvent)
+      .mock.calls.filter((call) => (call[2] as { type?: string })?.type === "change.merged");
+    expect(mergedEmits).toHaveLength(0);
   });
 
   it("merges the pinned evaluated sha, not the workspace's live tip", async () => {

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -12,7 +12,10 @@ vi.mock("../src/storage/changes", () => ({
   updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
   // Default: this request won the transition, so the merge path emits + records.
   markChangeMerged: vi.fn(async () => ({ success: true, data: { transitioned: true } })),
-  mergeTransitionOpts: (change: { evalScore?: number; evalPassed?: boolean; evalReason?: string }, mergedAt: string) => ({
+  mergeTransitionOpts: (
+    change: { evalScore?: number; evalPassed?: boolean; evalReason?: string },
+    mergedAt: string,
+  ) => ({
     ...(change?.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
     ...(change?.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
     ...(change?.evalReason !== undefined ? { evalReason: change.evalReason } : {}),

--- a/tests/deletion-consumer-noop.test.ts
+++ b/tests/deletion-consumer-noop.test.ts
@@ -4,6 +4,15 @@ vi.mock("../src/storage/changes", () => ({
   getChange: vi.fn(),
   updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
   markChangeMerged: vi.fn(async () => ({ success: true, data: { transitioned: true } })),
+  mergeTransitionOpts: (
+    change: { evalScore?: number; evalPassed?: boolean; evalReason?: string },
+    mergedAt: string,
+  ) => ({
+    ...(change?.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+    ...(change?.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
+    ...(change?.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
+    mergedAt,
+  }),
 }));
 vi.mock("../src/storage/state", () => ({
   getProject: vi.fn(),

--- a/tests/deletion-consumer-noop.test.ts
+++ b/tests/deletion-consumer-noop.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../src/storage/changes", () => ({
   getChange: vi.fn(),
   updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
+  markChangeMerged: vi.fn(async () => ({ success: true, data: { transitioned: true } })),
 }));
 vi.mock("../src/storage/state", () => ({
   getProject: vi.fn(),

--- a/tests/mark-change-merged.test.ts
+++ b/tests/mark-change-merged.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { markChangeMerged } from "../src/storage/changes";
+import { NotFoundError } from "../src/utils/errors";
+import type { Logger } from "../src/utils/logger";
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+};
+
+/**
+ * Fake D1 modelling a single change's status, so the CAS
+ * `UPDATE ... WHERE id = ? AND status != 'merged'` reports meta.changes exactly
+ * as real D1 would: 1 on the first transition, 0 once already merged.
+ */
+function makeStatusD1(initialStatus: string | null) {
+  const state = { status: initialStatus };
+  function makeStmt(sql: string, bindings: unknown[]) {
+    const upper = sql.trim().toUpperCase();
+    return {
+      bind: (...args: unknown[]) => makeStmt(sql, args),
+      first: async () => {
+        if (upper.startsWith("SELECT ID FROM CHANGES")) {
+          return state.status === null ? null : { id: bindings[0] };
+        }
+        return null;
+      },
+      run: async () => {
+        if (upper.startsWith("UPDATE CHANGES SET STATUS = 'MERGED'")) {
+          // WHERE id = ? AND status != 'merged'
+          const changed = state.status !== "merged" ? 1 : 0;
+          if (changed) state.status = "merged";
+          return { success: true, meta: { changes: changed } };
+        }
+        return { success: true, meta: { changes: 0 } };
+      },
+      all: async () => ({ results: [], success: true, meta: {} }),
+    };
+  }
+  return {
+    state,
+    db: { prepare: (sql: string) => makeStmt(sql, []) } as unknown as D1Database,
+  };
+}
+
+describe("markChangeMerged (CAS)", () => {
+  it("transitions an unmerged change and reports transitioned: true", async () => {
+    const { db, state } = makeStatusD1("approved");
+    const result = await markChangeMerged(db, logger, "chg_1", {
+      mergedAt: "2026-07-20T00:00:00Z",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.transitioned).toBe(true);
+    expect(state.status).toBe("merged");
+  });
+
+  it("reports transitioned: false when the change is already merged (a concurrent merger won)", async () => {
+    const { db } = makeStatusD1("merged");
+    const result = await markChangeMerged(db, logger, "chg_1");
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.transitioned).toBe(false);
+  });
+
+  it("only the first of two racing transitions reports transitioned: true", async () => {
+    const { db } = makeStatusD1("approved");
+    const first = await markChangeMerged(db, logger, "chg_1");
+    const second = await markChangeMerged(db, logger, "chg_1");
+    expect(first.success && first.data.transitioned).toBe(true);
+    expect(second.success && second.data.transitioned).toBe(false);
+  });
+
+  it("returns NotFound for a missing change", async () => {
+    const { db } = makeStatusD1(null);
+    const result = await markChangeMerged(db, logger, "chg_missing");
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+});

--- a/tests/merge-queue-metrics.test.ts
+++ b/tests/merge-queue-metrics.test.ts
@@ -4,6 +4,15 @@ vi.mock("../src/storage/changes", () => ({
   getChange: vi.fn(),
   updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
   markChangeMerged: vi.fn(async () => ({ success: true, data: { transitioned: true } })),
+  mergeTransitionOpts: (
+    change: { evalScore?: number; evalPassed?: boolean; evalReason?: string },
+    mergedAt: string,
+  ) => ({
+    ...(change?.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+    ...(change?.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
+    ...(change?.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
+    mergedAt,
+  }),
 }));
 vi.mock("../src/storage/state", () => ({
   getProject: vi.fn(),

--- a/tests/merge-queue-metrics.test.ts
+++ b/tests/merge-queue-metrics.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../src/storage/changes", () => ({
   getChange: vi.fn(),
   updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
+  markChangeMerged: vi.fn(async () => ({ success: true, data: { transitioned: true } })),
 }));
 vi.mock("../src/storage/state", () => ({
   getProject: vi.fn(),

--- a/tests/post-merge.test.ts
+++ b/tests/post-merge.test.ts
@@ -19,6 +19,7 @@ vi.mock("../src/storage/git-ops", () => ({
 
 vi.mock("../src/storage/changes", () => ({
   updateChangeStatus: vi.fn().mockResolvedValue({ success: true, data: undefined }),
+  markChangeMerged: vi.fn().mockResolvedValue({ success: true, data: { transitioned: true } }),
 }));
 
 vi.mock("../src/queue/events", () => ({

--- a/tests/post-merge.test.ts
+++ b/tests/post-merge.test.ts
@@ -20,6 +20,15 @@ vi.mock("../src/storage/git-ops", () => ({
 vi.mock("../src/storage/changes", () => ({
   updateChangeStatus: vi.fn().mockResolvedValue({ success: true, data: undefined }),
   markChangeMerged: vi.fn().mockResolvedValue({ success: true, data: { transitioned: true } }),
+  mergeTransitionOpts: (
+    change: { evalScore?: number; evalPassed?: boolean; evalReason?: string },
+    mergedAt: string,
+  ) => ({
+    ...(change?.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+    ...(change?.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
+    ...(change?.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
+    mergedAt,
+  }),
 }));
 
 vi.mock("../src/queue/events", () => ({

--- a/tests/pr-webhook-changes.test.ts
+++ b/tests/pr-webhook-changes.test.ts
@@ -16,6 +16,15 @@ vi.mock("../src/storage/changes", () => ({
   createChange: vi.fn(),
   updateChangeStatus: vi.fn().mockResolvedValue({ success: true, data: undefined }),
   markChangeMerged: vi.fn().mockResolvedValue({ success: true, data: { transitioned: true } }),
+  mergeTransitionOpts: (
+    change: { evalScore?: number; evalPassed?: boolean; evalReason?: string },
+    mergedAt: string,
+  ) => ({
+    ...(change?.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+    ...(change?.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
+    ...(change?.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
+    mergedAt,
+  }),
 }));
 
 vi.mock("../src/storage/state", () => ({

--- a/tests/pr-webhook-changes.test.ts
+++ b/tests/pr-webhook-changes.test.ts
@@ -15,6 +15,7 @@ vi.mock("../src/storage/changes", () => ({
   getChangeByGitHubBranch: vi.fn(),
   createChange: vi.fn(),
   updateChangeStatus: vi.fn().mockResolvedValue({ success: true, data: undefined }),
+  markChangeMerged: vi.fn().mockResolvedValue({ success: true, data: { transitioned: true } }),
 }));
 
 vi.mock("../src/storage/state", () => ({

--- a/tests/repo-do.test.ts
+++ b/tests/repo-do.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../src/storage/changes", () => ({
   getChange: vi.fn(),
   updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
+  markChangeMerged: vi.fn(async () => ({ success: true, data: { transitioned: true } })),
 }));
 vi.mock("../src/storage/state", () => ({
   getProject: vi.fn(),
@@ -22,9 +23,10 @@ vi.mock("../src/storage/metrics", () => ({
 }));
 
 import { RepoDO } from "../src/queue/repo-do";
-import { getChange } from "../src/storage/changes";
+import { getChange, markChangeMerged } from "../src/storage/changes";
 import { fastForwardMerge, mergeWorkspaceIntoProject } from "../src/storage/git-ops";
 import { recordCommitMetrics } from "../src/storage/metrics";
+import { recordProvenance } from "../src/storage/provenance";
 import { getProject, getWorkspace } from "../src/storage/state";
 import type { Env } from "../src/types";
 
@@ -96,7 +98,7 @@ describe("RepoDO.advance fast-forward path", () => {
     const repo = new RepoDO(ctx, env);
     const result = await repo.advance("chg_1");
 
-    expect(result).toEqual({ success: true, commit: "ws-tip" });
+    expect(result).toEqual({ success: true, commit: "ws-tip", transitioned: true });
     expect(fastForwardMerge).toHaveBeenCalledTimes(1);
     expect(mergeWorkspaceIntoProject).not.toHaveBeenCalled();
     expect(store.get("head")).toBe("ws-tip");
@@ -110,7 +112,7 @@ describe("RepoDO.advance cold fallback", () => {
     const repo = new RepoDO(ctx, env);
     const result = await repo.advance("chg_1");
 
-    expect(result).toEqual({ success: true, commit: "merge-commit" });
+    expect(result).toEqual({ success: true, commit: "merge-commit", transitioned: true });
     expect(fastForwardMerge).not.toHaveBeenCalled();
     expect(mergeWorkspaceIntoProject).toHaveBeenCalledTimes(1);
     expect(store.get("head")).toBe("merge-commit");
@@ -125,6 +127,22 @@ describe("RepoDO.advance cold fallback", () => {
     expect(result.success).toBe(true);
     expect(fastForwardMerge).not.toHaveBeenCalled();
     expect(mergeWorkspaceIntoProject).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports transitioned:false and skips provenance/metrics when a concurrent merge already won", async () => {
+    vi.mocked(markChangeMerged).mockResolvedValueOnce({
+      success: true,
+      data: { transitioned: false },
+    });
+    const { ctx, store } = makeCtx();
+    store.set("head", "base1"); // fast-forward path produces a commit
+    const repo = new RepoDO(ctx, env);
+
+    const result = await repo.advance("chg_1");
+
+    expect(result).toMatchObject({ success: true, transitioned: false });
+    expect(recordProvenance).not.toHaveBeenCalled();
+    expect(recordCommitMetrics).not.toHaveBeenCalled();
   });
 
   it("cold-merges when the change has no baseSha", async () => {
@@ -146,7 +164,7 @@ describe("RepoDO.advance cold fallback", () => {
     store.set("head", "base1");
     const repo = new RepoDO(ctx, env);
     const result = await repo.advance("chg_1");
-    expect(result).toEqual({ success: true, commit: "merge-commit" });
+    expect(result).toEqual({ success: true, commit: "merge-commit", transitioned: true });
     expect(fastForwardMerge).toHaveBeenCalledTimes(1);
     expect(mergeWorkspaceIntoProject).toHaveBeenCalledTimes(1);
   });

--- a/tests/repo-do.test.ts
+++ b/tests/repo-do.test.ts
@@ -4,6 +4,15 @@ vi.mock("../src/storage/changes", () => ({
   getChange: vi.fn(),
   updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
   markChangeMerged: vi.fn(async () => ({ success: true, data: { transitioned: true } })),
+  mergeTransitionOpts: (
+    change: { evalScore?: number; evalPassed?: boolean; evalReason?: string },
+    mergedAt: string,
+  ) => ({
+    ...(change?.evalScore !== undefined ? { evalScore: change.evalScore } : {}),
+    ...(change?.evalPassed !== undefined ? { evalPassed: change.evalPassed } : {}),
+    ...(change?.evalReason !== undefined ? { evalReason: change.evalReason } : {}),
+    mergedAt,
+  }),
 }));
 vi.mock("../src/storage/state", () => ({
   getProject: vi.fn(),


### PR DESCRIPTION
## The bug

The merge flow read the change status, updated it to `merged`, then emitted `change.merged` — a non-atomic read-guard-update-emit. Two concurrent merge requests (or interleaved Durable Object RPCs) for the same change could both pass the `MERGEABLE_STATUSES` guard and both emit `change.merged`, **double-delivering webhooks and re-running issue auto-close**.

## The fix — compare-and-swap on the transition

`markChangeMerged` runs the transition atomically and reports whether *this* caller performed it:

```sql
UPDATE changes SET status='merged', … WHERE id = ? AND status != 'merged'
```
→ `{ transitioned: (meta.changes > 0) }`

Emit `change.merged` (and record post-merge bookkeeping) **only when `transitioned` is true**:

- **storage** (`changes.ts`): new `markChangeMerged`; existing `updateChangeStatus` callers untouched.
- **cold path** (`routes/changes.ts`): uses it; a losing request returns `merged` (idempotent) without re-emitting or re-recording cost/provenance.
- **queue/DO paths** (`merge-queue.ts`, `repo-do.ts` `mergeViaR2` + `advanceLocked`): the internal transition is now the CAS; `transitioned` is threaded through `MergeOutcome`; the loser skips provenance/metrics. The route emits only when `result.transitioned !== false` (`undefined` = pre-CAS path = emit).

`change.merged` is emitted from exactly **one** place (the route — the DOs never emit it), so gating there dedups every path.

## Guarding the unsafe direction

A silent *failure to emit* would break issue-autoclose + webhooks, so that's the direction I verified hardest: a genuine first merge always has a mergeable status (`approved`/`accepted`/`promoted`), so `status != 'merged'` matches, `meta.changes = 1`, `transitioned = true`, and the event fires. `transitioned` is derived purely from the UPDATE's `meta.changes`, never from the existence-check SELECT, so there's no TOCTOU that flips a happy-path merge to silent.

## Tests

- `markChangeMerged` CAS semantics: win → `true`, already-merged → `false`, two racing calls → only the first `true`, missing change → `NotFound`.
- route: **emits** `change.merged` when this request wins; does **not** re-emit when a concurrent request already merged (still returns `merged: true`).
- DO: returns `transitioned: false` and skips provenance/metrics on a lost race.

Full suite **1057 passing**; typecheck + biome clean. Independently reviewed (adversarial pass focused on the unsafe direction) — the asymmetry it found (DO bookkeeping not gated) is fixed in this PR.

## Note for reviewer

The cold path's git merge still runs before the CAS, so a losing concurrent request on the unserialized cold path performs a redundant git merge (then suppresses the duplicate D1 status + event). Fixing the double git-merge would require cold-path locking and is out of scope — this PR dedups the **event** (the finding), which is what breaks webhooks/auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made change merges idempotent during concurrent requests.
  * Prevented duplicate events, provenance updates, and metrics when a merge was already completed.
  * Merges now return successful results when another request completes the transition first.
* **Reliability**
  * Added atomic merge handling so only one request performs merge side effects.
* **Tests**
  * Added coverage for concurrent merge races, duplicate-event prevention, idempotent outcomes, and missing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->