### PR TITLE
fix(audit): scope issue reads/updates by project_id + bound the list (T5)

### DIFF
--- a/src/routes/issues.ts
+++ b/src/routes/issues.ts
@@ -28,6 +28,10 @@ const app = new Hono<{ Bindings: Env }>();
 const MAX_TITLE_LENGTH = 200;
 const MAX_BODY_LENGTH = 20_000;
 
+/** Default + hard cap for the paginated issues listing (bounds the response). */
+const DEFAULT_ISSUES_PAGE = 100;
+const MAX_ISSUES_PAGE = 500;
+
 interface RouteContext {
   env: Env;
   get(key: "userId" | "agentId" | "agentOwnerId"): string | undefined;
@@ -163,8 +167,17 @@ app.get("/:namespace/:slug/issues", async (c) => {
   const status: IssueStatus | undefined =
     statusParam === "open" || statusParam === "closed" ? statusParam : undefined;
 
+  // Bound the response so a project with thousands of issues can't return them
+  // all at once. Client may request fewer via ?limit=, capped at the max.
+  const requested = Number(c.req.query("limit"));
+  const limit =
+    Number.isInteger(requested) && requested > 0
+      ? Math.min(requested, MAX_ISSUES_PAGE)
+      : DEFAULT_ISSUES_PAGE;
+
   const issuesResult = await listIssues(c.env.DB, logger, project.name, status, {
     projectId: project.id,
+    limit,
   });
   if (!issuesResult.success) {
     return internalError(issuesResult.error.message);

--- a/src/routes/issues.ts
+++ b/src/routes/issues.ts
@@ -163,7 +163,9 @@ app.get("/:namespace/:slug/issues", async (c) => {
   const status: IssueStatus | undefined =
     statusParam === "open" || statusParam === "closed" ? statusParam : undefined;
 
-  const issuesResult = await listIssues(c.env.DB, logger, project.name, status);
+  const issuesResult = await listIssues(c.env.DB, logger, project.name, status, {
+    projectId: project.id,
+  });
   if (!issuesResult.success) {
     return internalError(issuesResult.error.message);
   }
@@ -194,7 +196,9 @@ app.get("/:namespace/:slug/issues/:number", async (c) => {
   const number = parseIssueNumber(c.req.param("number"));
   if (number === null) return badRequest("Invalid issue number");
 
-  const issueResult = await getIssueByNumber(c.env.DB, logger, project.name, number);
+  const issueResult = await getIssueByNumber(c.env.DB, logger, project.name, number, {
+    projectId: project.id,
+  });
   if (!issueResult.success) {
     if (issueResult.error.code === "NOT_FOUND") return notFound("Issue", `#${number}`);
     return internalError(issueResult.error.message);
@@ -268,13 +272,18 @@ app.patch("/:namespace/:slug/issues/:number", async (c) => {
     }
   }
 
-  const before = await getIssueByNumber(c.env.DB, logger, project.name, number);
+  const before = await getIssueByNumber(c.env.DB, logger, project.name, number, {
+    projectId: project.id,
+  });
   if (!before.success) {
     if (before.error.code === "NOT_FOUND") return notFound("Issue", `#${number}`);
     return internalError(before.error.message);
   }
 
-  const updateResult = await updateIssue(c.env.DB, logger, project.name, number, updates);
+  const updateResult = await updateIssue(c.env.DB, logger, project.name, number, {
+    ...updates,
+    projectId: project.id,
+  });
   if (!updateResult.success) {
     if (updateResult.error.code === "NOT_FOUND") return notFound("Issue", `#${number}`);
     return internalError(updateResult.error.message);
@@ -322,7 +331,9 @@ app.post("/:namespace/:slug/issues/:number/close", async (c) => {
   const number = parseIssueNumber(c.req.param("number"));
   if (number === null) return badRequest("Invalid issue number");
 
-  const before = await getIssueByNumber(c.env.DB, logger, project.name, number);
+  const before = await getIssueByNumber(c.env.DB, logger, project.name, number, {
+    projectId: project.id,
+  });
   if (!before.success) {
     if (before.error.code === "NOT_FOUND") return notFound("Issue", `#${number}`);
     return internalError(before.error.message);
@@ -332,6 +343,7 @@ app.post("/:namespace/:slug/issues/:number/close", async (c) => {
   const updateResult = await updateIssue(c.env.DB, logger, project.name, number, {
     status: newStatus,
     actorId: userId,
+    projectId: project.id,
   });
   if (!updateResult.success) {
     return internalError(updateResult.error.message);

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -861,6 +861,7 @@ app.get("/:namespace/:slug/issues", async (c) => {
     logger,
     project.name,
     filter === "all" ? undefined : filter,
+    { projectId: project.id },
   );
   if (!issuesResult.success) {
     logger.error("Failed to list issues", issuesResult.error);
@@ -913,7 +914,9 @@ app.get("/:namespace/:slug/issues/:number", async (c) => {
     return c.html(issuePageError(400), 400);
   }
 
-  const issueResult = await getIssueByNumber(c.env.DB, logger, project.name, number);
+  const issueResult = await getIssueByNumber(c.env.DB, logger, project.name, number, {
+    projectId: project.id,
+  });
   if (!issueResult.success) {
     return c.html(
       <div style="padding:2rem;font-family:monospace;color:#f87171;">

--- a/src/storage/issues.ts
+++ b/src/storage/issues.ts
@@ -132,12 +132,23 @@ export async function getIssueByNumber(
   logger: Logger,
   project: string,
   number: number,
+  opts?: { projectId?: string },
 ): Promise<Result<Issue, NotFoundError | AppError>> {
   try {
-    const row = await db
-      .prepare("SELECT * FROM issues WHERE project = ? AND number = ?")
-      .bind(project, number)
-      .first<IssueRow>();
+    // Scope by the canonical project_id when known, falling back to the free-form
+    // name only for legacy rows whose project_id wasn't backfilled. Matching purely
+    // on `project` would return a same-named project's issue in ANOTHER namespace.
+    const row = opts?.projectId
+      ? await db
+          .prepare(
+            "SELECT * FROM issues WHERE (project_id = ? OR (project_id IS NULL AND project = ?)) AND number = ?",
+          )
+          .bind(opts.projectId, project, number)
+          .first<IssueRow>()
+      : await db
+          .prepare("SELECT * FROM issues WHERE project = ? AND number = ?")
+          .bind(project, number)
+          .first<IssueRow>();
     if (!row) {
       logger.debug("Issue not found", { project, number });
       return err(new NotFoundError("Issue", `${project}#${number}`));
@@ -155,16 +166,24 @@ export async function listIssues(
   logger: Logger,
   project: string,
   status?: IssueStatus,
+  opts?: { projectId?: string },
 ): Promise<Result<Issue[], AppError>> {
   try {
+    // project_id-first with a legacy name fallback (see getIssueByNumber).
+    const scope = opts?.projectId
+      ? {
+          clause: "(project_id = ? OR (project_id IS NULL AND project = ?))",
+          binds: [opts.projectId, project],
+        }
+      : { clause: "project = ?", binds: [project] };
     const result = status
       ? await db
-          .prepare("SELECT * FROM issues WHERE project = ? AND status = ? ORDER BY number DESC")
-          .bind(project, status)
+          .prepare(`SELECT * FROM issues WHERE ${scope.clause} AND status = ? ORDER BY number DESC`)
+          .bind(...scope.binds, status)
           .all<IssueRow>()
       : await db
-          .prepare("SELECT * FROM issues WHERE project = ? ORDER BY number DESC")
-          .bind(project)
+          .prepare(`SELECT * FROM issues WHERE ${scope.clause} ORDER BY number DESC`)
+          .bind(...scope.binds)
           .all<IssueRow>();
     return ok(result.results.map(rowToIssue));
   } catch (error) {
@@ -185,10 +204,12 @@ export async function updateIssue(
     status?: IssueStatus;
     linkedChangeId?: string | null;
     actorId: string;
+    projectId?: string;
   },
 ): Promise<Result<Issue, NotFoundError | AppError>> {
   try {
-    const existing = await getIssueByNumber(db, logger, project, number);
+    const scope = opts.projectId !== undefined ? { projectId: opts.projectId } : undefined;
+    const existing = await getIssueByNumber(db, logger, project, number, scope);
     if (!existing.success) return existing;
 
     const now = new Date().toISOString();
@@ -218,13 +239,25 @@ export async function updateIssue(
       }
     }
 
-    bindings.push(project, number);
-    await db
-      .prepare(`UPDATE issues SET ${assignments.join(", ")} WHERE project = ? AND number = ?`)
-      .bind(...bindings)
-      .run();
+    // Scope the write by project_id too, so a same-named project in another
+    // namespace can never be updated through this path.
+    if (scope) {
+      bindings.push(scope.projectId, project, number);
+      await db
+        .prepare(
+          `UPDATE issues SET ${assignments.join(", ")} WHERE (project_id = ? OR (project_id IS NULL AND project = ?)) AND number = ?`,
+        )
+        .bind(...bindings)
+        .run();
+    } else {
+      bindings.push(project, number);
+      await db
+        .prepare(`UPDATE issues SET ${assignments.join(", ")} WHERE project = ? AND number = ?`)
+        .bind(...bindings)
+        .run();
+    }
 
-    const updated = await getIssueByNumber(db, logger, project, number);
+    const updated = await getIssueByNumber(db, logger, project, number, scope);
     if (!updated.success) return updated;
     logger.info("Issue updated", { project, number });
     return updated;

--- a/src/storage/issues.ts
+++ b/src/storage/issues.ts
@@ -166,7 +166,7 @@ export async function listIssues(
   logger: Logger,
   project: string,
   status?: IssueStatus,
-  opts?: { projectId?: string },
+  opts?: { projectId?: string; limit?: number },
 ): Promise<Result<Issue[], AppError>> {
   try {
     // project_id-first with a legacy name fallback (see getIssueByNumber).
@@ -176,14 +176,20 @@ export async function listIssues(
           binds: [opts.projectId, project],
         }
       : { clause: "project = ?", binds: [project] };
+    // Bound the response when asked (the API route does); internal callers that
+    // omit `limit` still get every row.
+    const limitClause = opts?.limit !== undefined ? " LIMIT ?" : "";
+    const limitBind = opts?.limit !== undefined ? [opts.limit] : [];
     const result = status
       ? await db
-          .prepare(`SELECT * FROM issues WHERE ${scope.clause} AND status = ? ORDER BY number DESC`)
-          .bind(...scope.binds, status)
+          .prepare(
+            `SELECT * FROM issues WHERE ${scope.clause} AND status = ? ORDER BY number DESC${limitClause}`,
+          )
+          .bind(...scope.binds, status, ...limitBind)
           .all<IssueRow>()
       : await db
-          .prepare(`SELECT * FROM issues WHERE ${scope.clause} ORDER BY number DESC`)
-          .bind(...scope.binds)
+          .prepare(`SELECT * FROM issues WHERE ${scope.clause} ORDER BY number DESC${limitClause}`)
+          .bind(...scope.binds, ...limitBind)
           .all<IssueRow>();
     return ok(result.results.map(rowToIssue));
   } catch (error) {

--- a/tests/helpers/issues-d1.ts
+++ b/tests/helpers/issues-d1.ts
@@ -35,11 +35,22 @@ export function makeIssuesD1(): {
   const issues: IssueTableRow[] = [];
   const emittedEvents: OutboxRow[] = [];
 
+  // Mirror the storage predicate: match the canonical project_id, or fall back to
+  // the name only for legacy rows whose project_id is NULL.
+  const matchScope = (r: IssueTableRow, projectId: unknown, project: unknown) =>
+    r.project_id === projectId || (r.project_id === null && r.project === project);
+
   function applyUpdate(sql: string, bindings: unknown[]) {
-    // UPDATE issues SET <assignments> WHERE project = ? AND number = ?
-    const project = bindings[bindings.length - 2] as string;
+    // UPDATE issues SET <assignments> WHERE (project_id = ? OR (project_id IS NULL
+    // AND project = ?)) AND number = ?  — or the legacy name-only WHERE.
     const number = bindings[bindings.length - 1] as number;
-    const row = issues.find((r) => r.project === project && r.number === number);
+    const scoped = /PROJECT_ID = \? OR/i.test(sql);
+    const project = bindings[bindings.length - 2] as string;
+    const row = scoped
+      ? issues.find(
+          (r) => matchScope(r, bindings[bindings.length - 3], project) && r.number === number,
+        )
+      : issues.find((r) => r.project === project && r.number === number);
     if (!row) return;
 
     const assignmentsPart = sql.slice(sql.indexOf("SET") + 3, sql.indexOf("WHERE"));
@@ -122,6 +133,11 @@ export function makeIssuesD1(): {
           issues.push(row);
           return row as T;
         }
+        if (upper.includes("PROJECT_ID = ? OR") && upper.includes("AND NUMBER = ?")) {
+          return (issues.find(
+            (r) => matchScope(r, bindings[0], bindings[1]) && r.number === bindings[2],
+          ) ?? null) as T | null;
+        }
         if (upper.includes("FROM ISSUES WHERE PROJECT = ? AND NUMBER = ?")) {
           return (issues.find((r) => r.project === bindings[0] && r.number === bindings[1]) ??
             null) as T | null;
@@ -132,6 +148,13 @@ export function makeIssuesD1(): {
         let results: IssueTableRow[] = [];
         if (upper.includes("WHERE LINKED_CHANGE_ID = ? AND STATUS = 'OPEN'")) {
           results = issues.filter((r) => r.linked_change_id === bindings[0] && r.status === "open");
+        } else if (upper.includes("PROJECT_ID = ? OR")) {
+          const scoped = issues.filter((r) => matchScope(r, bindings[0], bindings[1]));
+          results = (
+            upper.includes("AND STATUS = ?")
+              ? scoped.filter((r) => r.status === bindings[2])
+              : scoped
+          ).sort((a, b) => b.number - a.number);
         } else if (upper.includes("WHERE PROJECT = ? AND STATUS = ?")) {
           results = issues
             .filter((r) => r.project === bindings[0] && r.status === bindings[1])

--- a/tests/helpers/issues-d1.ts
+++ b/tests/helpers/issues-d1.ts
@@ -164,6 +164,9 @@ export function makeIssuesD1(): {
             .filter((r) => r.project === bindings[0])
             .sort((a, b) => b.number - a.number);
         }
+        if (upper.includes("LIMIT ?")) {
+          results = results.slice(0, bindings[bindings.length - 1] as number);
+        }
         return { results: results as T[], success: true, meta: {} };
       },
     };

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -246,4 +246,17 @@ describe("issue tenant isolation (project_id-scoped reads)", () => {
     const found = await getIssueByNumber(db, mockLogger, "legacy", 1, { projectId: "proj_new" });
     expect(found.success).toBe(true);
   });
+
+  it("bounds the result with a limit when one is given", async () => {
+    const { db } = makeIssuesD1();
+    await seedIssue(db, { project: "acme", projectId: "proj_A" });
+    await seedIssue(db, { project: "acme", projectId: "proj_A" });
+    await seedIssue(db, { project: "acme", projectId: "proj_A" });
+
+    const capped = await listIssues(db, mockLogger, "acme", undefined, {
+      projectId: "proj_A",
+      limit: 2,
+    });
+    expect(capped.success && capped.data).toHaveLength(2);
+  });
 });

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -212,3 +212,38 @@ describe("autoCloseLinkedIssues", () => {
     expect(emittedEvents).toHaveLength(0);
   });
 });
+
+describe("issue tenant isolation (project_id-scoped reads)", () => {
+  it("does not return a same-named project's issue in another namespace", async () => {
+    const { db } = makeIssuesD1();
+    // Two projects share the name "acme" but have distinct canonical ids. Numbers
+    // are still name-sequenced (shared), so isolation must come from project_id.
+    await seedIssue(db, { project: "acme", projectId: "proj_A", title: "A's issue" });
+    await seedIssue(db, { project: "acme", projectId: "proj_B", title: "B's issue" });
+
+    const aOnly = await listIssues(db, mockLogger, "acme", undefined, { projectId: "proj_A" });
+    const bOnly = await listIssues(db, mockLogger, "acme", undefined, { projectId: "proj_B" });
+    expect(aOnly.success && aOnly.data.map((i) => i.title)).toEqual(["A's issue"]);
+    expect(bOnly.success && bOnly.data.map((i) => i.title)).toEqual(["B's issue"]);
+  });
+
+  it("getIssueByNumber scoped by project_id won't cross to a same-named tenant", async () => {
+    const { db } = makeIssuesD1();
+    await seedIssue(db, { project: "acme", projectId: "proj_A" }); // number 1
+    await seedIssue(db, { project: "acme", projectId: "proj_B" }); // number 2
+
+    const found = await getIssueByNumber(db, mockLogger, "acme", 1, { projectId: "proj_A" });
+    expect(found.success).toBe(true);
+    // Number 1 belongs to proj_A; proj_B must not see it.
+    const crossed = await getIssueByNumber(db, mockLogger, "acme", 1, { projectId: "proj_B" });
+    expect(crossed.success).toBe(false);
+  });
+
+  it("legacy rows with NULL project_id remain reachable via the name fallback", async () => {
+    const { db } = makeIssuesD1();
+    await seedIssue(db, { project: "legacy" }); // no projectId → project_id NULL
+
+    const found = await getIssueByNumber(db, mockLogger, "legacy", 1, { projectId: "proj_new" });
+    expect(found.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## What & why

`listIssues` / `getIssueByNumber` / `updateIssue` matched on the free-form `project` **name**, so a project could read (and update) a **same-named project's issues in another namespace** — the same cross-tenant leak class fixed for webhooks in #142.

Add an optional `projectId`; when provided, match:

```sql
WHERE (project_id = ? OR (project_id IS NULL AND project = ?)) …
```

Canonical id first, name only as a **legacy fallback** for rows whose `project_id` wasn't backfilled. Every route + UI caller (which already resolves the project for authz) now passes `project.id`.

## Deliberately scoped OUT (needs a gated migration)

This is the **read/update** isolation only. The hazardous parts of the KV→D1 identity migration are **not** here:
- switching issue-**number** generation to `MAX(number)+1 WHERE project_id=?`, and
- backfilling `project_id` onto legacy `NULL` rows.

Doing the numbering switch while legacy issues carry `NULL project_id` would **restart numbering at 1 and collide** with existing issue numbers — it needs a backfill-first, staged migration (its own `/ship` cycle with sign-off). This PR is intentionally non-breaking so it can land independently.

## Why it's safe / non-breaking

- Correctly-stamped rows return **identically** (project_id matches).
- Legacy `NULL`-project_id rows stay reachable via the name fallback.
- Number **generation is untouched**, so no renumber, no collision.
- New optional param → all existing storage-level callers/tests compile and pass unchanged.

## Tests

- Two same-named projects with distinct ids don't see each other's issues (`listIssues` + `getIssueByNumber`).
- A number that belongs to project A is **not** returned when scoped to project B.
- Legacy `NULL`-project_id rows remain reachable via the fallback.

Full suite **1053 passing**; typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)