### PR TITLE
fix(audit): scope listProvenance by project_id + fix always-empty provenance list

### DIFF
--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -977,8 +977,10 @@ app.get("/:namespace/:slug/provenance", async (c) => {
   const limitParam = c.req.query("limit");
   const limit = limitParam !== undefined ? Number(limitParam) : undefined;
 
-  // Use project ID for provenance lookup
-  const recordsResult = await listProvenance(c.env.DB, logger, project.id, limit);
+  // Scope provenance by the canonical project_id (name is the legacy fallback).
+  const recordsResult = await listProvenance(c.env.DB, logger, project.name, limit, {
+    projectId: project.id,
+  });
   if (!recordsResult.success) {
     logger.error("Failed to list provenance", recordsResult.error);
     return internalError(recordsResult.error.message);

--- a/src/storage/provenance.ts
+++ b/src/storage/provenance.ts
@@ -166,11 +166,21 @@ export async function listProvenance(
   logger: Logger,
   project: string,
   limit = 50,
+  opts?: { projectId?: string },
 ): Promise<Result<ProvenanceRecord[], AppError>> {
   try {
+    // Scope by the canonical project_id when known, falling back to the free-form
+    // name only for legacy rows whose project_id wasn't backfilled. Matching purely
+    // on `project` would list a same-named project's provenance in ANOTHER namespace.
+    const scope = opts?.projectId
+      ? {
+          clause: "(project_id = ? OR (project_id IS NULL AND project = ?))",
+          binds: [opts.projectId, project],
+        }
+      : { clause: "project = ?", binds: [project] };
     const result = await db
-      .prepare("SELECT * FROM provenance WHERE project = ? ORDER BY merged_at DESC LIMIT ?")
-      .bind(project, limit)
+      .prepare(`SELECT * FROM provenance WHERE ${scope.clause} ORDER BY merged_at DESC LIMIT ?`)
+      .bind(...scope.binds, limit)
       .all<ProvenanceRow>();
 
     const records = result.results.map(rowToRecord);

--- a/tests/provenance.test.ts
+++ b/tests/provenance.test.ts
@@ -49,6 +49,16 @@ function makeD1() {
           return { success: true };
         },
         async all() {
+          if (this._sql.toUpperCase().includes("PROJECT_ID = ? OR")) {
+            const [projectId, projectName] = this._binds;
+            return {
+              results: rows.filter(
+                (r) =>
+                  r.project_id === projectId ||
+                  (r.project_id === null && r.project === projectName),
+              ),
+            };
+          }
           const project = this._binds[0];
           return { results: rows.filter((r) => r.project === project) };
         },
@@ -102,5 +112,43 @@ describe("provenance model + prompt hash", () => {
       expect(read.data[0]?.model).toBeUndefined();
       expect(read.data[0]?.promptHash).toBeUndefined();
     }
+  });
+
+  it("scopes by project_id so same-named projects don't cross tenants", async () => {
+    const db = makeD1();
+    await recordProvenance(db, logger, {
+      commitSha: "aaa",
+      project: "acme",
+      projectId: "proj_A",
+      workspace: "ws",
+      changeId: "chg_a",
+    });
+    await recordProvenance(db, logger, {
+      commitSha: "bbb",
+      project: "acme",
+      projectId: "proj_B",
+      workspace: "ws",
+      changeId: "chg_b",
+    });
+
+    const a = await listProvenance(db, logger, "acme", 50, { projectId: "proj_A" });
+    expect(a.success && a.data.map((r) => r.changeId)).toEqual(["chg_a"]);
+    const b = await listProvenance(db, logger, "acme", 50, { projectId: "proj_B" });
+    expect(b.success && b.data.map((r) => r.changeId)).toEqual(["chg_b"]);
+  });
+
+  it("finds a stamped project's provenance when scoped by id (regression: the caller passes id)", async () => {
+    const db = makeD1();
+    await recordProvenance(db, logger, {
+      commitSha: "ccc",
+      project: "acme",
+      projectId: "proj_A",
+      workspace: "ws",
+      changeId: "chg_a",
+    });
+    // Before the fix, the route passed project.id into a `WHERE project = ?`
+    // (name) query, so this returned empty. Scoped by project_id it resolves.
+    const read = await listProvenance(db, logger, "acme", 50, { projectId: "proj_A" });
+    expect(read.success && read.data).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Two bugs, one fix

**1. The provenance list was always empty.** `GET` project provenance called `listProvenance(db, logger, project.id, limit)`, but the query was `WHERE project = ?` — the **name** column. Matching a `proj_…` id against project *names* never matches, so the project page's provenance list has been silently blank.

**2. Cross-tenant leak (T5).** Keying on the free-form name would list a same-named project's provenance from another namespace — same class as webhooks (#142), issues (#147), changes (#148).

## The fix

`listProvenance` gains an optional `projectId` and matches:
```sql
WHERE (project_id = ? OR (project_id IS NULL AND project = ?))
```
canonical id first, name only as a **legacy fallback**. The route now passes `project.name` + `{ projectId: project.id }` correctly — so stamped rows **resolve** (bug 1 fixed) and same-named tenants stay isolated (bug 2 fixed). Legacy `NULL`-project_id rows remain reachable via the fallback.

## Also checked

- `getChangeCostSummary` / `getProvenance` key on the globally-unique `change_id` — never cross-tenant.
- `getProjectCostSummary` (`WHERE project = ?`) has **no caller** — left as-is (latent, not wired).

## Tests

- Two same-named projects with distinct ids stay isolated.
- A stamped project's provenance **resolves** when scoped by id (regression guard for the empty-list bug).
- Existing name-only reads unchanged.

Full suite **1052 passing**; typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)