### PR TITLE
fix(audit): number issues by project_id, not name (T5 same-name collision → 500)

### DIFF
--- a/migrations/035_issue_number_by_project_id.sql
+++ b/migrations/035_issue_number_by_project_id.sql
@@ -1,0 +1,19 @@
+-- Issue numbers become per-project (by canonical project_id) instead of per-NAME.
+--
+-- Before: numbering was `MAX(number)+1 WHERE project = <name>` and the uniqueness
+-- guard was UNIQUE(project, number). Two projects sharing a name in different
+-- namespaces (@alice/api, @bob/api) therefore shared one number sequence, and
+-- switching to per-project numbering would make them collide on (name, number)
+-- and raise a spurious 500 on insert.
+--
+-- Swap the guard from (project, number) to (project_id, number). This is safe on
+-- existing data:
+--   * Post-025 rows carry distinct project_ids, and numbers were unique per name,
+--     so (project_id, number) has no duplicates to reject on index creation.
+--   * Legacy rows keep project_id = NULL; NULLs are DISTINCT in a SQLite unique
+--     index, so they never collide with each other or with new rows.
+-- createIssue (this migration ships with the code change) counts legacy NULL rows
+-- via a name fallback, so numbering does not restart at 1 for a project that has
+-- pre-migration issues.
+DROP INDEX IF EXISTS idx_issues_project_number;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_issues_project_id_number ON issues(project_id, number);

--- a/src/storage/issues.ts
+++ b/src/storage/issues.ts
@@ -90,11 +90,14 @@ export async function createIssue(
   try {
     // The per-project number is assigned inside the INSERT so concurrent
     // creates cannot race: SQLite executes the scalar subquery and the
-    // insert as one serialized statement.
+    // insert as one serialized statement. Numbering is scoped by the canonical
+    // project_id (migration 035), with a legacy name fallback so a project that
+    // already has pre-migration (NULL project_id) issues keeps counting up from
+    // its highest existing number instead of restarting at 1.
     const row = await db
       .prepare(
         `INSERT INTO issues (id, project, project_id, number, title, body, status, author_type, author_id, linked_change_id, created_at, updated_at)
-         VALUES (?1, ?2, ?9, (SELECT COALESCE(MAX(number), 0) + 1 FROM issues WHERE project = ?2), ?3, ?4, 'open', ?5, ?6, ?7, ?8, ?8)
+         VALUES (?1, ?2, ?9, (SELECT COALESCE(MAX(number), 0) + 1 FROM issues WHERE (project_id = ?9 OR (project_id IS NULL AND project = ?2))), ?3, ?4, 'open', ?5, ?6, ?7, ?8, ?8)
          RETURNING *`,
       )
       .bind(

--- a/tests/helpers/issues-d1.ts
+++ b/tests/helpers/issues-d1.ts
@@ -95,11 +95,20 @@ export function makeIssuesD1(): {
       },
       first: async <T>() => {
         if (upper.startsWith("INSERT INTO ISSUES")) {
-          // VALUES (?1, ?2, (SELECT COALESCE(MAX(number),0)+1 ...), ?3..?8) RETURNING *
+          // VALUES (?1, ?2, ?9, (SELECT MAX(number)+1 WHERE project_id=?9 OR
+          // (project_id IS NULL AND project=?2)), ...) RETURNING *
           const project = bindings[1] as string;
+          const projectId = (bindings[8] as string | null) ?? null;
+          // Mirror migration 035: number by project_id, with a legacy name fallback.
+          // `project_id = ?9` is never true when ?9 is NULL (SQL NULL comparison),
+          // so a projectId-less create numbers purely by the name fallback.
           const number =
             issues
-              .filter((r) => r.project === project)
+              .filter(
+                (r) =>
+                  (projectId !== null && r.project_id === projectId) ||
+                  (r.project_id === null && r.project === project),
+              )
               .reduce((max, r) => Math.max(max, r.number), 0) + 1;
           const row: IssueTableRow = {
             id: bindings[0] as string,

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -50,6 +50,32 @@ describe("issue storage", () => {
     expect(otherProject.number).toBe(1);
   });
 
+  it("numbers independently per project_id for same-named projects (no collision)", async () => {
+    const { db } = makeIssuesD1();
+    // Two projects share the name "acme" but have distinct canonical ids. Under
+    // the old per-name numbering + UNIQUE(project, number) this would collide;
+    // per project_id each gets its own sequence and (project_id, number) is unique.
+    const a1 = await seedIssue(db, { project: "acme", projectId: "proj_A" });
+    const b1 = await seedIssue(db, { project: "acme", projectId: "proj_B" });
+    const a2 = await seedIssue(db, { project: "acme", projectId: "proj_A" });
+
+    expect(a1.number).toBe(1);
+    expect(b1.number).toBe(1);
+    expect(a2.number).toBe(2);
+  });
+
+  it("continues from legacy NULL-project_id issues instead of restarting at 1", async () => {
+    const { db } = makeIssuesD1();
+    // A pre-migration issue: no project_id, numbered by name.
+    const legacy = await seedIssue(db, { project: "acme" });
+    expect(legacy.number).toBe(1);
+
+    // The first stamped issue for that project counts the legacy row via the name
+    // fallback, so it is #2 — not a colliding #1.
+    const stamped = await seedIssue(db, { project: "acme", projectId: "proj_A" });
+    expect(stamped.number).toBe(2);
+  });
+
   it("round-trips issues through getIssueByNumber", async () => {
     const { db } = makeIssuesD1();
     await seedIssue(db, { body: "Details here", linkedChangeId: "chg_1" });


### PR DESCRIPTION
## The bug

Issue numbers were assigned `MAX(number)+1 WHERE project = <name>`, guarded by `UNIQUE(project, number)`. Two projects sharing a **name** in different namespaces (`@alice/api`, `@bob/api`) therefore **shared one number sequence** — and with the per-tenant read isolation from #147, switching to per-project numbering would make them **collide on `(name, number)`** and raise a spurious **500** on insert.

## The fix

**migration 035** swaps the uniqueness guard from `(project, number)` to `(project_id, number)`. Safe on existing data:
- Post-025 rows carry **distinct** project_ids and had per-name-unique numbers → no duplicate for the new index to reject.
- Legacy rows keep `project_id = NULL`; **NULLs are distinct** in a SQLite unique index, so they never collide.

**`createIssue`** now numbers by `(project_id = ?9 OR (project_id IS NULL AND project = ?2))` — per `project_id`, with a **legacy name fallback** so a project that already has pre-migration (NULL) issues keeps counting up from its highest number instead of restarting at 1 (which would collide).

## Why it's safe to apply

- The index swap creates no dup-rejection on existing data (reasoned above).
- New issues always carry a non-NULL project_id (the route passes it), so `(project_id, number)` fully guards them.
- Numbering is monotonic per project; no renumbering of existing rows.
- It's a reviewed migration applied deliberately by the operator (migrations are operator-applied; see #144).

## Tests

- Same-named projects with distinct ids number **independently** (both start at 1) with no `(project_id, number)` collision.
- A stamped issue **continues** from a legacy NULL-project_id issue's number (no restart-at-1).
- Existing per-name numbering for NULL-project_id rows unchanged.

## Out of scope (separate operator step)

This fixes **new** numbering. Fully resolving the **read** ambiguity of *legacy* NULL-project_id issues shared across same-named projects still needs the one-time **backfill** — the name→id map lives in KV and needs a privileged write path (see `scripts/backfill-project-id.ts`, documentation-only today). That's the remaining T5 piece and is best done as its own gated cycle.

Full suite **1052 passing**; typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)