### PR TITLE
fix(audit): make the login endpoint enumeration-safe (T2)

### DIFF
--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -52,6 +52,10 @@ const ERROR_MESSAGES: Record<string, string> = {
 
 const SUCCESS_MESSAGES: Record<string, string> = {
   email_sent: "Check your email. We sent a magic link that expires in 15 minutes.",
+  // Enumeration-safe: identical whether or not the email has an account, so the
+  // login endpoint can't be probed to discover which emails are registered.
+  login_link_sent:
+    "If an account exists for that email, we've sent a magic link (it expires in 15 minutes).",
 };
 
 function emailAuthRedirect(
@@ -430,12 +434,12 @@ app.post("/send-login", async (c) => {
     return emailAuthRedirect(c, "error", "auth_config_incomplete", "/auth/login");
   }
 
-  // Check if email exists in database
+  // Do NOT reveal whether the email has an account (enumeration): the endpoint
+  // returns the same `login_link_sent` response either way. A magic link is only
+  // minted + sent when the account actually exists; a missing account skips the
+  // send silently. Rate limiting is applied first, to every request, so the
+  // send-only-for-real-accounts branch isn't a cheap oracle.
   const existingUser = await getUserByEmail(c.env.DB, email, logger);
-  if (!existingUser.success) {
-    logger.warn("Email not found for login", { emailHash });
-    return emailAuthRedirect(c, "error", "email_not_found", "/auth/login");
-  }
 
   // Check rate limit (fail open if KV fails)
   const rateLimitKey = getRateLimitKey(email);
@@ -457,38 +461,44 @@ app.post("/send-login", async (c) => {
       expirationTtl: MAGIC_LINK_RATE_WINDOW,
     });
 
-    // Generate secure magic link token
-    const token = generateSecureToken();
-    // Store token in D1 (atomic single-use at verify time) with login intent.
-    const stored = await createMagicLink(
-      c.env.DB,
-      token,
-      { email, intent: "login", createdAt: Date.now(), rememberMe },
-      15 * 60,
-      logger,
-    );
-    if (!stored.success) {
-      return emailAuthRedirect(c, "error", "send_failed", "/auth/login");
+    if (existingUser.success) {
+      // Generate secure magic link token
+      const token = generateSecureToken();
+      // Store token in D1 (atomic single-use at verify time) with login intent.
+      const stored = await createMagicLink(
+        c.env.DB,
+        token,
+        { email, intent: "login", createdAt: Date.now(), rememberMe },
+        15 * 60,
+        logger,
+      );
+      if (!stored.success) {
+        // A real send failure for a real account is worth surfacing; it is not a
+        // reliable enumeration oracle (it only fires on genuine infra errors).
+        return emailAuthRedirect(c, "error", "send_failed", "/auth/login");
+      }
+
+      // Build magic link URL
+      const url = new URL(c.req.url);
+      const baseUrl = `${url.protocol}//${url.host}`;
+      const magicLink = `${baseUrl}/auth/email/verify?token=${token}`;
+
+      // Send email using template
+      const emailContent = getMagicLinkEmail({ magicLink, email });
+      await c.env.EMAIL.send({
+        to: email,
+        from: { email: fromAddress, name: "Stratum" },
+        subject: emailContent.subject,
+        text: emailContent.text,
+        html: emailContent.html,
+      });
+
+      logger.info("Login magic link sent", { emailHash });
+    } else {
+      logger.info("Login requested for unknown email; returning uniform response", { emailHash });
     }
 
-    // Build magic link URL
-    const url = new URL(c.req.url);
-    const baseUrl = `${url.protocol}//${url.host}`;
-    const magicLink = `${baseUrl}/auth/email/verify?token=${token}`;
-
-    // Send email using template
-    const emailContent = getMagicLinkEmail({ magicLink, email });
-    await c.env.EMAIL.send({
-      to: email,
-      from: { email: fromAddress, name: "Stratum" },
-      subject: emailContent.subject,
-      text: emailContent.text,
-      html: emailContent.html,
-    });
-
-    logger.info("Login magic link sent", { emailHash });
-
-    return emailAuthRedirect(c, "success", "email_sent", "/auth/login");
+    return emailAuthRedirect(c, "success", "login_link_sent", "/auth/login");
   } catch (err) {
     logger.error("Failed to send login magic link", err instanceof Error ? err : undefined, {
       emailHash,

--- a/tests/auth-signup-login.test.ts
+++ b/tests/auth-signup-login.test.ts
@@ -743,7 +743,7 @@ describe("Auth Signup/Login Integration Tests", () => {
         );
 
         expect(res.status).toBe(302);
-        expect(res.headers.get("location")).toContain("success=email_sent");
+        expect(res.headers.get("location")).toContain("success=login_link_sent");
 
         expect(env.EMAIL?.send).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -764,7 +764,7 @@ describe("Auth Signup/Login Integration Tests", () => {
         });
       });
 
-      it("login fails if email not found", async () => {
+      it("does NOT reveal whether the email exists (enumeration-safe uniform response)", async () => {
         const formData = createFormData({
           email: "nonexistent@example.com",
         });
@@ -777,9 +777,13 @@ describe("Auth Signup/Login Integration Tests", () => {
           env,
         );
 
+        // Same success response an existing account gets — no email_not_found —
+        // but no link is minted or sent for the missing account.
         expect(res.status).toBe(302);
-        expect(res.headers.get("location")).toContain("error=email_not_found");
+        expect(res.headers.get("location")).toContain("success=login_link_sent");
+        expect(res.headers.get("location")).not.toContain("email_not_found");
         expect(env.EMAIL?.send).not.toHaveBeenCalled();
+        expect(await extractMagicLinkToken(env)).toBeNull();
       });
 
       it("rate limiting works on login endpoint", async () => {
@@ -800,7 +804,7 @@ describe("Auth Signup/Login Integration Tests", () => {
           );
 
           expect(res.status).toBe(302);
-          expect(res.headers.get("location")).toContain("success=email_sent");
+          expect(res.headers.get("location")).toContain("success=login_link_sent");
         }
 
         const formData = createFormData({ email });


### PR DESCRIPTION
## The vector

`POST /auth/email/send-login` returned `error=email_not_found` ("No account found with this email") when an email had no account, but `success=email_sent` when it did. An attacker can submit emails and read the redirect to **discover which are registered**.

## The fix

Return a **uniform** `login_link_sent` response — *"If an account exists for that email, we've sent a magic link"* — whether or not the account exists. A magic link is minted + sent **only** when the account actually exists; a missing account skips the send silently. Rate limiting runs **first, on every request**, so the "send only for real accounts" branch isn't a cheap timing/behavior oracle.

This is the standard, well-established fix for account enumeration on auth endpoints.

## Scope

- **This PR:** the login endpoint (`/send-login`) — the clear, explicit vector.
- **Not needed:** the legacy `/send` endpoint already sends a link regardless of existence (signup-or-login intent), so it doesn't reveal existence.
- **Follow-up:** signup's `email_exists` message is a weaker vector; the standard fix there (return uniform success + email the *existing* account "someone tried to sign up") needs a new email template — separate change.

## UX tradeoff (revertible)

Someone who **mistypes** their email no longer gets an explicit "no account, sign up first" message — they just don't receive a link. This is the accepted norm for enumeration-resistant auth, but it's a product/UX call, so it's isolated here for easy review/revert if you'd rather keep the guidance.

## Tests

- Existing user still gets a link (response now `login_link_sent`).
- **Unknown email gets the SAME response**, with **no email sent and no token minted** (the enumeration guard).
- Rate limiting on the login endpoint unchanged.

Full suite **1050 passing**; typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)