### PR TITLE
feat(admin): read-only backfill plan for KV→D1 project_id (T5)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { runTtlSweep } from "./queue/ttl-sweep";
 import { agentsRouter } from "./routes/agents";
 import { auditRouter } from "./routes/audit";
 import { authRouter } from "./routes/auth";
+import { backfillRouter } from "./routes/backfill";
 import { backupRouter } from "./routes/backup";
 import { bulkImportRouter } from "./routes/bulk-import";
 import { changesRouter } from "./routes/changes";
@@ -125,6 +126,7 @@ app.route("/api/admin/metrics", metricsRouter);
 // Admin audit trail endpoint
 app.route("/api/admin/audit", auditRouter);
 app.route("/api/admin/backup", backupRouter);
+app.route("/api/admin/backfill-project-id", backfillRouter);
 
 // Redirects from old /ui/* URLs to new paths (backward compatibility)
 app.get("/ui", (c) => c.redirect("/", 301));

--- a/src/routes/backfill.ts
+++ b/src/routes/backfill.ts
@@ -1,0 +1,46 @@
+import { Hono } from "hono";
+import { computeBackfillPlan } from "../storage/backfill-plan";
+import type { Env } from "../types";
+import { isAdminRequest } from "../utils/admin";
+import { createLogger } from "../utils/logger";
+import { forbidden, internalError, ok } from "../utils/response";
+
+const app = new Hono<{ Bindings: Env }>();
+
+async function requireAdmin(c: {
+  env: Env;
+  req: { header: (n: string) => string | undefined; path: string; method: string };
+  get: (k: "userId") => string | undefined;
+}): Promise<{ ok: true; logger: ReturnType<typeof createLogger> } | { ok: false }> {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+  const isAdmin = await isAdminRequest(
+    c.env,
+    {
+      ...(c.req.header("X-Admin-API-Key") !== undefined
+        ? { adminApiKeyHeader: c.req.header("X-Admin-API-Key") }
+        : {}),
+      ...(c.get("userId") !== undefined ? { userId: c.get("userId") } : {}),
+    },
+    logger,
+  );
+  return isAdmin ? { ok: true, logger } : { ok: false };
+}
+
+// GET /api/admin/backfill-project-id/plan — DRY-RUN: how much legacy (NULL
+// project_id) data exists per table, and which project names are safe to
+// backfill vs. collide and need manual resolution. Read-only; mutates nothing.
+app.get("/plan", async (c) => {
+  const auth = await requireAdmin(c);
+  if (!auth.ok) return forbidden("Administrator access required");
+
+  const plan = await computeBackfillPlan(c.env, auth.logger);
+  if (!plan.success) return internalError(plan.error.message);
+  return ok({ plan: plan.data });
+});
+
+export { app as backfillRouter };

--- a/src/storage/backfill-plan.ts
+++ b/src/storage/backfill-plan.ts
@@ -1,0 +1,95 @@
+import type { Env } from "../types";
+import { AppError } from "../utils/errors";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+import { listProjects } from "./state";
+
+/**
+ * The seven project-scoped tables that gained a nullable `project_id` in
+ * migration 025. Rows written before that migration keep `project_id` NULL and
+ * are what a backfill would stamp. This is a FIXED allow-list — never user input
+ * — so interpolating a name into the COUNT query below is safe.
+ */
+export const PROJECT_ID_TABLES = [
+  "changes",
+  "events",
+  "provenance",
+  "cost_records",
+  "commit_metrics",
+  "issues",
+  "webhooks",
+] as const;
+
+export interface BackfillPlan {
+  /** Per-table count of rows still missing a project_id (backfill candidates). */
+  tables: { table: string; nullRows: number }[];
+  totalNullRows: number;
+  projects: {
+    total: number;
+    /** Projects whose NAME is unique — their legacy rows can be stamped safely
+     *  by name, because no other project shares the name. */
+    backfillable: number;
+    /** Names shared by >1 project: their legacy rows can't be attributed by name
+     *  alone and need manual resolution before a backfill touches them. */
+    collisions: { name: string; projectIds: string[] }[];
+  };
+}
+
+/**
+ * DRY-RUN diagnostic for the KV→D1 project_id backfill. Reads only: reports how
+ * much legacy (NULL project_id) data exists per table and which project names
+ * are safe to backfill vs. which collide across namespaces and need manual
+ * resolution. Mutates nothing — this is the "plan" half; the actual stamping is
+ * a separate, deliberate operation.
+ */
+export async function computeBackfillPlan(
+  env: Pick<Env, "DB" | "STATE">,
+  logger: Logger,
+): Promise<Result<BackfillPlan, AppError>> {
+  try {
+    const tables: { table: string; nullRows: number }[] = [];
+    let totalNullRows = 0;
+    for (const table of PROJECT_ID_TABLES) {
+      const row = await env.DB.prepare(
+        `SELECT COUNT(*) AS n FROM ${table} WHERE project_id IS NULL`,
+      ).first<{ n: number }>();
+      const nullRows = row?.n ?? 0;
+      tables.push({ table, nullRows });
+      totalNullRows += nullRows;
+    }
+
+    const projectsResult = await listProjects(env.STATE, logger);
+    if (!projectsResult.success) return err(projectsResult.error);
+
+    const idsByName = new Map<string, string[]>();
+    for (const project of projectsResult.data) {
+      const ids = idsByName.get(project.name) ?? [];
+      ids.push(project.id);
+      idsByName.set(project.name, ids);
+    }
+    const collisions: { name: string; projectIds: string[] }[] = [];
+    let backfillable = 0;
+    for (const [name, ids] of idsByName) {
+      if (ids.length === 1) backfillable++;
+      else collisions.push({ name, projectIds: ids });
+    }
+
+    return ok({
+      tables,
+      totalNullRows,
+      projects: { total: projectsResult.data.length, backfillable, collisions },
+    });
+  } catch (error) {
+    const appError =
+      error instanceof AppError
+        ? error
+        : new AppError(
+            error instanceof Error ? error.message : "Failed to compute backfill plan",
+            "DATABASE_ERROR",
+            500,
+            { operation: "computeBackfillPlan" },
+          );
+    logger.error("Failed to compute backfill plan", appError);
+    return err(appError);
+  }
+}

--- a/tests/backfill-plan.test.ts
+++ b/tests/backfill-plan.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { computeBackfillPlan } from "../src/storage/backfill-plan";
+import type { Env } from "../src/types";
+import type { Logger } from "../src/utils/logger";
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+};
+
+/** Fake D1 returning a per-table NULL-project_id count from a map. */
+function makeD1(nullCounts: Record<string, number>): D1Database {
+  return {
+    prepare: (sql: string) => ({
+      bind: () => ({ first: async () => null }),
+      first: async () => {
+        const match = sql.match(/FROM (\w+) WHERE project_id IS NULL/);
+        const table = match?.[1] ?? "";
+        return { n: nullCounts[table] ?? 0 };
+      },
+    }),
+  } as unknown as D1Database;
+}
+
+/** Fake KV serving project entries for listProjects (single page). */
+function makeKV(projects: { id: string; name: string }[]): KVNamespace {
+  const store = new Map<string, string>();
+  for (const p of projects) {
+    store.set(`project:@ns:${p.id}`, JSON.stringify({ ...p, slug: p.name, namespace: "@ns" }));
+  }
+  return {
+    list: async () => ({
+      keys: [...store.keys()].map((name) => ({ name })),
+      list_complete: true,
+      cursor: "",
+    }),
+    get: async (key: string) => store.get(key) ?? null,
+  } as unknown as KVNamespace;
+}
+
+describe("computeBackfillPlan (read-only)", () => {
+  it("reports per-table NULL-project_id counts and their total", async () => {
+    const env = {
+      DB: makeD1({ changes: 3, issues: 2, webhooks: 1 }),
+      STATE: makeKV([{ id: "proj_a", name: "alpha" }]),
+    } as unknown as Env;
+
+    const result = await computeBackfillPlan(env, logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.totalNullRows).toBe(6);
+    expect(result.data.tables.find((t) => t.table === "changes")?.nullRows).toBe(3);
+    expect(result.data.tables).toHaveLength(7); // all seven tables reported
+  });
+
+  it("classifies unique names as backfillable and shared names as collisions", async () => {
+    const env = {
+      DB: makeD1({}),
+      STATE: makeKV([
+        { id: "proj_a", name: "alpha" }, // unique
+        { id: "proj_b1", name: "beta" }, // collision with proj_b2
+        { id: "proj_b2", name: "beta" },
+      ]),
+    } as unknown as Env;
+
+    const result = await computeBackfillPlan(env, logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.projects.total).toBe(3);
+    expect(result.data.projects.backfillable).toBe(1); // only "alpha"
+    expect(result.data.projects.collisions).toEqual([
+      { name: "beta", projectIds: ["proj_b1", "proj_b2"] },
+    ]);
+  });
+});

--- a/tests/backfill-route.test.ts
+++ b/tests/backfill-route.test.ts
@@ -1,0 +1,56 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../src/types";
+
+vi.mock("../src/storage/backfill-plan", () => ({ computeBackfillPlan: vi.fn() }));
+
+import { backfillRouter } from "../src/routes/backfill";
+import { computeBackfillPlan } from "../src/storage/backfill-plan";
+
+const ADMIN_KEY = "admin-secret";
+
+function makeApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.route("/api/admin/backfill-project-id", backfillRouter);
+  return app;
+}
+
+const env = { DB: {}, STATE: {}, ADMIN_API_KEY: ADMIN_KEY } as unknown as Env;
+const ctx = {
+  waitUntil: () => {},
+  passThroughOnException: () => {},
+} as unknown as ExecutionContext;
+
+function req(headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/admin/backfill-project-id/plan", {
+    method: "GET",
+    headers,
+  });
+}
+
+describe("GET /api/admin/backfill-project-id/plan", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("403 without admin credentials", async () => {
+    const res = await makeApp().fetch(req(), env, ctx);
+    expect(res.status).toBe(403);
+    expect(computeBackfillPlan).not.toHaveBeenCalled();
+  });
+
+  it("200 with the plan for an admin", async () => {
+    vi.mocked(computeBackfillPlan).mockResolvedValue({
+      success: true,
+      data: {
+        tables: [{ table: "changes", nullRows: 3 }],
+        totalNullRows: 3,
+        projects: { total: 1, backfillable: 1, collisions: [] },
+      },
+    } as never);
+
+    const res = await makeApp().fetch(req({ "X-Admin-API-Key": ADMIN_KEY }), env, ctx);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { plan: { totalNullRows: number } };
+    expect(body.plan.totalNullRows).toBe(3);
+  });
+});


### PR DESCRIPTION
## What & why

The KV→D1 identity backfill — stamping `project_id` onto pre-migration `NULL` rows — needs a privileged write path that intentionally doesn't exist yet, and its **hardest part is attribution**: a project name shared across namespaces (`@alice/api`, `@bob/api`) can't have its legacy rows assigned by name alone. So ship the **read-only "plan" half first** (mirrors restore-verify #145 → restore-apply):

`GET /api/admin/backfill-project-id/plan` (admin-only, **mutates nothing**) reports:
- per-table count of rows still missing `project_id` (the 7 tables from migration 025),
- the total, and
- which project names are **unique** (safe to backfill by name) vs. which **collide** across namespaces and need manual resolution before any stamping.

An operator can now quantify the remaining legacy debt and surface the collision cases *before* touching data.

## Scope

Read-only diagnostic. The actual **write** — and its batching (subrequest limits across all projects × 7 tables) and the manual-resolution decision for collisions — remains a separate, deliberate operation the operator runs. This PR is the safe, informative first step.

## Tests

- Per-table NULL counts + total across all 7 tables.
- Unique names → `backfillable`; shared names → `collisions` with their conflicting project ids.
- Route: 403 without admin creds, 200 with the plan.

Full suite **1054 passing**; typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)