### PR TITLE
fix(config): declare DEV_LOGIN_ENABLED="false" in prod/staging env vars

### DIFF
--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -316,10 +316,12 @@ npx wrangler secret list --env=staging
 
 `GET /dev-login` mints a session without credentials and is gated on the
 `DEV_LOGIN_ENABLED` var being `"true"` **and** a localhost request host. It is set
-in the top-level `[vars]` for local `wrangler dev`; named environments do not
-inherit top-level vars, so staging and production leave it unset and the route is
-inert there. Do **not** set `DEV_LOGIN_ENABLED` in `[env.production]` /
-`[env.staging]`.
+`"true"` in the top-level `[vars]` for local `wrangler dev`; named environments do
+not inherit top-level vars, so `[env.production]` and `[env.staging]` declare it
+explicitly as `DEV_LOGIN_ENABLED = "false"`. Any value other than `"true"` keeps
+the route inert, but declaring it `"false"` makes the intent provable (and stops
+wrangler warning about the missing per-environment override). Never set it
+`"true"` outside local dev.
 
 ### Security headers
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -223,6 +223,10 @@ name = "EMAIL"
 
 [env.production.vars]
 POSTHOG_HOST = "https://app.posthog.com"
+# The /dev-login session backdoor is local-only. Declare it "false" explicitly
+# here (named envs don't inherit the top-level "true") so the route is provably
+# inert in production — and so wrangler stops warning about the missing override.
+DEV_LOGIN_ENABLED = "false"
 # RepoDO fast-forward path (ADR 004); default off until staging numbers justify it.
 REPO_DO_ENABLED = "false"
 # Production OAuth callbacks. The matching callback URLs must also be registered
@@ -328,6 +332,8 @@ name = "EMAIL"
 
 [env.staging.vars]
 POSTHOG_HOST = "https://app.posthog.com"
+# Local-only session backdoor; explicitly off on staging (see env.production.vars).
+DEV_LOGIN_ENABLED = "false"
 # RepoDO + R2 merge path (ADR 004). "true" on staging: workspace commits stage to
 # R2 and merges route through the fetch-free R2 path (cold path as fallback).
 REPO_DO_ENABLED = "true"


### PR DESCRIPTION
## Why

Running any `wrangler ... --env=production|staging` command (e.g. `d1 migrations list`) prints:

> `vars.DEV_LOGIN_ENABLED exists at the top level, but not on "env.production.vars"`

The `/dev-login` backdoor is gated on `DEV_LOGIN_ENABLED === "true"` **and** a localhost host. It's `"true"` at the top level for local `wrangler dev`, but named environments don't inherit top-level vars, so prod/staging leave it unset — **inert**, but wrangler warns that the override is missing.

## Fix

Declare `DEV_LOGIN_ENABLED = "false"` explicitly in `[env.production.vars]` and `[env.staging.vars]`. This:
- silences the warning, and
- makes "backdoor off outside local dev" **provable** rather than relying on the var's absence.

**No behavior change** — unset and `"false"` are both non-`"true"`, so `/dev-login` stays disabled in prod/staging exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Disabled the local-only development login route in production and staging environments.
  * Prevented the development login backdoor from being enabled through inherited configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->