### PR TITLE
fix(health): fail deploys on data-plane breakage via /api/health (#155)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,8 @@ jobs:
           STAGING_URL: ${{ steps.deploy.outputs.url }}
         run: |
           set -e
-          echo "→ Testing health endpoint: $STAGING_URL/health"
-          curl -sfS --retry 5 --retry-delay 5 "$STAGING_URL/health"
+          echo "→ Testing health endpoint: $STAGING_URL/api/health"
+          curl -sfS --retry 5 --retry-delay 5 "$STAGING_URL/api/health"
           echo "✓ Health check passed"
 
   # ========================================================================
@@ -187,8 +187,8 @@ jobs:
           PRODUCTION_URL: ${{ steps.deploy.outputs.url }}
         run: |
           set -e
-          echo "→ Testing health endpoint: $PRODUCTION_URL/health"
-          curl -sfS --retry 5 --retry-delay 5 "$PRODUCTION_URL/health"
+          echo "→ Testing health endpoint: $PRODUCTION_URL/api/health"
+          curl -sfS --retry 5 --retry-delay 5 "$PRODUCTION_URL/api/health"
           echo "✓ Health check passed"
 
       - name: Smoke test - Critical paths

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,6 +24,15 @@ jobs:
 
       - run: npm ci
 
+      - name: Apply D1 Migrations (Production)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          echo "Applying D1 migrations for production..."
+          npx wrangler d1 migrations apply stratum --remote --env=production
+          echo "✓ Migrations applied successfully"
+
       - name: Deploy to Cloudflare
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -40,8 +49,8 @@ jobs:
             "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/subdomain" \
             | jq -r '.result.subdomain')
           URL="https://stratum.$SUBDOMAIN.workers.dev"
-          echo "→ Smoke testing $URL/health"
-          curl -sfS --retry 3 --retry-delay 5 "$URL/health"
+          echo "→ Smoke testing $URL/api/health"
+          curl -sfS --retry 3 --retry-delay 5 "$URL/api/health"
           echo "✓ Smoke test passed"
 
       - name: Notify on failure

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -349,13 +349,27 @@ wrangler tail --format pretty | grep "ERROR"
 
 ### Health Checks
 
-```bash
-# Check service health
-curl https://your-instance.workers.dev/health
+Two endpoints, with different jobs:
 
-# Expected response
-{"status": "ok", "service": "stratum"}
+```bash
+# Liveness ping — static, does not touch the data plane. Use for uptime monitors.
+curl https://your-instance.workers.dev/health
+# {"status": "ok", "service": "stratum"}
+
+# Deep health — checks D1 (incl. load-bearing schema), KV, queue, and artifacts.
+# Used by the deploy smoke tests: returns HTTP 503 on any critical failure.
+curl -i https://your-instance.workers.dev/api/health
 ```
+
+`/api/health` severity model:
+
+- **`unhealthy` → HTTP 503**: any *critical* dependency (database, KV, artifacts) is down, or the
+  database is reachable but missing a load-bearing table (unapplied migrations — the #118 failure
+  mode). Deploy smoke tests gate on this, so a broken data plane fails the deploy instead of
+  shipping green.
+- **`degraded` → HTTP 200**: only the non-critical queue is down (async delivery degrades; the app
+  still serves).
+- **`healthy` → HTTP 200**: all checks pass.
 
 ### Metrics
 

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -48,7 +48,20 @@ async function measureLatency<T>(
 }
 
 /**
- * Check D1 database connectivity
+ * Load-bearing tables whose absence means the schema is broken or unmigrated
+ * (a missing `events` outbox table was the root of the #118 production incident).
+ * Intentionally a minimal set of long-stable core tables — NOT the full schema,
+ * which lives in `migrations/` and must not be duplicated here. Every entry must
+ * be a real D1 table (projects/orgs live in KV, not D1); `health.test.ts` asserts
+ * this against `migrations/` so a bogus name can't silently 503 every deploy.
+ */
+export const CRITICAL_TABLES = ["users", "sessions", "changes", "events"] as const;
+
+/**
+ * Check D1 database connectivity and that the load-bearing schema is present.
+ * A shallow `SELECT 1` verifies the binding is reachable but not that migrations
+ * ran, so we also assert the critical tables exist — this is what turns an
+ * unmigrated production database into a failed (503) health check.
  */
 async function checkDatabase(db: D1Database): Promise<HealthCheckResult> {
   const result = await measureLatency(async () => {
@@ -57,6 +70,17 @@ async function checkDatabase(db: D1Database): Promise<HealthCheckResult> {
       .all<{ health_check: number }>();
     if (!results || results.length === 0 || !results[0] || results[0].health_check !== 1) {
       throw new Error("Unexpected query result");
+    }
+
+    const placeholders = CRITICAL_TABLES.map(() => "?").join(", ");
+    const { results: tableRows } = await db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name IN (${placeholders})`)
+      .bind(...CRITICAL_TABLES)
+      .all<{ name: string }>();
+    const present = new Set((tableRows ?? []).map((row) => row.name));
+    const missing = CRITICAL_TABLES.filter((table) => !present.has(table));
+    if (missing.length > 0) {
+      throw new Error(`Missing tables: ${missing.join(", ")}`);
     }
   });
 
@@ -173,10 +197,16 @@ app.get("/", async (c) => {
     ),
   ]);
 
-  // Determine overall health status
+  // Determine overall health status. Database, KV, and artifacts are critical:
+  // the app cannot serve requests without them, so any critical failure is
+  // `unhealthy` (503) — this is what lets a deploy smoke test fail on a broken
+  // data plane. The queue is non-critical (async delivery degrades but the app
+  // still serves), so a queue-only failure is `degraded` (200).
+  const criticalChecks = [database, kv, artifacts];
   const errors = [database, kv, queue, artifacts].filter((check) => check.status === "error");
+  const hasCriticalError = criticalChecks.some((check) => check.status === "error");
   let overallStatus: HealthCheckResponse["status"] = "healthy";
-  if (errors.length === 4) {
+  if (hasCriticalError) {
     overallStatus = "unhealthy";
   } else if (errors.length > 0) {
     overallStatus = "degraded";

--- a/tests/health-schema.test.ts
+++ b/tests/health-schema.test.ts
@@ -1,7 +1,4 @@
-// @ts-nocheck — reads the filesystem (node:fs/path); the repo's tsconfig is
-// Workers-only (no @types/node), matching the smoke tests' convention.
-import { readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+/// <reference types="vite/client" />
 import { describe, expect, it } from "vitest";
 import { CRITICAL_TABLES } from "../src/routes/health";
 
@@ -11,14 +8,24 @@ import { CRITICAL_TABLES } from "../src/routes/health";
  * `/api/health` 503 on every healthy deploy — the opposite of the intent. We
  * derive the real table set from migrations/ (the schema source of truth) and
  * assert every critical table exists there.
+ *
+ * The SQL is loaded via Vite's raw glob (not node:fs) so the test stays fully
+ * type-checked under the Workers tsconfig — no @ts-nocheck, no @types/node.
  */
+const migrationSql = import.meta.glob("../migrations/*.sql", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
 function tablesDefinedInMigrations(): Set<string> {
-  const dir = join(__dirname, "..", "migrations");
   const names = new Set<string>();
   const createTable = /CREATE TABLE (?:IF NOT EXISTS )?["'`]?([a-z_]+)/gi;
-  for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql"))) {
-    const sql = readFileSync(join(dir, file), "utf8");
-    for (const m of sql.matchAll(createTable)) names.add(m[1].toLowerCase());
+  for (const sql of Object.values(migrationSql)) {
+    for (const match of sql.matchAll(createTable)) {
+      const table = match[1];
+      if (table) names.add(table.toLowerCase());
+    }
   }
   return names;
 }

--- a/tests/health-schema.test.ts
+++ b/tests/health-schema.test.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck — reads the filesystem (node:fs/path); the repo's tsconfig is
+// Workers-only (no @types/node), matching the smoke tests' convention.
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { CRITICAL_TABLES } from "../src/routes/health";
+
+/**
+ * Regression guard for the class of bug where a name in CRITICAL_TABLES is not
+ * actually a D1 table (e.g. `projects`/`orgs` are KV-backed). Such a name makes
+ * `/api/health` 503 on every healthy deploy — the opposite of the intent. We
+ * derive the real table set from migrations/ (the schema source of truth) and
+ * assert every critical table exists there.
+ */
+function tablesDefinedInMigrations(): Set<string> {
+  const dir = join(__dirname, "..", "migrations");
+  const names = new Set<string>();
+  const createTable = /CREATE TABLE (?:IF NOT EXISTS )?["'`]?([a-z_]+)/gi;
+  for (const file of readdirSync(dir).filter((f) => f.endsWith(".sql"))) {
+    const sql = readFileSync(join(dir, file), "utf8");
+    for (const m of sql.matchAll(createTable)) names.add(m[1].toLowerCase());
+  }
+  return names;
+}
+
+describe("CRITICAL_TABLES schema guard", () => {
+  it("every CRITICAL_TABLES entry is a real D1 table created by a migration", () => {
+    const defined = tablesDefinedInMigrations();
+    expect(defined.size).toBeGreaterThan(0);
+    for (const table of CRITICAL_TABLES) {
+      expect(defined, `${table} must be a real D1 table, not KV-backed`).toContain(table);
+    }
+  });
+});

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { CRITICAL_TABLES, healthRouter } from "../src/routes/health";
+import type { Env } from "../src/types";
+
+const ALL_TABLES = [...CRITICAL_TABLES];
+
+function makeDb(opts: { tables?: string[]; fail?: boolean } = {}): D1Database {
+  const tables = opts.tables ?? ALL_TABLES;
+  const prepare = (sql: string) => {
+    const stmt = {
+      bind: (..._args: unknown[]) => stmt,
+      all: async () => {
+        if (opts.fail) throw new Error("D1_ERROR: database unreachable");
+        if (sql.includes("health_check")) return { results: [{ health_check: 1 }] };
+        if (sql.includes("sqlite_master")) return { results: tables.map((name) => ({ name })) };
+        return { results: [] };
+      },
+    };
+    return stmt;
+  };
+  return { prepare } as unknown as D1Database;
+}
+
+function makeKv(opts: { fail?: boolean } = {}): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    put: async (k: string, v: string) => {
+      if (opts.fail) throw new Error("KV unreachable");
+      store.set(k, v);
+    },
+    get: async (k: string) => {
+      if (opts.fail) throw new Error("KV unreachable");
+      return store.get(k) ?? null;
+    },
+    delete: async (k: string) => {
+      store.delete(k);
+    },
+  } as unknown as KVNamespace;
+}
+
+function makeQueue(opts: { fail?: boolean } = {}): Queue<unknown> {
+  return {
+    metrics: async () => {
+      if (opts.fail) throw new Error("Queue unreachable");
+      return {};
+    },
+  } as unknown as Queue<unknown>;
+}
+
+function makeArtifacts(opts: { fail?: boolean } = {}): Env["ARTIFACTS"] {
+  return {
+    list: async () => {
+      if (opts.fail) throw new Error("Artifacts unreachable");
+      return { objects: [] };
+    },
+  } as unknown as Env["ARTIFACTS"];
+}
+
+function makeEnv(
+  overrides: {
+    db?: Parameters<typeof makeDb>[0];
+    kv?: Parameters<typeof makeKv>[0];
+    queue?: Parameters<typeof makeQueue>[0];
+    artifacts?: Parameters<typeof makeArtifacts>[0];
+  } = {},
+): Env {
+  return {
+    DB: makeDb(overrides.db),
+    STATE: makeKv(overrides.kv),
+    IMPORT_QUEUE: makeQueue(overrides.queue),
+    ARTIFACTS: makeArtifacts(overrides.artifacts),
+  } as unknown as Env;
+}
+
+type Check = { status: string; message?: string };
+
+async function getHealth(env: Env) {
+  const res = await healthRouter.request("/", {}, env);
+  const body = (await res.json()) as {
+    status: string;
+    checks: { database: Check; kv: Check; queue: Check; artifacts: Check };
+  };
+  return { status: res.status, body };
+}
+
+describe("GET /api/health", () => {
+  it("returns 200 healthy when every dependency is up", async () => {
+    const { status, body } = await getHealth(makeEnv());
+    expect(status).toBe(200);
+    expect(body.status).toBe("healthy");
+    expect(body.checks.database.status).toBe("ok");
+    expect(body.checks.kv.status).toBe("ok");
+    expect(body.checks.queue.status).toBe("ok");
+    expect(body.checks.artifacts.status).toBe("ok");
+  });
+
+  it("returns 503 unhealthy when the database is unreachable (critical)", async () => {
+    const { status, body } = await getHealth(makeEnv({ db: { fail: true } }));
+    expect(status).toBe(503);
+    expect(body.status).toBe("unhealthy");
+    expect(body.checks.database.status).toBe("error");
+  });
+
+  it("returns 503 and names the missing table when the schema is unmigrated (#118)", async () => {
+    // events table absent — the exact #118 failure mode a shallow SELECT 1 misses.
+    const env = makeEnv({ db: { tables: ["users", "sessions", "changes"] } });
+    const { status, body } = await getHealth(env);
+    expect(status).toBe(503);
+    expect(body.status).toBe("unhealthy");
+    expect(body.checks.database.status).toBe("error");
+    expect(body.checks.database.message).toContain("events");
+  });
+
+  it("returns 503 when KV is down (critical)", async () => {
+    const { status, body } = await getHealth(makeEnv({ kv: { fail: true } }));
+    expect(status).toBe(503);
+    expect(body.status).toBe("unhealthy");
+    expect(body.checks.kv.status).toBe("error");
+  });
+
+  it("returns 503 when artifacts are down (critical)", async () => {
+    const { status, body } = await getHealth(makeEnv({ artifacts: { fail: true } }));
+    expect(status).toBe(503);
+    expect(body.status).toBe("unhealthy");
+    expect(body.checks.artifacts.status).toBe("error");
+  });
+
+  it("returns 200 degraded when only the (non-critical) queue is down", async () => {
+    const { status, body } = await getHealth(makeEnv({ queue: { fail: true } }));
+    expect(status).toBe(200);
+    expect(body.status).toBe("degraded");
+    expect(body.checks.queue.status).toBe("error");
+    expect(body.checks.database.status).toBe("ok");
+  });
+});


### PR DESCRIPTION
Closes #155. Prevents the #118 class of silent failure (a broken/unmigrated data plane shipping green).

## Problem
CI/CD smoke tests hit the static `GET /health` literal (`{status:"ok"}`), which never touches D1/KV/R2 — so a broken data plane passed the smoke test. That is exactly how #118 (missing `events` table in prod) shipped green and stayed green.

The real `/api/health` endpoint had two flaws that made it unusable as a gate:
1. It returned 503 only when **all four** checks failed (`errors.length === 4`) — a dead database alone returned `degraded` with **HTTP 200**.
2. The DB check was `SELECT 1` — connectivity but not schema, so the #118 missing-table failure mode was invisible.

## Changes
- **`src/routes/health.ts`**: database/KV/artifacts are **critical** (any failure → `unhealthy` 503); the queue is non-critical (→ `degraded` 200, async delivery degrades but the app still serves). The DB check now asserts a curated, minimal set of load-bearing tables exists (`users, sessions, changes, events`) — turning an unmigrated DB into a failed check.
- **`.github/workflows/ci.yml`**: repoint both smoke steps (staging + prod) to `/api/health`.
- **`.github/workflows/deploy-production.yml`**: repoint smoke to `/api/health` **and** add the missing `d1 migrations apply` step so the manual prod-deploy path can't ship against a stale schema.
- **tests**: unit tests for every severity branch (healthy/dead-DB/missing-table/KV-down/artifacts-down/queue-only-degraded), plus a schema guard (`tests/health-schema.test.ts`) that derives the real table set from `migrations/` so a non-D1 name (e.g. KV-backed `projects`) can't 503 every healthy deploy.
- **docs**: `docs/developer/deployment.md` documents the two endpoints and the severity model.

## Verification
- `tsc --noEmit` clean · `biome check` clean · **1112 tests pass** (+7 new), 0 failed.
- Confirmed the schema guard rejects `projects` (KV-backed, not a D1 table) — this caught a first-draft bug where `projects` in the critical list would have 503'd every healthy deploy.

## Non-goals
Not touching #124 (fast-path sha pinning). Not making the DB check a full schema validator (that would duplicate `migrations/`). The static `/health` liveness route is unchanged for uptime pings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced health checks now verify critical database tables and connected services.
  - Health responses clearly distinguish healthy, degraded, and unhealthy states with appropriate status codes.
  - Production deployments now apply database migrations before release.

- **Bug Fixes**
  - Updated staging and production smoke tests to use the correct `/api/health` endpoint.
  - Critical database, KV, and artifact failures now return `503 unhealthy`, while queue-only issues remain `200 degraded`.

- **Documentation**
  - Clarified the differences between basic liveness and comprehensive health checks, including response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->