### PR TITLE
docs(readme): correct feature status to match shipped reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ Stratum is a GitHub alternative where both humans and AI agents are first-class 
 
 | Feature | Status | Description |
 |---------|--------|-------------|
-| Organizations | 🚧 | Basic support (in progress) |
-| Teams | 🚧 | Team-based permissions |
-| CLI Tool | 🚧 | `@stratum/cli` built (`cli/`), not yet published to npm |
-| Bidirectional GitHub Sync | 📋 | Planned |
+| Organizations | ✅ | Org-owned projects, members, and role-based access |
+| Teams | ✅ | Team-based write permissions within an org |
+| Issue Tracker | ✅ | Per-project issues, auto-close on linked-change merge |
+| Bidirectional GitHub Sync | ✅ | Inbound webhooks + outbound PR promotion |
+| CLI Tool | 🚧 | `@stratum/cli` at full API parity; install from `cli/` (not yet published to npm) |
 
 **Legend:** ✅ Working | 🚧 In Progress | 📋 Planned
 
@@ -360,19 +361,20 @@ Before changing `[[artifacts]]` / `[[env.staging.artifacts]]` namespace values i
 
 ## Development Roadmap
 
-See [docs/stratum-master-plan-v2.md](docs/stratum-master-plan-v2.md) for the full implementation plan.
+For the authoritative, current state see [docs/CURRENT_CAPABILITIES.md](docs/CURRENT_CAPABILITIES.md);
+open items are tracked in [docs/REMAINING_WORK.md](docs/REMAINING_WORK.md).
 
 ### Phase 0 ✅
 - Basic fork/commit/merge loop on Artifacts
 - GitHub import
 
-### Phase 1 ✅ (Current)
+### Phase 1 ✅
 - Persistent storage (D1)
 - Authentication (OAuth + API tokens + email)
 - Evaluation engine (diff, webhook, secret scanning)
 - Basic web UI
 
-### Phase 2 (Next)
+### Phase 2 ✅
 - LLM evaluator via AI Gateway
 - Sandbox execution
 - Event-driven evaluation pipeline
@@ -380,17 +382,17 @@ See [docs/stratum-master-plan-v2.md](docs/stratum-master-plan-v2.md) for the ful
 - Durable Object merge queue
 - Provenance tracking
 
-### Phase 3
+### Phase 3 ✅
 - Organizations and teams
-- CLI tool (`@stratum/cli`)
+- CLI tool (`@stratum/cli`) — built at full parity, not yet published to npm
 - Reference agent integration
 - Bidirectional GitHub sync
 - Issue tracker
 
-### Phase 4
-- Stratum Cloud (managed offering)
-- Load testing and hardening
-- Billing and multi-tenancy
+### Phase 4 (Current)
+- ✅ Security & durability hardening (audit trail, backup/restore, deletion jobs)
+- 📋 Stratum Cloud (managed offering)
+- 📋 Billing and multi-tenancy
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -365,16 +365,19 @@ For the authoritative, current state see [docs/CURRENT_CAPABILITIES.md](docs/CUR
 open items are tracked in [docs/REMAINING_WORK.md](docs/REMAINING_WORK.md).
 
 ### Phase 0 ✅
+
 - Basic fork/commit/merge loop on Artifacts
 - GitHub import
 
 ### Phase 1 ✅
+
 - Persistent storage (D1)
 - Authentication (OAuth + API tokens + email)
 - Evaluation engine (diff, webhook, secret scanning)
 - Basic web UI
 
 ### Phase 2 ✅
+
 - LLM evaluator via AI Gateway
 - Sandbox execution
 - Event-driven evaluation pipeline
@@ -383,6 +386,7 @@ open items are tracked in [docs/REMAINING_WORK.md](docs/REMAINING_WORK.md).
 - Provenance tracking
 
 ### Phase 3 ✅
+
 - Organizations and teams
 - CLI tool (`@stratum/cli`) — built at full parity, not yet published to npm
 - Reference agent integration
@@ -390,6 +394,7 @@ open items are tracked in [docs/REMAINING_WORK.md](docs/REMAINING_WORK.md).
 - Issue tracker
 
 ### Phase 4 (Current)
+
 - ✅ Security & durability hardening (audit trail, backup/restore, deletion jobs)
 - 📋 Stratum Cloud (managed offering)
 - 📋 Billing and multi-tenancy


### PR DESCRIPTION
Closes #157.

The README's status tables and roadmap materially **under-stated** the product — a reader would conclude orgs/teams/CLI/bidirectional-sync are unbuilt when they ship today. This is the single biggest evaluator-trust problem in the docs. I verified every claim against the code before correcting it.

## Corrections (all code-verified)
| Claim | Was | Now | Evidence |
|-------|-----|-----|----------|
| Organizations | 🚧 | ✅ | `orgsRouter` at `/api/orgs` — org/member/team CRUD (`routes/orgs.ts`, `storage/orgs.ts`) |
| Teams | 🚧 | ✅ | team + team-member routes (`orgs.ts:198–429`), `storage/teams.ts` |
| Bidirectional GitHub Sync | 📋 Planned | ✅ | inbound webhooks (`github/webhooks.ts`) + outbound PR promotion (`github_pr_number`/`promoted_at`, `changes.ts` + `github/sync.ts`) |
| Issue Tracker | (absent) | ✅ added | `issues.ts` mounted at `/api/projects` |
| CLI | 🚧 | 🚧 (kept) | `@stratum/cli` is full-parity but **not on npm** (registry 404) — kept honest with an "install from `cli/`" note |

- **Roadmap**: Phases 0–3 → ✅ (done); Phase 4 → current (hardening ✅; Cloud + billing 📋).
- **Dead link**: replaced `docs/stratum-master-plan-v2.md` (missing) with the real source-of-truth docs. All 22 relative doc links in the README now resolve.

## Scope
Docs-only (no code touched). I deliberately kept this to the README; the sibling doc-staleness items (architecture.md drift, `PIVOT_SUMMARY` links in `docs/README.md`, the 2024-dated status table) are a separate finding I'll ship next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated feature status information for Organizations, Teams, Issue Tracker, and bidirectional GitHub Sync.
  * Clarified that the CLI is in progress, has full API parity, and is not yet published to npm.
  * Marked initial development phases as complete and documented ongoing hardening work.
  * Added details about planned cloud and billing initiatives.
  * Replaced outdated roadmap references with current capabilities and remaining work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->