### PR TITLE
test(migrations): apply-from-clean safety net + hygiene checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - run: npm ci
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: CLI — install, typecheck, test, build
         working-directory: cli
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies
@@ -153,7 +153,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/d1-migrate.yml
+++ b/.github/workflows/d1-migrate.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - run: npm ci

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - run: npm ci

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: CLI — install, typecheck, test, build
         working-directory: cli
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies
@@ -119,7 +119,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies
@@ -154,7 +154,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies
@@ -330,7 +330,7 @@ jobs:
       - name: Run secret scanner tests
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - run: npm ci

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -1,0 +1,103 @@
+/// <reference types="vite/client" />
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Migration safety net. D1 migrations are forward-only and are applied straight
+ * against staging/production at deploy time, so a syntax error, bad ordering, or
+ * schema drift is otherwise caught only in prod. These tests apply every
+ * migration from an empty database to a real SQLite engine (node:sqlite) — the
+ * engine family D1 is built on. This proves the SQL is well-formed SQLite and
+ * the schema is coherent; it approximates but does not perfectly replicate D1's
+ * exact dialect.
+ *
+ * SQL is loaded via Vite's raw glob (not node:fs) so the test type-checks under
+ * the Workers tsconfig; node:sqlite is typed by tests/node-sqlite.d.ts.
+ */
+const migrationModules = import.meta.glob("../migrations/*.sql", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+// Basename → SQL, sorted byte-wise by filename to mirror wrangler/D1's apply
+// order (a scalar filename sort, not locale collation).
+const migrations = Object.entries(migrationModules)
+  .map(([path, sql]) => [path.split("/").pop() ?? path, sql] as const)
+  .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+// Load-bearing tables that must exist after a full migration run. A missing one
+// means the schema is broken (a missing `events` outbox was the #118 incident).
+const EXPECTED_CORE_TABLES = [
+  "users",
+  "sessions",
+  "changes",
+  "events",
+  "issues",
+  "orgs",
+  "teams",
+  "webhooks",
+  "audit_log",
+];
+
+// 024 was duplicated historically and is already applied to production under
+// both names, so it cannot be renamed. We freeze the exact pair (not just the
+// number) so a THIRD file reusing 024 — or any other collision — still fails.
+const FROZEN_DUPLICATES: [string, string[]][] = [
+  ["024", ["024_backup_state.sql", "024_change_workspace_head_sha.sql"]],
+];
+
+function applyAllMigrations(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  for (const [, sql] of migrations) db.exec(sql);
+  return db;
+}
+
+function tableNames(db: DatabaseSync): Set<string> {
+  const rows = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+    name: string;
+  }[];
+  return new Set(rows.map((r) => r.name));
+}
+
+describe("migrations", () => {
+  it("has migration files to check", () => {
+    expect(migrations.length).toBeGreaterThan(0);
+  });
+
+  it("all filenames follow the NNN_name.sql convention", () => {
+    for (const [name] of migrations) {
+      expect(name, `${name} must match NNN_name.sql`).toMatch(/^\d{3}_[a-z0-9_]+\.sql$/);
+    }
+  });
+
+  it("does not reuse a migration number (only the exact frozen 024 pair)", () => {
+    const byNumber = new Map<string, string[]>();
+    for (const [name] of migrations) {
+      const num = name.slice(0, 3);
+      byNumber.set(num, [...(byNumber.get(num) ?? []), name].sort());
+    }
+    const duplicated = [...byNumber]
+      .filter(([, names]) => names.length > 1)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    // Asserting the exact filename pair (not just "024") means a third file
+    // reusing the 024 slot fails, and any new collision fails too.
+    expect(duplicated).toEqual(FROZEN_DUPLICATES);
+  });
+
+  it("applies cleanly from an empty database, in order", () => {
+    expect(() => {
+      const db = applyAllMigrations();
+      db.close();
+    }).not.toThrow();
+  });
+
+  it("produces the load-bearing schema", () => {
+    const db = applyAllMigrations();
+    const tables = tableNames(db);
+    db.close();
+    for (const table of EXPECTED_CORE_TABLES) {
+      expect(tables, `${table} must exist after all migrations`).toContain(table);
+    }
+  });
+});

--- a/tests/node-sqlite.d.ts
+++ b/tests/node-sqlite.d.ts
@@ -1,0 +1,12 @@
+// Minimal ambient declaration for the subset of node:sqlite the migration test
+// uses. The Workers tsconfig ships no @types/node, and node:sqlite is a Node 22+
+// built-in; this keeps the test fully type-checked without pulling in node types
+// globally (which would let src/ reference Node APIs that don't exist in workerd).
+declare module "node:sqlite" {
+  export class DatabaseSync {
+    constructor(location: string);
+    exec(sql: string): void;
+    prepare(sql: string): { all(...params: unknown[]): unknown[] };
+    close(): void;
+  }
+}


### PR DESCRIPTION
Closes #159.

## Problem
35 migration files, **zero tests**. D1 migrations are forward-only and CI applies them with `wrangler d1 migrations apply --remote` straight against staging/production, so a syntax error, bad ordering, or schema drift is caught only at deploy time — the same blast radius that made the #118 reconciliation painful.

## What this adds
`tests/migrations.test.ts` applies **every** migration from an empty database to a real SQLite engine (`node:sqlite`) and asserts:
- all migrations apply without throwing (catches SQL syntax / ordering errors) — verified: all 35 apply cleanly, producing 27 tables;
- the resulting schema contains the load-bearing tables (`users, sessions, changes, events, issues, orgs, teams, webhooks, audit_log`);
- filenames follow `NNN_name.sql`;
- no migration number is reused **except the exact, frozen 024 pair** (already applied to prod under both names; can't be renamed). Asserting the exact filename pair means a *third* `024_*` file — or any new collision — still fails.

## Infra notes
- SQL is loaded via Vite's **raw glob** (not `node:fs`) and `node:sqlite` is typed by a tiny ambient declaration (`tests/node-sqlite.d.ts`), so the test is **fully type-checked** under the Workers tsconfig — no `@ts-nocheck`, no `@types/node`.
- **Bumps CI Node 20 → 22** (14 workflow occurrences): `node:sqlite` requires ≥22.5. Node 22 is current LTS; the Worker runtime is workerd, so this only affects tooling (wrangler/tsc/biome/vitest all support 22). The `node-version` lines sit in `Setup Node` blocks, separate from #156's smoke/migration hunks, so the branches merge cleanly.

## Verification
`tsc` clean · `biome` clean · full suite **1110 passing** (+5). An adversarial review pass hardened the duplicate guard (freeze the exact 024 pair, not just the number) and switched to a byte-wise filename sort to mirror wrangler's ordering.

## Honest scope
This proves migrations are **valid SQLite** and the schema is coherent — it approximates but does not perfectly replicate D1's exact dialect. That's the right safety net for the forward-only deploy-time risk; a full D1-in-Miniflare harness would be a separate, heavier follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated checks to verify database migrations apply cleanly, follow naming conventions, avoid duplicate numbering, and create required core tables.
* **Chores**
  * Updated continuous integration, testing, validation, and deployment workflows to use Node.js 22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->