### PR TITLE
feat(csp): add form-action and frame-src directives (defense-in-depth)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { analyticsMiddleware } from "./middleware/analytics";
 import { authMiddleware } from "./middleware/auth";
 import { csrfMiddleware } from "./middleware/csrf";
 import { rateLimitMiddleware } from "./middleware/rate-limit";
-import { securityHeadersMiddleware } from "./middleware/security-headers";
+import { securityHeadersMiddleware, setHtmlSecurityHeaders } from "./middleware/security-headers";
 import { sweepDeletionJobs } from "./queue/deletion-runner";
 import { handleEventQueue, sweepStaleEvents } from "./queue/event-consumer";
 import type { EventQueueMessage } from "./queue/events";
@@ -186,11 +186,9 @@ app.onError((err, c) => {
     method: c.req.method,
   });
   // Belt-and-suspenders: the middleware registers headers before next(), but the
-  // error boundary builds a fresh response, so re-assert the full set here.
-  c.header("X-Content-Type-Options", "nosniff");
-  c.header("X-Frame-Options", "DENY");
-  c.header("Referrer-Policy", "strict-origin-when-cross-origin");
-  c.header("Content-Security-Policy", "frame-ancestors 'none'; object-src 'none'; base-uri 'self'");
+  // error boundary builds a fresh response, so re-assert the full set here via the
+  // shared helper (keeps the 500's CSP identical to the middleware's).
+  setHtmlSecurityHeaders(c);
   return c.json({ error: "Internal server error" }, 500);
 });
 

--- a/src/middleware/security-headers.ts
+++ b/src/middleware/security-headers.ts
@@ -1,6 +1,26 @@
-import type { MiddlewareHandler } from "hono";
+import type { Context, MiddlewareHandler } from "hono";
 import { isGitHttpPath } from "../routes/git-http";
 import type { Env } from "../types";
+
+/**
+ * CSP for the server-rendered UI and API. Exported so the request middleware and
+ * the error boundary (src/index.ts) share ONE source of truth — a 500 response
+ * must carry the same policy as a 200, and duplicating the string let them drift.
+ */
+export const CONTENT_SECURITY_POLICY =
+  "frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-src 'none'";
+
+/**
+ * Apply the static HTML security headers (content-type sniffing, framing,
+ * referrer, CSP). Used by both the middleware and the error boundary so the two
+ * paths stay identical. HSTS is applied separately — it is conditional on HTTPS.
+ */
+export function setHtmlSecurityHeaders(c: Context<{ Bindings: Env }>): void {
+  c.header("X-Content-Type-Options", "nosniff");
+  c.header("X-Frame-Options", "DENY");
+  c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+  c.header("Content-Security-Policy", CONTENT_SECURITY_POLICY);
+}
 
 /**
  * Response security headers for the server-rendered UI and API.
@@ -26,13 +46,7 @@ export const securityHeadersMiddleware: MiddlewareHandler<{ Bindings: Env }> = a
   // smart-HTTP responses are not HTML and must stay untouched, so they are
   // skipped — the single await next() below still runs for them.
   if (!isGitHttpPath(c.req.path)) {
-    c.header("X-Content-Type-Options", "nosniff");
-    c.header("X-Frame-Options", "DENY");
-    c.header("Referrer-Policy", "strict-origin-when-cross-origin");
-    c.header(
-      "Content-Security-Policy",
-      "frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-src 'none'",
-    );
+    setHtmlSecurityHeaders(c);
 
     // HSTS only over HTTPS (a plain-HTTP response with HSTS is ignored by
     // browsers and pointless; local http dev must stay usable).

--- a/src/middleware/security-headers.ts
+++ b/src/middleware/security-headers.ts
@@ -9,8 +9,13 @@ import type { Env } from "../types";
  * scripts: the UI ships inline `onclick` handlers and inline `<script>` blocks
  * (file-tree, conflict-resolution, import-progress), and inline event-handler
  * attributes cannot be nonce'd — a `script-src` policy would break them. So we
- * ship the safe subset (`frame-ancestors`/`object-src`/`base-uri`) now;
- * tightening `script-src` is deferred behind an inline-handler refactor.
+ * ship the script-safe subset now and defer `script-src` behind an
+ * inline-handler nonce refactor (tracked in issue #161).
+ *
+ * `form-action 'self'` and `frame-src 'none'` are safe to add without that
+ * refactor (all forms post same-origin; the UI embeds no iframes) and add real
+ * defense-in-depth: they stop a would-be injection from exfiltrating via a
+ * cross-origin form target or a smuggled iframe.
  *
  * Git smart-HTTP responses are left untouched — they are not HTML and must not
  * carry frame/CSP headers that could confuse git clients or proxies.
@@ -26,7 +31,7 @@ export const securityHeadersMiddleware: MiddlewareHandler<{ Bindings: Env }> = a
     c.header("Referrer-Policy", "strict-origin-when-cross-origin");
     c.header(
       "Content-Security-Policy",
-      "frame-ancestors 'none'; object-src 'none'; base-uri 'self'",
+      "frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-src 'none'",
     );
 
     // HSTS only over HTTPS (a plain-HTTP response with HSTS is ignored by

--- a/tests/security-headers.test.ts
+++ b/tests/security-headers.test.ts
@@ -32,10 +32,20 @@ describe("SEC-7: security headers", () => {
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(res.headers.get("X-Frame-Options")).toBe("DENY");
     expect(res.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
-    expect(res.headers.get("Content-Security-Policy")).toContain("frame-ancestors 'none'");
+    const csp = res.headers.get("Content-Security-Policy");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'self'");
   });
 
-  it("ships no script-src directive (inline UI handlers must keep working)", async () => {
+  it("restricts form targets and framing without touching scripts", async () => {
+    const res = await app.fetch(new Request("http://localhost/health"), makeEnv());
+    const csp = res.headers.get("Content-Security-Policy");
+    expect(csp).toContain("form-action 'self'");
+    expect(csp).toContain("frame-src 'none'");
+  });
+
+  it("ships no script-src directive (inline UI handlers must keep working; issue #161)", async () => {
     const res = await app.fetch(new Request("http://localhost/health"), makeEnv());
     expect(res.headers.get("Content-Security-Policy")).not.toContain("script-src");
   });

--- a/tests/security-headers.test.ts
+++ b/tests/security-headers.test.ts
@@ -50,6 +50,17 @@ describe("SEC-7: security headers", () => {
     expect(res.headers.get("Content-Security-Policy")).not.toContain("script-src");
   });
 
+  it("applies the same CSP to 500 error responses (error boundary parity)", async () => {
+    // GET / renders the dashboard, which throws under the bare test env and hits
+    // the error boundary — the 500 must carry the identical hardened policy.
+    const res = await app.fetch(new Request("http://localhost/"), makeEnv());
+    expect(res.status).toBe(500);
+    const csp = res.headers.get("Content-Security-Policy");
+    expect(csp).toContain("form-action 'self'");
+    expect(csp).toContain("frame-src 'none'");
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+
   it("sets HSTS only over HTTPS", async () => {
     const httpRes = await app.fetch(new Request("http://localhost/health"), makeEnv());
     expect(httpRes.headers.get("Strict-Transport-Security")).toBeNull();


### PR DESCRIPTION
Partial of the CSP-hardening finding. The full `script-src` fix needs a nonce refactor of ~7 inline scripts + 13 inline event handlers and browser E2E verification — tracked in **#161**. This PR ships the part that's **safe and verifiable now**.

## Change
CSP gains `form-action 'self'` and `frame-src 'none'`:
```
frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-src 'none'
```

## Why it's safe (verified)
- `form-action 'self'`: every form in the UI posts same-origin — `grep -rE "action=\"https?://" src/` → none. GitHub/Google OAuth are GET-redirect flows, not cross-origin form posts.
- `frame-src 'none'`: the UI embeds no iframes — `grep -rn "<iframe" src/` → none.
- **No `script-src`** is added, so the inline-handler UI keeps working (asserted by an existing test, now referencing #161).

## Value
Defense-in-depth: stops a would-be injection from exfiltrating via a cross-origin form target or a smuggled iframe, complementing the existing Origin/Referer CSRF checks.

## Tests
Extended `tests/security-headers.test.ts` (asserts the new directives + that script-src is still absent). `tsc` + full suite + `biome` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened browser security policies by restricting form submissions to the site and blocking embedded frames.
  * Applied consistent security protections to error pages.
  * Retained protections against framing, plugins, and unauthorized base URLs.
  * Preserved compatibility with existing inline script handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->