### PR TITLE
fix(backup): back up deletion_jobs + drift guard for the table allow-list

### DIFF
--- a/src/storage/d1-backup.ts
+++ b/src/storage/d1-backup.ts
@@ -31,7 +31,23 @@ export const BACKUP_TABLES: readonly string[] = [
   "sync_history",
   "issues",
   "audit_log",
+  "deletion_jobs",
   "commit_metrics",
+];
+
+/**
+ * D1 tables intentionally NOT backed up, with the reason each is safe to omit.
+ * Every table created by a migration must be in `BACKUP_TABLES` or here —
+ * `tests/backup-coverage.test.ts` enforces that so a new table holding real
+ * user data can't be silently dropped from every backup.
+ */
+export const BACKUP_EXCLUDED_TABLES: readonly string[] = [
+  // Ephemeral, single-use, short-TTL login tokens (stored hashed). They expire
+  // in minutes, so a backup would only ever hold dead rows — nothing to restore.
+  "magic_links",
+  // The backup orchestrator's own per-repo rotation cursor. It describes backup
+  // progress, not user data; restoring it into a fresh DB would be meaningless.
+  "backup_state",
 ];
 
 const PAGE_SIZE = 500;

--- a/tests/backup-coverage.test.ts
+++ b/tests/backup-coverage.test.ts
@@ -1,0 +1,59 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+import { BACKUP_EXCLUDED_TABLES, BACKUP_TABLES } from "../src/storage/d1-backup";
+
+/**
+ * Backup-coverage drift guard. `BACKUP_TABLES` is a hand-maintained allow-list,
+ * so a new table holding user data could be added in a migration and silently
+ * left out of every backup. This derives the real table set from migrations/
+ * (the schema source of truth) and asserts every table is either backed up or
+ * explicitly excluded — forcing that decision at PR time, not after data loss.
+ */
+const migrationModules = import.meta.glob("../migrations/*.sql", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+function tablesDefinedInMigrations(): Set<string> {
+  const names = new Set<string>();
+  const createTable = /CREATE TABLE (?:IF NOT EXISTS )?["'`]?([a-z_]+)/gi;
+  for (const sql of Object.values(migrationModules)) {
+    for (const match of sql.matchAll(createTable)) {
+      const table = match[1];
+      if (table) names.add(table.toLowerCase());
+    }
+  }
+  return names;
+}
+
+describe("backup coverage", () => {
+  const migrationTables = tablesDefinedInMigrations();
+  const backed = new Set(BACKUP_TABLES);
+  const excluded = new Set(BACKUP_EXCLUDED_TABLES);
+
+  it("has migration tables to check", () => {
+    expect(migrationTables.size).toBeGreaterThan(0);
+  });
+
+  it("classifies every migration table as backed-up or explicitly excluded", () => {
+    const unclassified = [...migrationTables]
+      .filter((t) => !backed.has(t) && !excluded.has(t))
+      .sort();
+    // If this fails, a new table was added without deciding its backup fate:
+    // add it to BACKUP_TABLES (in FK order) or to BACKUP_EXCLUDED_TABLES (with a reason).
+    expect(unclassified).toEqual([]);
+  });
+
+  it("never lists a table as both backed-up and excluded", () => {
+    const overlap = [...backed].filter((t) => excluded.has(t)).sort();
+    expect(overlap).toEqual([]);
+  });
+
+  it("references only real tables (no typos or dropped tables)", () => {
+    const phantomBacked = [...backed].filter((t) => !migrationTables.has(t)).sort();
+    const phantomExcluded = [...excluded].filter((t) => !migrationTables.has(t)).sort();
+    expect(phantomBacked).toEqual([]);
+    expect(phantomExcluded).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #163.

## Problem
`BACKUP_TABLES` (`src/storage/d1-backup.ts`) is a hand-maintained allow-list with **no drift detection**. A table added in a future migration is silently omitted from every backup, and `plan-restore` can't flag a table it doesn't know about. Auditing the list against `migrations/` found **3 unlisted tables**: `deletion_jobs`, `magic_links`, `backup_state`.

## Changes
- **Back up `deletion_jobs`** (added in FK-order after `audit_log`): it's the durable GDPR project/account-erasure audit trail — real data that should survive a restore. All its columns are TEXT, so it round-trips through the NDJSON backup cleanly.
- **Document the safe omissions** via an exported `BACKUP_EXCLUDED_TABLES`:
  - `magic_links` — ephemeral single-use hashed login tokens (expire in minutes); a backup would only hold dead rows.
  - `backup_state` — the backup orchestrator's own per-repo rotation cursor; restoring it is meaningless.
- **Drift guard** (`tests/backup-coverage.test.ts`): derives the real table set from `migrations/` and asserts every table is **either** backed up **or** explicitly excluded, the two sets don't overlap, and both reference only real tables. Any new table now **fails CI** until its backup fate is decided — closing the silent-omission gap.

## Verification
`tsc` clean · `biome` clean · full suite **1118 passing** (+4 new), 0 failed. Fully typed (Vite raw glob, no `@ts-nocheck`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Backup Improvements**
  * Clarified which system tables are intentionally excluded from backups.
  * Ensured deletion job data remains included in backups.

* **Quality Assurance**
  * Added automated checks to detect missing, overlapping, or invalid backup table coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->