### PR TITLE
docs(deployment): correct the rollback commands

### DIFF
--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -383,28 +383,35 @@ Monitor via Cloudflare Dashboard:
 
 ### Code Rollback
 
-```bash
-# Rollback to previous version
-git log --oneline
+Cloudflare keeps previous Worker versions, so a rollback re-points production at
+a prior version — no rebuild or redeploy needed.
 
-# Deploy previous commit
-npx wrangler deploy --version <previous-version>
+```bash
+# Find the version to roll back to (lists the 10 most recent deployments + IDs)
+npx wrangler deployments list                 # production
+npx wrangler deployments list --env=staging   # staging
+
+# Roll back to the previous version (prompts to confirm)…
+npx wrangler rollback --message "reason for rollback"
+# …or roll back to a specific version by ID
+npx wrangler rollback <version-id> --message "reason for rollback"
 ```
 
-Or via GitHub Actions:
-1. Revert the commit
-2. Push to trigger new deployment
+Or via git: revert the offending commit and push — this triggers a fresh forward
+deploy of the reverted code (slower than `wrangler rollback`, but re-runs CI).
 
 ### Database Rollback
 
-⚠️ **Caution:** Data loss possible
+⚠️ **Caution:** D1 migrations are **forward-only** — there is no down-migration
+and no `wrangler d1 migrations rollback`. To reverse a schema change:
 
-```bash
-# If migration needs rollback
-# 1. Create rollback migration
-# 2. Apply rollback
-npx wrangler d1 migrations apply stratum --remote
-```
+1. Write a **new** migration that undoes it (e.g. drop the added column/table).
+   Note SQLite's limited `ALTER TABLE DROP COLUMN` support — a table rebuild may
+   be required.
+2. Apply it forward: `npx wrangler d1 migrations apply stratum --remote`.
+3. If the bad migration **destroyed or corrupted data**, a forward "undo" only
+   fixes the schema — restore the data from the most recent backup via the
+   [backup/restore runbook](../runbooks/backup-restore.md).
 
 ### Emergency Procedures
 

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -399,8 +399,9 @@ npx wrangler deployments list --env=staging
 
 # Roll back to the previous version (prompts to confirm)…
 npx wrangler rollback --env=production --message "reason for rollback"
-# …or roll back to a specific version by ID
-npx wrangler rollback <version-id> --env=production --message "reason for rollback"
+# …or roll back to a specific version by ID (quote it — bash reads <…> as redirection)
+VERSION_ID="paste-the-ID-from-the-list-above"
+npx wrangler rollback "$VERSION_ID" --env=production --message "reason for rollback"
 ```
 
 Or via git: revert the offending commit and push — this triggers a fresh forward

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -383,18 +383,24 @@ Monitor via Cloudflare Dashboard:
 
 ### Code Rollback
 
-Cloudflare keeps previous Worker versions, so a rollback re-points production at
+Cloudflare keeps previous Worker versions, so a rollback re-points the Worker at
 a prior version — no rebuild or redeploy needed.
+
+> **Worker-code only.** `wrangler rollback` reverts the deployed **code**, not the
+> database. It does **not** undo an applied D1 migration or restore data — if the
+> bad version also ran a migration, roll the schema/data back separately (see
+> **Database Rollback**). Always pass an explicit `--env` so you act on the
+> intended environment.
 
 ```bash
 # Find the version to roll back to (lists the 10 most recent deployments + IDs)
-npx wrangler deployments list                 # production
-npx wrangler deployments list --env=staging   # staging
+npx wrangler deployments list --env=production
+npx wrangler deployments list --env=staging
 
 # Roll back to the previous version (prompts to confirm)…
-npx wrangler rollback --message "reason for rollback"
+npx wrangler rollback --env=production --message "reason for rollback"
 # …or roll back to a specific version by ID
-npx wrangler rollback <version-id> --message "reason for rollback"
+npx wrangler rollback <version-id> --env=production --message "reason for rollback"
 ```
 
 Or via git: revert the offending commit and push — this triggers a fresh forward
@@ -408,10 +414,18 @@ and no `wrangler d1 migrations rollback`. To reverse a schema change:
 1. Write a **new** migration that undoes it (e.g. drop the added column/table).
    Note SQLite's limited `ALTER TABLE DROP COLUMN` support — a table rebuild may
    be required.
-2. Apply it forward: `npx wrangler d1 migrations apply stratum --remote`.
-3. If the bad migration **destroyed or corrupted data**, a forward "undo" only
-   fixes the schema — restore the data from the most recent backup via the
-   [backup/restore runbook](../runbooks/backup-restore.md).
+2. **Validate on staging first.** Apply the corrective migration to staging and
+   confirm the schema/app are healthy before touching production:
+   `npx wrangler d1 migrations apply stratum-staging --env=staging --remote`.
+3. **Back up and verify before the production migration.** Trigger a backup
+   (`POST /api/admin/backup`) and verify it via the restore-plan check in the
+   [backup/restore runbook](../runbooks/backup-restore.md), then apply forward:
+   `npx wrangler d1 migrations apply stratum --env=production --remote`.
+4. If the bad migration **destroyed or corrupted data**, a forward "undo" only
+   fixes the schema — you must restore the data. Restore a **verified,
+   last-known-good** backup (⚠️ *not* necessarily the most recent — a backup taken
+   after the corruption contains it). Restore it into a fresh/staging instance and
+   validate the data **before** promoting to production, per the runbook.
 
 ### Emergency Procedures
 


### PR DESCRIPTION
Closes #165.

The 'Rollback Strategy' section had two incident-time footguns (verified against wrangler 4.86):

## Code rollback
Was: `npx wrangler deploy --version <previous-version>` — **not a real wrangler command**. An operator running it mid-incident just gets an error.
Now: `wrangler deployments list` to find the version, then `wrangler rollback [version-id]` to re-point production at a prior version (no rebuild). Plus the git-revert alternative, correctly described as a slower forward redeploy.

## Database rollback
Was: `wrangler d1 migrations apply` (a **forward** apply) presented as a rollback.
Now: states plainly that D1 is **forward-only** (no down-migration), so reversing a schema change means a new undo migration — and **data loss must be restored from backup**, linking the backup/restore runbook (the real recovery path).

Docs-only; all referenced links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment rollback guidance to use Cloudflare deployment history and `wrangler rollback`.
  * Clarified Git revert as an alternative forward-deployment approach.
  * Added guidance for D1’s forward-only migrations, corrective migrations, SQLite table rebuilds, and backup-based data restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->