### PR TITLE
fix(config): fail loud when REPO_DO_ENABLED='true' without REPO_OBJECTS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { runBackup } from "./backup/run-backup";
 import { githubWebhookRouter } from "./github/webhooks";
 import { analyticsMiddleware } from "./middleware/analytics";
 import { authMiddleware } from "./middleware/auth";
+import { configGuardMiddleware } from "./middleware/config-guard";
 import { csrfMiddleware } from "./middleware/csrf";
 import { rateLimitMiddleware } from "./middleware/rate-limit";
 import { securityHeadersMiddleware, setHtmlSecurityHeaders } from "./middleware/security-headers";
@@ -49,6 +50,7 @@ export { RepoDO } from "./queue/repo-do";
 const app = new Hono<{ Bindings: Env }>();
 
 app.use("*", securityHeadersMiddleware);
+app.use("*", configGuardMiddleware);
 app.use("*", analyticsMiddleware);
 app.use("*", authMiddleware);
 app.use("*", csrfMiddleware);

--- a/src/middleware/config-guard.ts
+++ b/src/middleware/config-guard.ts
@@ -1,0 +1,47 @@
+import type { MiddlewareHandler } from "hono";
+import type { Env } from "../types";
+import { createLogger } from "../utils/logger";
+
+/**
+ * Returns a human-readable error when the RepoDO / R2 fast-path config is
+ * incoherent, else null.
+ *
+ * Flipping `REPO_DO_ENABLED` to "true" without binding the `REPO_OBJECTS` R2
+ * bucket is a silent footgun (ADR 004): workspace staging no-ops and the merge
+ * fast path throws "REPO_OBJECTS not bound" only at merge time. Production binds
+ * no REPO_OBJECTS today, so enabling the flag there without adding the binding
+ * would break merges — this makes that misconfiguration detectable up front.
+ */
+export function repoDoConfigError(
+  env: Pick<Env, "REPO_DO_ENABLED" | "REPO_OBJECTS">,
+): string | null {
+  if (env.REPO_DO_ENABLED === "true" && !env.REPO_OBJECTS) {
+    return (
+      "REPO_DO_ENABLED is 'true' but the REPO_OBJECTS R2 bucket is not bound — " +
+      "the merge fast path will throw at merge time and workspace staging silently " +
+      "no-ops. Add the [[env.<env>.r2_buckets]] REPO_OBJECTS binding or set " +
+      "REPO_DO_ENABLED='false'."
+    );
+  }
+  return null;
+}
+
+// Log the config problem at most once per isolate rather than on every request.
+let hasLoggedConfigError = false;
+
+/**
+ * Surfaces an incoherent RepoDO/R2 configuration loudly in Workers Logs on the
+ * first request after a bad deploy, instead of only when a later merge throws.
+ * Non-fatal: reads and the UI still work without the bucket, so we log rather
+ * than reject the request.
+ */
+export const configGuardMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
+  if (!hasLoggedConfigError) {
+    const problem = repoDoConfigError(c.env);
+    if (problem) {
+      hasLoggedConfigError = true;
+      createLogger({ component: "config-guard" }).error(problem);
+    }
+  }
+  await next();
+};

--- a/tests/config-guard.test.ts
+++ b/tests/config-guard.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { repoDoConfigError } from "../src/middleware/config-guard";
+import type { Env } from "../src/types";
+
+const bucket = {} as Env["REPO_OBJECTS"];
+
+describe("repoDoConfigError", () => {
+  it("flags REPO_DO_ENABLED='true' with no REPO_OBJECTS bound", () => {
+    const problem = repoDoConfigError({ REPO_DO_ENABLED: "true", REPO_OBJECTS: undefined });
+    expect(problem).toContain("REPO_OBJECTS");
+    expect(problem).toContain("REPO_DO_ENABLED");
+  });
+
+  it("is silent when the flag is on and the bucket is bound (staging)", () => {
+    expect(repoDoConfigError({ REPO_DO_ENABLED: "true", REPO_OBJECTS: bucket })).toBeNull();
+  });
+
+  it("is silent when the flag is off, bound or not (production default)", () => {
+    expect(repoDoConfigError({ REPO_DO_ENABLED: "false", REPO_OBJECTS: undefined })).toBeNull();
+    expect(repoDoConfigError({ REPO_DO_ENABLED: undefined, REPO_OBJECTS: undefined })).toBeNull();
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -228,6 +228,10 @@ POSTHOG_HOST = "https://app.posthog.com"
 # inert in production — and so wrangler stops warning about the missing override.
 DEV_LOGIN_ENABLED = "false"
 # RepoDO fast-forward path (ADR 004); default off until staging numbers justify it.
+# To enable in prod you MUST also add a [[env.production.r2_buckets]] REPO_OBJECTS
+# binding (staging has one) — without it the fast path throws "REPO_OBJECTS not
+# bound" at merge time and workspace staging silently no-ops. The config-guard
+# middleware logs an error if this is set "true" with no bucket bound.
 REPO_DO_ENABLED = "false"
 # Production OAuth callbacks. The matching callback URLs must also be registered
 # in the GitHub and Google OAuth app settings.


### PR DESCRIPTION
Closes #167.

## Problem
The `REPO_OBJECTS` R2 bucket (ADR-004 merge fast path) is bound **only for staging** in wrangler.toml. Production runs `REPO_DO_ENABLED='false'`, but flipping it to `'true'` there without also adding the binding is a silent footgun:
- `workspaces.ts:282` **silently no-ops** (guards on `c.env.REPO_OBJECTS`), and
- `repo-do.ts:77` throws `REPO_OBJECTS not bound` — **only at merge time**.

So the misconfiguration stays invisible until the first prod merge fails.

## Fix
- **`configGuardMiddleware`**: on the first request after a bad deploy, logs a clear error to Workers Logs (once per isolate) — surfacing the problem immediately instead of at merge time. **Non-fatal**: reads and the UI work fine without the bucket, so it logs rather than rejecting requests.
- **`wrangler.toml` comment** coupling the prod `REPO_DO_ENABLED` flag to the required `[[env.production.r2_buckets]] REPO_OBJECTS` binding — catches it at config-edit time.
- **Unit test** for the pure `repoDoConfigError` decision (on+unbound → flagged; on+bound and off → silent).

## Verification
`tsc` clean · `biome` clean · full suite **1121 passing** (+3), 0 failed. Touches no workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added configuration checks to identify when repository features are enabled without the required object storage.
  * Requests continue safely while providing a clear diagnostic for misconfigured environments.
  * Configuration errors are logged only once per runtime instance to reduce noise.

* **Documentation**
  * Clarified the required object storage setup and the behavior of incomplete staging configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->