### PR TITLE
fix(cron): isolate the daily backup on its own trigger

### DIFF
--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -51,7 +51,8 @@ Backups also read these optional vars (see the
 `BACKUP_ENCRYPTION_SECRET` (set in production — encrypts backup blobs),
 `BACKUP_RETENTION` (runs to keep, default 14), `MAX_REPOS_PER_RUN` (default 25),
 `MAX_BACKUP_BYTES` (per-repo budget, default 128 MiB). The daily backup runs on
-the `0 6 * * *` cron.
+its own `0 4 * * *` cron — isolated from the `0 6 * * *` housekeeping so a slow
+project sync can't starve it of the invocation budget.
 
 ### Staging
 

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -53,7 +53,9 @@ tokens, and a bucket lifecycle policy that matches your retention expectations.
 | `MAX_REPOS_PER_RUN` | Repos snapshotted per run. | 25 |
 | `MAX_BACKUP_BYTES` | Per-repo object budget; larger repos are skipped, not failed. | 128 MiB |
 
-The daily run fires from the `0 6 * * *` cron (production and default configs).
+The daily run fires from its own `0 4 * * *` cron (production and default
+configs) — deliberately separate from the `0 6 * * *` housekeeping so a slow
+project sync can't starve the backup of its ~15-minute invocation budget.
 Staging has no backup cron by design — validate there via the manual endpoint.
 
 ## Triggering and verifying a run

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
-import { runBackup } from "./backup/run-backup";
 import { githubWebhookRouter } from "./github/webhooks";
 import { analyticsMiddleware } from "./middleware/analytics";
 import { authMiddleware } from "./middleware/auth";
@@ -8,11 +7,9 @@ import { configGuardMiddleware } from "./middleware/config-guard";
 import { csrfMiddleware } from "./middleware/csrf";
 import { rateLimitMiddleware } from "./middleware/rate-limit";
 import { securityHeadersMiddleware, setHtmlSecurityHeaders } from "./middleware/security-headers";
-import { sweepDeletionJobs } from "./queue/deletion-runner";
-import { handleEventQueue, sweepStaleEvents } from "./queue/event-consumer";
+import { handleEventQueue } from "./queue/event-consumer";
 import type { EventQueueMessage } from "./queue/events";
 import { handleImportQueue } from "./queue/import-queue";
-import { runTtlSweep } from "./queue/ttl-sweep";
 import { agentsRouter } from "./routes/agents";
 import { auditRouter } from "./routes/audit";
 import { authRouter } from "./routes/auth";
@@ -33,12 +30,13 @@ import { restoreRouter } from "./routes/restore";
 import { reviewsRouter } from "./routes/reviews";
 import { sessionRouter } from "./routes/sessions";
 import { signupRouter } from "./routes/signup";
-import { syncAllProjects, syncRouter } from "./routes/sync";
+import { syncRouter } from "./routes/sync";
 import { syncManagementRouter } from "./routes/sync-management";
 import { uiRouter } from "./routes/ui";
 import { usersRouter } from "./routes/users";
 import { webhooksRouter } from "./routes/webhooks";
 import { workspacesRouter } from "./routes/workspaces";
+import { runScheduledJobs } from "./scheduled";
 import { createSession } from "./storage/sessions";
 import { createUser, getUserByEmail } from "./storage/users";
 import type { Env, ImportJobMessage, MessageBatch, SyncJobMessage } from "./types";
@@ -198,20 +196,7 @@ export default {
   fetch: app.fetch,
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
     const logger = createLogger({ component: "scheduled" });
-    if (event.cron === "*/5 * * * *") {
-      ctx.waitUntil(sweepStaleEvents(env, logger));
-      // Authoritative deletion driver: re-drives unfinished deletion jobs with
-      // stale heartbeats (the enqueue at request time is only an optimization).
-      ctx.waitUntil(sweepDeletionJobs(env, logger));
-      return;
-    }
-    ctx.waitUntil(
-      Promise.all([
-        runTtlSweep(env, logger),
-        syncAllProjects(env),
-        runBackup(env, logger, new Date().toISOString()),
-      ]),
-    );
+    runScheduledJobs(event.cron, env, logger, (promise) => ctx.waitUntil(promise));
   },
   async queue(batch: MessageBatch<unknown>, env: Env): Promise<void> {
     const logger = createLogger({ component: "queue" });

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -1,0 +1,58 @@
+import { runBackup } from "./backup/run-backup";
+import { sweepDeletionJobs } from "./queue/deletion-runner";
+import { sweepStaleEvents } from "./queue/event-consumer";
+import { runTtlSweep } from "./queue/ttl-sweep";
+import { syncAllProjects } from "./routes/sync";
+import type { Env } from "./types";
+import type { Logger } from "./utils/logger";
+
+export type ScheduledJob =
+  | "event-sweep"
+  | "deletion-sweep"
+  | "backup"
+  | "ttl-sweep"
+  | "project-sync";
+
+/**
+ * Cron → jobs routing. Backup runs on its OWN trigger (`0 4 * * *`), isolated
+ * from the 06:00 housekeeping: a single Worker invocation has a ~15-minute
+ * wall-clock budget, and a slow `project-sync` sharing that budget could starve
+ * or truncate the DR-critical backup. Keeping them on separate crons gives each
+ * the full invocation budget.
+ */
+export function jobsForCron(cron: string): ScheduledJob[] {
+  switch (cron) {
+    case "*/5 * * * *":
+      return ["event-sweep", "deletion-sweep"];
+    case "0 4 * * *":
+      return ["backup"];
+    case "0 6 * * *":
+      return ["ttl-sweep", "project-sync"];
+    default:
+      return [];
+  }
+}
+
+const JOB_RUNNERS: Record<ScheduledJob, (env: Env, logger: Logger) => Promise<unknown>> = {
+  "event-sweep": (env, logger) => sweepStaleEvents(env, logger),
+  "deletion-sweep": (env, logger) => sweepDeletionJobs(env, logger),
+  backup: (env, logger) => runBackup(env, logger, new Date().toISOString()),
+  "ttl-sweep": (env, logger) => runTtlSweep(env, logger),
+  "project-sync": (env) => syncAllProjects(env),
+};
+
+/**
+ * Dispatch the jobs for a cron event. Each job is registered independently with
+ * `waitUntil` (rather than a single `Promise.all`) so one failing job cannot
+ * reject the others. `waitUntil` is injected so this stays unit-testable.
+ */
+export function runScheduledJobs(
+  cron: string,
+  env: Env,
+  logger: Logger,
+  waitUntil: (promise: Promise<unknown>) => void,
+): void {
+  for (const job of jobsForCron(cron)) {
+    waitUntil(JOB_RUNNERS[job](env, logger));
+  }
+}

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -33,7 +33,9 @@ export function jobsForCron(cron: string): ScheduledJob[] {
   }
 }
 
-const JOB_RUNNERS: Record<ScheduledJob, (env: Env, logger: Logger) => Promise<unknown>> = {
+export type JobRunners = Record<ScheduledJob, (env: Env, logger: Logger) => Promise<unknown>>;
+
+const JOB_RUNNERS: JobRunners = {
   "event-sweep": (env, logger) => sweepStaleEvents(env, logger),
   "deletion-sweep": (env, logger) => sweepDeletionJobs(env, logger),
   backup: (env, logger) => runBackup(env, logger, new Date().toISOString()),
@@ -44,15 +46,17 @@ const JOB_RUNNERS: Record<ScheduledJob, (env: Env, logger: Logger) => Promise<un
 /**
  * Dispatch the jobs for a cron event. Each job is registered independently with
  * `waitUntil` (rather than a single `Promise.all`) so one failing job cannot
- * reject the others. `waitUntil` is injected so this stays unit-testable.
+ * reject the others. `waitUntil` and `runners` are injected so this stays
+ * unit-testable without executing the real jobs.
  */
 export function runScheduledJobs(
   cron: string,
   env: Env,
   logger: Logger,
   waitUntil: (promise: Promise<unknown>) => void,
+  runners: JobRunners = JOB_RUNNERS,
 ): void {
   for (const job of jobsForCron(cron)) {
-    waitUntil(JOB_RUNNERS[job](env, logger));
+    waitUntil(runners[job](env, logger));
   }
 }

--- a/tests/scheduled.test.ts
+++ b/tests/scheduled.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { jobsForCron, runScheduledJobs } from "../src/scheduled";
+import type { Env } from "../src/types";
+import type { Logger } from "../src/utils/logger";
+
+describe("jobsForCron", () => {
+  it("runs the backup ALONE on its dedicated 0 4 trigger", () => {
+    // The whole point of F9: backup must not share a cron with project-sync,
+    // whose slowness could starve the DR-critical backup's invocation budget.
+    expect(jobsForCron("0 4 * * *")).toEqual(["backup"]);
+  });
+
+  it("runs housekeeping (no backup) on the 0 6 trigger", () => {
+    const jobs = jobsForCron("0 6 * * *");
+    expect(jobs).toEqual(["ttl-sweep", "project-sync"]);
+    expect(jobs).not.toContain("backup");
+  });
+
+  it("runs the event + deletion sweeps on the */5 trigger", () => {
+    expect(jobsForCron("*/5 * * * *")).toEqual(["event-sweep", "deletion-sweep"]);
+  });
+
+  it("returns nothing for an unknown cron", () => {
+    expect(jobsForCron("0 0 1 1 *")).toEqual([]);
+  });
+});
+
+describe("runScheduledJobs", () => {
+  it("registers one waitUntil per job for the cron", () => {
+    const scheduled: Promise<unknown>[] = [];
+    // Empty deps: the 0 4 branch only calls runBackup, which we don't await here —
+    // we assert the dispatch registers exactly one promise, not the job's result.
+    runScheduledJobs("0 4 * * *", {} as Env, {} as Logger, (p) => {
+      scheduled.push(p);
+      // swallow the (expected) rejection from running against an empty env
+      p.catch(() => {});
+    });
+    expect(scheduled).toHaveLength(1);
+  });
+
+  it("registers nothing for an unknown cron", () => {
+    const scheduled: Promise<unknown>[] = [];
+    runScheduledJobs("@bogus", {} as Env, {} as Logger, (p) => scheduled.push(p));
+    expect(scheduled).toHaveLength(0);
+  });
+});

--- a/tests/scheduled.test.ts
+++ b/tests/scheduled.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { jobsForCron, runScheduledJobs } from "../src/scheduled";
+import { type JobRunners, jobsForCron, runScheduledJobs } from "../src/scheduled";
 import type { Env } from "../src/types";
 import type { Logger } from "../src/utils/logger";
+
+// Stub runners that resolve immediately, so the dispatch is exercised without
+// executing (and failing) the real backup/sync/sweep jobs against a mock env.
+const noopRunners: JobRunners = {
+  "event-sweep": () => Promise.resolve(),
+  "deletion-sweep": () => Promise.resolve(),
+  backup: () => Promise.resolve(),
+  "ttl-sweep": () => Promise.resolve(),
+  "project-sync": () => Promise.resolve(),
+};
 
 describe("jobsForCron", () => {
   it("runs the backup ALONE on its dedicated 0 4 trigger", () => {
@@ -26,21 +36,23 @@ describe("jobsForCron", () => {
 });
 
 describe("runScheduledJobs", () => {
-  it("registers one waitUntil per job for the cron", () => {
+  function collect(cron: string): Promise<unknown>[] {
     const scheduled: Promise<unknown>[] = [];
-    // Empty deps: the 0 4 branch only calls runBackup, which we don't await here —
-    // we assert the dispatch registers exactly one promise, not the job's result.
-    runScheduledJobs("0 4 * * *", {} as Env, {} as Logger, (p) => {
-      scheduled.push(p);
-      // swallow the (expected) rejection from running against an empty env
-      p.catch(() => {});
-    });
-    expect(scheduled).toHaveLength(1);
+    runScheduledJobs(cron, {} as Env, {} as Logger, (p) => scheduled.push(p), noopRunners);
+    return scheduled;
+  }
+
+  it("registers one waitUntil for the backup-only cron", () => {
+    expect(collect("0 4 * * *")).toHaveLength(1);
+  });
+
+  it("registers a SEPARATE waitUntil per job (not one batched Promise.all)", () => {
+    // The 06:00 cron has two jobs; each must be its own waitUntil so one failing
+    // job can't reject the other — a single Promise.all would show up as length 1.
+    expect(collect("0 6 * * *")).toHaveLength(2);
   });
 
   it("registers nothing for an unknown cron", () => {
-    const scheduled: Promise<unknown>[] = [];
-    runScheduledJobs("@bogus", {} as Env, {} as Logger, (p) => scheduled.push(p));
-    expect(scheduled).toHaveLength(0);
+    expect(collect("@bogus")).toHaveLength(0);
   });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -95,10 +95,12 @@ max_batch_size = 1  # Process imports one at a time for resource management
 max_retries = 3     # Retry failed imports up to 3 times
 retry_delay = 30    # Wait 30 seconds between retries
 
+# "0 4 * * *"   — daily backup, on its OWN trigger so the ~15-min invocation
+#                 budget is never shared with (and starved by) the sync/TTL work
 # "0 6 * * *"   — daily housekeeping: workspace TTL sweep + auto-sync
 # "*/5 * * * *" — event outbox sweep: re-enqueue stale pending events
 [triggers]
-crons = ["0 6 * * *", "*/5 * * * *"]
+crons = ["0 4 * * *", "0 6 * * *", "*/5 * * * *"]
 
 # Email Sending — configure via: wrangler email sending enable yourdomain.com
 [[send_email]]
@@ -216,7 +218,7 @@ max_retries = 3
 retry_delay = 30
 
 [env.production.triggers]
-crons = ["0 6 * * *", "*/5 * * * *"]
+crons = ["0 4 * * *", "0 6 * * *", "*/5 * * * *"]
 
 [[env.production.send_email]]
 name = "EMAIL"


### PR DESCRIPTION
Closes #169.

## Problem
The `0 6 * * *` cron ran `runTtlSweep` + `syncAllProjects` + `runBackup` in one `Promise.all`, so all three shared a single Worker invocation's **~15-minute budget**. A slow full-project sync could consume it and **starve or truncate the DR-critical backup**.

## Fix
- **Dedicated backup trigger `0 4 * * *`** — backup gets the full invocation budget, isolated from the 06:00 housekeeping (which now runs only TTL-sweep + sync).
- **Testable dispatch** (`src/scheduled.ts`): `jobsForCron(cron)` maps cron→jobs and `runScheduledJobs` registers **one `waitUntil` per job`** — so one failing job no longer rejects the batch (the old `Promise.all` did). The `scheduled()` handler in index.ts is now a one-liner.
- **Config + docs**: added the cron to both `[triggers]` and `[env.production.triggers]` (staging stays cron-less by design); updated the backup-cron references in `deployment.md` and the backup/restore runbook.

## Review
An adversarial review pass confirmed: **behavior parity** (the old `Promise.all` had no ordering, so running backup 2h earlier breaks no invariant), correct job signatures, safe atomic cron addition, exhaustive `switch` replacing the old non-`*/5` catch-all, and no unhandled-rejection risk in the tests.

## Verification
`tsc` clean · `biome` clean · full suite **1127 passing** (+6). Touches no workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an independent daily backup schedule at 4:00 AM.
  - Scheduled maintenance tasks now run independently, preventing slower synchronization work from affecting other jobs.

- **Documentation**
  - Updated deployment and backup-restore guidance to reflect the separate backup schedule.
  - Clarified that staging does not run automatic backups.

- **Tests**
  - Added coverage for schedule routing, isolated backup execution, maintenance tasks, and unknown schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->