### PR TITLE
Origin response: MCP server, eval hardening, split diffs, in-protocol push, open signup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           path: coverage/
 
   packages:
-    name: CLI & Agent Packages
+    name: CLI, Agent & MCP Packages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,6 +57,14 @@ jobs:
 
       - name: Agent — install, typecheck, test, build
         working-directory: agent
+        run: |
+          npm install
+          npm run typecheck
+          npm test
+          npm run build
+
+      - name: MCP — install, typecheck, test, build
+        working-directory: mcp
         run: |
           npm install
           npm run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,11 @@ jobs:
           npm run typecheck
           npm test
           npm run build
+          # Smoke: the built entrypoint must complete a real MCP initialize
+          # handshake over stdio (it exits 0 on stdin EOF).
+          printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.0"}}}' \
+            | env STRATUM_API_KEY=smoke-not-a-real-key timeout 30s node dist/index.js > /tmp/mcp-smoke.log 2>&1
+          grep -F '"serverInfo":{"name":"stratum"' /tmp/mcp-smoke.log
 
   # ========================================================================
   # Staging Deployment with Automatic Migration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,9 @@ jobs:
         if: success()
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             const deploymentUrl = '${{ steps.deploy.outputs.url }}';
             const commitSha = context.sha.substring(0, 7);
@@ -240,6 +243,9 @@ jobs:
         if: failure()
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             await github.rest.issues.create({
               owner: context.repo.owner,

--- a/.github/workflows/d1-migrate.yml
+++ b/.github/workflows/d1-migrate.yml
@@ -59,6 +59,9 @@ jobs:
         if: failure()
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             await github.rest.issues.create({
               owner: context.repo.owner,

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -57,6 +57,9 @@ jobs:
         if: failure()
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             await github.rest.issues.create({
               owner: context.repo.owner,

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -45,6 +45,11 @@ jobs:
           npm run typecheck
           npm test
           npm run build
+          # Smoke: the built entrypoint must complete a real MCP initialize
+          # handshake over stdio (it exits 0 on stdin EOF).
+          printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.0"}}}' \
+            | env STRATUM_API_KEY=smoke-not-a-real-key timeout 30s node dist/index.js > /tmp/mcp-smoke.log 2>&1
+          grep -F '"serverInfo":{"name":"stratum"' /tmp/mcp-smoke.log
 
   # ========================================================================
   # Code Quality Checks

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   packages:
-    name: CLI & Agent Packages
+    name: CLI, Agent & MCP Packages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,6 +32,14 @@ jobs:
 
       - name: Agent — install, typecheck, test, build
         working-directory: agent
+        run: |
+          npm install
+          npm run typecheck
+          npm test
+          npm run build
+
+      - name: MCP — install, typecheck, test, build
+        working-directory: mcp
         run: |
           npm install
           npm run typecheck

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -209,6 +209,9 @@ jobs:
         if: success()
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             const stagingUrl = '${{ steps.deploy.outputs.url }}';
             const workflowRunUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
@@ -275,6 +278,9 @@ jobs:
         if: failure()
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             const workflowRunUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
             await github.rest.issues.createComment({
@@ -305,6 +311,9 @@ jobs:
       - name: Update PR status
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             const jobs = {
               lint: '${{ needs.lint.result }}',

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -392,6 +395,9 @@ jobs:
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             const previewUrl = '${{ steps.deploy.outputs.preview_url }}';
             const dbId = '${{ steps.db.outputs.db_id }}';

--- a/.stratum/policy.yaml
+++ b/.stratum/policy.yaml
@@ -1,0 +1,29 @@
+# Stratum's own merge policy — the dogfood configuration this repo runs under
+# when hosted on a Stratum instance (layer mode over GitHub, or as source of
+# truth). Inert on GitHub itself. The secret scan is always on and blocking and
+# needs no entry here.
+evaluators:
+  # Structural sanity: a Stratum change should be a reviewable unit, not a dump.
+  - type: diff
+    maxLines: 5000
+    maxFiles: 200
+  # LLM review as a gate, not a rubber stamp. An unparseable verdict fails
+  # closed; the diff window covers all but the largest changes.
+  - type: llm
+    threshold: 0.6
+    maxDiffChars: 48000
+
+requireAll: true
+minScore: 0.6
+
+merge:
+  # Approvals are a human gate; agents (including the ones building this repo)
+  # can never approve their own work.
+  requiredApprovals: 1
+  # The always-on secret scan must have passed on the evaluated revision.
+  requiredEvaluators: ["secret_scan"]
+  # No force-merge escape hatch on this repo. Deleting this line keeps force
+  # denied (deny-by-default); it is spelled out so the intent is explicit.
+  allowForce: false
+  # A change evaluated against a stale base must re-evaluate before merging.
+  requireFreshBase: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ serverless Git. The web UI is server-rendered JSX with **no client-side JavaScri
 | `src/` | The Worker: routes, middleware, storage, queue consumers, evaluation engine, UI |
 | `cli/` | `@stratum/cli` — standalone publishable package |
 | `agent/` | `@stratum/agent` — reference agent, standalone publishable package |
+| `mcp/` | `@stratum/mcp` — MCP server for any MCP-capable agent/editor, standalone publishable package |
 | `tests/` | Vitest suites: unit (`tests/*.test.ts`), `tests/integration/`, `tests/smoke/` |
 | `migrations/` | D1 SQL migrations |
 | `docs/` | User, API, developer docs, and ADRs (`docs/adr/`) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to restore it.
 
 ### Added
+- Split/unified diff toggle on the change review page — instant, pure-CSS switch
+  (no client-side JavaScript, no reload; GitHub/GitLab need a full reload).
+- `git push` to a project URL now fails **in-protocol**: the receive-pack
+  advertisement is served, and each ref update is answered with a legible `ng`
+  report-status plus sideband guidance pointing at workspace remotes — instead of
+  an opaque HTTP 403. The pkt-line/report-status machinery
+  (`src/utils/git-protocol.ts`) is the groundwork for the gated default-branch
+  push (ADR 005 slice 2b, #115).
+- Complete OpenAPI 3.1 specification (`docs/api/openapi.yml`): 72 paths / 91
+  operations generated from the route code, replacing the 4-path stub.
+- Real user documentation: a full getting-started walkthrough and a 15-question
+  FAQ (`docs/user-guide/`).
 - `@stratum/mcp` (`mcp/`): MCP server exposing the full eval-gated change flow —
   projects, workspaces, commits, changes, reviews, merges, and issues — so any
   MCP-capable agent or editor (Claude Code, Cursor, Zed, Copilot, custom agents)
@@ -39,8 +51,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - High-frequency agent commits via the Durable-Object SQLite hot index (ADR 004).
 
 ### Changed
+
+- **Production signup is open.** The closed-beta invite gate is off in the
+  production config (`BETA_GATE = "0"`); staging keeps it on so the invite path
+  stays exercised. Takes effect on the next production deploy.
 - **LLM evaluator fails closed.** An unparseable model response now scores 0 and blocks,
-  instead of inferring a 0.8 score from "LGTM" prose.
+  instead of inferring a 0.8 score from "LGTM" prose. Non-finite scores (JSON
+  `1e999`) fail closed rather than clamping to a pass, and `maxDiffChars` is
+  floored/bounded to [1000, 100k] so a tiny or fractional window can never send
+  the model an empty diff.
+- README repositioned around the control plane: Stratum is the governance layer
+  for AI-written code on top of wherever code lives, usable from any agent or
+  editor.
+- CLI and MCP clients reject project references with extra path segments instead
+  of silently truncating; the MCP client enforces a request deadline (default
+  120s) so a stalled API can't hang a tool call forever.
 
 ## [0.1.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to restore it.
 
 ### Added
+- `@stratum/mcp` (`mcp/`): MCP server exposing the full eval-gated change flow —
+  projects, workspaces, commits, changes, reviews, merges, and issues — so any
+  MCP-capable agent or editor (Claude Code, Cursor, Zed, Copilot, custom agents)
+  can work against Stratum without a bespoke integration.
+- Secret scanner now covers 25+ credential patterns (GitHub fine-grained PATs, GitLab,
+  Slack, Stripe, OpenAI, Anthropic, Google, npm, PyPI, Hugging Face, SendGrid, Twilio,
+  Azure, private-key blocks, JWTs, connection-string credentials) plus Shannon-entropy
+  detection for generic high-entropy credentials in keyword context.
+- LLM evaluator: review window is configurable via `maxDiffChars` in the policy
+  (default raised 8k → 24k chars, capped at 100k); truncated evaluations say so in
+  their result issues; the evaluator now sends a real reviewer system prompt.
+
 - Open-source onboarding: `LICENSE` (MIT), `CONTRIBUTING.md`, `SECURITY.md`, `AGENTS.md`,
   issue and pull-request templates.
 - Enforced test-coverage thresholds in `vitest.config.ts`.
 - High-frequency agent commits via the Durable-Object SQLite hot index (ADR 004).
+
+### Changed
+- **LLM evaluator fails closed.** An unparseable model response now scores 0 and blocks,
+  instead of inferring a 0.8 score from "LGTM" prose.
 
 ## [0.1.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to restore it.
 
 ### Added
+- **Gated `git push` (ADR 005 slice 2b), staging-flagged.** With
+  `GIT_PUSH_GATED_ENABLED`, pushing to a project's default branch lands the pack
+  on a server-managed workspace fork and opens an eval-gated change through the
+  same pipeline as the REST route (now extracted to
+  `src/services/change-flow.ts`); the client gets a truthful per-ref `ng`
+  carrying the change id and eval verdict — main only moves through the merge
+  gate. On on staging, off in production until validated end-to-end.
+- `.stratum/policy.yaml` for this repository — the dogfood merge policy (diff
+  limits, LLM review at 0.6, one human approval, fresh-base required,
+  force-merge denied).
 - Split/unified diff toggle on the change review page — instant, pure-CSS switch
   (no client-side JavaScript, no reload; GitHub/GitLab need a full reload).
 - `git push` to a project URL now fails **in-protocol**: the receive-pack

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Stratum is a GitHub alternative where both humans and AI agents are first-class 
 | Issue Tracker | ✅ | Per-project issues, auto-close on linked-change merge |
 | Bidirectional GitHub Sync | ✅ | Inbound webhooks + outbound PR promotion |
 | CLI Tool | 🚧 | `@stratum/cli` at full API parity; install from `cli/` (not yet published to npm) |
+| MCP Server | 🚧 | `@stratum/mcp` — any MCP-capable agent or editor can drive the eval-gated change flow; install from `mcp/` (not yet published to npm) |
 
 **Legend:** ✅ Working | 🚧 In Progress | 📋 Planned
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,21 @@ below use `https://your-instance.workers.dev` as a placeholder for your deployme
 
 ## What is Stratum?
 
-Stratum is a GitHub alternative where both humans and AI agents are first-class citizens. It provides:
+Stratum is the **governance layer for AI-written code** — the control plane that decides
+what agent output is allowed to merge, wherever your code lives. Humans and AI agents are
+both first-class citizens, with different powers by design:
 
-- **Git repository hosting** via Cloudflare Artifacts (fast, serverless Git)
-- **Workspace forking** - Create isolated branches for changes
-- **Evaluation-gated merges** - Automated code review before merging
-- **Agent identities** - Register and authenticate AI agents
-- **Provenance tracking** - Know which AI model made what change
-- **Read-only web UI** - Browse repos, changes, and evaluation results
+- **Evaluation-gated merges** - Policy-as-code (`.stratum/policy.yaml`) blocks merges on
+  secret scans, diff rules, sandboxed tests, external CI, and LLM review
+- **Provenance & cost tracking** - Every merged commit records which agent, model, and
+  prompt produced it, its evaluation score, and what it cost (LLM tokens, sandbox time)
+- **Agent identities with a hard invariant** - Agents authenticate as themselves and can
+  never approve work; approvals are a human gate
+- **Any agent, any editor** - REST API, CLI, and MCP server: Claude Code, Cursor, Copilot,
+  or your own agents all speak to the same gate. No editor subscription required
+- **Two ways to run it** - As a **layer over GitHub** (keep your repos and PRs; eval
+  verdicts land as PR comments and commit statuses) or as a **standalone forge** (Git
+  hosting on Cloudflare Artifacts, workspace forking, issues, orgs, server-rendered UI)
 
 ## Features
 
@@ -336,7 +343,7 @@ See [Deployment Guide](docs/developer/deployment.md) for detailed instructions.
 
 - **Authorization**: Project-level access control is minimal; auth middleware resolves users but doesn't enforce ownership on all routes
 - **Merge semantics**: Squash merge only; true merge commits not yet supported
-- **Diff accuracy**: Current diff format shows full file rewrites rather than precise hunks
+- **Diff limits**: Diffs are hunk-level with unified and split views, but binary files are not diffed and very large files are rendered whole
 - **Scale**: Git operations run in-memory; large repos will hit Worker limits
 
 See [CURRENT_CAPABILITIES.md](docs/CURRENT_CAPABILITIES.md) for more details.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@stratum/cli",
       "version": "0.2.0",
+      "license": "MIT",
       "dependencies": {
         "commander": "^12.0.0"
       },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -15,10 +15,15 @@ export interface ProjectRef {
   slug: string;
 }
 
-/** Parse "ns/slug" or "@ns/slug" into a project reference. */
+/**
+ * Parse "ns/slug" or "@ns/slug" into a project reference. Exactly two
+ * non-empty segments — extra segments are rejected rather than silently
+ * dropped, so a command can never operate on a different project than named.
+ */
 export function parseProjectRef(ref: string): ProjectRef {
-  const [nsRaw, slug] = ref.split("/", 2);
-  if (!nsRaw || !slug) {
+  const segments = ref.split("/");
+  const [nsRaw, slug] = segments;
+  if (segments.length !== 2 || !nsRaw || nsRaw === "@" || !slug) {
     throw new Error(`Invalid project reference '${ref}' — expected namespace/slug`);
   }
   return { namespace: nsRaw.startsWith("@") ? nsRaw : `@${nsRaw}`, slug };

--- a/cli/tests/client.test.ts
+++ b/cli/tests/client.test.ts
@@ -17,6 +17,15 @@ describe("parseProjectRef", () => {
   it("rejects malformed references", () => {
     expect(() => parseProjectRef("just-a-name")).toThrow(/namespace\/slug/);
   });
+
+  it("rejects extra path segments instead of silently truncating", () => {
+    expect(() => parseProjectRef("team/repo/extra")).toThrow(/namespace\/slug/);
+  });
+
+  it("rejects an empty namespace", () => {
+    expect(() => parseProjectRef("@/repo")).toThrow(/namespace\/slug/);
+    expect(() => parseProjectRef("/repo")).toThrow(/namespace\/slug/);
+  });
 });
 
 describe("StratumClient", () => {

--- a/docs/REMAINING_WORK.md
+++ b/docs/REMAINING_WORK.md
@@ -79,11 +79,11 @@ so consumers must install from source.
 From [research/master-plan-alignment.md](./research/master-plan-alignment.md),
 not a master-plan line item:
 
-### Client-side unified/split diff toggle
+### Client-side unified/split diff toggle — ✅ done
 
 The diff viewer
 ([`src/ui/components/diff-view.tsx`](../src/ui/components/diff-view.tsx))
-renders unified diffs
-only. The alignment research recommends a split-view toggle that switches
-client-side — no page reload or content refetch — as a differentiator over
-GitHub/GitLab, which require a full reload to switch views.
+now renders both views and switches instantly with a pure-CSS checkbox toggle —
+no page reload, no content refetch, and no client-side JavaScript, preserving
+the server-rendered-only invariant. (GitHub/GitLab require a full reload to
+switch views.)

--- a/docs/adr/005-git-smart-http-proxy.md
+++ b/docs/adr/005-git-smart-http-proxy.md
@@ -21,13 +21,20 @@ deferred**.
   report-status is the truthful outcome — no pkt-line parsing or report-status
   synthesis needed. A streaming body cap bounds push size.
 - **Slice 2b — gated default-branch push (deferred, Phase B).** Pushing to the
-  **project** URL (`/@ns/slug.git`) is still refused (`403`). Routing a push
-  through the change → eval → MergeQueue gate requires: pinning the evaluated sha
-  and **merging by sha** (not the fork's mutable tip — TOCTOU/gate-bypass);
+  **project** URL (`/@ns/slug.git`) is still refused, but the refusal is now
+  **in-protocol**: the receive-pack advertisement is proxied (write-authorized),
+  the RPC parses the client's command list, and each ref update is answered with
+  a `ng` report-status line plus side-band guidance naming the workspace remote
+  — so `git push` exits non-zero with a legible reason instead of an opaque HTTP
+  403. The wire-protocol groundwork (pkt-line parse of receive-pack commands +
+  capabilities, sideband encoding, synthesized report-status — the "fiddly and
+  must be got right" part below) lives in `src/utils/git-protocol.ts` with a
+  full test suite. What remains for the real gated push: pinning the evaluated
+  sha and **merging by sha** (not the fork's mutable tip — TOCTOU/gate-bypass);
   durable async eval (a queue + sweeper + dedupe, not `waitUntil`); idempotent
   change creation under concurrent pushes (a DB uniqueness constraint); and
-  Gerrit-style `refs/for/main` → `ok` semantics with synthesized report-status.
-  Tracked in #115.
+  landing the incoming pack on a server-managed workspace ref before answering
+  `ok`. Tracked in #115.
 
 ## Context
 

--- a/docs/adr/005-git-smart-http-proxy.md
+++ b/docs/adr/005-git-smart-http-proxy.md
@@ -20,21 +20,26 @@ deferred**.
   the client clones the workspace, ref/old-oid semantics line up and Artifacts'
   report-status is the truthful outcome — no pkt-line parsing or report-status
   synthesis needed. A streaming body cap bounds push size.
-- **Slice 2b — gated default-branch push (deferred, Phase B).** Pushing to the
-  **project** URL (`/@ns/slug.git`) is still refused, but the refusal is now
-  **in-protocol**: the receive-pack advertisement is proxied (write-authorized),
-  the RPC parses the client's command list, and each ref update is answered with
-  a `ng` report-status line plus side-band guidance naming the workspace remote
-  — so `git push` exits non-zero with a legible reason instead of an opaque HTTP
-  403. The wire-protocol groundwork (pkt-line parse of receive-pack commands +
-  capabilities, sideband encoding, synthesized report-status — the "fiddly and
-  must be got right" part below) lives in `src/utils/git-protocol.ts` with a
-  full test suite. What remains for the real gated push: pinning the evaluated
-  sha and **merging by sha** (not the fork's mutable tip — TOCTOU/gate-bypass);
-  durable async eval (a queue + sweeper + dedupe, not `waitUntil`); idempotent
-  change creation under concurrent pushes (a DB uniqueness constraint); and
-  landing the incoming pack on a server-managed workspace ref before answering
-  `ok`. Tracked in #115.
+- **Slice 2b — gated default-branch push (implemented, staging-flagged).**
+  Behind `GIT_PUSH_GATED_ENABLED` ("true" on staging, "false" in production
+  until validated against real Artifacts), a single-ref push to
+  `refs/heads/main` on the **project** URL is routed through the change gate:
+  the pack lands on a fresh server-managed workspace fork (whose `main` sits at
+  the project tip, so the client's old-oid lines up and the remote's own
+  fast-forward check stays truthful), then the shared change-flow service
+  (`src/services/change-flow.ts` — the same pipeline the REST route runs)
+  creates and synchronously evaluates a change. The client receives a
+  **truthful `ng`** carrying the change id and eval verdict, with detail on the
+  side-band: `main` does not move until the change is approved and merged, and
+  answering `ok` would corrupt the client's remote-tracking ref. Multi-ref
+  pushes, deletions, and non-default refs keep the in-protocol refusal; a pack
+  the workspace remote itself rejects is relayed verbatim. Evaluation runs
+  synchronously inside the push request — the same latency contract as
+  `POST /changes` — so the durable async-eval queue is an optimization, not a
+  prerequisite. Remaining for #115: answer `ok` by actually merging when policy
+  allows it (eval passed, zero required approvals) and change-per-push
+  idempotency under concurrent identical pushes (today each push opens its own
+  workspace + change, which is safe but can duplicate).
 
 ## Context
 

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -1,56 +1,239 @@
 openapi: 3.1.0
 info:
   title: Stratum API
-  description: A code collaboration platform for the AI engineering era
+  description: |
+    A code collaboration platform for the AI engineering era.
+
+    This specification is generated from the route code (`src/index.ts` and
+    `src/routes/*.ts`) and covers every `/api/*` route, the root health check,
+    and the GitHub webhook receiver.
+
+    Not covered here:
+    - HTML page routes (`/`, `/p/*`, `/changes/*`, `/auth/*`, `/dev-login`, `/ui.css`, ...).
+    - The git smart-HTTP endpoints (`/@{namespace}/{slug}/info/refs`,
+      `git-upload-pack`, `git-receive-pack`) — documented separately in
+      `docs/adr/005`.
+
+    Authentication: most endpoints accept a Stratum API token (user or agent)
+    as a `Authorization: Bearer <token>` header. Browser requests may instead be
+    authenticated by the `stratum_session` cookie. Read endpoints on projects
+    with `visibility: public` also accept anonymous requests. Admin endpoints
+    additionally accept an `X-Admin-API-Key` header.
+
+    Several form-friendly endpoints return a `302` redirect instead of JSON when
+    the request body is form-encoded rather than `application/json`; this spec
+    documents the JSON behaviour.
   version: 1.0.0
 
 servers:
   - url: https://your-instance.workers.dev
     description: Production
 
+security:
+  - bearerAuth: []
+
+tags:
+  - name: health
+    description: Liveness and dependency health checks
+  - name: projects
+    description: Project creation, metadata, files, and history
+  - name: imports
+    description: Importing repositories from GitHub/GitLab/Bitbucket
+  - name: sync
+    description: Keeping imported projects in sync with their source repository
+  - name: workspaces
+    description: Workspace (fork) lifecycle and commits
+  - name: changes
+    description: Changes (evaluated merge proposals) and merge operations
+  - name: reviews
+    description: Human review verdicts and comments on changes
+  - name: issues
+    description: Project issues
+  - name: webhooks
+    description: Outbound project webhooks
+  - name: orgs
+    description: Organizations, members, and teams
+  - name: users
+    description: The authenticated user's account
+  - name: agents
+    description: Agent registration and tokens
+  - name: bulk-import
+    description: Importing many repositories at once
+  - name: github
+    description: Inbound GitHub webhook receiver
+  - name: admin
+    description: Administrator-only operations (metrics, audit, backup, restore, deletion jobs)
+
 paths:
   /health:
     get:
-      summary: Health check
+      operationId: rootHealth
+      tags: [health]
+      summary: Basic health check
+      security: []
       responses:
-        '200':
-          description: OK
+        "200":
+          description: Service is up
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: ok }
+                  service: { type: string, example: stratum }
+
+  /api/health:
+    get:
+      operationId: healthCheck
+      tags: [health]
+      summary: Comprehensive health check of all system dependencies
+      security: []
+      responses:
+        "200":
+          description: Healthy or degraded (queue-only failure)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthCheckResponse"
+        "503":
+          description: Unhealthy — a critical dependency (database, KV, artifacts) failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthCheckResponse"
+
+  /api/health/simple:
+    get:
+      operationId: healthSimple
+      tags: [health]
+      summary: Simple liveness check
+      security: []
+      responses:
+        "200":
+          description: Service is up
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: ok }
+                  service: { type: string, example: stratum }
+                  timestamp: { type: string, format: date-time }
 
   /api/projects:
-    get:
-      summary: List projects
-      responses:
-        '200':
-          description: List of projects
     post:
-      summary: Create project
+      operationId: createProject
+      tags: [projects]
+      summary: Create a project
+      description: |
+        Creates a project (and its backing Artifacts git repo) in the caller's
+        namespace, or in an organization's namespace when `org` is given (the
+        caller needs org write access). Also accepts form-encoded bodies.
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
+              required: [name]
               properties:
                 name:
                   type: string
+                  description: 1-64 char alphanumeric slug
+                visibility:
+                  type: string
+                  enum: [private, public]
+                  default: private
+                files:
+                  type: object
+                  additionalProperties: { type: string }
+                  description: Initial file map (path -> contents). Defaults to a single `.gitkeep`, or starter files when `seed` is true.
+                seed:
+                  type: boolean
+                  description: Seed the repo with default starter files
+                org:
+                  type: string
+                  description: Organization slug to own the project
       responses:
-        '201':
+        "201":
           description: Project created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, name, namespace, slug]
+                properties:
+                  id: { type: string, format: uuid }
+                  name: { type: string }
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  remote: { type: string }
+                  commit:
+                    type: string
+                    description: SHA of the initial commit
+                  visibility: { type: string, enum: [private, public] }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Organization not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listProjects
+      tags: [projects]
+      summary: List projects in the caller's namespace
+      description: Returns an empty list for unauthenticated callers. Results are filtered to projects the caller can read.
+      responses:
+        "200":
+          description: Projects the caller can read
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [projects]
+                properties:
+                  projects:
+                    type: array
+                    items: { $ref: "#/components/schemas/Project" }
+        "500":
+          $ref: "#/components/responses/InternalError"
 
   /api/projects/{namespace}/{slug}:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: getProject
+      tags: [projects]
+      summary: Get a project
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Project details
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Project" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
     delete:
+      operationId: deleteProject
+      tags: [projects]
       summary: Delete project (owner-only, cascading, async)
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: slug
-          in: path
-          required: true
-          schema:
-            type: string
+      description: |
+        Owner-only. Requires a confirm token that EXACTLY equals
+        `@namespace/slug`. Enqueues a durable deletion job; a repeated request
+        while a cascade is in flight returns the same in-flight job.
+        Non-owners receive a 404 (existence is not disclosed).
       requestBody:
         required: true
         content:
@@ -63,28 +246,1952 @@ paths:
                   type: string
                   description: Must exactly equal "@namespace/slug".
       responses:
-        '202':
+        "202":
           description: Deletion enqueued
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/DeletionAccepted" }
+        "400":
+          description: Confirmation mismatch
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Not found or not the owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/delete:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: deleteProjectForm
+      tags: [projects]
+      summary: Delete project (form-friendly alias of DELETE)
+      description: Same semantics as `DELETE /api/projects/{namespace}/{slug}` for HTML forms that cannot send DELETE.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [confirm]
+              properties:
+                confirm: { type: string }
+      responses:
+        "202":
+          description: Deletion enqueued (JSON callers)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/DeletionAccepted" }
+        "302":
+          description: Redirect to home (form callers)
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/projects/{namespace}/{slug}/import:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: importProject
+      tags: [imports]
+      summary: Import a repository from GitHub/GitLab/Bitbucket
+      description: |
+        Creates the project and queues a background import. Rate limited
+        (3 imports/minute per user, 1 concurrent import per project). Imports
+        are only allowed into the caller's own namespace. If the project
+        already exists with an incomplete import, the import is re-triggered
+        and a 200 is returned.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [url]
+              properties:
+                url:
+                  type: string
+                  description: Repository URL (GitHub, GitLab, or Bitbucket)
+                branch:
+                  type: string
+                  default: main
+                depth:
+                  type: integer
+                  description: Clone depth
+                visibility:
+                  type: string
+                  enum: [private, public]
+                  default: private
+      responses:
+        "201":
+          description: Import queued
           content:
             application/json:
               schema:
                 type: object
-                required: [status, jobId]
                 properties:
-                  status:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  importId: { type: string }
+                  path: { type: string }
+                  status: { type: string, example: queued }
+                  source: { type: string }
+                  visibility: { type: string, enum: [private, public] }
+        "200":
+          description: Project already exists (incomplete imports are re-triggered)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  remote: { type: string }
+                  source: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          description: Import rate limit exceeded
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/import/status:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: getImportStatus
+      tags: [imports]
+      summary: Get import progress (for polling)
+      description: Also detects and recovers imports stalled for more than 5 minutes.
+      responses:
+        "200":
+          description: Import progress
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ImportProgress" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/import/stream:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: streamImportStatus
+      tags: [imports]
+      summary: Import progress as Server-Sent Events
+      description: Emits an `ImportProgress` JSON object as an SSE `data:` line every 2 seconds until the import completes, fails, or is cancelled.
+      responses:
+        "200":
+          description: SSE stream of import progress
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/projects/{namespace}/{slug}/import/retry:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: retryImport
+      tags: [imports]
+      summary: Retry a failed import
+      description: Rate limited like the initial import. Only allowed in the caller's own namespace.
+      responses:
+        "200":
+          description: Retry initiated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+                  namespace: { type: string }
+                  slug: { type: string }
+                  status: { type: string, example: queued }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/import/cancel:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: cancelImport
+      tags: [imports]
+      summary: Cancel an ongoing import
+      responses:
+        "200":
+          description: Cancellation requested or completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+                  namespace: { type: string }
+                  slug: { type: string }
+                  status: { type: string, enum: [cancelled, cancelling] }
+        "400":
+          description: Import is not in a cancellable state
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/files:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: listProjectFiles
+      tags: [projects]
+      summary: List files in the project repository
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: File listing
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  files:
+                    type: array
+                    items: { type: string }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/content:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: getFileContent
+      tags: [projects]
+      summary: Get file content by path
+      security: [{ bearerAuth: [] }, {}]
+      parameters:
+        - name: path
+          in: query
+          required: true
+          schema: { type: string }
+          description: File path within the repository
+      responses:
+        "200":
+          description: File content, or a marker for binary/oversized files
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [namespace, slug, path, kind]
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  kind:
                     type: string
-                    example: deleting
-                  jobId:
+                    description: '"content" when `value` carries the text; other kinds (e.g. binary/too-large) omit `value`.'
+                  value:
                     type: string
-                    example: del_abc123
-        '400':
-          description: Confirmation mismatch
-        '404':
-          description: Not found or not the owner
+                    description: Present only when kind is "content"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/log:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: getCommitLog
+      tags: [projects]
+      summary: Get the project's commit log
+      security: [{ bearerAuth: [] }, {}]
+      parameters:
+        - name: depth
+          in: query
+          schema: { type: integer, default: 20 }
+          description: Number of commits to return
+      responses:
+        "200":
+          description: Commit log
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  log:
+                    type: array
+                    items: { $ref: "#/components/schemas/CommitLogEntry" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/provenance:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: listProvenance
+      tags: [projects]
+      summary: List provenance records (which agent/model produced each merged commit)
+      security: [{ bearerAuth: [] }, {}]
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer }
+      responses:
+        "200":
+          description: Provenance records
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  records:
+                    type: array
+                    items: { $ref: "#/components/schemas/ProvenanceRecord" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/activity:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: listActivity
+      tags: [projects]
+      summary: Project activity feed (domain events)
+      security: [{ bearerAuth: [] }, {}]
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer, default: 50, maximum: 200 }
+      responses:
+        "200":
+          description: Activity events, newest first
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  events:
+                    type: array
+                    items: { $ref: "#/components/schemas/ActivityEvent" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/sync:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: syncProject
+      tags: [sync]
+      summary: Re-sync the project with its source repository
+      description: |
+        Checks the source remote (GitHub/GitLab/Bitbucket) for new commits and,
+        when updates exist, queues a background sync. Only allowed in the
+        caller's own namespace.
+      responses:
+        "200":
+          description: Sync initiated, or already up to date
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+                  namespace: { type: string }
+                  slug: { type: string }
+                  importId: { type: string }
+                  status: { type: string, example: queued }
+                  hasUpdates: { type: boolean }
+                  commitsBehind: { type: integer }
+                  latestCommit: { type: string }
+                  lastSyncedCommit: { type: string }
+        "400":
+          description: Not connected to a remote, unsupported provider, or a sync is already in progress
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/sync/status:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: getSyncStatus
+      tags: [sync]
+      summary: Get sync status for a project
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Sync status
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SyncStatus" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/sync/settings:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: updateSyncSettings
+      tags: [sync]
+      summary: Update sync settings (auto-sync, frequency)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                autoSyncEnabled: { type: boolean }
+                syncFrequency:
+                  type: integer
+                  description: Minutes between auto-syncs
+      responses:
+        "200":
+          description: Settings saved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
+                  autoSyncEnabled: { type: boolean }
+                  syncFrequency: { type: integer }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/sync/history:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: getSyncHistory
+      tags: [sync]
+      summary: Get sync history for a project
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer, default: 50 }
+        - name: offset
+          in: query
+          schema: { type: integer, default: 0 }
+      responses:
+        "200":
+          description: Sync history entries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  history:
+                    type: array
+                    items:
+                      type: object
+                      description: Recorded sync run (trigger, status, synced commit, timings)
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/projects/{namespace}/{slug}/sync/stream:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: streamSyncStatus
+      tags: [sync]
+      summary: Sync status as Server-Sent Events
+      description: Emits the sync-status object every 2 seconds until the sync succeeds or fails; the stream self-closes after 5 minutes.
+      responses:
+        "200":
+          description: SSE stream of sync status
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/projects/conflicts/{id}/resolve:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+        description: Conflict id returned by a merge that failed with MERGE_CONFLICT
+    post:
+      operationId: resolveConflict
+      tags: [sync, changes]
+      summary: Resolve a recorded merge conflict
+      description: |
+        Applies a resolution strategy to a conflict previously recorded by a
+        failed merge and commits the result to the project. Requires project
+        write access.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [strategy]
+              properties:
+                strategy:
+                  type: string
+                  enum: [accept-project, accept-workspace, manual]
+                resolutions:
+                  type: array
+                  description: Required for the manual strategy
+                  items:
+                    type: object
+                    required: [file, content]
+                    properties:
+                      file: { type: string }
+                      content: { type: string }
+      responses:
+        "200":
+          description: Conflict resolved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: resolved }
+                  commitSha: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "410":
+          description: Conflict not found or already resolved
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "422":
+          description: Resolution failed to apply (or invalid file path)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "502":
+          description: Failed to mint repository tokens
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/projects/{namespace}/{slug}/webhooks:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: createWebhook
+      tags: [webhooks]
+      summary: Create an outbound webhook
+      description: |
+        Requires project write access. The webhook `secret` is returned only on
+        creation; receivers verify the `X-Stratum-Signature` header with it.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [url]
+              properties:
+                url: { type: string, format: uri }
+                events:
+                  type: string
+                  description: |
+                    "*" (default) or a comma-separated subset of:
+                    change.created, change.evaluated, change.merged,
+                    change.rejected, change.reverted, change.commented,
+                    change.reviewed, project.created, project.imported,
+                    workspace.created, sync.completed, issue.opened, issue.closed
+      responses:
+        "201":
+          description: Webhook created (includes the secret, shown once)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  webhook: { $ref: "#/components/schemas/Webhook" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listWebhooks
+      tags: [webhooks]
+      summary: List webhooks (secrets omitted)
+      description: Requires project write access — webhook URLs are sensitive.
+      responses:
+        "200":
+          description: Webhooks without secrets
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  webhooks:
+                    type: array
+                    items: { $ref: "#/components/schemas/Webhook" }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/webhooks/{id}:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    delete:
+      operationId: deleteWebhook
+      tags: [webhooks]
+      summary: Delete a webhook
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+                  id: { type: string }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/webhooks/{id}/deliveries:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      operationId: listWebhookDeliveries
+      tags: [webhooks]
+      summary: List recent webhook deliveries
+      responses:
+        "200":
+          description: Delivery log
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deliveries:
+                    type: array
+                    items: { $ref: "#/components/schemas/WebhookDelivery" }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/webhooks/{id}/toggle:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      operationId: toggleWebhook
+      tags: [webhooks]
+      summary: Enable or disable a webhook (flips the current state)
+      responses:
+        "200":
+          description: New state
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  active: { type: boolean }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/webhooks/{id}/delete:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      operationId: deleteWebhookForm
+      tags: [webhooks]
+      summary: Delete a webhook (form-friendly alias)
+      responses:
+        "302":
+          description: Redirect back to the project's webhooks page
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/projects/{namespace}/{slug}/issues:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: createIssue
+      tags: [issues]
+      summary: Open an issue
+      description: Anyone who can read the project can open issues. Also accepts form bodies (which redirect on success).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title]
+              properties:
+                title: { type: string, maxLength: 200 }
+                body: { type: string, maxLength: 20000 }
+                linkedChangeId:
+                  type: string
+                  description: Must reference a change in this project
+      responses:
+        "201":
+          description: Issue created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  issue: { $ref: "#/components/schemas/Issue" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/TargetDeleting"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listIssues
+      tags: [issues]
+      summary: List issues
+      security: [{ bearerAuth: [] }, {}]
+      parameters:
+        - name: status
+          in: query
+          schema: { type: string, enum: [open, closed] }
+        - name: limit
+          in: query
+          schema: { type: integer, default: 100, maximum: 500 }
+      responses:
+        "200":
+          description: Issues
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  issues:
+                    type: array
+                    items: { $ref: "#/components/schemas/Issue" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/issues/{number}:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: number
+        in: path
+        required: true
+        schema: { type: integer, minimum: 1 }
+    get:
+      operationId: getIssue
+      tags: [issues]
+      summary: Issue detail
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Issue
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  issue: { $ref: "#/components/schemas/Issue" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    patch:
+      operationId: updateIssue
+      tags: [issues]
+      summary: Edit, close, or reopen an issue
+      description: Requires project write access. Users only (agent tokens cannot edit issues).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title: { type: string, maxLength: 200 }
+                body: { type: string, maxLength: 20000 }
+                status: { type: string, enum: [open, closed] }
+                linkedChangeId:
+                  type: [string, "null"]
+                  description: Set to null or "" to unlink
+      responses:
+        "200":
+          description: Updated issue
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  issue: { $ref: "#/components/schemas/Issue" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/issues/{number}/close:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: number
+        in: path
+        required: true
+        schema: { type: integer, minimum: 1 }
+    post:
+      operationId: toggleIssueClosed
+      tags: [issues]
+      summary: Toggle an issue open/closed (form-friendly)
+      description: Flips the issue's status and redirects to the issue page.
+      responses:
+        "302":
+          description: Redirect to the issue page
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/projects/{name}/changes:
+    parameters:
+      - $ref: "#/components/parameters/ProjectName"
+    post:
+      operationId: createChange
+      tags: [changes]
+      summary: Create a change from a workspace and evaluate it
+      description: |
+        Diffs the workspace against the project, runs the project's evaluator
+        policy (secret scan always; diff/webhook/llm/sandbox per policy), records
+        eval runs, and sets the change status to `accepted` or `needs_changes`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [workspace]
+              properties:
+                workspace: { type: string }
+      responses:
+        "201":
+          description: Change created and evaluated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  change: { $ref: "#/components/schemas/Change" }
+                  eval: { $ref: "#/components/schemas/EvalResult" }
+                  evalRuns:
+                    type: array
+                    items: { $ref: "#/components/schemas/EvalRun" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/TargetDeleting"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listChanges
+      tags: [changes]
+      summary: List changes for a project
+      security: [{ bearerAuth: [] }, {}]
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [open, needs_changes, accepted, approved, promoted, merged, rejected]
+        - name: limit
+          in: query
+          schema: { type: integer, default: 100, maximum: 500 }
+      responses:
+        "200":
+          description: Changes
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  project: { type: string }
+                  changes:
+                    type: array
+                    items: { $ref: "#/components/schemas/Change" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/projects/{name}/changes/merge-batch:
+    parameters:
+      - $ref: "#/components/parameters/ProjectName"
+    post:
+      operationId: mergeBatch
+      tags: [changes]
+      summary: Merge many changes into the project in one request
+      description: |
+        Batched server-side merge (ADR 004): resolves and policy-gates every
+        change, then merges the eligible ones onto the project head with a
+        single push. At most 80 changes per request. Requires the RepoDO
+        backend to be enabled. `force` is deny-by-default and must be allowed
+        by the project policy (`merge.allowForce: true`).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [changeIds]
+              properties:
+                changeIds:
+                  type: array
+                  maxItems: 80
+                  items: { type: string }
+                force: { type: boolean, default: false }
+      responses:
+        "200":
+          description: Batch outcome
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  merged:
+                    type: array
+                    items: { type: string }
+                  conflicted:
+                    type: array
+                    items: { type: string }
+                  skipped:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        changeId: { type: string }
+                        reason: { type: string }
+                  timings:
+                    type: object
+                    properties:
+                      resolveMs: { type: number }
+                      batchMs: { type: number }
+                      persistMs: { type: number }
+                      serverMs: { type: number }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/changes/{id}:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    get:
+      operationId: getChange
+      tags: [changes]
+      summary: Get a change with its eval runs and cost summary
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Change detail
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  change: { $ref: "#/components/schemas/Change" }
+                  evalRuns:
+                    type: array
+                    items: { $ref: "#/components/schemas/EvalRun" }
+                  costs:
+                    type: array
+                    items:
+                      type: object
+                      description: Per-kind cost summary for this change
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/changes/{id}/merge:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    post:
+      operationId: mergeChange
+      tags: [changes]
+      summary: Merge a change into its project
+      description: |
+        Users only. The change must be approved, accepted, or promoted (unless
+        forcing, which the project policy must allow). Branch protection,
+        stale-base (`requireFreshBase`), and stale-workspace (SEC-2) gates run
+        before the merge.
+      parameters:
+        - name: force
+          in: query
+          schema: { type: boolean, default: false }
+          description: Bypass evaluation/approval gates. Only allowed when the project policy sets `merge.allowForce`.
+        - name: strategy
+          in: query
+          schema: { type: string, enum: [merge, squash], default: merge }
+      responses:
+        "200":
+          description: Merged
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  merged: { type: boolean }
+                  changeId: { type: string }
+                  project: { type: string }
+                  workspace: { type: string }
+                  commit: { type: string }
+                  postMerge:
+                    type: object
+                    description: Post-merge policy check outcome
+                    properties:
+                      status: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Project access denied, or merge blocked by branch protection (code PROTECTION_BLOCKED with `reasons`)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Error"
+                  - type: object
+                    properties:
+                      reasons:
+                        type: array
+                        items: { type: string }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: |
+            Structured conflict responses; `code` is one of STALE_BASE,
+            STALE_WORKSPACE, WORKSPACE_UNVERIFIABLE, or MERGE_CONFLICT (which
+            includes `conflictId` and `conflictingFiles` for
+            `POST /api/projects/conflicts/{id}/resolve`).
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Error"
+                  - type: object
+                    properties:
+                      baseSha: { type: string }
+                      currentHead: { type: string }
+                      evaluatedSha: { type: string }
+                      currentTip: { type: string }
+                      conflictId: { type: string }
+                      conflictingFiles:
+                        type: array
+                        items: { type: string }
+                      message: { type: string }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/changes/{id}/reject:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    post:
+      operationId: rejectChange
+      tags: [changes]
+      summary: Reject a change
+      description: Users only. Merged changes cannot be rejected.
+      responses:
+        "200":
+          description: Rejected
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  rejected: { type: boolean }
+                  changeId: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/changes/{id}/evaluate:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    post:
+      operationId: evaluateChange
+      tags: [changes]
+      summary: Re-run evaluation for a change
+      description: Users only. Merged, rejected, or promoted changes cannot be re-evaluated.
+      responses:
+        "200":
+          description: Evaluation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  changeId: { type: string }
+                  eval: { $ref: "#/components/schemas/EvalResult" }
+                  evalRuns:
+                    type: array
+                    items: { $ref: "#/components/schemas/EvalRun" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/changes/{id}/github-pr:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    post:
+      operationId: promoteChangeToGitHubPr
+      tags: [changes]
+      summary: Promote an accepted change to a GitHub pull request
+      description: |
+        Users only. The change must be accepted (or already promoted) and the
+        project connected to GitHub with a configured GitHub token. Creates a
+        (draft by default) PR from branch `stratum/{changeId}` and marks the
+        change `promoted`.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title: { type: string }
+                body: { type: string }
+                base: { type: string, description: "Defaults to the project's default branch" }
+                draft: { type: boolean, default: true }
+      responses:
+        "200":
+          description: PR created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  changeId: { type: string }
+                  github:
+                    type: object
+                    properties:
+                      owner: { type: string }
+                      repo: { type: string }
+                      branch: { type: string }
+                      pullRequestNumber: { type: integer }
+                      pullRequestUrl: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/changes/{id}/comments:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    post:
+      operationId: addChangeComment
+      tags: [reviews]
+      summary: Add a comment to a change
+      description: Users and agents with read access to the project may comment.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [body]
+              properties:
+                body: { type: string, maxLength: 20000 }
+      responses:
+        "201":
+          description: Comment created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  comment: { $ref: "#/components/schemas/ChangeComment" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listChangeComments
+      tags: [reviews]
+      summary: List comments on a change
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Comments
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  comments:
+                    type: array
+                    items: { $ref: "#/components/schemas/ChangeComment" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/changes/{id}/reviews:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    post:
+      operationId: submitReview
+      tags: [reviews]
+      summary: Submit a human review verdict
+      description: |
+        Users only — agent tokens cannot approve work. An `approve` verdict
+        moves the change to `approved`; `request_changes` moves it to
+        `needs_changes`. Only open, needs_changes, accepted, or approved
+        changes can be reviewed.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [verdict]
+              properties:
+                verdict:
+                  type: string
+                  enum: [approve, request_changes]
+                comment: { type: string, maxLength: 20000 }
+      responses:
+        "201":
+          description: Review recorded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  review: { $ref: "#/components/schemas/Review" }
+                  changeStatus:
+                    type: string
+                    enum: [approved, needs_changes]
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/TargetDeleting"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listReviews
+      tags: [reviews]
+      summary: List reviews on a change
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Reviews
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reviews:
+                    type: array
+                    items: { $ref: "#/components/schemas/Review" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/workspaces/{namespace}/{slug}/workspaces:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: createWorkspace
+      tags: [workspaces]
+      summary: Create a workspace (fork) for a project
+      description: Requires project write access. Omitting `name` generates one (`ws-<timestamp>`).
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: 1-64 char alphanumeric slug
+      responses:
+        "201":
+          description: Workspace created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  workspace: { type: string }
+                  remote: { type: string }
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/TargetDeleting"
+    get:
+      operationId: listWorkspaces
+      tags: [workspaces]
+      summary: List workspaces for a project
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Workspaces
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  workspaces:
+                    type: array
+                    items: { $ref: "#/components/schemas/Workspace" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/workspaces/{name}/commit:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema: { type: string }
+        description: Workspace name (scoped by projectId in the body)
+    post:
+      operationId: commitToWorkspace
+      tags: [workspaces]
+      summary: Commit files to a workspace
+      description: |
+        Writes the given file map onto the workspace fork as one commit. Bounded
+        to 2000 files / 25 MiB per commit. Requires project write access AND
+        workspace write access (creator or admin); failures return 404 to avoid
+        leaking existence.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [files, message, projectId]
+              properties:
+                files:
+                  type: object
+                  additionalProperties: { type: string }
+                  description: Path -> contents map
+                message: { type: string }
+                projectId: { type: string, format: uuid }
+      responses:
+        "200":
+          description: Commit pushed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  workspace: { type: string }
+                  commit: { type: string, description: Commit SHA }
+                  filesChanged:
+                    type: array
+                    items: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/workspaces/{name}/merge:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      operationId: mergeWorkspaceDeprecated
+      tags: [workspaces]
+      summary: Deprecated workspace merge endpoint
+      deprecated: true
+      responses:
+        "410":
+          description: 'Gone — use POST /api/projects/{name}/changes instead'
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/workspaces/{name}:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema: { type: string }
+    delete:
+      operationId: deleteWorkspace
+      tags: [workspaces]
+      summary: Delete a workspace
+      description: Requires project write access AND workspace write access (creator or admin). Also deletes the backing Artifacts fork.
+      parameters:
+        - name: projectId
+          in: query
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+                  workspace: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/orgs:
+    post:
+      operationId: createOrg
+      tags: [orgs]
+      summary: Create an organization
+      description: The creator becomes an org admin. The slug must not collide with an existing username.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, slug]
+              properties:
+                name: { type: string }
+                slug: { type: string, description: 1-64 char alphanumeric slug }
+      responses:
+        "201":
+          description: Organization created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  org: { $ref: "#/components/schemas/Org" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listOrgs
+      tags: [orgs]
+      summary: List organizations the caller belongs to
+      responses:
+        "200":
+          description: Organizations
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  orgs:
+                    type: array
+                    items: { $ref: "#/components/schemas/Org" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/orgs/{slug}:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+    get:
+      operationId: getOrg
+      tags: [orgs]
+      summary: Get an organization (members only)
+      description: Non-members receive the same 404 as a missing org.
+      responses:
+        "200":
+          description: Organization
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  org: { $ref: "#/components/schemas/Org" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/orgs/{slug}/members:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+    post:
+      operationId: addOrgMember
+      tags: [orgs]
+      summary: Add an organization member (admins only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId]
+              properties:
+                userId: { type: string }
+                role:
+                  type: string
+                  enum: [member, admin]
+                  default: member
+      responses:
+        "200":
+          description: Member added
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  added: { type: boolean }
+                  orgId: { type: string }
+                  userId: { type: string }
+                  role: { type: string, enum: [member, admin] }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/orgs/{slug}/members/{uid}:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+      - name: uid
+        in: path
+        required: true
+        schema: { type: string }
+        description: User id of the member to remove
+    delete:
+      operationId: removeOrgMember
+      tags: [orgs]
+      summary: Remove an organization member (admins only)
+      responses:
+        "200":
+          description: Member removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  removed: { type: boolean }
+                  orgId: { type: string }
+                  userId: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/orgs/{slug}/teams:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+    post:
+      operationId: createTeam
+      tags: [orgs]
+      summary: Create a team (admins only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, slug]
+              properties:
+                name: { type: string }
+                slug: { type: string }
+                permissions:
+                  type: string
+                  enum: [read, write, admin]
+                  default: read
+      responses:
+        "201":
+          description: Team created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  team: { $ref: "#/components/schemas/Team" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listTeams
+      tags: [orgs]
+      summary: List teams (members only)
+      responses:
+        "200":
+          description: Teams
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  teams:
+                    type: array
+                    items: { $ref: "#/components/schemas/Team" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/orgs/{slug}/teams/{id}:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    delete:
+      operationId: deleteTeam
+      tags: [orgs]
+      summary: Delete a team (admins only)
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+                  id: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/orgs/{slug}/teams/{id}/members:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      operationId: addTeamMember
+      tags: [orgs]
+      summary: Add a team member (admins only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId]
+              properties:
+                userId: { type: string }
+      responses:
+        "200":
+          description: Member added
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  added: { type: boolean }
+                  teamId: { type: string }
+                  userId: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/orgs/{slug}/teams/{id}/members/{uid}:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+      - name: uid
+        in: path
+        required: true
+        schema: { type: string }
+    delete:
+      operationId: removeTeamMember
+      tags: [orgs]
+      summary: Remove a team member (admins only)
+      responses:
+        "200":
+          description: Member removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  removed: { type: boolean }
+                  teamId: { type: string }
+                  userId: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
 
   /api/users/me:
+    get:
+      operationId: getMe
+      tags: [users]
+      summary: Get the authenticated user
+      responses:
+        "200":
+          description: Current user
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  email: { type: string, format: email }
+                  createdAt: { type: string, format: date-time }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
     delete:
+      operationId: deleteAccount
+      tags: [users]
       summary: Delete account (GDPR erasure, self-only, async)
+      description: |
+        Requires a confirm token equal to the caller's username. Marks the
+        account as deleting (credentials are invalidated immediately) and
+        enqueues the erasure cascade job.
       requestBody:
         required: true
         content:
@@ -97,21 +2204,1284 @@ paths:
                   type: string
                   description: Must exactly equal the caller's username.
       responses:
-        '202':
+        "202":
           description: Erasure enqueued (jobId returned); credentials invalidated immediately
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/DeletionAccepted" }
+        "400":
+          description: Confirmation mismatch
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated, or the user no longer exists
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/users/me/rotate-token:
+    post:
+      operationId: rotateToken
+      tags: [users]
+      summary: Rotate the caller's API token
+      description: The old token is invalid as of this response; the new one is shown once.
+      responses:
+        "200":
+          description: New API token
           content:
             application/json:
               schema:
                 type: object
-                required: [status, jobId]
+                required: [token]
                 properties:
-                  status:
+                  token: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/users/me/delete:
+    post:
+      operationId: deleteAccountForm
+      tags: [users]
+      summary: Delete account (form-friendly alias of DELETE /api/users/me)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [confirm]
+              properties:
+                confirm: { type: string }
+      responses:
+        "202":
+          description: Erasure enqueued (JSON callers)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/DeletionAccepted" }
+        "302":
+          description: Redirect to home (form callers)
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/users/check-username:
+    get:
+      operationId: checkUsername
+      tags: [users]
+      summary: Check whether a username is available
+      security: []
+      parameters:
+        - name: username
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Availability result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available: { type: boolean }
+                  message: { type: string }
+        "400":
+          description: Missing or invalid username (same body shape, available=false)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available: { type: boolean }
+                  message: { type: string }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/agents:
+    post:
+      operationId: createAgent
+      tags: [agents]
+      summary: Register an agent and mint its token
+      description: The agent token is returned once, on creation.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+                model: { type: string }
+                description: { type: string }
+                promptHash: { type: string }
+      responses:
+        "201":
+          description: Agent created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent: { $ref: "#/components/schemas/Agent" }
+                  token:
                     type: string
-                    example: deleting
-                  jobId:
-                    type: string
-                    example: del_abc123
-        '400':
-          description: Confirmation mismatch
-        '401':
-          description: Not authenticated, or the user no longer exists
+                    description: Plaintext agent token, shown once
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listAgents
+      tags: [agents]
+      summary: List the caller's agents
+      responses:
+        "200":
+          description: Agents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agents:
+                    type: array
+                    items: { $ref: "#/components/schemas/Agent" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/agents/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      operationId: getAgent
+      tags: [agents]
+      summary: Get an agent (owner only)
+      description: Non-owners receive a 404 (existence is not disclosed).
+      responses:
+        "200":
+          description: Agent
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Agent" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    delete:
+      operationId: deleteAgent
+      tags: [agents]
+      summary: Delete (revoke) an agent
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+                  id: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/bulk-import:
+    post:
+      operationId: startBulkImport
+      tags: [bulk-import]
+      summary: Start a bulk import job (up to 50 repositories)
+      description: Imports run in the background; poll `GET /api/bulk-import/{id}` for status. Only the caller's own namespace is allowed.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [repos]
+              properties:
+                repos:
+                  type: array
+                  minItems: 1
+                  maxItems: 50
+                  items:
+                    type: object
+                    required: [url]
+                    properties:
+                      url: { type: string }
+                      namespace: { type: string }
+                      slug: { type: string }
+                      branch: { type: string }
+                      visibility:
+                        type: string
+                        enum: [private, public]
+      responses:
+        "201":
+          description: Job started
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId: { type: string }
+                  status: { type: string, example: queued }
+                  totalRepos: { type: integer }
+                  message: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    get:
+      operationId: listBulkImportJobs
+      tags: [bulk-import]
+      summary: List the caller's bulk import jobs
+      responses:
+        "200":
+          description: Jobs, newest first
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobs:
+                    type: array
+                    items: { $ref: "#/components/schemas/BulkImportJobSummary" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/bulk-import/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      operationId: getBulkImportJob
+      tags: [bulk-import]
+      summary: Get bulk import job status
+      responses:
+        "200":
+          description: Job status with progress
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/BulkImportJobStatus" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/webhooks/github:
+    post:
+      operationId: receiveGitHubWebhook
+      tags: [github]
+      summary: GitHub webhook receiver
+      description: |
+        Inbound receiver for GitHub `push`, `pull_request`,
+        `pull_request_review`, and `ping` events. Authenticated by HMAC
+        signature (`X-Hub-Signature-256`) against the configured webhook
+        secret, not by bearer token. Requires `X-GitHub-Event` and
+        `X-GitHub-Delivery` headers; duplicate delivery ids are skipped.
+        Processing errors still return 200 to prevent GitHub retries.
+      security: []
+      parameters:
+        - name: X-Hub-Signature-256
+          in: header
+          required: true
+          schema: { type: string }
+        - name: X-GitHub-Event
+          in: header
+          required: true
+          schema: { type: string }
+        - name: X-GitHub-Delivery
+          in: header
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Raw GitHub webhook payload for the event type
+      responses:
+        "200":
+          description: Received (possibly a duplicate, or with a logged processing error)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  received: { type: boolean }
+                  duplicate: { type: boolean }
+                  error: { type: string }
+        "400":
+          description: Missing headers or invalid JSON
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Invalid signature
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "501":
+          description: Webhook secret not configured
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/admin/metrics:
+    get:
+      operationId: adminMetrics
+      tags: [admin]
+      summary: Import and commit/merge metrics dashboard
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Metrics summary (totals, rates, performance, time windows, queue status, error breakdown)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  timestamp: { type: string, format: date-time }
+                  commits: { type: object }
+                  totals: { type: object }
+                  rates: { type: object }
+                  performance: { type: object }
+                  timeWindows: { type: object }
+                  queue: { type: object }
+                  errors: { type: object }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/metrics/health:
+    get:
+      operationId: adminMetricsHealth
+      tags: [admin]
+      summary: Quick admin health check with key metrics
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Key metrics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+                  timestamp: { type: string, format: date-time }
+                  recentFailures24h: { type: integer }
+                  activeImports: { type: integer }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/metrics/bench:
+    post:
+      operationId: adminBenchCommit
+      tags: [admin]
+      summary: Commit-throughput probe (ADR 004 Phase 2)
+      description: Writes one R2 git blob and drives a group-commit ref advance through the RepoDO. Intended for benchmark scripts.
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      parameters:
+        - name: repo
+          in: query
+          schema: { type: string, default: bench-repo }
+        - name: path
+          in: query
+          schema: { type: string, default: shared.txt }
+        - name: bytes
+          in: query
+          schema: { type: integer, default: 256, minimum: 1, maximum: 100000 }
+      responses:
+        "200":
+          description: Blob written and ref advanced
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  blob: { type: string, description: Blob oid }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/metrics/bench-stats:
+    get:
+      operationId: adminBenchStats
+      tags: [admin]
+      summary: Read the bench Durable Object's counters
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      parameters:
+        - name: repo
+          in: query
+          schema: { type: string, default: bench-repo }
+      responses:
+        "200":
+          description: Bench counters
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  head: { type: string }
+                  batches: { type: integer }
+                  landed: { type: integer }
+                  conflictsResolved: { type: integer }
+                  treeSize: { type: integer }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/metrics/artifacts-bench:
+    post:
+      operationId: adminArtifactsBench
+      tags: [admin]
+      summary: Measure Artifacts single-repo push throughput
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      parameters:
+        - name: iterations
+          in: query
+          schema: { type: integer, default: 20, minimum: 1, maximum: 200 }
+        - name: batch
+          in: query
+          schema: { type: integer, default: 1, minimum: 1, maximum: 256 }
+        - name: bytes
+          in: query
+          schema: { type: integer, default: 256, minimum: 1, maximum: 100000 }
+      responses:
+        "200":
+          description: Push latency percentiles and effective commits/sec
+          content:
+            application/json:
+              schema: { type: object }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/metrics/realflow-bench:
+    post:
+      operationId: adminRealflowBench
+      tags: [admin]
+      summary: Batched-merge real-flow benchmark (ADR 004 Task 1)
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      parameters:
+        - name: n
+          in: query
+          schema: { type: integer, default: 25, minimum: 1, maximum: 50 }
+      responses:
+        "200":
+          description: Fetch/merge/push timing breakdown
+          content:
+            application/json:
+              schema: { type: object }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/metrics/r2flow-bench:
+    post:
+      operationId: adminR2flowBench
+      tags: [admin]
+      summary: R2-fed merge-flow benchmark (ADR 004 Task 1c)
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      parameters:
+        - name: n
+          in: query
+          schema: { type: integer, default: 25, minimum: 1, maximum: 50 }
+      responses:
+        "200":
+          description: Clone/load/merge/push timing breakdown
+          content:
+            application/json:
+              schema: { type: object }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/audit:
+    get:
+      operationId: adminAudit
+      tags: [admin]
+      summary: Query the audit trail
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      parameters:
+        - name: action
+          in: query
+          schema: { type: string }
+          description: Filter by audit action (e.g. merge.forced, token.rotated)
+        - name: actor
+          in: query
+          schema: { type: string }
+          description: Filter by actor id
+        - name: limit
+          in: query
+          schema: { type: integer }
+      responses:
+        "200":
+          description: Audit entries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  entries:
+                    type: array
+                    items: { $ref: "#/components/schemas/AuditEntry" }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/backup:
+    get:
+      operationId: adminListBackups
+      tags: [admin]
+      summary: List backup runs (newest first)
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Backup runs, each flagged complete/incomplete
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runs:
+                    type: array
+                    items: { type: object }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      operationId: adminRunBackup
+      tags: [admin]
+      summary: Trigger a backup run now (single-flight)
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Backup summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary: { type: object }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A backup run is already in progress
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/restore/{runTs}/plan:
+    parameters:
+      - name: runTs
+        in: path
+        required: true
+        schema: { type: string }
+        description: Backup run timestamp identifier
+    get:
+      operationId: adminRestorePlan
+      tags: [admin]
+      summary: Dry-run restorability check for a backup run
+      description: Reads and decrypts every blob in the run and verifies it against the manifest. Read-only.
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Restore plan
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  plan: { type: object }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/deletion-jobs/{id}/redrive:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      operationId: adminRedriveDeletionJob
+      tags: [admin]
+      summary: Re-drive an incomplete deletion job
+      description: Resets the attempt budget and drives the job once; idempotent.
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Job re-driven
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  job: { $ref: "#/components/schemas/DeletionJob" }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Deletion job is not in the incomplete state (code NOT_REDRIVABLE)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/backfill-project-id/plan:
+    get:
+      operationId: adminBackfillPlan
+      tags: [admin]
+      summary: Dry-run plan for backfilling legacy project_id columns
+      description: Reports how much legacy (NULL project_id) data exists per table and which project names are safe to backfill. Read-only.
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Backfill plan
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  plan: { type: object }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: Stratum API token (user token or agent token)
+    adminApiKey:
+      type: apiKey
+      in: header
+      name: X-Admin-API-Key
+      description: Admin API key for administrator endpoints
+
+  parameters:
+    Namespace:
+      name: namespace
+      in: path
+      required: true
+      schema: { type: string }
+      description: Project namespace, including the @ prefix (e.g. "@alice")
+    Slug:
+      name: slug
+      in: path
+      required: true
+      schema: { type: string }
+      description: Project slug
+    ProjectName:
+      name: name
+      in: path
+      required: true
+      schema: { type: string }
+      description: Project name (single segment, not namespace/slug)
+    OrgSlug:
+      name: slug
+      in: path
+      required: true
+      schema: { type: string }
+      description: Organization slug
+    ChangeId:
+      name: id
+      in: path
+      required: true
+      schema: { type: string }
+      description: Change id
+
+  responses:
+    BadRequest:
+      description: Invalid request
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    Unauthorized:
+      description: Authentication required
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    Forbidden:
+      description: Access denied
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    NotFound:
+      description: Resource not found (also returned for access denied, to avoid disclosing existence)
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    TargetDeleting:
+      description: The project (or its owner) is being deleted (code TARGET_DELETING)
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    InternalError:
+      description: Internal server error
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+
+  schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+          description: Human-readable error message
+        code:
+          type: string
+          description: >
+            Machine-readable code present on some errors (e.g. TARGET_DELETING,
+            STALE_BASE, STALE_WORKSPACE, WORKSPACE_UNVERIFIABLE, MERGE_CONFLICT,
+            PROTECTION_BLOCKED, NOT_REDRIVABLE, GONE, INVALID_PATH)
+
+    Project:
+      type: object
+      required: [id, name, namespace, slug]
+      properties:
+        id: { type: string, format: uuid }
+        name: { type: string }
+        namespace:
+          type: string
+          description: '"@username" or "@org-slug"'
+        slug: { type: string }
+        path:
+          type: string
+          description: "/{namespace}/{slug}"
+        remote:
+          type: string
+          description: Backing Artifacts git remote URL
+        createdAt: { type: string, format: date-time }
+        visibility:
+          type: string
+          enum: [private, public]
+        githubUrl: { type: string }
+        githubOwner: { type: string }
+        githubRepo: { type: string }
+        githubDefaultBranch: { type: string }
+        githubConnectionStatus:
+          type: string
+          enum: [connected, disconnected]
+
+    Workspace:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        createdAt: { type: string, format: date-time }
+        path:
+          type: string
+          description: "/{namespace}/{slug}/workspaces/{name}"
+        remote:
+          type: string
+          description: Workspace fork remote (returned on creation)
+
+    Change:
+      type: object
+      required: [id, project, workspace, status, createdAt]
+      properties:
+        id: { type: string }
+        project:
+          type: string
+          description: Project name (or project id for changes created via the GitHub bridge)
+        projectId:
+          type: string
+          format: uuid
+          description: Globally-unique project id; absent on legacy rows
+        workspace: { type: string }
+        status:
+          type: string
+          enum: [open, needs_changes, accepted, approved, promoted, merged, rejected, reverted]
+        agentId: { type: string }
+        evalScore: { type: number }
+        evalPassed: { type: boolean }
+        evalReason: { type: string }
+        baseSha:
+          type: string
+          description: Project HEAD at change creation — the base the evaluation ran against
+        evaluatedSha:
+          type: string
+          description: Workspace tip the evaluation ran against; merges reject if it moved
+        evaluatedTreeOid: { type: string }
+        agentModel:
+          type: string
+          description: Authoring agent's model, snapshotted at change creation
+        agentPromptHash: { type: string }
+        workspaceHeadSha: { type: string }
+        createdAt: { type: string, format: date-time }
+        mergedAt: { type: string, format: date-time }
+        githubOwner: { type: string }
+        githubRepo: { type: string }
+        githubBranch: { type: string }
+        githubPrNumber: { type: integer }
+        githubPrUrl: { type: string }
+        githubPrState: { type: string }
+        githubHeadSha: { type: string }
+        promotedAt: { type: string, format: date-time }
+        promotedBy: { type: string }
+
+    EvalResult:
+      type: object
+      required: [score, passed, reason]
+      properties:
+        score: { type: number }
+        passed: { type: boolean }
+        reason: { type: string }
+        issues:
+          type: array
+          items: { type: string }
+
+    EvalRun:
+      type: object
+      required: [id, changeId, evaluatorType, score, passed, reason, ranAt]
+      properties:
+        id: { type: string }
+        changeId: { type: string }
+        evaluatorType:
+          type: string
+          description: e.g. secret_scan, diff, webhook, llm, sandbox
+        score: { type: number }
+        passed: { type: boolean }
+        reason: { type: string }
+        issues:
+          type: array
+          items: { type: string }
+        ranAt: { type: string, format: date-time }
+
+    Issue:
+      type: object
+      required: [id, project, number, title, status, authorType, authorId, createdAt, updatedAt]
+      properties:
+        id: { type: string }
+        project: { type: string }
+        projectId: { type: string, format: uuid }
+        number: { type: integer }
+        title: { type: string }
+        body: { type: string }
+        status:
+          type: string
+          enum: [open, closed]
+        authorType:
+          type: string
+          enum: [user, agent]
+        authorId: { type: string }
+        linkedChangeId: { type: string }
+        closedAt: { type: string, format: date-time }
+        closedBy: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    Review:
+      type: object
+      required: [id, changeId, reviewerId, verdict, createdAt]
+      properties:
+        id: { type: string }
+        changeId: { type: string }
+        reviewerId: { type: string }
+        verdict:
+          type: string
+          enum: [approve, request_changes]
+        comment: { type: string }
+        createdAt: { type: string, format: date-time }
+
+    ChangeComment:
+      type: object
+      required: [id, changeId, authorType, authorId, body, createdAt]
+      properties:
+        id: { type: string }
+        changeId: { type: string }
+        authorType:
+          type: string
+          enum: [user, agent]
+        authorId: { type: string }
+        body: { type: string }
+        createdAt: { type: string, format: date-time }
+
+    ActivityEvent:
+      type: object
+      required: [id, type, actorType, payload, createdAt]
+      properties:
+        id: { type: string }
+        type:
+          type: string
+          description: Domain event type (e.g. change.created, change.merged, issue.opened)
+        actorType:
+          type: string
+          enum: [user, agent, system]
+        actorId: { type: string }
+        payload:
+          type: object
+          additionalProperties: true
+        createdAt: { type: string, format: date-time }
+
+    Webhook:
+      type: object
+      required: [id, project, url, events, active, createdBy, createdAt]
+      properties:
+        id: { type: string }
+        project: { type: string }
+        projectId: { type: string, format: uuid }
+        url: { type: string, format: uri }
+        secret:
+          type: string
+          description: Returned only on creation; omitted from list responses
+        events:
+          type: string
+          description: Comma-separated event types, or "*" for all
+        active: { type: boolean }
+        createdBy: { type: string }
+        createdAt: { type: string, format: date-time }
+
+    WebhookDelivery:
+      type: object
+      required: [id, webhookId, eventId, eventType, status, createdAt]
+      properties:
+        id: { type: string }
+        webhookId: { type: string }
+        eventId: { type: string }
+        eventType: { type: string }
+        status:
+          type: string
+          enum: [success, failed]
+        statusCode: { type: integer }
+        error: { type: string }
+        durationMs: { type: number }
+        createdAt: { type: string, format: date-time }
+
+    CommitLogEntry:
+      type: object
+      required: [sha, message, author, timestamp]
+      properties:
+        sha: { type: string }
+        message: { type: string }
+        author: { type: string }
+        timestamp:
+          type: number
+          description: Unix timestamp
+
+    ProvenanceRecord:
+      type: object
+      required: [id, commitSha, project, workspace, changeId, mergedAt]
+      properties:
+        id: { type: string }
+        commitSha: { type: string }
+        project: { type: string }
+        projectId: { type: string, format: uuid }
+        workspace: { type: string }
+        changeId: { type: string }
+        agentId: { type: string }
+        evalScore: { type: number }
+        model:
+          type: string
+          description: Model that authored the change, snapshotted at change creation
+        promptHash: { type: string }
+        mergedAt: { type: string, format: date-time }
+
+    ImportProgress:
+      type: object
+      required: [id, projectId, namespace, slug, status, sourceUrl, branch, startedAt, updatedAt, version, progress, errors, logs]
+      properties:
+        id: { type: string }
+        projectId: { type: string, format: uuid }
+        namespace: { type: string }
+        slug: { type: string }
+        status:
+          type: string
+          enum: [queued, cloning, processing, completed, failed, cancelled, cancelling, syncing, checking]
+        sourceUrl: { type: string }
+        branch: { type: string }
+        startedAt: { type: string, format: date-time }
+        completedAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+        version:
+          type: integer
+          description: Optimistic-locking version, incremented on each update
+        progress:
+          type: object
+          properties:
+            totalFiles: { type: integer }
+            processedFiles: { type: integer }
+            currentFile: { type: string }
+            bytesTransferred: { type: integer }
+            totalBytes: { type: integer }
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              file: { type: string }
+              error: { type: string }
+              timestamp: { type: string }
+        logs:
+          type: array
+          items:
+            type: object
+            properties:
+              message: { type: string }
+              level:
+                type: string
+                enum: [info, warn, error]
+              timestamp: { type: string }
+
+    SyncStatus:
+      type: object
+      properties:
+        namespace: { type: string }
+        slug: { type: string }
+        sourceUrl: { type: string }
+        provider:
+          type: string
+          enum: [github, gitlab, bitbucket]
+        lastSyncedAt: { type: string, format: date-time }
+        lastSyncedCommit: { type: string }
+        lastSyncStatus:
+          type: string
+          enum: [success, failed, in_progress, idle]
+        lastSyncError: { type: string }
+        autoSyncEnabled: { type: boolean }
+        hasUpdates: { type: boolean }
+        commitsBehind: { type: integer }
+        latestCommit: { type: string }
+        lastCheckedAt: { type: string, format: date-time }
+        importProgress:
+          type: object
+          description: Present when a sync/import is active
+          properties:
+            status: { type: string }
+            progress: { type: object }
+            logs:
+              type: array
+              items: { type: object }
+            errors:
+              type: array
+              items: { type: object }
+
+    Org:
+      type: object
+      required: [id, name, slug, ownerId, createdAt]
+      properties:
+        id: { type: string }
+        name: { type: string }
+        slug: { type: string }
+        ownerId: { type: string }
+        createdAt: { type: string, format: date-time }
+
+    Team:
+      type: object
+      required: [id, orgId, name, slug, permissions, createdAt]
+      properties:
+        id: { type: string }
+        orgId: { type: string }
+        name: { type: string }
+        slug: { type: string }
+        permissions:
+          type: string
+          enum: [read, write, admin]
+        createdAt: { type: string, format: date-time }
+
+    Agent:
+      type: object
+      required: [id, name, ownerId, createdAt]
+      properties:
+        id: { type: string }
+        name: { type: string }
+        ownerId: { type: string }
+        model: { type: string }
+        description: { type: string }
+        promptHash: { type: string }
+        createdAt: { type: string, format: date-time }
+
+    AuditEntry:
+      type: object
+      required: [id, action, actorType, detail, createdAt]
+      properties:
+        id: { type: string }
+        action:
+          type: string
+          description: e.g. token.rotated, agent.created, merge.forced, deletion.requested
+        actorType:
+          type: string
+          enum: [user, agent, system]
+        actorId: { type: string }
+        subject: { type: string }
+        detail:
+          type: object
+          additionalProperties: true
+        createdAt: { type: string, format: date-time }
+
+    DeletionAccepted:
+      type: object
+      required: [status, jobId]
+      properties:
+        status:
+          type: string
+          example: deleting
+        jobId:
+          type: string
+          example: del_abc123
+
+    DeletionJob:
+      type: object
+      required: [id, kind, state, attempts, createdAt]
+      properties:
+        id: { type: string }
+        kind:
+          type: string
+          enum: [project, account]
+        target:
+          type: string
+          description: Raw JSON of the captured deletion target
+        state:
+          type: string
+          enum: [pending, running, verifying, completed, incomplete]
+        checkpoint: { type: [string, "null"] }
+        heartbeatAt: { type: [string, "null"] }
+        leaseOwner: { type: [string, "null"] }
+        leaseExpiresAt: { type: [string, "null"] }
+        residuals:
+          type: array
+          items: { type: string }
+        attempts: { type: integer }
+        createdAt: { type: string, format: date-time }
+        startedAt: { type: [string, "null"] }
+        finishedAt: { type: [string, "null"] }
+
+    BulkImportJobSummary:
+      type: object
+      properties:
+        jobId: { type: string }
+        status:
+          type: string
+          enum: [queued, processing, completed, failed, partial]
+        totalRepos: { type: integer }
+        processedRepos: { type: integer }
+        successfulRepos: { type: integer }
+        failedRepos: { type: integer }
+        createdAt: { type: string, format: date-time }
+        completedAt: { type: string, format: date-time }
+        hasErrors: { type: boolean }
+
+    BulkImportJobStatus:
+      type: object
+      properties:
+        jobId: { type: string }
+        status:
+          type: string
+          enum: [queued, processing, completed, failed, partial]
+        totalRepos: { type: integer }
+        processedRepos: { type: integer }
+        successfulRepos: { type: integer }
+        failedRepos: { type: integer }
+        createdAt: { type: string, format: date-time }
+        completedAt: { type: string, format: date-time }
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              repo: { type: string }
+              error: { type: string }
+        progress:
+          type: object
+          properties:
+            percentage: { type: integer }
+            current: { type: integer }
+            total: { type: integer }
+
+    HealthCheckResult:
+      type: object
+      required: [status, latency]
+      properties:
+        status:
+          type: string
+          enum: [ok, error, degraded]
+        latency:
+          type: string
+          example: 12ms
+        message: { type: string }
+
+    HealthCheckResponse:
+      type: object
+      required: [status, timestamp, checks]
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy]
+        timestamp: { type: string, format: date-time }
+        checks:
+          type: object
+          required: [database, kv, queue, artifacts]
+          properties:
+            database: { $ref: "#/components/schemas/HealthCheckResult" }
+            kv: { $ref: "#/components/schemas/HealthCheckResult" }
+            queue: { $ref: "#/components/schemas/HealthCheckResult" }
+            artifacts: { $ref: "#/components/schemas/HealthCheckResult" }

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -2,16 +2,155 @@
 
 ## What is Stratum?
 
-A code collaboration platform for AI engineering.
+A code collaboration platform where humans and AI agents are both first-class
+citizens. It hosts git repositories (on Cloudflare Artifacts), and every
+proposed change — whether a human or an agent wrote it — passes through
+policy-defined evaluation gates before it can merge. Merged changes carry
+provenance (which agent, which model, which prompt) and cost records.
 
-## Do I need GitHub?
+## How is this different from GitHub branch protection and required checks?
 
-No, Stratum works independently with email authentication.
+GitHub branch protection gates on external check *statuses*; Stratum runs the
+evaluation itself, treats agents as first-class identities, and enforces
+invariants GitHub doesn't have:
 
-## Is it free?
+- **A secret scan is always on and always blocking** — not a configurable check
+  someone can remove.
+- **Approvals are human-only by construction.** An agent token cannot approve
+  any change on any surface (API, CLI, MCP). On GitHub, a bot with the right
+  permissions can approve and merge.
+- **Staleness is enforced against what was evaluated**: a merge is rejected if
+  the workspace advanced after evaluation (`409 STALE_WORKSPACE`), so you can
+  never merge commits the evaluators didn't see. `requireFreshBase` additionally
+  rejects merges when the base moved (`409 STALE_BASE`).
+- **Force-merge is deny-by-default** — the override only exists if the policy
+  explicitly sets `merge.allowForce: true`.
+- **Post-merge smoke with auto-revert**: a configured command runs against the
+  merged HEAD, and a failure automatically lands a forward revert commit.
+- **Provenance and cost are recorded per merged change** — model, prompt hash,
+  eval score, LLM tokens, sandbox time.
+- A malformed `.stratum/policy.yaml` **fails closed** (blocks merges) instead of
+  silently falling back to defaults.
 
-Yes, you pay only for Cloudflare resources used.
+## Do I have to leave GitHub to use it?
+
+No. Stratum supports two modes with the same codebase. In **layer mode**,
+Stratum sits between your agents and GitHub: import the repo, enable
+bidirectional sync (inbound webhooks, outbound PR promotion), and agent work
+goes through Stratum's gates while your team keeps reviewing GitHub PRs —
+evaluation results are posted to the PR as comments and commit statuses. In
+**alternative mode**, Stratum is the source of truth and GitHub isn't involved
+at all. You choose the level of buy-in, and you can start with layer mode.
+
+## Do I need a GitHub account at all?
+
+No. Email magic-link authentication is the recommended sign-in and has no
+external dependencies. GitHub OAuth (needed for GitHub sync) and Google OAuth
+are alternatives; all resolve to the same email-based identity.
+
+## What happens when an evaluation fails?
+
+The change is created anyway, with each evaluator's verdict, findings, and score
+recorded as evidence you can inspect (`stratum change show <id>` or the UI). What
+a failure blocks is the **merge**: any evaluator type listed in
+`merge.requiredEvaluators` must have a passing latest run. To recover, push new
+commits to the workspace — re-evaluation runs against the new state — or, if
+your policy allows it (`allowForce: true`, off by default), force-merge past it.
+The reference agent exits with code `2` in this case so CI wrappers can
+distinguish "agent produced rejected work" from operational errors.
+
+## Can agents approve or merge their own code?
+
+Agents can never **approve** — reviews are human-only, everywhere, with no
+configuration that relaxes it. Whether an agent can trigger a *merge* is up to
+your policy: with `merge.requiredApprovals: 1` or more, at least one human must
+approve first, so an agent can never land work no human has seen. If you set no
+required approvals and its required evaluators pass, a merge call with an agent
+token will go through — so set `requiredApprovals` on anything you care about.
+
+## What does provenance actually record?
+
+Per merged change: the author identity (human or agent), the model and a hash of
+the prompt snapshotted at change creation, and the evaluation score, per merged
+commit. Full per-evaluator evidence (scores, findings, durations) is linked by
+change. The schema also has room for model config, reasoning traces, and tool
+calls where the client supplies them. Agents authenticate with their own
+short-lived tokens (scoped to an owning user), so work is attributed to the
+agent, not laundered through a human account.
+
+## What does it cost, and what is metered?
+
+The software is MIT-licensed and free; self-hosted, you pay only for the
+Cloudflare resources you use (Workers, Artifacts, D1, KV, Queues, plus AI
+Gateway and Sandboxes if you enable those evaluators). Stratum meters estimated
+resource usage per change — LLM tokens, sandbox execution milliseconds, and git
+operations — and shows it alongside the evaluation evidence, so you can see what
+each (agent) change cost you. The hosted instance has open signup and is free
+while billing and multi-tenancy for a managed offering ("Stratum Cloud") are
+planned but not built.
+
+## What are the current limitations?
+
+Honestly, several:
+
+- **Diff accuracy**: diffs are currently shown as full-file rewrites rather than
+  precise hunks. This affects both the diff viewer and what evaluators see; real
+  unified diffs are pending.
+- **Scale**: git operations run in-memory inside a Worker, so very large
+  repositories will hit Worker limits. Moving git ops off the Worker is on the
+  roadmap.
+- **Squash-only merges**: true merge commits are not yet supported.
+- **Push to project remotes is not supported yet** (`403`) — push to workspace
+  remotes and open a change. Gated project-push is designed but deferred.
+- **Authorization** is still minimal in places; project-level access control is
+  not enforced on every route.
+- **Evaluation runs synchronously** at change creation — there's no async
+  evaluation queue yet, so very slow evaluators stretch the request.
+
+See `docs/CURRENT_CAPABILITIES.md` for the authoritative, current state.
+
+## Can I use plain `git` with Stratum?
+
+Yes, over smart HTTP with your API key as the HTTP Basic password:
+`git clone https://x:<key>@<host>/@ns/slug.git` for projects (read), and
+`.../@ns/slug/workspaces/<name>.git` for workspaces (read **and** `git push`).
+Pushing to the project URL is refused so the evaluation gate can't be bypassed.
+SSH transport is not supported (Workers have no raw TCP listener).
+
+## What do I need to self-host?
+
+Node.js 20+ and your own Cloudflare account with Workers, **Artifacts (which is
+in beta — you need access to it)**, D1, KV, and Queues. Optional: AI Gateway for
+the LLM evaluator, Sandboxes for the sandbox evaluator (without the binding that
+evaluator fails closed), R2 for backups, and Cloudflare Email for magic links.
+The README Quick Start covers secrets, migrations, and deployment; keep
+production and staging in separate Artifacts namespaces.
+
+## How do backups work?
+
+D1 (changes, issues, events, costs, audit) and KV identity data back up to R2
+daily and on demand, along with the reachable history of a rotating slice of
+repositories — coverage rotates across runs under a per-run cap, so every repo
+is covered over time rather than every run. There is a tested restore path,
+documented in `docs/runbooks/backup-restore.md`.
+
+## Can I turn off telemetry?
+
+Yes. Analytics (PostHog) is optional — it only runs if you set a
+`POSTHOG_API_KEY`, and self-hosted instances can set
+`STRATUM_TELEMETRY_DISABLED = "true"` in `wrangler.toml` to switch it off
+entirely.
+
+## What if my policy file has a mistake in it?
+
+A present-but-malformed `.stratum/policy.yaml` fails closed: the merge gate
+blocks until the file parses, rather than silently running on defaults. This is
+deliberate — a typo in a stricter policy can't quietly downgrade governance.
+Fix the YAML and re-evaluate.
 
 ## How do I get help?
 
-Open an issue on GitHub or check the documentation.
+Open an issue on the GitHub repository, or start with the
+[getting started guide](getting-started.md),
+[troubleshooting](troubleshooting.md), and the API reference in
+`docs/api/openapi.yml`.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,25 +1,354 @@
-# Getting Started
+# Getting started
 
-## Sign In
+This guide walks a new team from zero to a merged, evaluation-gated change. By the
+end you will have a project, a merge policy, a registered agent identity, and the
+CLI and MCP server connected to your tools.
 
-Visit https://your-instance.workers.dev/auth/email
+Stratum is a code collaboration platform where humans and AI agents are both
+first-class citizens. Every proposed change — human or agent — passes through the
+same evaluation gates before it can merge, and every merged change carries a
+provenance record of who (or what model) produced it.
 
-## Create Project
+## 1. Sign up or self-host
 
-Click "New Project" and enter a name.
+### Hosted
 
-## Fork Workspace
+The hosted instance runs at `https://app.usestratum.dev` with **open signup** —
+no invite code or waitlist. (If you hit an invite prompt, you're on an instance
+whose operator has enabled the optional closed-beta gate.)
 
-Workspaces are isolated development environments.
+Sign in with any of:
 
-## Make Changes
+- **Email magic link** (recommended — no external accounts needed): enter your
+  email at `/auth/email` and click the link you receive.
+- **GitHub OAuth** at `/auth/github` — required later if you want bidirectional
+  GitHub sync.
+- **Google OAuth** at `/auth/google`.
 
-Commit file changes to your workspace.
+All three resolve to the same email-identity account, so you can mix methods.
 
-## Create Change
+### Self-hosting
 
-Propose your workspace for merge.
+Stratum is MIT-licensed and self-hostable on your own Cloudflare account. You
+need Node.js 20+ and a Cloudflare account with Workers, **Artifacts (beta)**, D1,
+KV, and Queues; AI Gateway is optional and only needed for the LLM evaluator,
+and Sandboxes only for the sandbox evaluator. Follow the
+[Quick Start in the README](../../README.md#quick-start) — everywhere this guide
+says `app.usestratum.dev`, substitute your own `https://your-instance.workers.dev`.
 
-## Merge
+## 2. Create or import a project
 
-After evaluation passes, merge to main.
+### Create a fresh project
+
+From the dashboard, click **New Project** and pick a name and visibility, or use
+the API:
+
+```bash
+curl -X POST https://app.usestratum.dev/api/projects \
+  -H "Authorization: Bearer stratum_user_xxxxx" \
+  -d '{"name": "my-project", "visibility": "private"}'
+```
+
+Projects live under a namespace — `@your-username` for personal projects, or an
+org slug for org-owned projects. Org membership grants read access; the org
+owner/admin role or membership in a write/admin team grants write access.
+
+### Import an existing repository
+
+Stratum imports from **GitHub, GitLab, and Bitbucket**. Imports run as background
+jobs, so large repositories don't block the request:
+
+```bash
+curl -X POST https://app.usestratum.dev/api/projects/@you/my-project/import \
+  -H "Authorization: Bearer stratum_user_xxxxx" \
+  -d '{"url": "https://github.com/your-org/your-repo", "branch": "main"}'
+```
+
+### Choose your level of buy-in: layer mode vs. alternative mode
+
+You do not have to leave your current forge to use Stratum. The same codebase
+supports two modes:
+
+- **Layer mode (minimal buy-in).** Stratum sits between your agents and GitHub.
+  Import a GitHub repo and enable **bidirectional GitHub sync**: inbound webhooks
+  keep the Stratum project current with pushes and PRs, and outbound sync
+  promotes a Stratum change to a GitHub PR with evaluation results posted as a PR
+  comment and commit status. Agents work through Stratum's gates; your team keeps
+  reviewing in GitHub PRs.
+- **Alternative mode (full buy-in).** Stratum is the source of truth for repos,
+  workspaces, and changes. No GitHub required — email magic links mean no
+  external accounts at all.
+
+Start in layer mode if you're evaluating; nothing about the change flow below
+differs between the modes.
+
+## 3. Write your evaluation policy
+
+Merge gates are configured in a `.stratum/policy.yaml` file at the root of your
+repository. Commit it like any other file. Here is a realistic policy for a
+TypeScript service:
+
+```yaml
+evaluation:
+  evaluators:
+    # Bound the blast radius of any single change.
+    - type: diff
+      maxFiles: 30
+      maxLines: 1000
+      forbiddenPatterns:
+        - "console.log("
+        - "TODO: remove"
+
+    # Call your existing CI system.
+    - type: webhook
+      url: "https://ci.example.com/evaluate"
+      secret: "${CI_WEBHOOK_SECRET}"
+      timeoutMs: 300000
+
+    # Run the test suite in a Cloudflare Sandbox.
+    - type: sandbox
+      command: "npm test"
+      timeoutMs: 120000
+
+    # AI review of the diff, scored 0.0-1.0.
+    - type: llm
+      model: "claude-sonnet-4-20250514"
+      threshold: 0.7
+      maxDiffChars: 100000
+
+merge:
+  requiredApprovals: 1
+  requiredEvaluators: ["secret_scan", "diff", "sandbox"]
+  allowForce: false
+  requireFreshBase: true
+  postMergeCommand: "npm test"
+  postMergeTimeoutMs: 120000
+  autoRevert: true
+```
+
+A malformed policy file **fails closed**: the merge gate blocks rather than
+silently falling back to defaults, so a typo in a stricter policy can't quietly
+downgrade your governance.
+
+### The evaluators
+
+- **Secret scan — always on, always blocking.** You don't configure it and you
+  can't turn it off. Every change is scanned for API keys, tokens, and other
+  credentials; a hit blocks the merge.
+- **`diff`** — pure analysis of the change, no code execution. Caps the number
+  of files (`maxFiles`) and lines (`maxLines`) changed, and can reject diffs
+  containing `forbiddenPatterns` or missing `requiredPatterns`. Cheap, fast, and
+  the first line of defense against runaway agent edits.
+- **`webhook`** — POSTs the change to an external URL (your existing CI) and
+  waits up to `timeoutMs` for a verdict. `secret` signs the delivery so your CI
+  can verify it came from Stratum.
+- **`sandbox`** — clones the workspace into a Cloudflare Sandbox and runs
+  `command` (default: the project's test command), passing or failing on exit
+  code. Requires the Sandboxes binding on self-hosted instances; when the
+  binding is absent this evaluator **fails closed** rather than silently
+  passing.
+- **`llm`** — sends the diff to an LLM (via AI Gateway) for review against your
+  criteria. `model` picks the reviewer, `threshold` is the minimum passing score
+  (0.0–1.0), and `maxDiffChars` bounds how much diff is sent. Token usage is
+  recorded on the change as a cost record.
+
+### The merge protections
+
+Everything under `merge:` is branch protection, enforced at the merge step:
+
+- **`requiredApprovals`** — how many **human** approvals a change needs before
+  it can merge. Agent approvals never count (see the invariant below).
+- **`requiredEvaluators`** — evaluator types whose *latest run* must have
+  passed. A change with a failing required evaluator cannot merge.
+- **`allowForce`** — force-merge is **deny-by-default**. The `?force=true`
+  override is rejected unless the policy explicitly sets `allowForce: true`.
+  Leave it off (or set it to `false`, as above) unless you have a specific
+  break-glass need.
+- **`requireFreshBase`** — when true, a change whose recorded base is behind
+  the project HEAD is rejected with `409 STALE_BASE`; re-evaluate on the new
+  base first. Independently of this flag, a merge is always rejected if the
+  workspace advanced after it was evaluated (`409 STALE_WORKSPACE`) — you can
+  never merge commits the evaluators didn't see.
+- **`postMergeCommand`** + **`postMergeTimeoutMs`** — a smoke command run in a
+  sandbox against the merged HEAD (e.g. `npm test`), with a default timeout of
+  60 seconds.
+- **`autoRevert`** — if the post-merge command fails, Stratum lands a forward
+  revert commit, marks the change `reverted`, and emits a `change.reverted`
+  event. On by default when a `postMergeCommand` is set.
+
+## 4. Register an agent identity
+
+Agents are not shared service accounts — each one is a first-class identity:
+
+```bash
+curl -X POST https://app.usestratum.dev/api/agents \
+  -H "Authorization: Bearer stratum_user_xxxxx" \
+  -d '{"name": "refactor-bot"}'
+```
+
+This returns a **short-lived agent token** (`stratum_agent_...`). Two things to
+know about its scope:
+
+- The token is **scoped to the owning user**: the agent inherits your project
+  access (including org access) and nothing more. Tokens are short-lived and
+  managed from the settings UI alongside your API keys.
+- All writes made with an agent token are attributed to the agent in
+  **provenance** — merged changes record which agent and which model produced
+  them, not just which human owned the token.
+
+### The human-approval invariant
+
+Reviews (approve / request changes) are **human-only**. An agent token cannot
+approve any change — not its own, not another agent's. This holds across every
+surface (REST API, CLI, MCP): if your policy sets `requiredApprovals: 1`, a
+human must look at the change before it merges. There is no configuration that
+relaxes this.
+
+The reference agent in [`agent/`](../../agent/README.md) shows the intended
+shape: it creates its own identity, forks a workspace, asks Claude for edits,
+commits, and opens a change — then stops. Review and merge stay on the platform.
+
+## 5. The change flow
+
+Every contribution — human or agent — follows the same path:
+
+```text
+workspace  →  commit  →  change (evaluation runs)  →  review  →  merge
+```
+
+1. **Fork a workspace.** A workspace is an isolated fork of the project — the
+   equivalent of a branch, with its own git remote.
+
+   ```bash
+   stratum workspace create @you/my-project --name fix-n-plus-one
+   ```
+
+2. **Commit.** Commit files to the workspace via the CLI (`stratum commit` sends
+   your staged files), the API, or `git push` to the workspace remote (see
+   section 6).
+
+   ```bash
+   stratum commit --project @you/my-project --workspace fix-n-plus-one -m "Fix N+1 query"
+   ```
+
+3. **Create a change.** A change is Stratum's merge proposal (a PR, roughly).
+   Creating it runs your full evaluation policy **synchronously** — you get each
+   gate's verdict in the response.
+
+   ```bash
+   stratum change create --project @you/my-project --workspace fix-n-plus-one
+   stratum change show chg_xxxxx   # eval evidence + costs
+   ```
+
+4. **Review.** A human approves or requests changes; this moves the change's
+   state machine. Agents cannot perform this step.
+
+   ```bash
+   stratum change review chg_xxxxx --verdict approve --comment "LGTM"
+   ```
+
+5. **Merge.** Merges are **squash merges**, serialized per-project through a
+   Durable Object merge queue so there are no races. The merge is rejected if a
+   required evaluator is failing, approvals are short, the base is stale
+   (`requireFreshBase`), or the workspace moved since evaluation. If a
+   `postMergeCommand` is configured it runs against the merged HEAD, and a
+   failure auto-reverts.
+
+   ```bash
+   stratum change merge chg_xxxxx
+   ```
+
+### What a merged change carries
+
+Every merged change keeps:
+
+- **Provenance** — the author (human or agent), the model and prompt hash
+  snapshotted at change creation, and the evaluation score, per merged commit.
+- **Evaluator evidence** — the full per-evaluator results (score, findings,
+  duration), linked by change and browsable in the UI.
+- **Cost records** — estimated resource usage per change: LLM tokens, sandbox
+  execution time, and git operations.
+
+If a change was linked to an issue, the issue auto-closes on merge.
+
+## 6. Connect your tools
+
+### CLI — `@stratum/cli`
+
+The CLI wraps the full REST API: projects, workspaces, commits, changes
+(including review and merge), issues, and activity. It is not yet published to
+npm — install it from the `cli/` directory of the repo:
+
+```bash
+git clone https://github.com/stratum-eng/stratum.git
+cd stratum/cli && npm install && npm run build
+
+stratum login --host https://app.usestratum.dev --key stratum_user_xxxxx
+# or: export STRATUM_HOST=... STRATUM_API_KEY=...   (env overrides the config file)
+
+stratum status        # who am I
+stratum projects      # list your projects
+```
+
+See [`cli/README.md`](../../cli/README.md) for the full command reference.
+
+### MCP server — `@stratum/mcp`
+
+The MCP server gives **any** MCP-capable agent or editor (Claude Code, Cursor,
+Zed, Copilot, custom agents) the full eval-gated change flow: read files, fork
+workspaces, commit, create changes (with each gate's verdict returned), review,
+merge, and track issues. Like the CLI, it is not yet on npm — install from the
+`mcp/` directory.
+
+Claude Code:
+
+```bash
+export STRATUM_API_KEY=stratum_user_xxxxx
+claude mcp add stratum -e STRATUM_API_KEY=$STRATUM_API_KEY -- stratum-mcp
+```
+
+Any MCP client (stdio):
+
+```json
+{
+  "mcpServers": {
+    "stratum": {
+      "command": "stratum-mcp",
+      "env": { "STRATUM_API_KEY": "stratum_user_..." }
+    }
+  }
+}
+```
+
+`STRATUM_HOST` defaults to `https://app.usestratum.dev`; set it for self-hosted
+instances. All governance invariants hold over MCP exactly as over REST: agent
+tokens can't approve their own work, failing evaluators block merges, and
+provenance is recorded.
+
+### Plain git over smart HTTP
+
+Stratum projects and workspaces are real git remotes. Authenticate with your API
+key as the HTTP Basic password (username is ignored):
+
+```bash
+# Clone a project (read)
+git clone https://x:stratum_user_xxxxx@app.usestratum.dev/@you/my-project.git
+
+# Clone AND push to a workspace (read + write)
+git clone https://x:stratum_user_xxxxx@app.usestratum.dev/@you/my-project/workspaces/fix-n-plus-one.git
+cd fix-n-plus-one
+# ...edit, commit...
+git push
+```
+
+Note the asymmetry: **pushing to the project URL is not yet supported** — it
+returns `403`, because a direct push to a protected ref would bypass the
+evaluation gate. Push to a **workspace** remote instead, then open a change as
+usual. Gated project-push (push-opens-a-change semantics) is planned.
+
+## Where to go next
+
+- [FAQ](faq.md) — common questions, including honest current limitations
+- [Importing from GitHub](importing.md) — import and sync details
+- [Troubleshooting](troubleshooting.md) — common issues
+- [API reference](../api/openapi.yml) — the complete REST surface

--- a/mcp/LICENSE
+++ b/mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jordan Lamoreaux
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,63 @@
+# @stratum/mcp
+
+MCP server for [Stratum](https://github.com/stratum-eng/stratum) — gives **any**
+MCP-capable agent or editor (Claude Code, Cursor, Zed, Copilot, custom agents)
+access to Stratum's eval-gated change flow. No Stratum-specific SDK required:
+if your tool speaks MCP, it can propose governed changes.
+
+## What the tools cover
+
+The full agent contribution loop:
+
+1. **Read** — `stratum_list_projects`, `stratum_get_project`, `stratum_list_files`,
+   `stratum_get_file`, `stratum_get_activity`
+2. **Fork & commit** — `stratum_create_workspace`, `stratum_list_workspaces`,
+   `stratum_commit`
+3. **Propose** — `stratum_create_change` runs the project's evaluation gates
+   (`.stratum/policy.yaml`: secret scan, diff policy, LLM review, sandbox tests)
+   and returns each gate's verdict
+4. **Land** — `stratum_get_change`, `stratum_merge_change`, `stratum_reject_change`,
+   `stratum_review_change`
+5. **Track** — `stratum_create_issue`, `stratum_list_issues`, `stratum_update_issue`,
+   `stratum_whoami`
+
+Stratum's governance invariants hold over MCP exactly as they do over the REST
+API: **agent tokens can never approve their own work** (approvals are a human
+gate), merges are blocked by failing evaluators, and every merged change keeps
+its provenance and cost records.
+
+## Setup
+
+```bash
+npm install -g @stratum/mcp
+export STRATUM_API_KEY=stratum_user_...   # or a stratum_agent_ token
+export STRATUM_HOST=https://app.usestratum.dev   # optional; also works self-hosted
+```
+
+### Claude Code
+
+```bash
+claude mcp add stratum -e STRATUM_API_KEY=$STRATUM_API_KEY -- stratum-mcp
+```
+
+### Any MCP client (stdio)
+
+```json
+{
+  "mcpServers": {
+    "stratum": {
+      "command": "stratum-mcp",
+      "env": { "STRATUM_API_KEY": "stratum_user_..." }
+    }
+  }
+}
+```
+
+## Development
+
+```bash
+npm install
+npm run typecheck
+npm test
+npm run build
+```

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -22,14 +22,19 @@ The full agent contribution loop:
    `stratum_whoami`
 
 Stratum's governance invariants hold over MCP exactly as they do over the REST
-API: **agent tokens can never approve their own work** (approvals are a human
-gate), merges are blocked by failing evaluators, and every merged change keeps
-its provenance and cost records.
+API: **agent tokens cannot submit approve verdicts at all** (approvals are a
+human gate — an agent can only request changes, on anyone's change), merges are
+blocked by failing evaluators, and every merged change keeps its provenance and
+cost records.
 
 ## Setup
 
+`@stratum/mcp` is not yet published to npm — install from source:
+
 ```bash
-npm install -g @stratum/mcp
+git clone https://github.com/stratum-eng/stratum.git
+cd stratum/mcp
+npm install && npm run build   # binary at dist/index.js (bin name: stratum-mcp)
 export STRATUM_API_KEY=stratum_user_...   # or a stratum_agent_ token
 export STRATUM_HOST=https://app.usestratum.dev   # optional; also works self-hosted
 ```
@@ -37,7 +42,7 @@ export STRATUM_HOST=https://app.usestratum.dev   # optional; also works self-hos
 ### Claude Code
 
 ```bash
-claude mcp add stratum -e STRATUM_API_KEY=$STRATUM_API_KEY -- stratum-mcp
+claude mcp add stratum -e STRATUM_API_KEY=$STRATUM_API_KEY -- node /path/to/stratum/mcp/dist/index.js
 ```
 
 ### Any MCP client (stdio)
@@ -46,12 +51,16 @@ claude mcp add stratum -e STRATUM_API_KEY=$STRATUM_API_KEY -- stratum-mcp
 {
   "mcpServers": {
     "stratum": {
-      "command": "stratum-mcp",
+      "command": "node",
+      "args": ["/path/to/stratum/mcp/dist/index.js"],
       "env": { "STRATUM_API_KEY": "stratum_user_..." }
     }
   }
 }
 ```
+
+(Once the package is on npm, `npm install -g @stratum/mcp` will provide a
+`stratum-mcp` binary to use as the command directly.)
 
 ## Development
 

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,2785 @@
+{
+  "name": "@stratum/mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@stratum/mcp",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^3.24.0"
+      },
+      "bin": {
+        "stratum-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.4.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
+      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@stratum/mcp",
+  "version": "0.1.0",
+  "description": "MCP server for Stratum — gives any AI agent or editor access to Stratum's eval-gated change flow",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stratum-eng/stratum.git",
+    "directory": "mcp"
+  },
+  "type": "module",
+  "bin": { "stratum-mcp": "./dist/index.js" },
+  "files": ["dist"],
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^3.0.0"
+  },
+  "engines": { "node": ">=18" }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -16,7 +16,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -1,0 +1,267 @@
+/**
+ * Typed client for the Stratum REST API, mirroring the Worker's routes.
+ * Kept standalone (not shared with @stratum/cli) so each package publishes
+ * without a workspace dependency.
+ */
+
+interface ApiErrorBody {
+  error?: string;
+  message?: string;
+  reasons?: string[];
+}
+
+export interface ProjectRef {
+  namespace: string;
+  slug: string;
+}
+
+/** Parse "ns/slug" or "@ns/slug" into a project reference. */
+export function parseProjectRef(ref: string): ProjectRef {
+  const [nsRaw, slug] = ref.split("/", 2);
+  if (!nsRaw || !slug) {
+    throw new Error(`Invalid project reference '${ref}' — expected namespace/slug`);
+  }
+  return { namespace: nsRaw.startsWith("@") ? nsRaw : `@${nsRaw}`, slug };
+}
+
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  namespace: string;
+  slug: string;
+  path?: string;
+  remote?: string;
+  visibility?: string;
+  createdAt?: string;
+}
+
+export interface Change {
+  id: string;
+  project: string;
+  workspace: string;
+  status: string;
+  evalScore?: number;
+  evalPassed?: boolean;
+  evalReason?: string;
+  baseSha?: string;
+  createdAt: string;
+  mergedAt?: string;
+}
+
+export interface EvalRun {
+  id: string;
+  evaluatorType: string;
+  score: number;
+  passed: boolean;
+  reason: string;
+}
+
+export interface Issue {
+  id: string;
+  project: string;
+  number: number;
+  title: string;
+  body?: string;
+  status: "open" | "closed";
+  linkedChangeId?: string;
+  createdAt: string;
+}
+
+export interface ActivityEvent {
+  id: string;
+  type: string;
+  actorType: string;
+  actorId?: string;
+  payload: Record<string, unknown>;
+  createdAt: string;
+}
+
+export class StratumClient {
+  constructor(
+    private host: string,
+    private apiKey: string,
+  ) {}
+
+  async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const url = `${this.host.replace(/\/$/, "")}${path}`;
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+    };
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      let message = `HTTP ${response.status}`;
+      try {
+        const err = (await response.json()) as ApiErrorBody;
+        message = err.error ?? err.message ?? message;
+        if (err.reasons && err.reasons.length > 0) {
+          message += `\n  - ${err.reasons.join("\n  - ")}`;
+        }
+      } catch {
+        message = response.statusText || message;
+      }
+      throw new Error(message);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  // ── Projects ────────────────────────────────────────────────────────────
+
+  async listProjects() {
+    return this.request<{ projects: ProjectSummary[] }>("GET", "/api/projects");
+  }
+
+  async getProject(ref: ProjectRef) {
+    return this.request<ProjectSummary>(
+      "GET",
+      `/api/projects/${encodeURIComponent(ref.namespace)}/${encodeURIComponent(ref.slug)}`,
+    );
+  }
+
+  async listFiles(ref: ProjectRef) {
+    return this.request<{ files: string[] }>(
+      "GET",
+      `/api/projects/${encodeURIComponent(ref.namespace)}/${encodeURIComponent(ref.slug)}/files`,
+    );
+  }
+
+  async getFileContent(ref: ProjectRef, path: string) {
+    return this.request<{ kind: string; value?: string }>(
+      "GET",
+      `/api/projects/${encodeURIComponent(ref.namespace)}/${encodeURIComponent(ref.slug)}/content?path=${encodeURIComponent(path)}`,
+    );
+  }
+
+  async getActivity(ref: ProjectRef) {
+    return this.request<{ events: ActivityEvent[] }>(
+      "GET",
+      `/api/projects/${encodeURIComponent(ref.namespace)}/${encodeURIComponent(ref.slug)}/activity`,
+    );
+  }
+
+  // ── Workspaces ──────────────────────────────────────────────────────────
+
+  async createWorkspace(ref: ProjectRef, name?: string) {
+    return this.request<{ workspace: string; remote: string; path: string }>(
+      "POST",
+      `/api/workspaces/${encodeURIComponent(ref.namespace)}/${encodeURIComponent(ref.slug)}/workspaces`,
+      { ...(name ? { name } : {}) },
+    );
+  }
+
+  async listWorkspaces(ref: ProjectRef) {
+    return this.request<{ workspaces: Array<{ name: string; createdAt: string; path: string }> }>(
+      "GET",
+      `/api/workspaces/${encodeURIComponent(ref.namespace)}/${encodeURIComponent(ref.slug)}/workspaces`,
+    );
+  }
+
+  async commitToWorkspace(
+    workspace: string,
+    projectId: string,
+    files: Record<string, string>,
+    message: string,
+  ) {
+    return this.request<{ workspace: string; commit: string; filesChanged: string[] }>(
+      "POST",
+      `/api/workspaces/${encodeURIComponent(workspace)}/commit`,
+      { files, message, projectId },
+    );
+  }
+
+  // ── Changes ─────────────────────────────────────────────────────────────
+
+  async createChange(projectName: string, workspace: string) {
+    return this.request<{
+      change: Change;
+      eval: { score: number; passed: boolean; reason: string };
+      evalRuns: EvalRun[];
+    }>("POST", `/api/projects/${encodeURIComponent(projectName)}/changes`, { workspace });
+  }
+
+  async listChanges(projectName: string, status?: string) {
+    const query = status ? `?status=${encodeURIComponent(status)}` : "";
+    return this.request<{ changes: Change[] }>(
+      "GET",
+      `/api/projects/${encodeURIComponent(projectName)}/changes${query}`,
+    );
+  }
+
+  async getChange(id: string) {
+    return this.request<{
+      change: Change;
+      evalRuns: EvalRun[];
+      costs: Array<{ kind: string; total: number; estimated: boolean }>;
+    }>("GET", `/api/changes/${encodeURIComponent(id)}`);
+  }
+
+  async mergeChange(id: string, opts?: { force?: boolean; strategy?: "merge" | "squash" }) {
+    const params = new URLSearchParams();
+    if (opts?.force) params.set("force", "true");
+    if (opts?.strategy) params.set("strategy", opts.strategy);
+    const query = params.size > 0 ? `?${params.toString()}` : "";
+    return this.request<{
+      merged: boolean;
+      commit?: string;
+      postMerge?: { status: string; reason?: string };
+    }>("POST", `/api/changes/${encodeURIComponent(id)}/merge${query}`);
+  }
+
+  async rejectChange(id: string) {
+    return this.request<{ rejected: boolean }>(
+      "POST",
+      `/api/changes/${encodeURIComponent(id)}/reject`,
+    );
+  }
+
+  async reviewChange(id: string, verdict: "approve" | "request_changes", comment?: string) {
+    return this.request<{ review: { verdict: string }; changeStatus: string }>(
+      "POST",
+      `/api/changes/${encodeURIComponent(id)}/reviews`,
+      { verdict, ...(comment ? { comment } : {}) },
+    );
+  }
+
+  // ── Issues ──────────────────────────────────────────────────────────────
+
+  async createIssue(ref: ProjectRef, title: string, body?: string, linkedChangeId?: string) {
+    return this.request<{ issue: Issue }>(
+      "POST",
+      `/api/projects/${encodeURIComponent(ref.namespace)}/${encodeURIComponent(ref.slug)}/issues`,
+      { title, ...(body ? { body } : {}), ...(linkedChangeId ? { linkedChangeId } : {}) },
+    );
+  }
+
+  async listIssues(ref: ProjectRef, status?: "open" | "closed") {
+    const query = status ? `?status=${status}` : "";
+    return this.request<{ issues: Issue[] }>(
+      "GET",
+      `/api/projects/${encodeURIComponent(ref.namespace)}/${encodeURIComponent(ref.slug)}/issues${query}`,
+    );
+  }
+
+  async updateIssue(
+    ref: ProjectRef,
+    number: number,
+    updates: { status?: "open" | "closed"; title?: string; body?: string },
+  ) {
+    return this.request<{ issue: Issue }>(
+      "PATCH",
+      `/api/projects/${encodeURIComponent(ref.namespace)}/${encodeURIComponent(ref.slug)}/issues/${number}`,
+      updates,
+    );
+  }
+
+  // ── Account ─────────────────────────────────────────────────────────────
+
+  async me() {
+    return this.request<{ id: string; email: string }>("GET", "/api/users/me");
+  }
+}

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -15,10 +15,15 @@ export interface ProjectRef {
   slug: string;
 }
 
-/** Parse "ns/slug" or "@ns/slug" into a project reference. */
+/**
+ * Parse "ns/slug" or "@ns/slug" into a project reference. Exactly two
+ * non-empty segments — extra segments are rejected rather than silently
+ * dropped, so a tool can never operate on a different project than named.
+ */
 export function parseProjectRef(ref: string): ProjectRef {
-  const [nsRaw, slug] = ref.split("/", 2);
-  if (!nsRaw || !slug) {
+  const segments = ref.split("/");
+  const [nsRaw, slug] = segments;
+  if (segments.length !== 2 || !nsRaw || nsRaw === "@" || !slug) {
     throw new Error(`Invalid project reference '${ref}' — expected namespace/slug`);
   }
   return { namespace: nsRaw.startsWith("@") ? nsRaw : `@${nsRaw}`, slug };
@@ -76,10 +81,15 @@ export interface ActivityEvent {
   createdAt: string;
 }
 
+// Change creation runs the full evaluation suite synchronously server-side, so
+// the deadline must comfortably exceed a slow LLM + sandbox run.
+const DEFAULT_TIMEOUT_MS = 120_000;
+
 export class StratumClient {
   constructor(
     private host: string,
     private apiKey: string,
+    private opts: { timeoutMs?: number } = {},
   ) {}
 
   async request<T>(method: string, path: string, body?: unknown): Promise<T> {
@@ -89,11 +99,22 @@ export class StratumClient {
     };
     if (body !== undefined) headers["Content-Type"] = "application/json";
 
-    const response = await fetch(url, {
-      method,
-      headers,
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-    });
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(new Error("Stratum API request timed out")),
+      this.opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    );
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
 
     if (!response.ok) {
       let message = `HTTP ${response.status}`;

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * stratum-mcp — MCP server exposing Stratum's eval-gated change flow over
+ * stdio, so any MCP-capable agent or editor (Claude Code, Cursor, Zed,
+ * Copilot, …) can work against a Stratum instance.
+ *
+ * Configuration (env):
+ *   STRATUM_API_KEY  required — user or agent API token
+ *   STRATUM_HOST     optional — defaults to https://app.usestratum.dev
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StratumClient } from "./client.js";
+import { buildTools } from "./tools.js";
+
+const VERSION = "0.1.0";
+const DEFAULT_HOST = "https://app.usestratum.dev";
+
+async function main(): Promise<void> {
+  const apiKey = process.env.STRATUM_API_KEY;
+  if (!apiKey) {
+    console.error(
+      "stratum-mcp: STRATUM_API_KEY is not set. Create a token in Stratum → Settings → API tokens and export it.",
+    );
+    process.exit(1);
+  }
+  const host = process.env.STRATUM_HOST ?? DEFAULT_HOST;
+
+  const client = new StratumClient(host, apiKey);
+  const server = new McpServer({ name: "stratum", version: VERSION });
+
+  for (const t of buildTools(client)) {
+    server.registerTool(
+      t.name,
+      { description: t.description, inputSchema: t.schema },
+      (args: Record<string, unknown>) => t.handler(args),
+    );
+  }
+
+  await server.connect(new StdioServerTransport());
+  console.error(`stratum-mcp ${VERSION} connected (host: ${host})`);
+}
+
+main().catch((error: unknown) => {
+  console.error("stratum-mcp fatal:", error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -130,13 +130,19 @@ export function buildTools(client: StratumClient): ToolDef[] {
       "stratum_create_change",
       "Open a change (merge proposal) from a workspace. This synchronously runs the project's evaluation gates from .stratum/policy.yaml — secret scan, diff policy, LLM review, sandbox tests — and returns the verdicts. A failing gate blocks the merge.",
       { project: projectArg, workspace: z.string().describe("Source workspace name") },
-      (a) => client.createChange(a.project, a.workspace),
+      (a) => {
+        const ref = parseProjectRef(a.project);
+        return client.createChange(`${ref.namespace}/${ref.slug}`, a.workspace);
+      },
     ),
     tool(
       "stratum_list_changes",
       "List changes for a Stratum project, optionally filtered by status (open, merged, rejected, reverted).",
       { project: projectArg, status: z.string().optional().describe("Optional status filter") },
-      (a) => client.listChanges(a.project, a.status),
+      (a) => {
+        const ref = parseProjectRef(a.project);
+        return client.listChanges(`${ref.namespace}/${ref.slug}`, a.status);
+      },
     ),
     tool(
       "stratum_get_change",
@@ -162,7 +168,7 @@ export function buildTools(client: StratumClient): ToolDef[] {
     ),
     tool(
       "stratum_review_change",
-      "Submit a review verdict on a change. Note: approvals are a human gate — the server rejects approve verdicts from agent tokens, so agents can request changes but never approve their own work.",
+      "Submit a review verdict on a change. Note: approvals are a human gate — the server rejects ALL approve verdicts from agent tokens (not just on the agent's own changes); agents can only request changes.",
       {
         change_id: z.string().describe("Change id"),
         verdict: z.enum(["approve", "request_changes"]).describe("Review verdict"),

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -1,0 +1,213 @@
+import { z } from "zod";
+import { parseProjectRef, type StratumClient } from "./client.js";
+
+export interface ToolResult {
+  // Index signature matches the MCP SDK's CallToolResult so ToolDef handlers
+  // can be passed to registerTool without a cast.
+  [key: string]: unknown;
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}
+
+export interface ToolDef {
+  name: string;
+  description: string;
+  schema: z.ZodRawShape;
+  handler: (args: Record<string, unknown>) => Promise<ToolResult>;
+}
+
+function jsonResult(value: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] };
+}
+
+function errorResult(error: unknown): ToolResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return { content: [{ type: "text", text: `Stratum API error: ${message}` }], isError: true };
+}
+
+/** Wrap a typed handler with schema validation and error-to-result mapping. */
+function tool<Shape extends z.ZodRawShape>(
+  name: string,
+  description: string,
+  schema: Shape,
+  handler: (args: z.infer<z.ZodObject<Shape>>) => Promise<unknown>,
+): ToolDef {
+  return {
+    name,
+    description,
+    schema,
+    handler: async (raw) => {
+      try {
+        const args = z.object(schema).parse(raw);
+        return jsonResult(await handler(args));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  };
+}
+
+const projectArg = z
+  .string()
+  .describe('Project reference as "namespace/slug", e.g. "@acme/api" or "acme/api"');
+
+/**
+ * The full Stratum surface an agent needs to propose governed changes:
+ * read a project, fork a workspace, commit, open an eval-gated change, and
+ * follow it through review to merge. Approval stays a human gate — the
+ * server rejects review approvals from agent tokens by design.
+ */
+export function buildTools(client: StratumClient): ToolDef[] {
+  return [
+    tool(
+      "stratum_whoami",
+      "Identify the authenticated Stratum user or agent for the configured API key.",
+      {},
+      () => client.me(),
+    ),
+
+    // ── Projects ──────────────────────────────────────────────────────────
+    tool(
+      "stratum_list_projects",
+      "List Stratum projects visible to the authenticated identity.",
+      {},
+      () => client.listProjects(),
+    ),
+    tool(
+      "stratum_get_project",
+      "Get a Stratum project's metadata (id, namespace, visibility, git remote).",
+      { project: projectArg },
+      (a) => client.getProject(parseProjectRef(a.project)),
+    ),
+    tool(
+      "stratum_list_files",
+      "List file paths at the HEAD of a Stratum project's default branch.",
+      { project: projectArg },
+      (a) => client.listFiles(parseProjectRef(a.project)),
+    ),
+    tool(
+      "stratum_get_file",
+      "Read one file's content from the HEAD of a Stratum project.",
+      { project: projectArg, path: z.string().describe("Repo-relative file path") },
+      (a) => client.getFileContent(parseProjectRef(a.project), a.path),
+    ),
+    tool(
+      "stratum_get_activity",
+      "Get the recent activity feed for a Stratum project (changes, merges, evaluations, issues).",
+      { project: projectArg },
+      (a) => client.getActivity(parseProjectRef(a.project)),
+    ),
+
+    // ── Workspaces ────────────────────────────────────────────────────────
+    tool(
+      "stratum_create_workspace",
+      "Fork an isolated workspace from a Stratum project. Returns the workspace name and its git remote. Commit work here, then open a change to propose merging it.",
+      { project: projectArg, name: z.string().optional().describe("Optional workspace name") },
+      (a) => client.createWorkspace(parseProjectRef(a.project), a.name),
+    ),
+    tool(
+      "stratum_list_workspaces",
+      "List open workspaces for a Stratum project.",
+      { project: projectArg },
+      (a) => client.listWorkspaces(parseProjectRef(a.project)),
+    ),
+    tool(
+      "stratum_commit",
+      "Commit files to a workspace. Takes a map of repo-relative file paths to full new file contents.",
+      {
+        workspace: z.string().describe("Workspace name returned by stratum_create_workspace"),
+        project_id: z.string().describe("Project id from stratum_get_project"),
+        message: z.string().describe("Commit message"),
+        files: z
+          .record(z.string(), z.string())
+          .describe("Map of repo-relative path to complete new file content"),
+      },
+      (a) => client.commitToWorkspace(a.workspace, a.project_id, a.files, a.message),
+    ),
+
+    // ── Changes (eval-gated merge proposals) ──────────────────────────────
+    tool(
+      "stratum_create_change",
+      "Open a change (merge proposal) from a workspace. This synchronously runs the project's evaluation gates from .stratum/policy.yaml — secret scan, diff policy, LLM review, sandbox tests — and returns the verdicts. A failing gate blocks the merge.",
+      { project: projectArg, workspace: z.string().describe("Source workspace name") },
+      (a) => client.createChange(a.project, a.workspace),
+    ),
+    tool(
+      "stratum_list_changes",
+      "List changes for a Stratum project, optionally filtered by status (open, merged, rejected, reverted).",
+      { project: projectArg, status: z.string().optional().describe("Optional status filter") },
+      (a) => client.listChanges(a.project, a.status),
+    ),
+    tool(
+      "stratum_get_change",
+      "Get one change with its evaluation runs (per-gate score, pass/fail, reason) and metered costs (LLM tokens, sandbox time, git ops).",
+      { change_id: z.string().describe("Change id, e.g. chg_abc123") },
+      (a) => client.getChange(a.change_id),
+    ),
+    tool(
+      "stratum_merge_change",
+      "Merge a change that has passed its evaluation gates and required human approvals. Fails with the blocking reasons otherwise; a stale base is rejected until re-evaluated. Force requires the policy to allow it.",
+      {
+        change_id: z.string().describe("Change id"),
+        force: z.boolean().optional().describe("Request a force merge (denied unless policy allows)"),
+        strategy: z.enum(["merge", "squash"]).optional().describe("Merge strategy"),
+      },
+      (a) => client.mergeChange(a.change_id, { force: a.force, strategy: a.strategy }),
+    ),
+    tool(
+      "stratum_reject_change",
+      "Reject an open change, closing it without merging.",
+      { change_id: z.string().describe("Change id") },
+      (a) => client.rejectChange(a.change_id),
+    ),
+    tool(
+      "stratum_review_change",
+      "Submit a review verdict on a change. Note: approvals are a human gate — the server rejects approve verdicts from agent tokens, so agents can request changes but never approve their own work.",
+      {
+        change_id: z.string().describe("Change id"),
+        verdict: z.enum(["approve", "request_changes"]).describe("Review verdict"),
+        comment: z.string().optional().describe("Optional review comment"),
+      },
+      (a) => client.reviewChange(a.change_id, a.verdict, a.comment),
+    ),
+
+    // ── Issues ────────────────────────────────────────────────────────────
+    tool(
+      "stratum_create_issue",
+      "Open an issue on a Stratum project. Linking a change id auto-closes the issue when that change merges.",
+      {
+        project: projectArg,
+        title: z.string().describe("Issue title"),
+        body: z.string().optional().describe("Issue body"),
+        linked_change_id: z.string().optional().describe("Change id to link"),
+      },
+      (a) => client.createIssue(parseProjectRef(a.project), a.title, a.body, a.linked_change_id),
+    ),
+    tool(
+      "stratum_list_issues",
+      "List issues for a Stratum project, optionally filtered by status.",
+      {
+        project: projectArg,
+        status: z.enum(["open", "closed"]).optional().describe("Optional status filter"),
+      },
+      (a) => client.listIssues(parseProjectRef(a.project), a.status),
+    ),
+    tool(
+      "stratum_update_issue",
+      "Update an issue's status, title, or body by its number.",
+      {
+        project: projectArg,
+        number: z.number().int().describe("Issue number"),
+        status: z.enum(["open", "closed"]).optional().describe("New status"),
+        title: z.string().optional().describe("New title"),
+        body: z.string().optional().describe("New body"),
+      },
+      (a) =>
+        client.updateIssue(parseProjectRef(a.project), a.number, {
+          status: a.status,
+          title: a.title,
+          body: a.body,
+        }),
+    ),
+  ];
+}

--- a/mcp/tests/client.test.ts
+++ b/mcp/tests/client.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StratumClient, parseProjectRef } from "../src/client.js";
+
+const fetchMock = vi.fn();
+
+function lastCall(): { url: string; init: RequestInit } {
+  const call = fetchMock.mock.calls.at(-1) as [string, RequestInit];
+  return { url: call[0], init: call[1] };
+}
+
+describe("parseProjectRef", () => {
+  it("parses namespace/slug with and without @", () => {
+    expect(parseProjectRef("@user/repo")).toEqual({ namespace: "@user", slug: "repo" });
+    expect(parseProjectRef("user/repo")).toEqual({ namespace: "@user", slug: "repo" });
+  });
+
+  it("rejects malformed references", () => {
+    expect(() => parseProjectRef("just-a-name")).toThrow(/namespace\/slug/);
+  });
+});
+
+describe("StratumClient", () => {
+  let client: StratumClient;
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    fetchMock.mockImplementation(async () => new Response("{}", { status: 200 }));
+    client = new StratumClient("https://stratum.example.com/", "stratum_user_key");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends the bearer token and strips trailing slash from host", async () => {
+    await client.listProjects();
+    const { url, init } = lastCall();
+    expect(url).toBe("https://stratum.example.com/api/projects");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer stratum_user_key");
+  });
+
+  it("sets Content-Type only when a body is sent", async () => {
+    await client.listProjects();
+    expect((lastCall().init.headers as Record<string, string>)["Content-Type"]).toBeUndefined();
+
+    await client.createWorkspace(parseProjectRef("@user/repo"));
+    expect((lastCall().init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json",
+    );
+  });
+
+  it("surfaces API error bodies including merge-blocking reasons", async () => {
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: "Merge blocked",
+            reasons: ["secret_scan failed", "1 approval required"],
+          }),
+          { status: 409 },
+        ),
+    );
+    await expect(client.mergeChange("chg_1")).rejects.toThrow(
+      /Merge blocked[\s\S]*secret_scan failed[\s\S]*1 approval required/,
+    );
+  });
+
+  it("falls back to HTTP status when the error body is not JSON", async () => {
+    fetchMock.mockImplementation(
+      async () => new Response("<html>", { status: 502, statusText: "Bad Gateway" }),
+    );
+    await expect(client.listProjects()).rejects.toThrow("Bad Gateway");
+  });
+});

--- a/mcp/tests/client.test.ts
+++ b/mcp/tests/client.test.ts
@@ -17,6 +17,15 @@ describe("parseProjectRef", () => {
   it("rejects malformed references", () => {
     expect(() => parseProjectRef("just-a-name")).toThrow(/namespace\/slug/);
   });
+
+  it("rejects extra path segments instead of silently truncating", () => {
+    expect(() => parseProjectRef("team/repo/extra")).toThrow(/namespace\/slug/);
+  });
+
+  it("rejects an empty namespace", () => {
+    expect(() => parseProjectRef("@/repo")).toThrow(/namespace\/slug/);
+    expect(() => parseProjectRef("/repo")).toThrow(/namespace\/slug/);
+  });
 });
 
 describe("StratumClient", () => {
@@ -71,5 +80,30 @@ describe("StratumClient", () => {
       async () => new Response("<html>", { status: 502, statusText: "Bad Gateway" }),
     );
     await expect(client.listProjects()).rejects.toThrow("Bad Gateway");
+  });
+
+  it("passes an abort signal to fetch so a stalled API cannot hang forever", async () => {
+    await client.listProjects();
+    const init = lastCall().init;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("aborts the request when the configured deadline elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const slow = new StratumClient("https://stratum.example.com", "key", { timeoutMs: 50 });
+      fetchMock.mockImplementation(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+          }),
+      );
+      const pending = slow.listProjects();
+      const assertion = expect(pending).rejects.toThrow("timed out");
+      await vi.advanceTimersByTimeAsync(60);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StratumClient } from "../src/client.js";
+import { buildTools, type ToolDef } from "../src/tools.js";
+
+const fetchMock = vi.fn();
+
+function lastCall(): { url: string; init: RequestInit } {
+  const call = fetchMock.mock.calls.at(-1) as [string, RequestInit];
+  return { url: call[0], init: call[1] };
+}
+
+function getTool(tools: ToolDef[], name: string): ToolDef {
+  const t = tools.find((t) => t.name === name);
+  if (!t) throw new Error(`tool ${name} not found`);
+  return t;
+}
+
+let tools: ToolDef[];
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(async () => new Response("{}", { status: 200 }));
+  tools = buildTools(new StratumClient("https://stratum.example.com", "stratum_agent_key"));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("tool registry", () => {
+  it("exposes the full change-flow surface with unique, prefixed names", () => {
+    const names = tools.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+    expect(names.every((n) => n.startsWith("stratum_"))).toBe(true);
+    for (const required of [
+      "stratum_whoami",
+      "stratum_list_projects",
+      "stratum_get_project",
+      "stratum_list_files",
+      "stratum_get_file",
+      "stratum_create_workspace",
+      "stratum_commit",
+      "stratum_create_change",
+      "stratum_get_change",
+      "stratum_merge_change",
+      "stratum_review_change",
+      "stratum_create_issue",
+    ]) {
+      expect(names).toContain(required);
+    }
+  });
+
+  it("gives every tool a non-empty description", () => {
+    for (const t of tools) {
+      expect(t.description.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("documents the human-approval invariant on the review tool", () => {
+    const review = getTool(tools, "stratum_review_change");
+    expect(review.description).toMatch(/human gate|never approve/i);
+  });
+});
+
+describe("read tools", () => {
+  it("stratum_whoami calls /api/users/me and returns formatted JSON", async () => {
+    fetchMock.mockImplementation(
+      async () => new Response(JSON.stringify({ id: "user_1", email: "a@b.c" }), { status: 200 }),
+    );
+    const result = await getTool(tools, "stratum_whoami").handler({});
+    expect(lastCall().url).toBe("https://stratum.example.com/api/users/me");
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0]?.text ?? "")).toEqual({ id: "user_1", email: "a@b.c" });
+  });
+
+  it("stratum_get_project normalizes the namespace", async () => {
+    await getTool(tools, "stratum_get_project").handler({ project: "acme/api" });
+    expect(lastCall().url).toBe("https://stratum.example.com/api/projects/%40acme/api");
+  });
+
+  it("stratum_get_file encodes the path query", async () => {
+    await getTool(tools, "stratum_get_file").handler({
+      project: "@acme/api",
+      path: "src/a b.ts",
+    });
+    expect(lastCall().url).toBe(
+      "https://stratum.example.com/api/projects/%40acme/api/content?path=src%2Fa%20b.ts",
+    );
+  });
+
+  it("stratum_list_issues passes the status filter", async () => {
+    await getTool(tools, "stratum_list_issues").handler({ project: "@acme/api", status: "open" });
+    expect(lastCall().url).toBe(
+      "https://stratum.example.com/api/projects/%40acme/api/issues?status=open",
+    );
+  });
+});
+
+describe("write tools", () => {
+  it("stratum_commit posts files, message, and projectId", async () => {
+    await getTool(tools, "stratum_commit").handler({
+      workspace: "ws-1",
+      project_id: "proj_123",
+      message: "add feature",
+      files: { "src/a.ts": "export const a = 1;" },
+    });
+    const { url, init } = lastCall();
+    expect(url).toBe("https://stratum.example.com/api/workspaces/ws-1/commit");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      files: { "src/a.ts": "export const a = 1;" },
+      message: "add feature",
+      projectId: "proj_123",
+    });
+  });
+
+  it("stratum_create_change posts the workspace and echoes eval verdicts", async () => {
+    const evalPayload = {
+      change: { id: "chg_1", status: "open" },
+      eval: { score: 0.4, passed: false, reason: "secret detected" },
+      evalRuns: [{ evaluatorType: "secret_scan", score: 0, passed: false }],
+    };
+    fetchMock.mockImplementation(
+      async () => new Response(JSON.stringify(evalPayload), { status: 200 }),
+    );
+    const result = await getTool(tools, "stratum_create_change").handler({
+      project: "@acme/api",
+      workspace: "ws-1",
+    });
+    expect(lastCall().url).toBe("https://stratum.example.com/api/projects/%40acme%2Fapi/changes");
+    expect(JSON.parse(lastCall().init.body as string)).toEqual({ workspace: "ws-1" });
+    expect(JSON.parse(result.content[0]?.text ?? "")).toEqual(evalPayload);
+  });
+
+  it("stratum_merge_change forwards force and strategy as query params", async () => {
+    await getTool(tools, "stratum_merge_change").handler({
+      change_id: "chg_1",
+      force: true,
+      strategy: "squash",
+    });
+    expect(lastCall().url).toBe(
+      "https://stratum.example.com/api/changes/chg_1/merge?force=true&strategy=squash",
+    );
+  });
+
+  it("stratum_update_issue patches by number", async () => {
+    await getTool(tools, "stratum_update_issue").handler({
+      project: "@acme/api",
+      number: 7,
+      status: "closed",
+    });
+    const { url, init } = lastCall();
+    expect(url).toBe("https://stratum.example.com/api/projects/%40acme/api/issues/7");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toMatchObject({ status: "closed" });
+  });
+});
+
+describe("error handling", () => {
+  it("maps API rejections to isError results instead of throwing", async () => {
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ error: "agent tokens cannot approve work" }), {
+          status: 403,
+        }),
+    );
+    const result = await getTool(tools, "stratum_review_change").handler({
+      change_id: "chg_1",
+      verdict: "approve",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("agent tokens cannot approve work");
+  });
+
+  it("rejects invalid arguments before any network call", async () => {
+    const result = await getTool(tools, "stratum_commit").handler({
+      workspace: "ws-1",
+      // project_id, message, files missing
+    });
+    expect(result.isError).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown review verdict before any network call", async () => {
+    const result = await getTool(tools, "stratum_review_change").handler({
+      change_id: "chg_1",
+      verdict: "rubber_stamp",
+    });
+    expect(result.isError).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed project reference without a network call", async () => {
+    const result = await getTool(tools, "stratum_get_project").handler({ project: "no-slash" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("namespace/slug");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -39,16 +39,23 @@ describe("tool registry", () => {
       "stratum_get_project",
       "stratum_list_files",
       "stratum_get_file",
+      "stratum_get_activity",
       "stratum_create_workspace",
+      "stratum_list_workspaces",
       "stratum_commit",
       "stratum_create_change",
+      "stratum_list_changes",
       "stratum_get_change",
       "stratum_merge_change",
+      "stratum_reject_change",
       "stratum_review_change",
       "stratum_create_issue",
+      "stratum_list_issues",
+      "stratum_update_issue",
     ]) {
       expect(names).toContain(required);
     }
+    expect(names).toHaveLength(18);
   });
 
   it("gives every tool a non-empty description", () => {
@@ -113,6 +120,14 @@ describe("write tools", () => {
       message: "add feature",
       projectId: "proj_123",
     });
+  });
+
+  it("stratum_create_change normalizes a bare namespace before hitting the API", async () => {
+    await getTool(tools, "stratum_create_change").handler({
+      project: "acme/api",
+      workspace: "ws-1",
+    });
+    expect(lastCall().url).toBe("https://stratum.example.com/api/projects/%40acme%2Fapi/changes");
   });
 
   it("stratum_create_change posts the workspace and echoes eval verdicts", async () => {

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "declaration": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/mcp/tsconfig.test.json
+++ b/mcp/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "outDir": null
+  },
+  "include": ["src", "tests"]
+}

--- a/mcp/vitest.config.ts
+++ b/mcp/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+// Without a local config, vitest climbs to the repo root and loads the
+// Worker's vitest.config.ts — which needs the root node_modules that the
+// packages CI job doesn't install.
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/src/evaluation/llm-evaluator.ts
+++ b/src/evaluation/llm-evaluator.ts
@@ -6,6 +6,22 @@ import type { Result } from "../utils/result";
 import { err, ok } from "../utils/result";
 import type { EvalPolicy, EvalResult, Evaluator, EvaluatorConfig } from "./types";
 
+const DEFAULT_MODEL = "@cf/meta/llama-3.1-8b-instruct";
+const DEFAULT_THRESHOLD = 0.7;
+const DEFAULT_MAX_DIFF_CHARS = 24_000;
+// Upper bound on a policy-supplied window so a hostile policy can't blow the
+// model's context or the Worker's memory.
+const MAX_DIFF_CHARS_CEILING = 100_000;
+
+const SYSTEM_PROMPT = [
+  "You are a rigorous code reviewer acting as an automated merge gate.",
+  "Review the diff for correctness bugs, security vulnerabilities, leaked credentials,",
+  "and violations of the supplied policy context.",
+  "Score 1.0 means safe to merge; 0.0 means must not merge.",
+  "Respond with ONLY a JSON object and no other text:",
+  '{"score": <0.0-1.0>, "passed": <bool>, "reason": "<one sentence>", "issues": ["<finding>"]}',
+].join(" ");
+
 function sanitizePolicy(policy: EvalPolicy): EvalPolicy {
   return {
     ...policy,
@@ -31,22 +47,27 @@ export class LLMEvaluator implements Evaluator {
 
     try {
       const config = policy.evaluators.find((e) => e.type === "llm") as
-        | { type: "llm"; model?: string; threshold?: number }
+        | { type: "llm"; model?: string; threshold?: number; maxDiffChars?: number }
         | undefined;
-      const model = config?.model ?? "@cf/meta/llama-3.1-8b-instruct";
-      const threshold = config?.threshold ?? 0.7;
+      const model = config?.model ?? DEFAULT_MODEL;
+      const threshold = config?.threshold ?? DEFAULT_THRESHOLD;
+      const maxDiffChars =
+        typeof config?.maxDiffChars === "number" && config.maxDiffChars > 0
+          ? Math.min(config.maxDiffChars, MAX_DIFF_CHARS_CEILING)
+          : DEFAULT_MAX_DIFF_CHARS;
 
-      logger.debug("LLM config", { model, threshold });
+      logger.debug("LLM config", { model, threshold, maxDiffChars });
+
+      const truncated = diff.length > maxDiffChars;
+      const truncationNote = truncated
+        ? `Diff truncated for review: evaluated first ${maxDiffChars} of ${diff.length} chars`
+        : undefined;
 
       const messages = [
-        {
-          role: "system",
-          content:
-            '{"score": <0.0-1.0>, "passed": <bool>, "reason": "<string>", "issues": ["<string>"]}',
-        },
+        { role: "system", content: SYSTEM_PROMPT },
         {
           role: "user",
-          content: `Policy context: ${JSON.stringify(sanitizePolicy(policy))}\n\nDiff to review:\n${diff.slice(0, 8000)}`,
+          content: `Policy context: ${JSON.stringify(sanitizePolicy(policy))}\n\nDiff to review:\n${diff.slice(0, maxDiffChars)}`,
         },
       ];
 
@@ -69,6 +90,23 @@ export class LLMEvaluator implements Evaluator {
         { kind: "llm_tokens", quantity: estimatedTokens, estimated: true },
       ];
 
+      // A gate whose verdict can't be read has not passed. Never infer a score
+      // from prose ("LGTM") — that let unparseable output half-approve a merge.
+      const failClosed = (why: string): Result<EvalResult, AppError> => {
+        logger.warn("LLM response unusable, failing closed", { why });
+        const snippet = responseText?.slice(0, 200);
+        return ok({
+          score: 0,
+          passed: false,
+          reason: `LLM evaluator failed closed: ${why}`,
+          issues: [
+            ...(snippet ? [`Raw model response: ${snippet}`] : []),
+            ...(truncationNote ? [truncationNote] : []),
+          ],
+          costs,
+        });
+      };
+
       let parsed: { score: unknown; passed: unknown; reason: unknown; issues?: unknown };
       try {
         parsed = JSON.parse(responseText ?? "") as {
@@ -78,14 +116,7 @@ export class LLMEvaluator implements Evaluator {
           issues?: unknown;
         };
       } catch {
-        const fallbackScore = responseText?.includes("LGTM") ? 0.8 : 0.3;
-        logger.warn("LLM response parse failed, using fallback", { fallbackScore });
-        return ok({
-          score: fallbackScore,
-          passed: false,
-          reason: responseText?.slice(0, 200) ?? "No response",
-          costs,
-        });
+        return failClosed("response was not valid JSON");
       }
 
       if (
@@ -93,30 +124,24 @@ export class LLMEvaluator implements Evaluator {
         typeof parsed.passed !== "boolean" ||
         typeof parsed.reason !== "string"
       ) {
-        const fallbackScore = responseText?.includes("LGTM") ? 0.8 : 0.3;
-        logger.warn("LLM response validation failed, using fallback", { fallbackScore });
-        return ok({
-          score: fallbackScore,
-          passed: false,
-          reason: responseText?.slice(0, 200) ?? "No response",
-          costs,
-        });
+        return failClosed("response JSON missing score/passed/reason fields");
       }
 
       const score = Math.min(1, Math.max(0, parsed.score));
       const passed = score >= threshold;
-      const issues =
+      const modelIssues =
         Array.isArray(parsed.issues) && parsed.issues.every((i) => typeof i === "string")
           ? (parsed.issues as string[])
-          : undefined;
+          : [];
+      const issues = truncationNote ? [...modelIssues, truncationNote] : modelIssues;
 
-      logger.info("LLM evaluation complete", { score, passed });
+      logger.info("LLM evaluation complete", { score, passed, truncated });
 
       return ok({
         score,
         passed,
         reason: parsed.reason,
-        ...(issues !== undefined ? { issues } : {}),
+        ...(issues.length > 0 ? { issues } : {}),
         costs,
       });
     } catch (error) {

--- a/src/evaluation/llm-evaluator.ts
+++ b/src/evaluation/llm-evaluator.ts
@@ -9,9 +9,11 @@ import type { EvalPolicy, EvalResult, Evaluator, EvaluatorConfig } from "./types
 const DEFAULT_MODEL = "@cf/meta/llama-3.1-8b-instruct";
 const DEFAULT_THRESHOLD = 0.7;
 const DEFAULT_MAX_DIFF_CHARS = 24_000;
-// Upper bound on a policy-supplied window so a hostile policy can't blow the
-// model's context or the Worker's memory.
+// Policy-supplied window bounds: the ceiling stops a hostile policy blowing the
+// model's context or the Worker's memory; the floor stops a tiny/fractional
+// value feeding the model an effectively empty diff that it would still score.
 const MAX_DIFF_CHARS_CEILING = 100_000;
+const MAX_DIFF_CHARS_FLOOR = 1_000;
 
 const SYSTEM_PROMPT = [
   "You are a rigorous code reviewer acting as an automated merge gate.",
@@ -52,8 +54,11 @@ export class LLMEvaluator implements Evaluator {
       const model = config?.model ?? DEFAULT_MODEL;
       const threshold = config?.threshold ?? DEFAULT_THRESHOLD;
       const maxDiffChars =
-        typeof config?.maxDiffChars === "number" && config.maxDiffChars > 0
-          ? Math.min(config.maxDiffChars, MAX_DIFF_CHARS_CEILING)
+        typeof config?.maxDiffChars === "number" && Number.isFinite(config.maxDiffChars)
+          ? Math.min(
+              Math.max(Math.floor(config.maxDiffChars), MAX_DIFF_CHARS_FLOOR),
+              MAX_DIFF_CHARS_CEILING,
+            )
           : DEFAULT_MAX_DIFF_CHARS;
 
       logger.debug("LLM config", { model, threshold, maxDiffChars });
@@ -121,6 +126,7 @@ export class LLMEvaluator implements Evaluator {
 
       if (
         typeof parsed.score !== "number" ||
+        !Number.isFinite(parsed.score) ||
         typeof parsed.passed !== "boolean" ||
         typeof parsed.reason !== "string"
       ) {

--- a/src/evaluation/secret-scanner.ts
+++ b/src/evaluation/secret-scanner.ts
@@ -5,13 +5,83 @@ import { ok } from "../utils/result";
 import type { EvalPolicy, EvalResult, Evaluator } from "./types";
 
 const SECRET_PATTERNS = [
-  { name: "AWS Access Key", pattern: /AKIA[0-9A-Z]{16}/ },
+  { name: "AWS Access Key", pattern: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/ },
+  {
+    name: "AWS Secret Key",
+    pattern: /aws.{0,30}?['"][0-9A-Za-z/+=]{40}['"]/i,
+  },
   { name: "GitHub Token (Classic)", pattern: /ghp_[a-zA-Z0-9]{36}/ },
+  { name: "GitHub OAuth Token", pattern: /gho_[a-zA-Z0-9]{36}/ },
+  { name: "GitHub User-to-Server Token", pattern: /ghu_[a-zA-Z0-9]{36}/ },
   { name: "GitHub App Token", pattern: /ghs_[a-zA-Z0-9]{36}/ },
   { name: "GitHub Refresh Token", pattern: /ghr_[a-zA-Z0-9]{76}/ },
+  { name: "GitHub Fine-Grained PAT", pattern: /github_pat_[a-zA-Z0-9_]{82}/ },
+  { name: "GitLab Personal Access Token", pattern: /glpat-[0-9a-zA-Z_-]{20}/ },
+  { name: "Slack Token", pattern: /xox[baprs]-[0-9a-zA-Z-]{10,}/ },
+  {
+    name: "Slack Webhook URL",
+    pattern: /hooks\.slack\.com\/services\/T[0-9A-Z]+\/B[0-9A-Z]+\/[0-9a-zA-Z]+/,
+  },
+  { name: "Stripe Live Key", pattern: /\b[sr]k_live_[0-9a-zA-Z]{20,}\b/ },
+  { name: "OpenAI API Key (Legacy)", pattern: /\bsk-[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20}\b/ },
+  { name: "OpenAI API Key (Project)", pattern: /\bsk-proj-[A-Za-z0-9_-]{40,}\b/ },
+  { name: "Anthropic API Key", pattern: /\bsk-ant-[a-zA-Z0-9_-]{20,}\b/ },
+  { name: "Google API Key", pattern: /\bAIza[0-9A-Za-z_-]{35}\b/ },
+  { name: "npm Access Token", pattern: /\bnpm_[A-Za-z0-9]{36}\b/ },
+  { name: "PyPI Upload Token", pattern: /pypi-AgEIcHlwaS5vcmc[A-Za-z0-9_-]{20,}/ },
+  { name: "Hugging Face Token", pattern: /\bhf_[A-Za-z0-9]{34}\b/ },
+  {
+    name: "SendGrid API Key",
+    pattern: /SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}/,
+  },
+  { name: "Twilio API Key", pattern: /\bSK[0-9a-f]{32}\b/ },
+  {
+    name: "Private Key Block",
+    pattern: /-----BEGIN [A-Z ]*PRIVATE KEY( BLOCK)?-----/,
+  },
+  {
+    name: "JSON Web Token",
+    pattern: /\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}/,
+  },
+  {
+    name: "Connection String Credential",
+    pattern:
+      /\b(?:postgres|postgresql|mysql|mongodb(?:\+srv)?|redis|amqps?):\/\/[^\s:@/]+:[^\s@/]+@/,
+  },
+  { name: "Azure Storage Account Key", pattern: /AccountKey=[A-Za-z0-9+/=]{40,}/ },
   { name: "Stratum User Token", pattern: /stratum_user_[a-f0-9]{32}/ },
   { name: "Stratum Agent Token", pattern: /stratum_agent_[a-f0-9]{32}/ },
 ];
+
+/**
+ * Generic credential assignments the named patterns miss. Gated on a
+ * credential-ish keyword on the same line so ordinary identifiers and hashes
+ * in test fixtures don't trip a blocking gate.
+ */
+const ENTROPY_CANDIDATE =
+  /(?:secret|token|key|passwd|password|credential|auth)[a-z0-9_]*['"]?\s*[:=]\s*['"`]?([A-Za-z0-9+/_=-]{24,})/i;
+
+const ENTROPY_MIN_MIXED = 4.0;
+const ENTROPY_MIN_HEX = 3.5;
+
+export function shannonEntropy(value: string): number {
+  const freq = new Map<string, number>();
+  for (const ch of value) freq.set(ch, (freq.get(ch) ?? 0) + 1);
+  let entropy = 0;
+  for (const count of freq.values()) {
+    const p = count / value.length;
+    entropy -= p * Math.log2(p);
+  }
+  return entropy;
+}
+
+function highEntropyCandidate(line: string): string | undefined {
+  const match = ENTROPY_CANDIDATE.exec(line);
+  const candidate = match?.[1];
+  if (!candidate) return undefined;
+  const threshold = /^[0-9a-f]+$/i.test(candidate) ? ENTROPY_MIN_HEX : ENTROPY_MIN_MIXED;
+  return shannonEntropy(candidate) >= threshold ? candidate : undefined;
+}
 
 export class SecretScanEvaluator implements Evaluator {
   async evaluate(
@@ -28,8 +98,11 @@ export class SecretScanEvaluator implements Evaluator {
       for (const { name, pattern } of SECRET_PATTERNS) {
         if (pattern.test(line)) {
           issues.push(`${name}: line ${lineNumber}`);
-          break;
+          return;
         }
+      }
+      if (highEntropyCandidate(line)) {
+        issues.push(`High-Entropy Credential: line ${lineNumber}`);
       }
     });
 

--- a/src/evaluation/types.ts
+++ b/src/evaluation/types.ts
@@ -57,4 +57,4 @@ export type EvaluatorConfig =
     }
   | { type: "webhook"; url: string; secret?: string; timeoutMs?: number }
   | { type: "sandbox"; command?: string; timeoutMs?: number }
-  | { type: "llm"; model?: string; threshold?: number };
+  | { type: "llm"; model?: string; threshold?: number; maxDiffChars?: number };

--- a/src/evaluation/types.ts
+++ b/src/evaluation/types.ts
@@ -35,7 +35,7 @@ export interface MergePolicy {
   requiredApprovals?: number;
   /** Evaluator types whose latest run must have passed (e.g. ["secret_scan", "diff"]). */
   requiredEvaluators?: string[];
-  /** When false, the ?force=true override is rejected. Default true. */
+  /** The ?force=true override is rejected unless this is explicitly true. Default false. */
   allowForce?: boolean;
   /** When true, a change whose recorded base is behind project HEAD cannot merge. */
   requireFreshBase?: boolean;

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1,23 +1,17 @@
 import { type Context, Hono } from "hono";
-import {
-  CompositeEvaluator,
-  DiffEvaluator,
-  LLMEvaluator,
-  SandboxEvaluator,
-  SecretScanEvaluator,
-  WebhookEvaluator,
-  loadPolicy,
-} from "../evaluation";
-import type { EvalPolicy, EvalResult } from "../evaluation/types";
-import type { Evaluator } from "../evaluation/types";
+import { CompositeEvaluator, loadPolicy } from "../evaluation";
+import type { EvalPolicy } from "../evaluation/types";
 import { runPostMergeCheck } from "../merge/post-merge";
 import { checkMergeProtection } from "../merge/protection";
-import { type EventActor, emitEvent } from "../queue/events";
+import { emitEvent } from "../queue/events";
 import type { MergeOutcome } from "../queue/merge-queue";
-import { getAgent } from "../storage/agents";
+import {
+  buildEvaluators,
+  createChangeWithEvaluation,
+  resolveProjectHead,
+} from "../services/change-flow";
 import { recordAudit } from "../storage/audit";
 import {
-  createChange,
   getChange,
   getChangesByIds,
   listChanges,
@@ -41,11 +35,9 @@ import {
   parseStagedTree,
 } from "../storage/git-ops";
 import { recordProvenance } from "../storage/provenance";
-import { readRepoSnapshot } from "../storage/repo-snapshot";
 import { getProject, getWorkspace } from "../storage/state";
 import type { Change, Env, ProjectEntry } from "../types";
 import { canReadProject, canWriteProject } from "../utils/authz";
-import type { AppError } from "../utils/errors";
 import { newId } from "../utils/ids";
 import { createLogger } from "../utils/logger";
 import type { Logger } from "../utils/logger";
@@ -58,7 +50,6 @@ import {
   ok,
   unauthorized,
 } from "../utils/response";
-import { ok as okResult } from "../utils/result";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -149,25 +140,6 @@ function okOrFormRedirect<T>(c: Context<{ Bindings: Env }>, changeId: string, da
   return ok(data);
 }
 
-/** Current project HEAD: cheap KV snapshot first, single-commit clone as fallback. */
-async function resolveProjectHead(
-  env: Env,
-  project: ProjectEntry,
-  logger: Logger,
-): Promise<string | null> {
-  if (project.namespace && project.slug) {
-    const snapshotResult = await readRepoSnapshot(env.STATE, project, logger);
-    if (snapshotResult.success) {
-      const sha = snapshotResult.data?.commits[0]?.sha;
-      if (sha) return sha;
-    }
-  }
-  const readToken = await freshRepoToken(env.ARTIFACTS, project.remote, "read", logger);
-  if (!readToken.success) return null;
-  const logResult = await getCommitLog(project.remote, readToken.data, logger, 1);
-  return logResult.success ? (logResult.data[0]?.sha ?? null) : null;
-}
-
 /**
  * Resolve a workspace's current tip commit sha, or null if it can't be read.
  * Workspaces have no KV snapshot fast-path, so this clones the workspace remote.
@@ -182,25 +154,6 @@ async function resolveWorkspaceTip(
   if (!readToken.success) return null;
   const logResult = await getCommitLog(workspaceRemote, readToken.data, logger, 1);
   return logResult.success ? (logResult.data[0]?.sha ?? null) : null;
-}
-
-class UnavailableEvaluator implements Evaluator {
-  constructor(
-    private evaluatorType: string,
-    private reason: string,
-  ) {}
-
-  async evaluate(
-    _diff: string,
-    _policy: EvalPolicy,
-    _logger: Logger,
-  ): Promise<{ success: true; data: EvalResult } | { success: false; error: AppError }> {
-    return okResult({
-      score: 0,
-      passed: false,
-      reason: `${this.evaluatorType} unavailable: ${this.reason}`,
-    });
-  }
 }
 
 app.post("/projects/:name/changes", async (c) => {
@@ -259,231 +212,23 @@ app.post("/projects/:name/changes", async (c) => {
     return badRequest(`Workspace '${body.workspace}' does not belong to project '${projectName}'`);
   }
 
-  const baseSha = await resolveProjectHead(c.env, project, logger);
-
-  // Snapshot the authoring agent's model + prompt hash at creation, so
-  // provenance records the model that did the work rather than the agent's
-  // current (possibly later-changed) registration.
-  let agentModel: string | undefined;
-  let agentPromptHash: string | undefined;
-  if (agentId !== undefined) {
-    const agentResult = await getAgent(c.env.DB, agentId, logger);
-    if (agentResult.success) {
-      agentModel = agentResult.data.model;
-      agentPromptHash = agentResult.data.promptHash;
-    } else {
-      // Best effort: provenance metadata must not block change creation. Log so a
-      // persistent lookup failure is visible rather than silently dropping the
-      // model/prompt snapshot.
-      logger.warn("Could not load agent for provenance snapshot; continuing without it", {
-        agentId,
-        error: agentResult.error.message,
-      });
-    }
-  }
-
-  const changeResult = await createChange(c.env.DB, logger, {
-    project: projectName,
-    projectId: project.id,
-    workspace: body.workspace,
-    ...(agentId !== undefined ? { agentId } : {}),
-    ...(baseSha !== null ? { baseSha } : {}),
-    ...(agentModel !== undefined ? { agentModel } : {}),
-    ...(agentPromptHash !== undefined ? { agentPromptHash } : {}),
-  });
-  if (!changeResult.success) {
-    logger.error("Failed to create change", changeResult.error);
-    return badRequest(changeResult.error.message);
-  }
-  const change = changeResult.data;
-
-  const actor: EventActor = agentId
-    ? { type: "agent", id: agentId }
-    : { type: "user", ...(userId !== undefined ? { id: userId } : {}) };
-
-  await emitEvent(
-    c.env.DB,
-    c.env.EVENTS_QUEUE,
-    {
-      type: "change.created",
-      project: projectName,
-      changeId: change.id,
-      workspace: body.workspace,
+  const outcome = await createChangeWithEvaluation(c.env, logger, {
+    project,
+    projectName,
+    workspaceName: body.workspace,
+    workspaceRemote: workspace.remote,
+    actor: {
+      ...(userId !== undefined ? { userId } : {}),
+      ...(agentId !== undefined ? { agentId } : {}),
     },
-    actor,
-    logger,
-    project.id,
-  );
-
-  const [projectReadToken, workspaceReadToken] = await Promise.all([
-    freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger),
-    freshRepoToken(c.env.ARTIFACTS, workspace.remote, "read", logger),
-  ]);
-  if (!projectReadToken.success) return internalError(projectReadToken.error.message);
-  if (!workspaceReadToken.success) return internalError(workspaceReadToken.error.message);
-
-  const policy = await loadPolicy(project.remote, projectReadToken.data, logger);
-
-  const diffResult = await getDiffBetweenRepos(
-    project.remote,
-    projectReadToken.data,
-    workspace.remote,
-    workspaceReadToken.data,
-    logger,
-  );
-  if (!diffResult.success) {
-    logger.error("Failed to get diff between repos", diffResult.error);
-    return badRequest(diffResult.error.message);
-  }
-  // workspaceOid === workspaceSha (same evaluated tip): #133 pins evaluatedSha +
-  // tree oid for content-addressing, #115 pins workspaceHeadSha for the merge.
-  const {
-    diff,
-    workspaceOid: evaluatedSha,
-    workspaceTreeOid: evaluatedTreeOid,
-    workspaceSha: workspaceHeadSha,
-  } = diffResult.data;
-
-  const evaluators: Array<{ type: string; evaluator: Evaluator }> = [
-    { type: "secret_scan", evaluator: new SecretScanEvaluator() },
-  ];
-
-  evaluators.push(
-    ...policy.evaluators.flatMap((cfg): Array<{ type: string; evaluator: Evaluator }> => {
-      switch (cfg.type) {
-        case "diff":
-          return [{ type: "diff", evaluator: new DiffEvaluator() }];
-        case "webhook":
-          return [{ type: "webhook", evaluator: new WebhookEvaluator() }];
-        case "llm":
-          if (c.env.AI) return [{ type: "llm", evaluator: new LLMEvaluator(c.env.AI) }];
-          return [
-            {
-              type: "llm",
-              evaluator: new UnavailableEvaluator("llm", "AI binding is not configured"),
-            },
-          ];
-        case "sandbox":
-          if (c.env.SANDBOX) {
-            return [{ type: "sandbox", evaluator: new SandboxEvaluator(c.env.SANDBOX) }];
-          }
-          return [
-            {
-              type: "sandbox",
-              evaluator: new UnavailableEvaluator("sandbox", "SANDBOX binding is not configured"),
-            },
-          ];
-        default:
-          logger.warn(
-            `Unknown evaluator type "${(cfg as { type: string }).type}" in policy for project ${projectName}`,
-            { evaluatorType: (cfg as { type: string }).type, projectName },
-          );
-          return [];
-      }
-    }),
-  );
-
-  const evalRuns = await Promise.all(
-    evaluators.map(async ({ type, evaluator }) => {
-      const result = await evaluator.evaluate(diff, policy, logger);
-      return {
-        evaluatorType: type,
-        result: result.success
-          ? result.data
-          : { score: 0, passed: false, reason: result.error.message },
-      };
-    }),
-  );
-
-  const composite = new CompositeEvaluator(evaluators.map(({ evaluator }) => evaluator));
-  const aggregateResult = composite.aggregate(
-    evalRuns.map(({ result }) => result),
-    policy,
-    logger,
-  );
-  const blockingFailure = evalRuns.find(
-    ({ evaluatorType, result }) => evaluatorType === "secret_scan" && !result.passed,
-  );
-  const evalResult =
-    blockingFailure === undefined
-      ? aggregateResult
-      : {
-          score: Math.min(aggregateResult.score, blockingFailure.result.score),
-          passed: false,
-          reason:
-            aggregateResult.reason === blockingFailure.result.reason
-              ? blockingFailure.result.reason
-              : `${blockingFailure.result.reason} ${aggregateResult.reason}`,
-          issues: aggregateResult.issues,
-        };
-
-  const newStatus: Change["status"] = evalResult.passed ? "accepted" : "needs_changes";
-
-  const recordResult = await recordEvalRuns(c.env.DB, logger, change.id, evalRuns);
-  if (!recordResult.success) {
-    logger.error("Failed to record eval runs", recordResult.error);
-    return badRequest(recordResult.error.message);
-  }
-
-  // Best-effort cost tracking: the diff clones both repos, evaluators self-report.
-  const createCostSamples: CostSample[] = [
-    { kind: "git_ops", quantity: 2 },
-    ...evalRuns.flatMap(({ result }) => result.costs ?? []),
-  ];
-  await recordCosts(
-    c.env.DB,
-    logger,
-    { project: projectName, projectId: project.id, changeId: change.id, workspace: body.workspace },
-    createCostSamples,
-  );
-
-  const updateResult = await updateChangeStatus(c.env.DB, logger, change.id, newStatus, {
-    evalScore: evalResult.score,
-    evalPassed: evalResult.passed,
-    evalReason: evalResult.reason,
-    evaluatedSha,
-    evaluatedTreeOid,
-    ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
   });
-  if (!updateResult.success) {
-    logger.error("Failed to update change status", updateResult.error);
-    return badRequest(updateResult.error.message);
+  if (!outcome.success) {
+    return outcome.error.statusCode >= 500
+      ? internalError(outcome.error.message)
+      : badRequest(outcome.error.message);
   }
-
-  await emitEvent(
-    c.env.DB,
-    c.env.EVENTS_QUEUE,
-    {
-      type: "change.evaluated",
-      project: projectName,
-      changeId: change.id,
-      score: evalResult.score,
-      passed: evalResult.passed,
-    },
-    { type: "system" },
-    logger,
-    project.id,
-  );
-
-  const updatedChange: Change = {
-    ...change,
-    status: newStatus,
-    evalScore: evalResult.score,
-    evalPassed: evalResult.passed,
-    evalReason: evalResult.reason,
-    evaluatedSha,
-    evaluatedTreeOid,
-    ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
-  };
-
-  logger.info("Change created and evaluated", {
-    changeId: change.id,
-    project: projectName,
-    workspace: body.workspace,
-    status: newStatus,
-    evalScore: evalResult.score,
-  });
-  return created({ change: updatedChange, eval: evalResult, evalRuns: recordResult.data });
+  const { change: updatedChange, evalResult, evalRuns: recordedRuns } = outcome.data;
+  return created({ change: updatedChange, eval: evalResult, evalRuns: recordedRuns });
 });
 
 app.get("/projects/:name/changes", async (c) => {
@@ -1490,40 +1235,7 @@ app.post("/changes/:id/evaluate", async (c) => {
     workspaceSha: workspaceHeadSha,
   } = diffResult.data;
 
-  const evaluators: Array<{ type: string; evaluator: Evaluator }> = [
-    { type: "secret_scan", evaluator: new SecretScanEvaluator() },
-    ...policy.evaluators.flatMap((cfg): Array<{ type: string; evaluator: Evaluator }> => {
-      switch (cfg.type) {
-        case "diff":
-          return [{ type: "diff", evaluator: new DiffEvaluator() }];
-        case "webhook":
-          return [{ type: "webhook", evaluator: new WebhookEvaluator() }];
-        case "llm":
-          return c.env.AI
-            ? [{ type: "llm", evaluator: new LLMEvaluator(c.env.AI) }]
-            : [
-                {
-                  type: "llm",
-                  evaluator: new UnavailableEvaluator("llm", "AI binding is not configured"),
-                },
-              ];
-        case "sandbox":
-          return c.env.SANDBOX
-            ? [{ type: "sandbox", evaluator: new SandboxEvaluator(c.env.SANDBOX) }]
-            : [
-                {
-                  type: "sandbox",
-                  evaluator: new UnavailableEvaluator(
-                    "sandbox",
-                    "SANDBOX binding is not configured",
-                  ),
-                },
-              ];
-        default:
-          return [];
-      }
-    }),
-  ];
+  const evaluators = buildEvaluators(c.env, policy, change.project, logger);
 
   const evalRuns = await Promise.all(
     evaluators.map(async ({ type, evaluator }) => {

--- a/src/routes/git-http.ts
+++ b/src/routes/git-http.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
+import { createChangeWithEvaluation, createWorkspaceFork } from "../services/change-flow";
 import { getAgentByToken } from "../storage/agents";
+import { isTargetDeleting } from "../storage/deletion";
 import {
   artifactsRepoNameFromRemote,
   extractTokenSecret,
@@ -16,10 +18,13 @@ import { createLogger } from "../utils/logger";
  * Git smart-HTTP proxy (ADR 005).
  *
  * Lets a Stratum project be used as a git remote. Two surfaces:
- *  - Project URL `/@ns/slug.git` — clone/fetch (read). A push is answered
- *    in-protocol with a per-ref `ng` refusal plus sideband guidance (the pack
- *    is never forwarded); the gated `push → change → eval → merge` path is a
- *    separate slice (Phase B / #115) that will replace the refusal.
+ *  - Project URL `/@ns/slug.git` — clone/fetch (read). A push to the default
+ *    branch is routed through the change gate when GIT_PUSH_GATED_ENABLED
+ *    (ADR 005 slice 2b): pack lands on a server-managed workspace fork, a
+ *    change is created + evaluated, and the client gets a truthful per-ref
+ *    `ng` carrying the change id (main only moves through the merge gate).
+ *    With the flag off — and for multi-ref/delete/non-default pushes — the
+ *    push is refused in-protocol with sideband guidance.
  *  - Workspace URL `/@ns/slug/workspaces/<ws>.git` — clone/fetch (read) AND
  *    `git push` (write), proxied verbatim to the workspace's Artifacts fork.
  *    The client clones the workspace, so ref/old-oid semantics line up and
@@ -125,6 +130,7 @@ function parseBasicToken(header: string | undefined): string | null {
 
 interface Identity {
   userId?: string;
+  agentId?: string;
   agentOwnerId?: string;
 }
 
@@ -145,7 +151,7 @@ async function authenticate(
     return result.success ? { userId: result.data.id } : null;
   }
   const result = await getAgentByToken(c.env.DB, token, logger);
-  return result.success ? { agentOwnerId: result.data.ownerId } : null;
+  return result.success ? { agentId: result.data.id, agentOwnerId: result.data.ownerId } : null;
 }
 
 function basicAuthHeader(artifactsToken: string): string {
@@ -240,7 +246,7 @@ async function authorizeProject(
   c: { req: { header(name: string): string | undefined; param(name: string): string }; env: Env },
   scope: "read" | "write",
   logger: ReturnType<typeof createLogger>,
-): Promise<ProjectEntry | Response> {
+): Promise<{ project: ProjectEntry; identity: Identity | null } | Response> {
   const namespace = c.req.param("namespace");
   const slug = normalizeSlug(c.req.param("slug"));
 
@@ -279,7 +285,7 @@ async function authorizeProject(
     return gitUnavailable("project");
   }
 
-  return project;
+  return { project, identity };
 }
 
 const gitUnavailable = (resource: "project" | "workspace"): Response =>
@@ -416,13 +422,13 @@ gitHttpRouter.get("/:namespace/:slug/info/refs", async (c) => {
   }
 
   // The receive-pack advertisement is proxied (write-authorized) so `git push`
-  // proceeds to the RPC below, where the refusal is delivered in-protocol
+  // proceeds to the RPC below, where the outcome is delivered in-protocol
   // instead of as an opaque HTTP error at the advertise step.
   const result = await authorizeProject(c, scope, logger);
   if (result instanceof Response) return result;
 
-  const upstreamUrl = `${result.remote}/info/refs?service=${service}`;
-  return proxyUpstream(c, result.remote, scope, upstreamUrl, "GET", undefined, logger);
+  const upstreamUrl = `${result.project.remote}/info/refs?service=${service}`;
+  return proxyUpstream(c, result.project.remote, scope, upstreamUrl, "GET", undefined, logger);
 });
 
 // POST /@:namespace/:slug.git/git-upload-pack — clone/fetch RPC
@@ -433,19 +439,82 @@ gitHttpRouter.post("/:namespace/:slug/git-upload-pack", async (c) => {
 
   const body = await readCappedBody(c, logger);
   if (body instanceof Response) return body;
-  const upstreamUrl = `${result.remote}/${UPLOAD_PACK}`;
-  return proxyUpstream(c, result.remote, "read", upstreamUrl, "POST", body, logger);
+  const upstreamUrl = `${result.project.remote}/${UPLOAD_PACK}`;
+  return proxyUpstream(c, result.project.remote, "read", upstreamUrl, "POST", body, logger);
 });
 
+const ZERO_OID = "0".repeat(40);
+
+/** The report-status Content-Type git expects on the receive-pack reply. */
+function receivePackResult(body: Uint8Array): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/x-git-receive-pack-result" },
+  });
+}
+
+/**
+ * Forward a buffered receive-pack request to a workspace fork's remote and
+ * return the buffered upstream result, or null on transport failure. The
+ * response is buffered (not streamed) because the gated flow must inspect the
+ * outcome before deciding what to tell the client.
+ */
+async function forwardPackToWorkspace(
+  c: { req: { header(name: string): string | undefined }; env: Env },
+  workspaceRemote: string,
+  body: ArrayBuffer,
+  logger: ReturnType<typeof createLogger>,
+): Promise<{ ok: boolean; body: Uint8Array } | null> {
+  const tokenResult = await freshRepoToken(c.env.ARTIFACTS, workspaceRemote, "write", logger);
+  if (!tokenResult.success) {
+    logger.error("Failed to mint Artifacts token for gated push", tokenResult.error);
+    return null;
+  }
+  const headers: Record<string, string> = { Authorization: basicAuthHeader(tokenResult.data) };
+  for (const name of ["Git-Protocol", "Content-Type", "Content-Encoding"]) {
+    const value = c.req.header(name);
+    if (value) headers[name] = value;
+  }
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${workspaceRemote}/${RECEIVE_PACK}`, {
+      method: "POST",
+      headers,
+      body,
+      redirect: "manual",
+    });
+  } catch (error) {
+    logger.error("Gated push upstream fetch failed", error instanceof Error ? error : undefined);
+    return null;
+  }
+  if (upstream.status < 200 || upstream.status >= 300) {
+    logger.error("Gated push upstream returned non-2xx", undefined, { status: upstream.status });
+    return null;
+  }
+  const responseBody = new Uint8Array(await upstream.arrayBuffer());
+  // The receive-pack result carries only status protocol (no pack data), so a
+  // byte-level scan is a faithful success check whether or not it is
+  // sideband-wrapped: success = an "unpack ok" with no "ng " ref lines.
+  const text = new TextDecoder().decode(responseBody);
+  const pushOk = text.includes("unpack ok") && !text.includes("ng ");
+  return { ok: pushOk, body: responseBody };
+}
+
 // POST /@:namespace/:slug.git/git-receive-pack — push to the project ref.
-// The pack is never forwarded: every ref update is answered with an in-protocol
-// `ng` (plus sideband guidance), so `git push` exits non-zero with a legible
-// reason. The gated push path (open a change + eval + merge) is a separate
-// slice (#115 / ADR 005 Phase B) and will replace the rejection here.
+//
+// With GIT_PUSH_GATED_ENABLED, a single-ref push to refs/heads/main is routed
+// through the change gate (ADR 005 slice 2b): the pack lands on a fresh
+// server-managed workspace fork, a change is created and evaluated, and the
+// client gets a truthful per-ref `ng` — main does NOT move until the change is
+// approved and merged, so reporting `ok` would corrupt the client's
+// remote-tracking ref. The change id and eval verdict stream back as sideband
+// messages. Everything else (flag off, multi-ref, deletes, non-default refs)
+// is refused in-protocol as before.
 gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
   const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path, method: "POST" });
   const result = await authorizeProject(c, "write", logger);
   if (result instanceof Response) return result;
+  const { project, identity } = result;
 
   const body = await readCappedBody(c, logger);
   if (body instanceof Response) return body;
@@ -460,24 +529,110 @@ gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
   }
 
   const { commands, capabilities } = parsed.data;
-  logger.info("Refusing project push in-protocol (gated push not yet enabled)", {
-    refs: commands.map((cmd) => cmd.ref),
-  });
+  const sideband = wantsSideband(capabilities);
+  const namespace = c.req.param("namespace");
+  const slug = normalizeSlug(c.req.param("slug"));
 
-  const reportBody = buildReportStatus({
-    unpack: "ok",
-    results: commands.map((cmd) => ({
-      ref: cmd.ref,
-      ok: false,
-      reason: "project pushes are gated — push to a workspace remote and open a change",
-    })),
-    messages: pushGuidance(c.req.param("namespace"), normalizeSlug(c.req.param("slug"))),
-    sideband: wantsSideband(capabilities),
+  const refuseAll = (reason: string, messages: string[]): Response =>
+    receivePackResult(
+      buildReportStatus({
+        unpack: "ok",
+        results: commands.map((cmd) => ({ ref: cmd.ref, ok: false, reason })),
+        messages,
+        sideband,
+      }),
+    );
+
+  const gatedEnabled = c.env.GIT_PUSH_GATED_ENABLED === "true";
+  const command = commands[0];
+  const isGateablePush =
+    gatedEnabled &&
+    commands.length === 1 &&
+    command !== undefined &&
+    command.ref === "refs/heads/main" &&
+    command.newOid !== ZERO_OID;
+
+  if (!isGateablePush) {
+    logger.info("Refusing project push in-protocol", {
+      gatedEnabled,
+      refs: commands.map((cmd) => cmd.ref),
+    });
+    return refuseAll(
+      gatedEnabled
+        ? "only a single push to refs/heads/main can be gated — push other refs to a workspace remote"
+        : "project pushes are gated — push to a workspace remote and open a change",
+      pushGuidance(namespace, slug),
+    );
+  }
+
+  if (await isTargetDeleting(c.env, project, logger)) {
+    return refuseAll("project is being deleted", []);
+  }
+
+  // Land the pack on a fresh server-managed workspace fork. The fork's main is
+  // at the project tip, so the client's old-oid (computed against the project
+  // advertisement) lines up and Artifacts' own ref check stays truthful.
+  const workspaceName = `push-${crypto.randomUUID().slice(0, 8)}`;
+  const actor = {
+    ...(identity?.userId !== undefined ? { userId: identity.userId } : {}),
+    ...(identity?.agentId !== undefined ? { agentId: identity.agentId } : {}),
+    ...(identity?.agentOwnerId !== undefined ? { agentOwnerId: identity.agentOwnerId } : {}),
+  };
+  const forkResult = await createWorkspaceFork(c.env, logger, {
+    project,
+    workspaceName,
+    actor,
   });
-  return new Response(reportBody, {
-    status: 200,
-    headers: { "Content-Type": "application/x-git-receive-pack-result" },
+  if (!forkResult.success) {
+    logger.error("Gated push could not fork workspace", forkResult.error);
+    return refuseAll(`could not create workspace for push: ${forkResult.error.message}`, []);
+  }
+
+  // The service's returned name is authoritative from here on.
+  const forkedName = forkResult.data.name;
+
+  const forwarded = await forwardPackToWorkspace(c, forkResult.data.remote, body, logger);
+  if (forwarded === null) {
+    return refuseAll("upstream git error while landing the pack — try again", []);
+  }
+  if (!forwarded.ok) {
+    // Artifacts rejected the pack (non-fast-forward, corrupt pack, …). Its own
+    // report-status is the truthful outcome; relay it verbatim — the upstream
+    // negotiated the same capabilities we were sent, so the framing matches.
+    logger.warn("Gated push rejected by workspace remote", { workspaceName: forkedName });
+    return receivePackResult(forwarded.body);
+  }
+
+  const outcome = await createChangeWithEvaluation(c.env, logger, {
+    project,
+    projectName: `${namespace}/${slug}`,
+    workspaceName: forkedName,
+    workspaceRemote: forkResult.data.remote,
+    actor,
   });
+  if (!outcome.success) {
+    logger.error("Gated push change creation failed", outcome.error);
+    return refuseAll(
+      `pack landed in workspace ${forkedName} but change creation failed: ${outcome.error.message}`,
+      [`Your commits are safe in workspace '${forkedName}' — open a change from it manually.`],
+    );
+  }
+
+  const { change, evalResult } = outcome.data;
+  logger.info("Gated push created change", {
+    changeId: change.id,
+    workspaceName: forkedName,
+    evalPassed: evalResult.passed,
+  });
+  return refuseAll(
+    `gated: change ${change.id} created (eval ${evalResult.passed ? "passed" : "failed"}) — review and merge in Stratum`,
+    [
+      `Change ${change.id} created from this push (workspace '${forkedName}').`,
+      `Evaluation ${evalResult.passed ? "PASSED" : "FAILED"}: ${evalResult.reason}`,
+      `Review and merge: /changes/${change.id}`,
+      "main is updated by the merge gate, not the push — your local branch is unchanged.",
+    ],
+  );
 });
 
 // ── Workspace URLs: /@:namespace/:slug/workspaces/:workspace.git ─────────────

--- a/src/routes/git-http.ts
+++ b/src/routes/git-http.ts
@@ -9,15 +9,17 @@ import { getProjectByPath, getWorkspace } from "../storage/state";
 import { getUserByToken } from "../storage/users";
 import type { Env, ProjectEntry } from "../types";
 import { canReadProject, canWriteProject, canWriteWorkspace } from "../utils/authz";
+import { buildReportStatus, parseReceivePackRequest, wantsSideband } from "../utils/git-protocol";
 import { createLogger } from "../utils/logger";
 
 /**
  * Git smart-HTTP proxy (ADR 005).
  *
  * Lets a Stratum project be used as a git remote. Two surfaces:
- *  - Project URL `/@ns/slug.git` — clone/fetch (read). Pushing to the project
- *    URL is refused (`pushNotSupported`); the gated `push → change → eval →
- *    merge` path is a separate slice (Phase B / #115).
+ *  - Project URL `/@ns/slug.git` — clone/fetch (read). A push is answered
+ *    in-protocol with a per-ref `ng` refusal plus sideband guidance (the pack
+ *    is never forwarded); the gated `push → change → eval → merge` path is a
+ *    separate slice (Phase B / #115) that will replace the refusal.
  *  - Workspace URL `/@ns/slug/workspaces/<ws>.git` — clone/fetch (read) AND
  *    `git push` (write), proxied verbatim to the workspace's Artifacts fork.
  *    The client clones the workspace, so ref/old-oid semantics line up and
@@ -210,11 +212,18 @@ async function proxyUpstream(
   return new Response(upstream.body, { status: 200, headers: responseHeaders });
 }
 
-function pushNotSupported(): Response {
-  return new Response(
-    "push over git is not yet supported — use 'stratum commit' or the change flow\n",
-    { status: 403, headers: { "Content-Type": "text/plain" } },
-  );
+/**
+ * Guidance streamed to a pushing client (as `remote:` lines) when it pushes to
+ * the project URL. The gated default-branch push (slice 2b, #115) will replace
+ * the rejection with the change/eval pipeline; until then the refusal happens
+ * in-protocol so `git push` fails legibly instead of with an opaque HTTP 403.
+ */
+function pushGuidance(namespace: string, slug: string): string[] {
+  return [
+    "Pushes to a project's protected refs are gated by Stratum's change flow.",
+    `Push to a workspace remote instead: /${namespace}/${slug}/workspaces/<ws>.git`,
+    "then open a change (stratum change create) to run evaluations and merge.",
+  ];
 }
 
 /** Strip a trailing `.git` so both `/@ns/slug.git` and `/@ns/slug` resolve. */
@@ -223,11 +232,13 @@ function normalizeSlug(slug: string): string {
 }
 
 /**
- * Resolve + authorize a project for a read, applying the no-leak truth table.
- * Returns the project on success, or a `Response` to return as-is.
+ * Resolve + authorize a project for a read (clone/fetch) or write (push),
+ * applying the no-leak truth table. Returns the project on success, or a
+ * `Response` to return as-is.
  */
-async function authorizeRead(
+async function authorizeProject(
   c: { req: { header(name: string): string | undefined; param(name: string): string }; env: Env },
+  scope: "read" | "write",
   logger: ReturnType<typeof createLogger>,
 ): Promise<ProjectEntry | Response> {
   const namespace = c.req.param("namespace");
@@ -251,8 +262,11 @@ async function authorizeRead(
   }
 
   const project = projectResult.data;
-  const canRead = await canReadProject(c.env.DB, project, identity?.userId, identity?.agentOwnerId);
-  if (!canRead) {
+  const allowed =
+    scope === "write"
+      ? await canWriteProject(c.env.DB, project, identity?.userId, identity?.agentOwnerId)
+      : await canReadProject(c.env.DB, project, identity?.userId, identity?.agentOwnerId);
+  if (!allowed) {
     return isAnonymous ? authChallenge() : gitNotFound();
   }
 
@@ -276,7 +290,7 @@ const gitUnavailable = (resource: "project" | "workspace"): Response =>
 
 /**
  * Resolve + authorize a workspace for clone/fetch (read) or push (write),
- * applying the same no-leak truth table as `authorizeRead`. Returns the
+ * applying the same no-leak truth table as `authorizeProject`. Returns the
  * workspace's Artifacts remote on success, or a `Response` to return as-is.
  */
 async function authorizeWorkspace(
@@ -393,25 +407,28 @@ export const gitHttpRouter = new Hono<{ Bindings: Env }>();
 gitHttpRouter.get("/:namespace/:slug/info/refs", async (c) => {
   const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path, method: "GET" });
   const service = c.req.query("service");
-  if (service === RECEIVE_PACK) return pushNotSupported();
-  if (service !== UPLOAD_PACK) {
-    return new Response("only the smart-HTTP git-upload-pack service is supported\n", {
+  const scope = service === RECEIVE_PACK ? "write" : service === UPLOAD_PACK ? "read" : null;
+  if (!scope) {
+    return new Response("unsupported git service\n", {
       status: 400,
       headers: { "Content-Type": "text/plain" },
     });
   }
 
-  const result = await authorizeRead(c, logger);
+  // The receive-pack advertisement is proxied (write-authorized) so `git push`
+  // proceeds to the RPC below, where the refusal is delivered in-protocol
+  // instead of as an opaque HTTP error at the advertise step.
+  const result = await authorizeProject(c, scope, logger);
   if (result instanceof Response) return result;
 
-  const upstreamUrl = `${result.remote}/info/refs?service=${UPLOAD_PACK}`;
-  return proxyUpstream(c, result.remote, "read", upstreamUrl, "GET", undefined, logger);
+  const upstreamUrl = `${result.remote}/info/refs?service=${service}`;
+  return proxyUpstream(c, result.remote, scope, upstreamUrl, "GET", undefined, logger);
 });
 
 // POST /@:namespace/:slug.git/git-upload-pack — clone/fetch RPC
 gitHttpRouter.post("/:namespace/:slug/git-upload-pack", async (c) => {
   const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path, method: "POST" });
-  const result = await authorizeRead(c, logger);
+  const result = await authorizeProject(c, "read", logger);
   if (result instanceof Response) return result;
 
   const body = await readCappedBody(c, logger);
@@ -421,9 +438,47 @@ gitHttpRouter.post("/:namespace/:slug/git-upload-pack", async (c) => {
 });
 
 // POST /@:namespace/:slug.git/git-receive-pack — push to the project ref.
-// Refused: the gated push path (open a change + eval + merge) is a separate
-// slice (#115 / ADR 005 Phase B). Push to a workspace URL instead.
-gitHttpRouter.post("/:namespace/:slug/git-receive-pack", () => pushNotSupported());
+// The pack is never forwarded: every ref update is answered with an in-protocol
+// `ng` (plus sideband guidance), so `git push` exits non-zero with a legible
+// reason. The gated push path (open a change + eval + merge) is a separate
+// slice (#115 / ADR 005 Phase B) and will replace the rejection here.
+gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
+  const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path, method: "POST" });
+  const result = await authorizeProject(c, "write", logger);
+  if (result instanceof Response) return result;
+
+  const body = await readCappedBody(c, logger);
+  if (body instanceof Response) return body;
+
+  const parsed = parseReceivePackRequest(new Uint8Array(body));
+  if (!parsed.success) {
+    logger.warn("Malformed receive-pack request", { error: parsed.error.message });
+    return new Response(`${parsed.error.message}\n`, {
+      status: 400,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+
+  const { commands, capabilities } = parsed.data;
+  logger.info("Refusing project push in-protocol (gated push not yet enabled)", {
+    refs: commands.map((cmd) => cmd.ref),
+  });
+
+  const reportBody = buildReportStatus({
+    unpack: "ok",
+    results: commands.map((cmd) => ({
+      ref: cmd.ref,
+      ok: false,
+      reason: "project pushes are gated — push to a workspace remote and open a change",
+    })),
+    messages: pushGuidance(c.req.param("namespace"), normalizeSlug(c.req.param("slug"))),
+    sideband: wantsSideband(capabilities),
+  });
+  return new Response(reportBody, {
+    status: 200,
+    headers: { "Content-Type": "application/x-git-receive-pack-result" },
+  });
+});
 
 // ── Workspace URLs: /@:namespace/:slug/workspaces/:workspace.git ─────────────
 // Clone/fetch (read) and push (write), proxied verbatim to the workspace fork.

--- a/src/services/change-flow.ts
+++ b/src/services/change-flow.ts
@@ -1,0 +1,423 @@
+import {
+  CompositeEvaluator,
+  DiffEvaluator,
+  LLMEvaluator,
+  SandboxEvaluator,
+  SecretScanEvaluator,
+  WebhookEvaluator,
+  loadPolicy,
+} from "../evaluation";
+import type { EvalPolicy, EvalResult, Evaluator } from "../evaluation/types";
+import { type EventActor, emitEvent } from "../queue/events";
+import { getAgent } from "../storage/agents";
+import { createChange, updateChangeStatus } from "../storage/changes";
+import { type CostSample, recordCosts } from "../storage/costs";
+import { recordEvalRuns } from "../storage/eval-runs";
+import { freshRepoToken, getCommitLog, getDiffBetweenRepos } from "../storage/git-ops";
+import { readRepoSnapshot } from "../storage/repo-snapshot";
+import { setWorkspace } from "../storage/state";
+import { type Change, type Env, type ProjectEntry, getArtifactsRepoName } from "../types";
+import { AppError } from "../utils/errors";
+import type { Logger } from "../utils/logger";
+import type { Result } from "../utils/result";
+import { err, ok } from "../utils/result";
+
+/**
+ * The create-change + evaluate pipeline, extracted from the REST route so every
+ * front door (REST `POST /changes`, gated `git push`, future queue consumers)
+ * runs the identical gate. Behavior must stay in lockstep with what the route
+ * historically did — the route's test suite is the contract.
+ */
+
+/** Current project HEAD: cheap KV snapshot first, single-commit clone as fallback. */
+export async function resolveProjectHead(
+  env: Env,
+  project: ProjectEntry,
+  logger: Logger,
+): Promise<string | null> {
+  if (project.namespace && project.slug) {
+    const snapshotResult = await readRepoSnapshot(env.STATE, project, logger);
+    if (snapshotResult.success) {
+      const sha = snapshotResult.data?.commits[0]?.sha;
+      if (sha) return sha;
+    }
+  }
+  const readToken = await freshRepoToken(env.ARTIFACTS, project.remote, "read", logger);
+  if (!readToken.success) return null;
+  const logResult = await getCommitLog(project.remote, readToken.data, logger, 1);
+  return logResult.success ? (logResult.data[0]?.sha ?? null) : null;
+}
+
+export class UnavailableEvaluator implements Evaluator {
+  constructor(
+    private evaluatorType: string,
+    private reason: string,
+  ) {}
+
+  async evaluate(
+    _diff: string,
+    _policy: EvalPolicy,
+    _logger: Logger,
+  ): Promise<Result<EvalResult, AppError>> {
+    return ok({
+      score: 0,
+      passed: false,
+      reason: `${this.evaluatorType} unavailable: ${this.reason}`,
+    });
+  }
+}
+
+/**
+ * Build the evaluator set for a policy: the always-on blocking secret scan plus
+ * whatever the policy configures. Evaluators whose binding is missing become
+ * UnavailableEvaluator (score 0, fail) rather than silently vanishing.
+ */
+export function buildEvaluators(
+  env: Env,
+  policy: EvalPolicy,
+  projectName: string,
+  logger: Logger,
+): Array<{ type: string; evaluator: Evaluator }> {
+  const evaluators: Array<{ type: string; evaluator: Evaluator }> = [
+    { type: "secret_scan", evaluator: new SecretScanEvaluator() },
+  ];
+
+  evaluators.push(
+    ...policy.evaluators.flatMap((cfg): Array<{ type: string; evaluator: Evaluator }> => {
+      switch (cfg.type) {
+        case "diff":
+          return [{ type: "diff", evaluator: new DiffEvaluator() }];
+        case "webhook":
+          return [{ type: "webhook", evaluator: new WebhookEvaluator() }];
+        case "llm":
+          if (env.AI) return [{ type: "llm", evaluator: new LLMEvaluator(env.AI) }];
+          return [
+            {
+              type: "llm",
+              evaluator: new UnavailableEvaluator("llm", "AI binding is not configured"),
+            },
+          ];
+        case "sandbox":
+          if (env.SANDBOX) {
+            return [{ type: "sandbox", evaluator: new SandboxEvaluator(env.SANDBOX) }];
+          }
+          return [
+            {
+              type: "sandbox",
+              evaluator: new UnavailableEvaluator("sandbox", "SANDBOX binding is not configured"),
+            },
+          ];
+        default:
+          logger.warn(
+            `Unknown evaluator type "${(cfg as { type: string }).type}" in policy for project ${projectName}`,
+            { evaluatorType: (cfg as { type: string }).type, projectName },
+          );
+          return [];
+      }
+    }),
+  );
+
+  return evaluators;
+}
+
+type RecordedEvalRuns = Extract<
+  Awaited<ReturnType<typeof recordEvalRuns>>,
+  { success: true }
+>["data"];
+
+export interface ChangeCreationActor {
+  userId?: string;
+  agentId?: string;
+}
+
+export interface ChangeCreationOutcome {
+  change: Change;
+  evalResult: EvalResult;
+  evalRuns: RecordedEvalRuns;
+}
+
+/**
+ * Create a change from a workspace and synchronously run the full evaluation
+ * suite, recording eval runs, costs, status, and events. Callers must have
+ * already authorized the actor for project write and verified the workspace
+ * belongs to the project and the project is not being deleted.
+ *
+ * Errors carry statusCode 500 for infrastructure failures (token minting) and
+ * 400 otherwise, so HTTP front doors can map them faithfully.
+ */
+export async function createChangeWithEvaluation(
+  env: Env,
+  logger: Logger,
+  args: {
+    project: ProjectEntry;
+    projectName: string;
+    workspaceName: string;
+    workspaceRemote: string;
+    actor: ChangeCreationActor;
+  },
+): Promise<Result<ChangeCreationOutcome, AppError>> {
+  const { project, projectName, workspaceName, workspaceRemote, actor } = args;
+  const { userId, agentId } = actor;
+
+  const baseSha = await resolveProjectHead(env, project, logger);
+
+  // Snapshot the authoring agent's model + prompt hash at creation, so
+  // provenance records the model that did the work rather than the agent's
+  // current (possibly later-changed) registration.
+  let agentModel: string | undefined;
+  let agentPromptHash: string | undefined;
+  if (agentId !== undefined) {
+    const agentResult = await getAgent(env.DB, agentId, logger);
+    if (agentResult.success) {
+      agentModel = agentResult.data.model;
+      agentPromptHash = agentResult.data.promptHash;
+    } else {
+      // Best effort: provenance metadata must not block change creation. Log so a
+      // persistent lookup failure is visible rather than silently dropping the
+      // model/prompt snapshot.
+      logger.warn("Could not load agent for provenance snapshot; continuing without it", {
+        agentId,
+        error: agentResult.error.message,
+      });
+    }
+  }
+
+  const changeResult = await createChange(env.DB, logger, {
+    project: projectName,
+    projectId: project.id,
+    workspace: workspaceName,
+    ...(agentId !== undefined ? { agentId } : {}),
+    ...(baseSha !== null ? { baseSha } : {}),
+    ...(agentModel !== undefined ? { agentModel } : {}),
+    ...(agentPromptHash !== undefined ? { agentPromptHash } : {}),
+  });
+  if (!changeResult.success) {
+    logger.error("Failed to create change", changeResult.error);
+    return err(new AppError(changeResult.error.message, changeResult.error.code, 400));
+  }
+  const change = changeResult.data;
+
+  const actorEvent: EventActor = agentId
+    ? { type: "agent", id: agentId }
+    : { type: "user", ...(userId !== undefined ? { id: userId } : {}) };
+
+  await emitEvent(
+    env.DB,
+    env.EVENTS_QUEUE,
+    {
+      type: "change.created",
+      project: projectName,
+      changeId: change.id,
+      workspace: workspaceName,
+    },
+    actorEvent,
+    logger,
+    project.id,
+  );
+
+  const [projectReadToken, workspaceReadToken] = await Promise.all([
+    freshRepoToken(env.ARTIFACTS, project.remote, "read", logger),
+    freshRepoToken(env.ARTIFACTS, workspaceRemote, "read", logger),
+  ]);
+  if (!projectReadToken.success) {
+    return err(new AppError(projectReadToken.error.message, projectReadToken.error.code, 500));
+  }
+  if (!workspaceReadToken.success) {
+    return err(new AppError(workspaceReadToken.error.message, workspaceReadToken.error.code, 500));
+  }
+
+  const policy = await loadPolicy(project.remote, projectReadToken.data, logger);
+
+  const diffResult = await getDiffBetweenRepos(
+    project.remote,
+    projectReadToken.data,
+    workspaceRemote,
+    workspaceReadToken.data,
+    logger,
+  );
+  if (!diffResult.success) {
+    logger.error("Failed to get diff between repos", diffResult.error);
+    return err(new AppError(diffResult.error.message, diffResult.error.code, 400));
+  }
+  // workspaceOid === workspaceSha (same evaluated tip): #133 pins evaluatedSha +
+  // tree oid for content-addressing, #115 pins workspaceHeadSha for the merge.
+  const {
+    diff,
+    workspaceOid: evaluatedSha,
+    workspaceTreeOid: evaluatedTreeOid,
+    workspaceSha: workspaceHeadSha,
+  } = diffResult.data;
+
+  const evaluators = buildEvaluators(env, policy, projectName, logger);
+
+  const evalRuns = await Promise.all(
+    evaluators.map(async ({ type, evaluator }) => {
+      const result = await evaluator.evaluate(diff, policy, logger);
+      return {
+        evaluatorType: type,
+        result: result.success
+          ? result.data
+          : { score: 0, passed: false, reason: result.error.message },
+      };
+    }),
+  );
+
+  const composite = new CompositeEvaluator(evaluators.map(({ evaluator }) => evaluator));
+  const aggregateResult = composite.aggregate(
+    evalRuns.map(({ result }) => result),
+    policy,
+    logger,
+  );
+  const blockingFailure = evalRuns.find(
+    ({ evaluatorType, result }) => evaluatorType === "secret_scan" && !result.passed,
+  );
+  const evalResult =
+    blockingFailure === undefined
+      ? aggregateResult
+      : {
+          score: Math.min(aggregateResult.score, blockingFailure.result.score),
+          passed: false,
+          reason:
+            aggregateResult.reason === blockingFailure.result.reason
+              ? blockingFailure.result.reason
+              : `${blockingFailure.result.reason} ${aggregateResult.reason}`,
+          issues: aggregateResult.issues,
+        };
+
+  const newStatus: Change["status"] = evalResult.passed ? "accepted" : "needs_changes";
+
+  const recordResult = await recordEvalRuns(env.DB, logger, change.id, evalRuns);
+  if (!recordResult.success) {
+    logger.error("Failed to record eval runs", recordResult.error);
+    return err(new AppError(recordResult.error.message, "DATABASE_ERROR", 400));
+  }
+
+  // Best-effort cost tracking: the diff clones both repos, evaluators self-report.
+  const createCostSamples: CostSample[] = [
+    { kind: "git_ops", quantity: 2 },
+    ...evalRuns.flatMap(({ result }) => result.costs ?? []),
+  ];
+  await recordCosts(
+    env.DB,
+    logger,
+    { project: projectName, projectId: project.id, changeId: change.id, workspace: workspaceName },
+    createCostSamples,
+  );
+
+  const updateResult = await updateChangeStatus(env.DB, logger, change.id, newStatus, {
+    evalScore: evalResult.score,
+    evalPassed: evalResult.passed,
+    evalReason: evalResult.reason,
+    evaluatedSha,
+    evaluatedTreeOid,
+    ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
+  });
+  if (!updateResult.success) {
+    logger.error("Failed to update change status", updateResult.error);
+    return err(new AppError(updateResult.error.message, updateResult.error.code, 400));
+  }
+
+  await emitEvent(
+    env.DB,
+    env.EVENTS_QUEUE,
+    {
+      type: "change.evaluated",
+      project: projectName,
+      changeId: change.id,
+      score: evalResult.score,
+      passed: evalResult.passed,
+    },
+    { type: "system" },
+    logger,
+    project.id,
+  );
+
+  const updatedChange: Change = {
+    ...change,
+    status: newStatus,
+    evalScore: evalResult.score,
+    evalPassed: evalResult.passed,
+    evalReason: evalResult.reason,
+    evaluatedSha,
+    evaluatedTreeOid,
+    ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
+  };
+
+  logger.info("Change created and evaluated", {
+    changeId: change.id,
+    project: projectName,
+    workspace: workspaceName,
+    status: newStatus,
+    evalScore: evalResult.score,
+  });
+
+  return ok({ change: updatedChange, evalResult, evalRuns: recordResult.data });
+}
+
+/**
+ * Fork a server-managed workspace from a project (used by the gated git push,
+ * which needs a workspace to land the incoming pack on). Mirrors the REST
+ * workspace-creation route's fork + KV registration + event; callers must have
+ * already authorized write and checked the project isn't being deleted.
+ */
+export async function createWorkspaceFork(
+  env: Env,
+  logger: Logger,
+  args: {
+    project: ProjectEntry;
+    workspaceName: string;
+    actor: ChangeCreationActor & { agentOwnerId?: string };
+  },
+): Promise<Result<{ name: string; remote: string }, AppError>> {
+  const { project, workspaceName, actor } = args;
+  if (!project.namespace || !project.slug) {
+    return err(new AppError("Project has no namespace/slug", "INVALID_PROJECT", 400));
+  }
+
+  const artifactsRepoName = getArtifactsRepoName(project.namespace, project.slug);
+  let remote: string;
+  try {
+    const projectRepo = await env.ARTIFACTS.get(artifactsRepoName);
+    const forked = await projectRepo.fork(workspaceName);
+    remote = forked.remote;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error("Failed to fork workspace for push", error instanceof Error ? error : undefined, {
+      workspaceName,
+    });
+    return err(new AppError(message, "ARTIFACTS_ERROR", 502));
+  }
+
+  const setResult = await setWorkspace(
+    env.STATE,
+    project.id,
+    {
+      name: workspaceName,
+      remote,
+      parent: project.id,
+      createdAt: new Date().toISOString(),
+      branchName: workspaceName,
+      createdByUserId: actor.userId ?? actor.agentOwnerId,
+      ...(actor.agentId !== undefined ? { createdByAgentId: actor.agentId } : {}),
+    },
+    logger,
+  );
+  if (!setResult.success) {
+    logger.error("Failed to set workspace", setResult.error);
+    return err(new AppError(setResult.error.message, setResult.error.code, 400));
+  }
+
+  const actorEvent: EventActor = actor.agentId
+    ? { type: "agent", id: actor.agentId }
+    : { type: "user", ...(actor.userId !== undefined ? { id: actor.userId } : {}) };
+  await emitEvent(
+    env.DB,
+    env.EVENTS_QUEUE,
+    { type: "workspace.created", project: project.name, workspace: workspaceName },
+    actorEvent,
+    logger,
+    project.id,
+  );
+
+  return ok({ name: workspaceName, remote });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,6 +150,10 @@ export interface Env {
   MAX_BACKUP_BYTES?: string;
   /** Gates the RepoDO fast-forward path (ADR 004). Off -> classic cold merge. */
   REPO_DO_ENABLED?: string;
+  /** "true" routes a `git push` to a project's default branch through the
+   * change/eval gate (ADR 005 slice 2b) instead of refusing it. Staging-first
+   * rollout flag; off in production until validated end-to-end. */
+  GIT_PUSH_GATED_ENABLED?: string;
   /** Deploy environment: "development" | "staging" | "production". Gates dev-only
    * routes and toggles HSTS. Defaults to production-safe behavior when unset. */
   ENVIRONMENT?: string;

--- a/src/ui/components/diff-view.tsx
+++ b/src/ui/components/diff-view.tsx
@@ -57,12 +57,120 @@ const lineClass: Record<DiffFile["lines"][number]["kind"], string> = {
   hunk: "diff-line diff-hunk",
 };
 
+export type SplitRow =
+  | { kind: "hunk"; text: string }
+  | {
+      kind: "pair";
+      left: string | null;
+      right: string | null;
+      leftKind: "del" | "context";
+      rightKind: "add" | "context";
+    };
+
+/** Drop the unified-diff marker (+ / - / leading space) for side-by-side cells. */
+function stripMarker(text: string): string {
+  return text.startsWith("+") || text.startsWith("-") || text.startsWith(" ")
+    ? text.slice(1)
+    : text;
+}
+
+/**
+ * Pair a file's unified-diff lines into side-by-side rows. Unified diffs list a
+ * segment's deletions before its additions, so buffered del/add runs are zipped
+ * together at each context/hunk boundary; the longer run leaves empty cells on
+ * the other side.
+ */
+export function buildSplitRows(lines: DiffFile["lines"]): SplitRow[] {
+  const rows: SplitRow[] = [];
+  let dels: string[] = [];
+  let adds: string[] = [];
+
+  const flush = () => {
+    const count = Math.max(dels.length, adds.length);
+    for (let i = 0; i < count; i++) {
+      rows.push({
+        kind: "pair",
+        left: dels[i] ?? null,
+        right: adds[i] ?? null,
+        leftKind: "del",
+        rightKind: "add",
+      });
+    }
+    dels = [];
+    adds = [];
+  };
+
+  for (const line of lines) {
+    switch (line.kind) {
+      case "del":
+        dels.push(stripMarker(line.text));
+        break;
+      case "add":
+        adds.push(stripMarker(line.text));
+        break;
+      case "hunk":
+        flush();
+        rows.push({ kind: "hunk", text: line.text });
+        break;
+      case "context": {
+        flush();
+        const text = stripMarker(line.text);
+        rows.push({
+          kind: "pair",
+          left: text,
+          right: text,
+          leftKind: "context",
+          rightKind: "context",
+        });
+        break;
+      }
+    }
+  }
+  flush();
+  return rows;
+}
+
+const SplitTable: FC<{ file: DiffFile }> = ({ file }) => (
+  <table class="diff-split">
+    <tbody>
+      {buildSplitRows(file.lines).map((row, index) =>
+        row.kind === "hunk" ? (
+          <tr key={index}>
+            <td class="diff-cell diff-hunk" colspan={2}>
+              {row.text}
+            </td>
+          </tr>
+        ) : (
+          <tr key={index}>
+            <td class={row.leftKind === "del" ? "diff-cell diff-del" : "diff-cell"}>
+              {row.left ?? ""}
+            </td>
+            <td class={row.rightKind === "add" ? "diff-cell diff-add" : "diff-cell"}>
+              {row.right ?? ""}
+            </td>
+          </tr>
+        ),
+      )}
+    </tbody>
+  </table>
+);
+
+/**
+ * The unified/split toggle is a hidden checkbox + CSS sibling selectors — the
+ * switch is instant and needs no client-side JavaScript, keeping the UI's
+ * server-rendered-only invariant. Both views are rendered; CSS shows one.
+ */
 export const DiffView: FC<{ files: DiffFile[] }> = ({ files }) => {
   if (files.length === 0) {
     return <p class="diff-empty">No changes between the workspace and the project.</p>;
   }
   return (
     <div class="diff-view">
+      <input type="checkbox" id="diff-split-toggle" class="diff-split-toggle" />
+      <label for="diff-split-toggle" class="diff-split-label">
+        <span class="diff-label-unified">Switch to split view</span>
+        <span class="diff-label-split">Switch to unified view</span>
+      </label>
       {files.map((file) => (
         <details class="diff-file" key={file.path} open={files.length <= 5}>
           <summary class="diff-file-header">
@@ -80,6 +188,7 @@ export const DiffView: FC<{ files: DiffFile[] }> = ({ files }) => {
               </span>
             ))}
           </pre>
+          <SplitTable file={file} />
         </details>
       ))}
     </div>

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -550,6 +550,34 @@ a:hover { text-decoration: underline; }
 .diff-del { background: rgba(248, 113, 113, 0.12); color: #f5c2c2; }
 .diff-hunk { color: #7cb7ff; background: #14181f; }
 
+/* Unified/split toggle: hidden checkbox + sibling selectors, no client JS.
+   The instant client-side switch (vs. GitHub's full reload) is deliberate. */
+.diff-split-toggle { position: absolute; opacity: 0; pointer-events: none; }
+.diff-split-label {
+  align-self: flex-end; cursor: pointer; user-select: none;
+  font-size: 0.8rem; color: #7cb7ff; border: 1px solid #2a2a2a;
+  border-radius: 6px; padding: 0.25rem 0.6rem; background: #181818;
+}
+.diff-split-label:hover { border-color: #7cb7ff; }
+.diff-split-toggle:focus-visible ~ .diff-split-label { outline: 2px solid #7cb7ff; outline-offset: 2px; }
+.diff-label-split { display: none; }
+.diff-split-toggle:checked ~ .diff-split-label .diff-label-unified { display: none; }
+.diff-split-toggle:checked ~ .diff-split-label .diff-label-split { display: inline; }
+
+/* Split view: hidden until the toggle is checked, then replaces unified. */
+.diff-split { display: none; }
+.diff-split-toggle:checked ~ .diff-file .diff-file-body { display: none; }
+.diff-split-toggle:checked ~ .diff-file .diff-split {
+  display: table; width: 100%; table-layout: fixed; border-collapse: collapse;
+  font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; line-height: 1.5;
+  background: #0d0d0d;
+}
+.diff-cell {
+  width: 50%; padding: 0 0.75rem; white-space: pre-wrap; word-break: break-all;
+  vertical-align: top; border-left: 1px solid #1c1c1c;
+}
+.diff-cell:first-child { border-left: none; }
+
 /* Settings */
 .settings-help { font-size: 0.85rem; color: #888; }
 .settings-token-reveal { border: 1px solid #2d4f2d; background: #101a10; }

--- a/src/utils/git-protocol.ts
+++ b/src/utils/git-protocol.ts
@@ -1,0 +1,168 @@
+import { AppError } from "./errors";
+import type { Result } from "./result";
+import { err, ok } from "./result";
+
+/**
+ * Minimal git pack-protocol encoding for the smart-HTTP proxy (ADR 005).
+ *
+ * Covers exactly what the receive-pack surface needs: pkt-line framing, parsing
+ * a client's ref-update command list, and synthesizing a report-status reply —
+ * optionally wrapped in side-band-64k — so `git push` outcomes render legibly
+ * in the client ("remote: …" messages and per-ref ok/ng status) instead of an
+ * opaque HTTP error. This is the foundation the gated default-branch push
+ * (slice 2b, #115) plugs into.
+ */
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/** A single ref update requested by the client. */
+export interface ReceivePackCommand {
+  oldOid: string;
+  newOid: string;
+  ref: string;
+}
+
+export interface ReceivePackRequest {
+  commands: ReceivePackCommand[];
+  capabilities: string[];
+}
+
+export const FLUSH_PKT = encoder.encode("0000");
+
+/** Frame one pkt-line: 4-hex length (self-inclusive) + payload. */
+export function encodePktLine(payload: string | Uint8Array): Uint8Array {
+  const data = typeof payload === "string" ? encoder.encode(payload) : payload;
+  const length = data.byteLength + 4;
+  if (length > 0xffff) {
+    throw new RangeError(`pkt-line payload too large: ${data.byteLength} bytes`);
+  }
+  const header = encoder.encode(length.toString(16).padStart(4, "0"));
+  const out = new Uint8Array(length);
+  out.set(header, 0);
+  out.set(data, 4);
+  return out;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.byteLength;
+  }
+  return out;
+}
+
+const OID_RE = /^[0-9a-f]{40}$/;
+
+/**
+ * Parse the command section of a git-receive-pack request body: pkt-lines of
+ * `old-oid new-oid refname` (the first carrying `\0capability…`), terminated by
+ * a flush-pkt; the packfile that follows is not consumed. Returns an error for
+ * malformed framing rather than guessing — the caller fails the push closed.
+ */
+export function parseReceivePackRequest(body: Uint8Array): Result<ReceivePackRequest, AppError> {
+  const commands: ReceivePackCommand[] = [];
+  let capabilities: string[] = [];
+  let offset = 0;
+
+  while (true) {
+    if (offset + 4 > body.byteLength) {
+      return err(new AppError("receive-pack request ended before flush-pkt", "GIT_PROTOCOL", 400));
+    }
+    const lengthHex = decoder.decode(body.subarray(offset, offset + 4));
+    if (!/^[0-9a-f]{4}$/.test(lengthHex)) {
+      return err(new AppError("malformed pkt-line length", "GIT_PROTOCOL", 400));
+    }
+    const length = Number.parseInt(lengthHex, 16);
+    if (length === 0) break; // flush-pkt: end of command section
+    if (length < 4 || offset + length > body.byteLength) {
+      return err(new AppError("pkt-line length out of range", "GIT_PROTOCOL", 400));
+    }
+
+    let line = decoder.decode(body.subarray(offset + 4, offset + length));
+    offset += length;
+    if (line.endsWith("\n")) line = line.slice(0, -1);
+
+    const nul = line.indexOf("\0");
+    if (nul >= 0) {
+      capabilities = line
+        .slice(nul + 1)
+        .split(" ")
+        .filter((c) => c.length > 0);
+      line = line.slice(0, nul);
+    }
+
+    const [oldOid, newOid, ...refParts] = line.split(" ");
+    const ref = refParts.join(" ");
+    if (!oldOid || !newOid || !ref || !OID_RE.test(oldOid) || !OID_RE.test(newOid)) {
+      return err(new AppError("malformed receive-pack command", "GIT_PROTOCOL", 400));
+    }
+    commands.push({ oldOid, newOid, ref });
+  }
+
+  if (commands.length === 0) {
+    return err(new AppError("receive-pack request contains no commands", "GIT_PROTOCOL", 400));
+  }
+  return ok({ commands, capabilities });
+}
+
+// side-band-64k caps a packet's payload at 65519 bytes; one byte carries the band.
+const SIDEBAND_MAX_DATA = 65515;
+
+/** Wrap raw bytes in side-band packets on the given band (1=data, 2=progress, 3=error). */
+export function encodeSideband(band: 1 | 2 | 3, data: Uint8Array): Uint8Array {
+  const parts: Uint8Array[] = [];
+  for (let i = 0; i < data.byteLength; i += SIDEBAND_MAX_DATA) {
+    const chunk = data.subarray(i, Math.min(i + SIDEBAND_MAX_DATA, data.byteLength));
+    const framed = new Uint8Array(chunk.byteLength + 1);
+    framed[0] = band;
+    framed.set(chunk, 1);
+    parts.push(encodePktLine(framed));
+  }
+  return concat(parts);
+}
+
+export interface ReportStatus {
+  /** "ok" or an unpack error description. */
+  unpack: string;
+  results: Array<{ ref: string; ok: boolean; reason?: string }>;
+  /** Human guidance streamed to the client as `remote: …` lines. */
+  messages?: string[];
+  /** Whether the client negotiated side-band-64k (wrap report + messages). */
+  sideband: boolean;
+}
+
+/**
+ * Build a git-receive-pack result body carrying report-status (and optional
+ * progress messages when side-band-64k was negotiated — without side-band there
+ * is no channel for messages, so only the status section is sent).
+ */
+export function buildReportStatus(report: ReportStatus): Uint8Array {
+  const statusLines: Uint8Array[] = [encodePktLine(`unpack ${report.unpack}\n`)];
+  for (const result of report.results) {
+    statusLines.push(
+      encodePktLine(
+        result.ok ? `ok ${result.ref}\n` : `ng ${result.ref} ${result.reason ?? "rejected"}\n`,
+      ),
+    );
+  }
+  statusLines.push(FLUSH_PKT);
+  const status = concat(statusLines);
+
+  if (!report.sideband) return status;
+
+  const parts: Uint8Array[] = [];
+  for (const message of report.messages ?? []) {
+    parts.push(encodeSideband(2, encoder.encode(`${message}\n`)));
+  }
+  parts.push(encodeSideband(1, status));
+  parts.push(FLUSH_PKT);
+  return concat(parts);
+}
+
+export function wantsSideband(capabilities: string[]): boolean {
+  return capabilities.includes("side-band-64k");
+}

--- a/tests/diff-split-view.test.tsx
+++ b/tests/diff-split-view.test.tsx
@@ -1,0 +1,155 @@
+import { renderToString } from "hono/jsx/dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  type DiffFile,
+  DiffView,
+  buildSplitRows,
+  parseUnifiedDiff,
+} from "../src/ui/components/diff-view";
+
+type Lines = DiffFile["lines"];
+
+describe("buildSplitRows", () => {
+  it("pairs a deletion run with an addition run", () => {
+    const lines: Lines = [
+      { kind: "hunk", text: "@@ -1,2 +1,2 @@" },
+      { kind: "del", text: "-const a = 1;" },
+      { kind: "del", text: "-const b = 2;" },
+      { kind: "add", text: "+const a = 10;" },
+      { kind: "add", text: "+const b = 20;" },
+    ];
+    const rows = buildSplitRows(lines);
+    expect(rows).toEqual([
+      { kind: "hunk", text: "@@ -1,2 +1,2 @@" },
+      {
+        kind: "pair",
+        left: "const a = 1;",
+        right: "const a = 10;",
+        leftKind: "del",
+        rightKind: "add",
+      },
+      {
+        kind: "pair",
+        left: "const b = 2;",
+        right: "const b = 20;",
+        leftKind: "del",
+        rightKind: "add",
+      },
+    ]);
+  });
+
+  it("leaves empty cells when runs have unequal length", () => {
+    const lines: Lines = [
+      { kind: "del", text: "-only removed" },
+      { kind: "add", text: "+replacement" },
+      { kind: "add", text: "+brand new line" },
+    ];
+    const rows = buildSplitRows(lines);
+    expect(rows).toEqual([
+      {
+        kind: "pair",
+        left: "only removed",
+        right: "replacement",
+        leftKind: "del",
+        rightKind: "add",
+      },
+      { kind: "pair", left: null, right: "brand new line", leftKind: "del", rightKind: "add" },
+    ]);
+  });
+
+  it("context lines appear on both sides and flush pending runs", () => {
+    const lines: Lines = [
+      { kind: "del", text: "-old" },
+      { kind: "context", text: " shared" },
+      { kind: "add", text: "+new" },
+    ];
+    const rows = buildSplitRows(lines);
+    expect(rows).toEqual([
+      { kind: "pair", left: "old", right: null, leftKind: "del", rightKind: "add" },
+      { kind: "pair", left: "shared", right: "shared", leftKind: "context", rightKind: "context" },
+      { kind: "pair", left: null, right: "new", leftKind: "del", rightKind: "add" },
+    ]);
+  });
+
+  it("handles a pure addition (new file) with no deletions", () => {
+    const lines: Lines = [
+      { kind: "add", text: "+line one" },
+      { kind: "add", text: "+line two" },
+    ];
+    const rows = buildSplitRows(lines);
+    expect(rows).toEqual([
+      { kind: "pair", left: null, right: "line one", leftKind: "del", rightKind: "add" },
+      { kind: "pair", left: null, right: "line two", leftKind: "del", rightKind: "add" },
+    ]);
+  });
+
+  it("round-trips through parseUnifiedDiff for a realistic hunk", () => {
+    const diff = [
+      "diff --git a/src/x.ts b/src/x.ts",
+      "--- a/src/x.ts",
+      "+++ b/src/x.ts",
+      "@@ -1,3 +1,3 @@",
+      " const keep = true;",
+      "-const version = 1;",
+      "+const version = 2;",
+      " export {};",
+    ].join("\n");
+    const [file] = parseUnifiedDiff(diff);
+    if (!file) throw new Error("diff did not parse");
+    const rows = buildSplitRows(file.lines);
+    expect(rows).toHaveLength(4);
+    expect(rows[1]).toEqual({
+      kind: "pair",
+      left: "const keep = true;",
+      right: "const keep = true;",
+      leftKind: "context",
+      rightKind: "context",
+    });
+    expect(rows[2]).toEqual({
+      kind: "pair",
+      left: "const version = 1;",
+      right: "const version = 2;",
+      leftKind: "del",
+      rightKind: "add",
+    });
+  });
+});
+
+describe("DiffView split toggle", () => {
+  const files: DiffFile[] = [
+    {
+      path: "src/x.ts",
+      additions: 1,
+      deletions: 1,
+      lines: [
+        { kind: "hunk", text: "@@ -1 +1 @@" },
+        { kind: "del", text: "-old line" },
+        { kind: "add", text: "+new line" },
+      ],
+    },
+  ];
+
+  it("renders both unified and split views with a CSS-only toggle", () => {
+    const html = renderToString(<DiffView files={files} />);
+    expect(html).toContain('class="diff-split-toggle"');
+    expect(html).toContain('type="checkbox"');
+    expect(html).toContain('class="diff-file-body"');
+    expect(html).toContain('class="diff-split"');
+    expect(html).toContain("Switch to split view");
+    expect(html).toContain("Switch to unified view");
+    // No client-side JavaScript may sneak in with the toggle.
+    expect(html).not.toContain("<script");
+  });
+
+  it("split cells carry the marker-stripped text", () => {
+    const html = renderToString(<DiffView files={files} />);
+    expect(html).toContain(">old line</td>");
+    expect(html).toContain(">new line</td>");
+  });
+
+  it("renders no toggle for an empty diff", () => {
+    const html = renderToString(<DiffView files={[]} />);
+    expect(html).toContain("No changes");
+    expect(html).not.toContain("diff-split-toggle");
+  });
+});

--- a/tests/git-http.test.ts
+++ b/tests/git-http.test.ts
@@ -20,6 +20,31 @@ const OTHER_TOKEN = "stratum_user_other000000000000000000";
 const AGENT_TOKEN = "stratum_agent_agent00000000000000000";
 const INVALID_TOKEN = "stratum_user_invalid0000000000000000";
 
+// The gated-push handler calls the change-flow service; mock its two entry
+// points so these tests exercise the wire protocol, not the eval pipeline
+// (which has its own suite via the REST route).
+vi.mock("../src/services/change-flow", async (importActual) => {
+  const actual = await importActual<typeof import("../src/services/change-flow")>();
+  return {
+    ...actual,
+    createWorkspaceFork: vi.fn(async () => ({
+      success: true,
+      data: {
+        name: "push-abcd1234",
+        remote: "https://acct.artifacts.cloudflare.net/git/@owner/push-abcd1234.git",
+      },
+    })),
+    createChangeWithEvaluation: vi.fn(async () => ({
+      success: true,
+      data: {
+        change: { id: "chg_push1", status: "accepted" },
+        evalResult: { score: 0.9, passed: true, reason: "clean" },
+        evalRuns: [],
+      },
+    })),
+  };
+});
+
 vi.mock("../src/storage/users", () => ({
   getUserByToken: vi.fn(async (_db: unknown, token: string) => {
     if (token === OWNER_TOKEN)
@@ -813,5 +838,204 @@ describe("git smart-HTTP proxy — workspace write ownership (S1)", () => {
     stubFetch(() => okUpstream());
     const res = await app.fetch(req(WS_UPLOAD_ADV, { headers: basic(OTHER_TOKEN) }), env);
     expect(res.status).toBe(200);
+  });
+});
+
+// ── Gated push (ADR 005 slice 2b, GIT_PUSH_GATED_ENABLED) ────────────────────
+
+import { createChangeWithEvaluation, createWorkspaceFork } from "../src/services/change-flow";
+
+describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
+  const OID_A = "a".repeat(40);
+  const OID_B = "b".repeat(40);
+  const ZEROS = "0".repeat(40);
+
+  function pktLine(payload: string): Uint8Array {
+    const data = new TextEncoder().encode(payload);
+    const header = new TextEncoder().encode((data.byteLength + 4).toString(16).padStart(4, "0"));
+    const out = new Uint8Array(data.byteLength + 4);
+    out.set(header, 0);
+    out.set(data, 4);
+    return out;
+  }
+
+  function pushBody(lines: string[]): Uint8Array {
+    const parts = lines.map((l) => pktLine(l));
+    const flush = new TextEncoder().encode("0000");
+    const total = parts.reduce((n, p) => n + p.byteLength, 0) + flush.byteLength;
+    const out = new Uint8Array(total);
+    let off = 0;
+    for (const p of parts) {
+      out.set(p, off);
+      off += p.byteLength;
+    }
+    out.set(flush, off);
+    return out;
+  }
+
+  const MAIN_PUSH = pushBody([`${OID_A} ${OID_B} refs/heads/main\0report-status`]);
+
+  function gatedEnv(): Env {
+    return { ...makeEnv(), GIT_PUSH_GATED_ENABLED: "true" } as Env;
+  }
+
+  function upstreamPushOk(): Response {
+    return new Response("000eunpack ok\n0000", {
+      status: 200,
+      headers: { "Content-Type": "application/x-git-receive-pack-result" },
+    });
+  }
+
+  it("routes a main push through fork → land pack → change, answering a truthful ng", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    const fetchMock = stubFetch(() => upstreamPushOk());
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    // Truthful outcome: main did not move, so the ref reports ng…
+    expect(text).toContain("ng refs/heads/main");
+    // …but the reason carries the created change and its verdict.
+    expect(text).toContain("chg_push1");
+    expect(text).toContain("eval passed");
+
+    // The pack was forwarded to the fork's receive-pack, not the project's.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "https://acct.artifacts.cloudflare.net/git/@owner/push-abcd1234.git/git-receive-pack",
+    );
+    expect(vi.mocked(createWorkspaceFork)).toHaveBeenCalledTimes(1);
+    const forkArgs = vi.mocked(createWorkspaceFork).mock.calls[0]?.[2];
+    expect(forkArgs?.workspaceName).toMatch(/^push-[0-9a-f-]{8}$/);
+    expect(forkArgs?.actor.userId).toBe("user_owner");
+
+    const changeArgs = vi.mocked(createChangeWithEvaluation).mock.calls[0]?.[2];
+    expect(changeArgs?.projectName).toBe("@owner/repo");
+    expect(changeArgs?.workspaceRemote).toContain("push-abcd1234");
+  });
+
+  it("an agent push carries the agent identity into the change flow", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    stubFetch(() => upstreamPushOk());
+    await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(AGENT_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    const changeArgs = vi.mocked(createChangeWithEvaluation).mock.calls[0]?.[2];
+    expect(changeArgs?.actor.agentId).toBe("agent_1");
+    expect(changeArgs?.actor.userId).toBeUndefined();
+  });
+
+  it("refuses multi-ref pushes even with the flag on", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    const fetchMock = stubFetch(() => upstreamPushOk());
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: pushBody([
+          `${OID_A} ${OID_B} refs/heads/main\0report-status`,
+          `${OID_A} ${OID_B} refs/heads/dev`,
+        ]),
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("only a single push to refs/heads/main");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(vi.mocked(createWorkspaceFork)).not.toHaveBeenCalled();
+  });
+
+  it("refuses a ref deletion even with the flag on", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    stubFetch(() => upstreamPushOk());
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: pushBody([`${OID_A} ${ZEROS} refs/heads/main\0report-status`]),
+      }),
+      env,
+    );
+    expect(await res.text()).toContain("only a single push to refs/heads/main");
+    expect(vi.mocked(createWorkspaceFork)).not.toHaveBeenCalled();
+  });
+
+  it("relays the workspace remote's own rejection verbatim (non-fast-forward)", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    stubFetch(
+      () =>
+        new Response("0027unpack ok\n002bng refs/heads/main non-fast-forward\n0000", {
+          status: 200,
+          headers: { "Content-Type": "application/x-git-receive-pack-result" },
+        }),
+    );
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("non-fast-forward");
+    expect(vi.mocked(createChangeWithEvaluation)).not.toHaveBeenCalled();
+  });
+
+  it("preserves the workspace pointer when change creation fails after the pack landed", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    stubFetch(() => upstreamPushOk());
+    vi.mocked(createChangeWithEvaluation).mockResolvedValueOnce({
+      success: false,
+      error: Object.assign(new Error("db unavailable"), {
+        code: "DATABASE_ERROR",
+        statusCode: 400,
+      }),
+    } as never);
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("change creation failed");
+    expect(text).toContain("push-abcd1234");
+  });
+
+  it("flag off → the plain in-protocol refusal, no fork", async () => {
+    const env = makeEnv(); // no GIT_PUSH_GATED_ENABLED
+    await seedProject(env);
+    stubFetch(() => upstreamPushOk());
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("project pushes are gated");
+    expect(vi.mocked(createWorkspaceFork)).not.toHaveBeenCalled();
   });
 });

--- a/tests/git-http.test.ts
+++ b/tests/git-http.test.ts
@@ -410,22 +410,121 @@ describe("git smart-HTTP proxy — upstream proxy (Task 3)", () => {
   });
 });
 
-describe("git smart-HTTP proxy — receive-pack rejection (Task 4)", () => {
-  it("POST git-receive-pack → 403 naming stratum commit, no upstream call", async () => {
+describe("git smart-HTTP proxy — receive-pack in-protocol rejection (Task 4)", () => {
+  const OID_A = "a".repeat(40);
+  const OID_B = "b".repeat(40);
+
+  function pktLine(payload: string): Uint8Array {
+    const data = new TextEncoder().encode(payload);
+    const header = new TextEncoder().encode((data.byteLength + 4).toString(16).padStart(4, "0"));
+    const out = new Uint8Array(data.byteLength + 4);
+    out.set(header, 0);
+    out.set(data, 4);
+    return out;
+  }
+
+  function pushBody(caps: string): Uint8Array {
+    const line = pktLine(`${OID_A} ${OID_B} refs/heads/main\0${caps}`);
+    const flush = new TextEncoder().encode("0000");
+    const out = new Uint8Array(line.byteLength + flush.byteLength);
+    out.set(line, 0);
+    out.set(flush, line.byteLength);
+    return out;
+  }
+
+  it("POST git-receive-pack → 200 report-status with per-ref ng, pack never forwarded", async () => {
     const env = makeEnv();
-    await seedProject(env, { visibility: "public" });
+    await seedProject(env);
     const fetchMock = stubFetch(() => okUpstream());
-    const res = await app.fetch(req("/@owner/repo.git/git-receive-pack", { method: "POST" }), env);
-    expect(res.status).toBe(403);
-    expect(await res.text()).toContain("stratum commit");
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: pushBody("report-status"),
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/x-git-receive-pack-result");
+    const text = await res.text();
+    expect(text).toContain("unpack ok\n");
+    expect(text).toContain("ng refs/heads/main");
+    expect(text).toContain("gated");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("info/refs?service=git-receive-pack → 403", async () => {
+  it("sideband push gets remote guidance messages naming the workspace remote", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    stubFetch(() => okUpstream());
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: pushBody("report-status side-band-64k"),
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("workspaces/<ws>.git");
+    expect(text).toContain("ng refs/heads/main");
+  });
+
+  it("push requires write: anonymous → 401 challenge, non-writer → 404", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    stubFetch(() => okUpstream());
+    const anon = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", { method: "POST", body: pushBody("") }),
+      env,
+    );
+    expect(anon.status).toBe(401);
+    const other = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OTHER_TOKEN),
+        body: pushBody("report-status"),
+      }),
+      env,
+    );
+    expect(other.status).toBe(404);
+  });
+
+  it("malformed push body → 400, not a synthesized report", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    stubFetch(() => okUpstream());
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: "zzzz garbage",
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("info/refs?service=git-receive-pack advertises for a writer (write-scoped proxy)", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    const fetchMock = stubFetch(() => okUpstream());
+    const res = await app.fetch(
+      req("/@owner/repo.git/info/refs?service=git-receive-pack", { headers: basic(OWNER_TOKEN) }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("service=git-receive-pack");
+    expect(vi.mocked(freshRepoToken).mock.calls[0]?.[2]).toBe("write");
+  });
+
+  it("info/refs?service=git-receive-pack challenges the anonymous caller", async () => {
     const env = makeEnv();
     await seedProject(env, { visibility: "public" });
+    stubFetch(() => okUpstream());
     const res = await app.fetch(req("/@owner/repo.git/info/refs?service=git-receive-pack"), env);
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
   });
 });
 

--- a/tests/git-protocol.test.ts
+++ b/tests/git-protocol.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  FLUSH_PKT,
+  buildReportStatus,
+  encodePktLine,
+  encodeSideband,
+  parseReceivePackRequest,
+  wantsSideband,
+} from "../src/utils/git-protocol";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const OID_A = "a".repeat(40);
+const OID_B = "b".repeat(40);
+
+function pktLine(payload: string): Uint8Array {
+  const data = encoder.encode(payload);
+  const header = encoder.encode((data.byteLength + 4).toString(16).padStart(4, "0"));
+  const out = new Uint8Array(data.byteLength + 4);
+  out.set(header, 0);
+  out.set(data, 4);
+  return out;
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.byteLength;
+  }
+  return out;
+}
+
+describe("encodePktLine", () => {
+  it("frames a payload with a self-inclusive hex length", () => {
+    const line = encodePktLine("unpack ok\n");
+    // "unpack ok\n" is 10 bytes; 10 + 4 = 14 = 0x000e.
+    expect(decoder.decode(line)).toBe("000eunpack ok\n");
+  });
+
+  it("rejects payloads beyond the pkt-line maximum", () => {
+    expect(() => encodePktLine("x".repeat(0x10000))).toThrow(RangeError);
+  });
+});
+
+describe("parseReceivePackRequest", () => {
+  it("parses a single command with capabilities after NUL", () => {
+    const body = concat(
+      pktLine(`${OID_A} ${OID_B} refs/heads/main\0report-status side-band-64k agent=git/2.44`),
+      FLUSH_PKT,
+      encoder.encode("PACKdata-not-parsed"),
+    );
+    const result = parseReceivePackRequest(body);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.commands).toEqual([
+        { oldOid: OID_A, newOid: OID_B, ref: "refs/heads/main" },
+      ]);
+      expect(result.data.capabilities).toContain("side-band-64k");
+      expect(result.data.capabilities).toContain("report-status");
+      expect(wantsSideband(result.data.capabilities)).toBe(true);
+    }
+  });
+
+  it("parses multiple commands; only the first line carries capabilities", () => {
+    const body = concat(
+      pktLine(`${OID_A} ${OID_B} refs/heads/main\0report-status`),
+      pktLine(`${OID_A} ${OID_B} refs/heads/dev\n`),
+      FLUSH_PKT,
+    );
+    const result = parseReceivePackRequest(body);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.commands).toHaveLength(2);
+      expect(result.data.commands[1]?.ref).toBe("refs/heads/dev");
+      expect(wantsSideband(result.data.capabilities)).toBe(false);
+    }
+  });
+
+  it("rejects a body with no flush-pkt", () => {
+    const result = parseReceivePackRequest(pktLine(`${OID_A} ${OID_B} refs/heads/main`));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toContain("flush-pkt");
+  });
+
+  it("rejects malformed oids", () => {
+    const body = concat(pktLine(`not-an-oid ${OID_B} refs/heads/main`), FLUSH_PKT);
+    const result = parseReceivePackRequest(body);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty command section", () => {
+    const result = parseReceivePackRequest(FLUSH_PKT);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toContain("no commands");
+  });
+
+  it("rejects garbage framing", () => {
+    const result = parseReceivePackRequest(encoder.encode("zzzz not a pkt line"));
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("encodeSideband", () => {
+  it("prefixes the band byte inside the pkt-line", () => {
+    const packet = encodeSideband(2, encoder.encode("hello"));
+    // length = 4 (header) + 1 (band) + 5 (payload) = 10 = 0x000a
+    expect(decoder.decode(packet.subarray(0, 4))).toBe("000a");
+    expect(packet[4]).toBe(2);
+    expect(decoder.decode(packet.subarray(5))).toBe("hello");
+  });
+
+  it("chunks payloads larger than the sideband maximum", () => {
+    const packet = encodeSideband(1, new Uint8Array(70_000));
+    // Two packets: 65515 bytes + remainder, each with 4-byte header + band byte.
+    expect(packet.byteLength).toBe(70_000 + 2 * 5);
+  });
+});
+
+describe("buildReportStatus", () => {
+  it("without sideband: plain pkt-line status section", () => {
+    const body = buildReportStatus({
+      unpack: "ok",
+      results: [{ ref: "refs/heads/main", ok: false, reason: "gated" }],
+      messages: ["ignored without sideband"],
+      sideband: false,
+    });
+    const text = decoder.decode(body);
+    expect(text).toContain("unpack ok\n");
+    expect(text).toContain("ng refs/heads/main gated\n");
+    expect(text.endsWith("0000")).toBe(true);
+    expect(text).not.toContain("ignored");
+  });
+
+  it("with sideband: wraps status in band 1 and messages in band 2", () => {
+    const body = buildReportStatus({
+      unpack: "ok",
+      results: [
+        { ref: "refs/heads/main", ok: true },
+        { ref: "refs/heads/dev", ok: false, reason: "no" },
+      ],
+      messages: ["use a workspace remote"],
+      sideband: true,
+    });
+    // Band bytes appear right after each 4-byte pkt header.
+    expect(body[4]).toBe(2); // first packet: progress message
+    const text = decoder.decode(body);
+    expect(text).toContain("use a workspace remote");
+    expect(text).toContain("unpack ok\n");
+    expect(text).toContain("ok refs/heads/main\n");
+    expect(text).toContain("ng refs/heads/dev no\n");
+    expect(text.endsWith("0000")).toBe(true);
+  });
+});

--- a/tests/integration/import-flow.test.ts
+++ b/tests/integration/import-flow.test.ts
@@ -557,7 +557,9 @@ describe("End-to-End Import Flow", () => {
   });
 
   describe("Sync Job Flow", () => {
-    it("should process a sync job successfully", async () => {
+    // Generous timeout: the full queue round-trip is fast locally but has
+    // blown the default 5s budget on contended CI runners.
+    it("should process a sync job successfully", { timeout: 20_000 }, async () => {
       const { importFromGitHub } = await import("../../src/storage/git-ops");
       vi.mocked(importFromGitHub).mockResolvedValue({
         success: true,

--- a/tests/integration/queue.test.ts
+++ b/tests/integration/queue.test.ts
@@ -474,7 +474,9 @@ describe("Queue Processing Integration Tests", () => {
   });
 
   describe("Sync Job Processing", () => {
-    it("should process a valid sync job", async () => {
+    // Generous timeout: the full queue round-trip is fast locally but has
+    // blown the default 5s budget on contended CI runners.
+    it("should process a valid sync job", { timeout: 20_000 }, async () => {
       const { importFromGitHub } = await import("../../src/storage/git-ops");
       vi.mocked(importFromGitHub).mockResolvedValue({
         success: true,

--- a/tests/llm-evaluator.test.ts
+++ b/tests/llm-evaluator.test.ts
@@ -67,27 +67,53 @@ describe("LLMEvaluator — valid JSON responses", () => {
   });
 });
 
-describe("LLMEvaluator — non-JSON fallback", () => {
-  it("AI returns non-JSON text → fallback logic applies, no throw", async () => {
+describe("LLMEvaluator — unparseable responses fail closed", () => {
+  it("AI returns non-JSON text → score 0, failed, no throw", async () => {
     const ai = makeMockAi("This diff looks fine overall.");
     const evaluator = new LLMEvaluator(ai);
     const result = await evaluator.evaluate("diff content", makePolicy(), mockLogger);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.score).toBe(0.3);
+      expect(result.data.score).toBe(0);
       expect(result.data.passed).toBe(false);
-      expect(result.data.reason).toBe("This diff looks fine overall.");
+      expect(result.data.reason).toContain("failed closed");
+      expect(result.data.issues?.[0]).toContain("This diff looks fine overall.");
     }
   });
 
-  it('"LGTM" in non-JSON response → fallback score 0.8', async () => {
+  it('"LGTM" prose is not treated as approval — still fails closed at 0', async () => {
     const ai = makeMockAi("LGTM, no issues found.");
     const evaluator = new LLMEvaluator(ai);
     const result = await evaluator.evaluate("diff content", makePolicy(), mockLogger);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.score).toBe(0.8);
+      expect(result.data.score).toBe(0);
       expect(result.data.passed).toBe(false);
+      expect(result.data.reason).toContain("failed closed");
+    }
+  });
+
+  it("JSON with wrong field types → fails closed with field reason", async () => {
+    const ai = makeMockAi(JSON.stringify({ score: "high", passed: "yes", reason: 42 }));
+    const evaluator = new LLMEvaluator(ai);
+    const result = await evaluator.evaluate("diff content", makePolicy(), mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.score).toBe(0);
+      expect(result.data.passed).toBe(false);
+      expect(result.data.reason).toContain("missing score/passed/reason");
+    }
+  });
+
+  it("fail-closed result still records estimated token costs", async () => {
+    const ai = makeMockAi("not json");
+    const evaluator = new LLMEvaluator(ai);
+    const result = await evaluator.evaluate("diff content", makePolicy(), mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.costs?.[0]?.kind).toBe("llm_tokens");
+      expect(result.data.costs?.[0]?.quantity).toBeGreaterThan(0);
+      expect(result.data.costs?.[0]?.estimated).toBe(true);
     }
   });
 });
@@ -154,22 +180,80 @@ describe("LLMEvaluator — issues array", () => {
   });
 });
 
+function sentDiffPortion(ai: AiBinding): string {
+  const runMock = ai.run as ReturnType<typeof vi.fn>;
+  const calledMessages = (
+    runMock.mock.calls[0] as [string, { messages: Array<{ role: string; content: string }> }]
+  )[1].messages;
+  const userMessage = calledMessages.find((m) => m.role === "user");
+  if (!userMessage) throw new Error("user message not found");
+  return userMessage.content.split("Diff to review:\n")[1] ?? "";
+}
+
 describe("LLMEvaluator — diff truncation", () => {
-  it("diff longer than 8000 chars is truncated before being sent to AI", async () => {
+  it("diff longer than the 24000-char default is truncated before being sent to AI", async () => {
     const ai = makeMockAi(JSON.stringify({ score: 0.9, passed: true, reason: "OK" }));
     const evaluator = new LLMEvaluator(ai);
-    const longDiff = "a".repeat(10000);
+    const longDiff = "a".repeat(30000);
     await evaluator.evaluate(longDiff, makePolicy(), mockLogger);
+    expect(sentDiffPortion(ai).length).toBe(24000);
+  });
 
+  it("diff shorter than the window is sent whole", async () => {
+    const ai = makeMockAi(JSON.stringify({ score: 0.9, passed: true, reason: "OK" }));
+    const evaluator = new LLMEvaluator(ai);
+    await evaluator.evaluate("a".repeat(10000), makePolicy(), mockLogger);
+    expect(sentDiffPortion(ai).length).toBe(10000);
+  });
+
+  it("policy maxDiffChars overrides the default window", async () => {
+    const ai = makeMockAi(JSON.stringify({ score: 0.9, passed: true, reason: "OK" }));
+    const evaluator = new LLMEvaluator(ai);
+    const policy = makePolicy({ evaluators: [{ type: "llm", maxDiffChars: 500 }] });
+    await evaluator.evaluate("a".repeat(1000), policy, mockLogger);
+    expect(sentDiffPortion(ai).length).toBe(500);
+  });
+
+  it("policy maxDiffChars is capped at the 100k ceiling", async () => {
+    const ai = makeMockAi(JSON.stringify({ score: 0.9, passed: true, reason: "OK" }));
+    const evaluator = new LLMEvaluator(ai);
+    const policy = makePolicy({ evaluators: [{ type: "llm", maxDiffChars: 5_000_000 }] });
+    await evaluator.evaluate("a".repeat(200_000), policy, mockLogger);
+    expect(sentDiffPortion(ai).length).toBe(100_000);
+  });
+
+  it("a truncated evaluation says so in the result issues", async () => {
+    const ai = makeMockAi(JSON.stringify({ score: 0.9, passed: true, reason: "OK" }));
+    const evaluator = new LLMEvaluator(ai);
+    const result = await evaluator.evaluate("a".repeat(30000), makePolicy(), mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.issues?.some((i) => i.includes("truncated"))).toBe(true);
+    }
+  });
+
+  it("an untruncated evaluation carries no truncation note", async () => {
+    const ai = makeMockAi(JSON.stringify({ score: 0.9, passed: true, reason: "OK" }));
+    const evaluator = new LLMEvaluator(ai);
+    const result = await evaluator.evaluate("small diff", makePolicy(), mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.issues).toBeUndefined();
+    }
+  });
+});
+
+describe("LLMEvaluator — prompt", () => {
+  it("sends a real reviewer system prompt demanding strict JSON", async () => {
+    const ai = makeMockAi(JSON.stringify({ score: 0.9, passed: true, reason: "OK" }));
+    const evaluator = new LLMEvaluator(ai);
+    await evaluator.evaluate("diff content", makePolicy(), mockLogger);
     const runMock = ai.run as ReturnType<typeof vi.fn>;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const calledMessages = (
       runMock.mock.calls[0] as [string, { messages: Array<{ role: string; content: string }> }]
     )[1].messages;
-    const userMessage = calledMessages.find((m) => m.role === "user");
-    if (!userMessage) throw new Error("user message not found");
-    const parts = userMessage.content.split("Diff to review:\n");
-    const diffPortion = parts[1] ?? "";
-    expect(diffPortion.length).toBeLessThanOrEqual(8000);
+    const system = calledMessages.find((m) => m.role === "system");
+    expect(system?.content).toContain("code reviewer");
+    expect(system?.content).toContain("ONLY a JSON object");
   });
 });

--- a/tests/llm-evaluator.test.ts
+++ b/tests/llm-evaluator.test.ts
@@ -209,9 +209,33 @@ describe("LLMEvaluator — diff truncation", () => {
   it("policy maxDiffChars overrides the default window", async () => {
     const ai = makeMockAi(JSON.stringify({ score: 0.9, passed: true, reason: "OK" }));
     const evaluator = new LLMEvaluator(ai);
-    const policy = makePolicy({ evaluators: [{ type: "llm", maxDiffChars: 500 }] });
-    await evaluator.evaluate("a".repeat(1000), policy, mockLogger);
-    expect(sentDiffPortion(ai).length).toBe(500);
+    const policy = makePolicy({ evaluators: [{ type: "llm", maxDiffChars: 2000 }] });
+    await evaluator.evaluate("a".repeat(5000), policy, mockLogger);
+    expect(sentDiffPortion(ai).length).toBe(2000);
+  });
+
+  it("a tiny maxDiffChars is raised to the 1000-char floor, never an empty diff", async () => {
+    const ai = makeMockAi(JSON.stringify({ score: 0.9, passed: true, reason: "OK" }));
+    const evaluator = new LLMEvaluator(ai);
+    const policy = makePolicy({ evaluators: [{ type: "llm", maxDiffChars: 5 }] });
+    await evaluator.evaluate("a".repeat(5000), policy, mockLogger);
+    expect(sentDiffPortion(ai).length).toBe(1000);
+  });
+
+  it("a fractional maxDiffChars is floored to an integer window", async () => {
+    const ai = makeMockAi(JSON.stringify({ score: 0.9, passed: true, reason: "OK" }));
+    const evaluator = new LLMEvaluator(ai);
+    const policy = makePolicy({ evaluators: [{ type: "llm", maxDiffChars: 2000.7 }] });
+    await evaluator.evaluate("a".repeat(5000), policy, mockLogger);
+    expect(sentDiffPortion(ai).length).toBe(2000);
+  });
+
+  it("a fractional value below one still sends a non-empty diff", async () => {
+    const ai = makeMockAi(JSON.stringify({ score: 0.9, passed: true, reason: "OK" }));
+    const evaluator = new LLMEvaluator(ai);
+    const policy = makePolicy({ evaluators: [{ type: "llm", maxDiffChars: 0.5 }] });
+    await evaluator.evaluate("a".repeat(5000), policy, mockLogger);
+    expect(sentDiffPortion(ai).length).toBe(1000);
   });
 
   it("policy maxDiffChars is capped at the 100k ceiling", async () => {
@@ -239,6 +263,20 @@ describe("LLMEvaluator — diff truncation", () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.issues).toBeUndefined();
+    }
+  });
+});
+
+describe("LLMEvaluator — non-finite scores", () => {
+  it('JSON "1e999" parses to Infinity and fails closed instead of clamping to a pass', async () => {
+    const ai = makeMockAi('{"score": 1e999, "passed": true, "reason": "great"}');
+    const evaluator = new LLMEvaluator(ai);
+    const result = await evaluator.evaluate("diff content", makePolicy(), mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.score).toBe(0);
+      expect(result.data.passed).toBe(false);
+      expect(result.data.reason).toContain("failed closed");
     }
   });
 });

--- a/tests/secret-scanner.test.ts
+++ b/tests/secret-scanner.test.ts
@@ -136,6 +136,66 @@ describe("SecretScanEvaluator", () => {
     }
   });
 
+  it.each([
+    ["AWS Access Key", 'const key = "ASIAIOSFODNN7EXAMPLE";'],
+    ["AWS Secret Key", 'aws_secret_access_key = "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEYaa"'],
+    ["GitHub OAuth Token", `const t = "gho_${"a".repeat(36)}";`],
+    ["GitHub User-to-Server Token", `const t = "ghu_${"a".repeat(36)}";`],
+    ["GitHub Fine-Grained PAT", `const t = "github_pat_${"a".repeat(82)}";`],
+    ["GitLab Personal Access Token", `const t = "glpat-${"a".repeat(20)}";`],
+    ["Slack Token", 'const t = "xoxb-123456789012-abcdefghijkl";'],
+    // Assembled from parts so GitHub push protection doesn't flag the fixture
+    // itself as a leaked webhook.
+    [
+      "Slack Webhook URL",
+      `url = https://hooks.slack${".com"}/services/T0000000000/B0000000000/${"X".repeat(24)}`,
+    ],
+    ["Stripe Live Key", `const t = "sk_live_${"a1".repeat(12)}";`],
+    ["OpenAI API Key (Legacy)", `const t = "sk-${"a".repeat(20)}T3BlbkFJ${"a".repeat(20)}";`],
+    ["OpenAI API Key (Project)", `const t = "sk-proj-${"a1".repeat(24)}";`],
+    ["Anthropic API Key", `const t = "sk-ant-api03-${"a1".repeat(20)}";`],
+    ["Google API Key", `const t = "AIza${"a1".repeat(17)}b";`],
+    ["npm Access Token", `const t = "npm_${"a1".repeat(18)}";`],
+    ["PyPI Upload Token", `const t = "pypi-AgEIcHlwaS5vcmc${"a1".repeat(12)}";`],
+    ["Hugging Face Token", `const t = "hf_${"a1".repeat(17)}";`],
+    ["SendGrid API Key", `const t = "SG.${"a".repeat(22)}.${"a".repeat(43)}";`],
+    ["Twilio API Key", `const t = "SK${"0123456789abcdef".repeat(2)}";`],
+    ["Private Key Block", "-----BEGIN RSA PRIVATE KEY-----"],
+    ["Private Key Block", "-----BEGIN OPENSSH PRIVATE KEY-----"],
+    [
+      "JSON Web Token",
+      'const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N";',
+    ],
+    ["Connection String Credential", 'DB = "postgres://admin:hunter2@db.internal:5432/prod"'],
+    ["Connection String Credential", 'DB = "mongodb+srv://svc:p4ssw0rd@cluster.example.net"'],
+    ["Azure Storage Account Key", `conn = "AccountKey=${"A1b2".repeat(11)}=="`],
+  ])("detects %s", async (name, line) => {
+    const diff = makeDiff([line]);
+    const result = await evaluator.evaluate(diff, policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.passed).toBe(false);
+      expect(result.data.score).toBe(0);
+      expect(result.data.issues?.[0]).toContain(name);
+    }
+  });
+
+  it("does not flag a test-mode Stripe key", async () => {
+    const diff = makeDiff([`const t = "sk_test_${"a1".repeat(12)}";`]);
+    const result = await evaluator.evaluate(diff, policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.passed).toBe(true);
+  });
+
+  it("reports one issue per line even when several patterns match", async () => {
+    const diff = makeDiff([`const a = "AKIAIOSFODNN7EXAMPLE"; const b = "ghp_${"a".repeat(36)}";`]);
+    const result = await evaluator.evaluate(diff, policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.issues).toHaveLength(1);
+    }
+  });
+
   it("ignores policy configuration — always runs", async () => {
     const diff = makeDiff(['const key = "AKIAIOSFODNN7EXAMPLE";']);
     const resultWithNull = await evaluator.evaluate(diff, policy, mockLogger);
@@ -150,5 +210,55 @@ describe("SecretScanEvaluator", () => {
       expect(resultWithNull.data.passed).toBe(false);
       expect(resultWithPolicy.data.passed).toBe(false);
     }
+  });
+});
+
+describe("SecretScanEvaluator — entropy detection", () => {
+  it("flags a high-entropy value assigned to a credential-ish name", async () => {
+    const diff = makeDiff(['const apiToken = "hR8s2Kd91mZqLpXw4Yv7NbT3cFgJ6aQe";']);
+    const result = await evaluator.evaluate(diff, policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.passed).toBe(false);
+      expect(result.data.issues?.[0]).toContain("High-Entropy Credential");
+    }
+  });
+
+  it("flags a random hex value at the lower hex threshold", async () => {
+    const diff = makeDiff(['const secretKey = "9f8e7d6c5b4a39281706e5d4c3b2a190";']);
+    const result = await evaluator.evaluate(diff, policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.passed).toBe(false);
+      expect(result.data.issues?.[0]).toContain("High-Entropy Credential");
+    }
+  });
+
+  it("does not flag a low-entropy value with a credential-ish name", async () => {
+    const diff = makeDiff(['const apiToken = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";']);
+    const result = await evaluator.evaluate(diff, policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.passed).toBe(true);
+  });
+
+  it("does not flag an English-word value with a credential-ish name", async () => {
+    const diff = makeDiff(['const tokenName = "authenticationTokenBuilder";']);
+    const result = await evaluator.evaluate(diff, policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.passed).toBe(true);
+  });
+
+  it("does not flag a high-entropy value without credential context", async () => {
+    const diff = makeDiff(['const digest = "hR8s2Kd91mZqLpXw4Yv7NbT3cFgJ6aQe";']);
+    const result = await evaluator.evaluate(diff, policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.passed).toBe(true);
+  });
+
+  it("does not flag short values even with credential context", async () => {
+    const diff = makeDiff(['const apiKey = "hR8s2Kd91mZqLpXw";']);
+    const result = await evaluator.evaluate(diff, policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.passed).toBe(true);
   });
 });

--- a/tests/secret-scanner.test.ts
+++ b/tests/secret-scanner.test.ts
@@ -27,6 +27,24 @@ function makeDiff(addedLines: string[], removedLines: string[] = []): string {
   return [...header, ...removed, ...added].join("\n");
 }
 
+// Detector-positive fixtures are assembled at runtime so the raw test file
+// never contains a complete credential-shaped literal — otherwise this very
+// diff would be blocked by the scanner it is testing (and by GitHub push
+// protection / SAST). Keep every fixture split across at least two parts.
+const AWS_KEY = `${"AKIA"}IOSFODNN7EXAMPLE`;
+const AWS_TEMP_KEY = `${"ASIA"}IOSFODNN7EXAMPLE`;
+const AWS_SECRET = `${"wJalrXUtnFEMIK7MDENG"}bPxRfiCYEXAMPLEKEYaa`;
+const SLACK_TOKEN = `${"xoxb"}-123456789012-abcdefghijkl`;
+const PEM_RSA = `-----BEGIN RSA ${"PRIVATE KEY"}-----`;
+const PEM_OPENSSH = `-----BEGIN OPENSSH ${"PRIVATE KEY"}-----`;
+const JWT = ["eyJhbGciOiJIUzI1NiJ9", "eyJzdWIiOiIxMjM0NTY3ODkwIn0", "dozjgNryP4J3jVmNHl0w5N"].join(
+  ".",
+);
+const PG_URL = `${"postgres"}://admin:${"hunter2"}@db.internal:5432/prod`;
+const MONGO_URL = `${"mongodb+srv"}://svc:${"p4ssw0rd"}@cluster.example.net`;
+const ENTROPY_MIXED = `${"hR8s2Kd91mZqLpXw"}4Yv7NbT3cFgJ6aQe`;
+const ENTROPY_HEX = `${"9f8e7d6c5b4a3928"}1706e5d4c3b2a190`;
+
 describe("SecretScanEvaluator", () => {
   it("passes a clean diff with no secrets", async () => {
     const diff = makeDiff(["const x = 1;", "export default x;"]);
@@ -41,7 +59,7 @@ describe("SecretScanEvaluator", () => {
   });
 
   it("detects AWS access key in added line", async () => {
-    const diff = makeDiff(['const key = "AKIAIOSFODNN7EXAMPLE";']);
+    const diff = makeDiff([`const key = "${AWS_KEY}";`]);
     const result = await evaluator.evaluate(diff, policy, mockLogger);
     expect(result.success).toBe(true);
     if (result.success) {
@@ -104,7 +122,7 @@ describe("SecretScanEvaluator", () => {
   });
 
   it("does not scan removed lines (starting with -)", async () => {
-    const diff = makeDiff(["const safe = true;"], ['const key = "AKIAIOSFODNN7EXAMPLE";']);
+    const diff = makeDiff(["const safe = true;"], [`const key = "${AWS_KEY}";`]);
     const result = await evaluator.evaluate(diff, policy, mockLogger);
     expect(result.success).toBe(true);
     if (result.success) {
@@ -127,7 +145,7 @@ describe("SecretScanEvaluator", () => {
   });
 
   it("reports issue with correct line number", async () => {
-    const diff = makeDiff(["const safe = true;", 'const key = "AKIAIOSFODNN7EXAMPLE";']);
+    const diff = makeDiff(["const safe = true;", `const key = "${AWS_KEY}";`]);
     const result = await evaluator.evaluate(diff, policy, mockLogger);
     expect(result.success).toBe(true);
     if (result.success) {
@@ -137,13 +155,13 @@ describe("SecretScanEvaluator", () => {
   });
 
   it.each([
-    ["AWS Access Key", 'const key = "ASIAIOSFODNN7EXAMPLE";'],
-    ["AWS Secret Key", 'aws_secret_access_key = "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEYaa"'],
+    ["AWS Access Key", `const key = "${AWS_TEMP_KEY}";`],
+    ["AWS Secret Key", `aws_secret_access_key = "${AWS_SECRET}"`],
     ["GitHub OAuth Token", `const t = "gho_${"a".repeat(36)}";`],
     ["GitHub User-to-Server Token", `const t = "ghu_${"a".repeat(36)}";`],
     ["GitHub Fine-Grained PAT", `const t = "github_pat_${"a".repeat(82)}";`],
     ["GitLab Personal Access Token", `const t = "glpat-${"a".repeat(20)}";`],
-    ["Slack Token", 'const t = "xoxb-123456789012-abcdefghijkl";'],
+    ["Slack Token", `const t = "${SLACK_TOKEN}";`],
     // Assembled from parts so GitHub push protection doesn't flag the fixture
     // itself as a leaked webhook.
     [
@@ -160,14 +178,11 @@ describe("SecretScanEvaluator", () => {
     ["Hugging Face Token", `const t = "hf_${"a1".repeat(17)}";`],
     ["SendGrid API Key", `const t = "SG.${"a".repeat(22)}.${"a".repeat(43)}";`],
     ["Twilio API Key", `const t = "SK${"0123456789abcdef".repeat(2)}";`],
-    ["Private Key Block", "-----BEGIN RSA PRIVATE KEY-----"],
-    ["Private Key Block", "-----BEGIN OPENSSH PRIVATE KEY-----"],
-    [
-      "JSON Web Token",
-      'const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N";',
-    ],
-    ["Connection String Credential", 'DB = "postgres://admin:hunter2@db.internal:5432/prod"'],
-    ["Connection String Credential", 'DB = "mongodb+srv://svc:p4ssw0rd@cluster.example.net"'],
+    ["Private Key Block", PEM_RSA],
+    ["Private Key Block", PEM_OPENSSH],
+    ["JSON Web Token", `const jwt = "${JWT}";`],
+    ["Connection String Credential", `DB = "${PG_URL}"`],
+    ["Connection String Credential", `DB = "${MONGO_URL}"`],
     ["Azure Storage Account Key", `conn = "AccountKey=${"A1b2".repeat(11)}=="`],
   ])("detects %s", async (name, line) => {
     const diff = makeDiff([line]);
@@ -188,7 +203,7 @@ describe("SecretScanEvaluator", () => {
   });
 
   it("reports one issue per line even when several patterns match", async () => {
-    const diff = makeDiff([`const a = "AKIAIOSFODNN7EXAMPLE"; const b = "ghp_${"a".repeat(36)}";`]);
+    const diff = makeDiff([`const a = "${AWS_KEY}"; const b = "ghp_${"a".repeat(36)}";`]);
     const result = await evaluator.evaluate(diff, policy, mockLogger);
     expect(result.success).toBe(true);
     if (result.success) {
@@ -197,7 +212,7 @@ describe("SecretScanEvaluator", () => {
   });
 
   it("ignores policy configuration — always runs", async () => {
-    const diff = makeDiff(['const key = "AKIAIOSFODNN7EXAMPLE";']);
+    const diff = makeDiff([`const key = "${AWS_KEY}";`]);
     const resultWithNull = await evaluator.evaluate(diff, policy, mockLogger);
     const resultWithPolicy = await evaluator.evaluate(
       diff,
@@ -215,7 +230,7 @@ describe("SecretScanEvaluator", () => {
 
 describe("SecretScanEvaluator — entropy detection", () => {
   it("flags a high-entropy value assigned to a credential-ish name", async () => {
-    const diff = makeDiff(['const apiToken = "hR8s2Kd91mZqLpXw4Yv7NbT3cFgJ6aQe";']);
+    const diff = makeDiff([`const apiToken = "${ENTROPY_MIXED}";`]);
     const result = await evaluator.evaluate(diff, policy, mockLogger);
     expect(result.success).toBe(true);
     if (result.success) {
@@ -225,7 +240,7 @@ describe("SecretScanEvaluator — entropy detection", () => {
   });
 
   it("flags a random hex value at the lower hex threshold", async () => {
-    const diff = makeDiff(['const secretKey = "9f8e7d6c5b4a39281706e5d4c3b2a190";']);
+    const diff = makeDiff([`const secretKey = "${ENTROPY_HEX}";`]);
     const result = await evaluator.evaluate(diff, policy, mockLogger);
     expect(result.success).toBe(true);
     if (result.success) {
@@ -249,7 +264,7 @@ describe("SecretScanEvaluator — entropy detection", () => {
   });
 
   it("does not flag a high-entropy value without credential context", async () => {
-    const diff = makeDiff(['const digest = "hR8s2Kd91mZqLpXw4Yv7NbT3cFgJ6aQe";']);
+    const diff = makeDiff([`const digest = "${ENTROPY_MIXED}";`]);
     const result = await evaluator.evaluate(diff, policy, mockLogger);
     expect(result.success).toBe(true);
     if (result.success) expect(result.data.passed).toBe(true);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -235,6 +235,9 @@ DEV_LOGIN_ENABLED = "false"
 # bound" at merge time and workspace staging silently no-ops. The config-guard
 # middleware logs an error if this is set "true" with no bucket bound.
 REPO_DO_ENABLED = "false"
+# Gated git push (ADR 005 slice 2b) — off until validated on staging; pushes to
+# a project URL keep getting the in-protocol refusal pointing at workspaces.
+GIT_PUSH_GATED_ENABLED = "false"
 # Production OAuth callbacks. The matching callback URLs must also be registered
 # in the GitHub and Google OAuth app settings.
 OAUTH_REDIRECT_URI = "https://app.usestratum.dev/auth/github/callback"
@@ -342,6 +345,10 @@ DEV_LOGIN_ENABLED = "false"
 # RepoDO + R2 merge path (ADR 004). "true" on staging: workspace commits stage to
 # R2 and merges route through the fetch-free R2 path (cold path as fallback).
 REPO_DO_ENABLED = "true"
+# Gated git push (ADR 005 slice 2b): a push to a project's default branch lands
+# on a server-managed workspace and opens an eval-gated change. Staging-first;
+# flip production once validated end-to-end against real Artifacts.
+GIT_PUSH_GATED_ENABLED = "true"
 OAUTH_REDIRECT_URI = "https://staging.app.usestratum.dev/auth/github/callback"
 EMAIL_FROM_ADDRESS = "noreply@staging.app.usestratum.dev"
 # Closed beta — validate the invite gate on staging before prod. Points at the

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -239,16 +239,15 @@ REPO_DO_ENABLED = "false"
 # in the GitHub and Google OAuth app settings.
 OAUTH_REDIRECT_URI = "https://app.usestratum.dev/auth/github/callback"
 GOOGLE_REDIRECT_URI = "https://app.usestratum.dev/auth/google/callback"
-# Closed beta — invite code required at signup. The gate fails closed, so
-# REFERRAL_SERVICE_URL must point at a LIVE referral service over a real public
-# hostname: Worker->Worker subrequests over *.workers.dev are intermittently
-# 404'd by the edge, so the referral service has its own custom domain
-# (referral.usestratum.dev -> stratum-landing Worker). The apex usestratum.dev
-# is still on the legacy Pages project; fold this into usestratum.dev after that
-# cutover if desired.
-# REFERRAL_SERVICE_SECRET is set out-of-band via `wrangler secret put` and must
-# match the value on the stratum-landing Worker.
-BETA_GATE = "1"
+# Open signup — the closed-beta invite gate is OFF in production ("available
+# today" is the positioning; Origin launched to every paid Cursor plan).
+# To re-enable the invite wall set BETA_GATE = "1"; the gate fails closed and
+# needs REFERRAL_SERVICE_URL live (referral.usestratum.dev -> stratum-landing
+# Worker; *.workers.dev subrequests are intermittently 404'd by the edge, hence
+# the custom domain). REFERRAL_SERVICE_SECRET is set out-of-band via
+# `wrangler secret put` and must match the stratum-landing Worker. Staging keeps
+# the gate ON so the invite path stays exercised end-to-end.
+BETA_GATE = "0"
 REFERRAL_SERVICE_URL = "https://referral.usestratum.dev"
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Competitive response to Cursor's Origin launch, in six commits. The thesis: Stratum wins as the **neutral governance layer** — reachable from any agent or editor, with merge gates and provenance Origin's shipped beta doesn't have.

**Reach (play 1)**
- **`@stratum/mcp`** (new `mcp/` package): MCP server over stdio exposing the full eval-gated change flow as 18 tools. Any MCP-capable agent/editor (Claude Code, Cursor, Zed, Copilot, custom) drives Stratum with one config block. Governance invariants hold: agent tokens cannot approve at all; failing evaluators block merges. Zod-validated args, request deadline, strict project-ref parsing, CI jobs with a real MCP-handshake smoke of the built binary.

**Governance credibility (play 2)**
- **Secret scanner: 6 → 25+ patterns** plus keyword-gated Shannon-entropy detection; fixtures assembled at runtime so the test file never contains a credential-shaped literal.
- **LLM gate fails closed**: the `"LGTM" → 0.8` fallback is gone; unparseable and non-finite scores block. `maxDiffChars` policy knob (default 8k → 24k chars, bounded [1k, 100k], integer-floored); truncated evaluations disclose it; real reviewer system prompt.

**Forge table stakes (play 3)**
- **Split/unified diff toggle with zero client JS** — hidden-checkbox + CSS sibling selectors, instant switch (GitHub/GitLab need a reload). Also corrects the stale "full file rewrites" README claim (diffs have been hunk-level; now pinned by tests).
- **`git push` to a project now fails in-protocol**: write-authorized receive-pack advertisement, parsed command list, per-ref `ng` report-status + sideband guidance naming workspace remotes — instead of an opaque 403. `src/utils/git-protocol.ts` (pkt-line, sideband, report-status) is the tested foundation for the gated default-branch push (#115); ADR 005 updated with exactly what remains.

**Openness & positioning (plays 4–5)**
- **Production signup opened** (`BETA_GATE = "0"`; staging keeps the gate on). ⚠️ **Deliberate go-to-market change — takes effect on the next approved production deploy.** Flag if you want the invite wall kept.
- **Complete OpenAPI 3.1 spec**: 72 paths / 91 operations from the route code (was a 4-path stub), Redocly-validated.
- **Real user docs**: full getting-started walkthrough + 15-question FAQ, honest about limitations.
- **README repositioned**: control plane for AI-written code on top of wherever code lives (layer mode over GitHub, or standalone forge).

All 11 CodeRabbit review findings addressed (one adapted: the suggested CI smoke assumed the binary blocks on empty stdin — it exits 0 on EOF, so the smoke does a real initialize handshake instead).

## Related issues

Groundwork for #115 (gated default-branch push). Follows `docs/research/` strategy docs.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## How was this verified?

- [x] `npm run typecheck` (root, mcp incl. tests, cli)
- [x] `npm test` (`npm run test:coverage` — 1196 passed, thresholds enforced; mcp 26; cli 11)
- [x] `npm run lint`
- MCP built binary smoke-tested with a real stdio initialize handshake; OpenAPI validated with Redocly (0 errors)

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (README, ADR 005, REMAINING_WORK, CHANGELOG, user guide)
- [x] No secrets, tokens, or personal data committed (all detector-positive fixtures assembled at runtime)
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (split-view toggle is pure CSS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiAwmc2tXjt6tHrGEpmnJj