### PR TITLE
Split/unified diff toggle with zero client JavaScript

### DIFF
--- a/docs/REMAINING_WORK.md
+++ b/docs/REMAINING_WORK.md
@@ -79,11 +79,11 @@ so consumers must install from source.
 From [research/master-plan-alignment.md](./research/master-plan-alignment.md),
 not a master-plan line item:
 
-### Client-side unified/split diff toggle
+### Client-side unified/split diff toggle — ✅ done
 
 The diff viewer
 ([`src/ui/components/diff-view.tsx`](../src/ui/components/diff-view.tsx))
-renders unified diffs
-only. The alignment research recommends a split-view toggle that switches
-client-side — no page reload or content refetch — as a differentiator over
-GitHub/GitLab, which require a full reload to switch views.
+now renders both views and switches instantly with a pure-CSS checkbox toggle —
+no page reload, no content refetch, and no client-side JavaScript, preserving
+the server-rendered-only invariant. (GitHub/GitLab require a full reload to
+switch views.)

--- a/docs/REMAINING_WORK.md
+++ b/docs/REMAINING_WORK.md
@@ -1,6 +1,6 @@
 # Remaining Work
 
-Last updated: 2026-06-12
+Last updated: 2026-08-17
 
 The master-plan feature roadmap (Phases 0–3 plus the code-level Phase 4
 hardening items) is complete as of 2026-06-11. See
@@ -85,5 +85,4 @@ The diff viewer
 ([`src/ui/components/diff-view.tsx`](../src/ui/components/diff-view.tsx))
 now renders both views and switches instantly with a pure-CSS checkbox toggle —
 no page reload, no content refetch, and no client-side JavaScript, preserving
-the server-rendered-only invariant. (GitHub/GitLab require a full reload to
-switch views.)
+the server-rendered-only invariant.

--- a/src/ui/components/diff-view.tsx
+++ b/src/ui/components/diff-view.tsx
@@ -4,7 +4,7 @@ export interface DiffFile {
   path: string;
   additions: number;
   deletions: number;
-  lines: Array<{ kind: "add" | "del" | "context" | "hunk"; text: string }>;
+  lines: Array<{ kind: "add" | "del" | "context" | "hunk" | "meta"; text: string }>;
 }
 
 /**
@@ -36,6 +36,10 @@ export function parseUnifiedDiff(diff: string): DiffFile[] {
 
     if (line.startsWith("@@")) {
       current.lines.push({ kind: "hunk", text: line });
+    } else if (line.startsWith("\\")) {
+      // "\ No newline at end of file" — metadata about the adjacent line, not
+      // file content; kept distinct so the split view doesn't pair it.
+      current.lines.push({ kind: "meta", text: line });
     } else if (line.startsWith("+")) {
       current.additions += 1;
       current.lines.push({ kind: "add", text: line });
@@ -55,6 +59,7 @@ const lineClass: Record<DiffFile["lines"][number]["kind"], string> = {
   del: "diff-line diff-del",
   context: "diff-line",
   hunk: "diff-line diff-hunk",
+  meta: "diff-line diff-meta",
 };
 
 export type SplitRow =
@@ -112,6 +117,10 @@ export function buildSplitRows(lines: DiffFile["lines"]): SplitRow[] {
         flush();
         rows.push({ kind: "hunk", text: line.text });
         break;
+      case "meta":
+        // Skip without flushing: the marker sits inside a del/add segment and
+        // must not break the pairing (or render as content in both columns).
+        break;
       case "context": {
         flush();
         const text = stripMarker(line.text);
@@ -132,6 +141,13 @@ export function buildSplitRows(lines: DiffFile["lines"]): SplitRow[] {
 
 const SplitTable: FC<{ file: DiffFile }> = ({ file }) => (
   <table class="diff-split">
+    <caption class="visually-hidden">Side-by-side diff of {file.path}</caption>
+    <thead class="visually-hidden">
+      <tr>
+        <th scope="col">Original</th>
+        <th scope="col">Modified</th>
+      </tr>
+    </thead>
     <tbody>
       {buildSplitRows(file.lines).map((row, index) =>
         row.kind === "hunk" ? (

--- a/src/ui/components/diff-view.tsx
+++ b/src/ui/components/diff-view.tsx
@@ -57,12 +57,120 @@ const lineClass: Record<DiffFile["lines"][number]["kind"], string> = {
   hunk: "diff-line diff-hunk",
 };
 
+export type SplitRow =
+  | { kind: "hunk"; text: string }
+  | {
+      kind: "pair";
+      left: string | null;
+      right: string | null;
+      leftKind: "del" | "context";
+      rightKind: "add" | "context";
+    };
+
+/** Drop the unified-diff marker (+ / - / leading space) for side-by-side cells. */
+function stripMarker(text: string): string {
+  return text.startsWith("+") || text.startsWith("-") || text.startsWith(" ")
+    ? text.slice(1)
+    : text;
+}
+
+/**
+ * Pair a file's unified-diff lines into side-by-side rows. Unified diffs list a
+ * segment's deletions before its additions, so buffered del/add runs are zipped
+ * together at each context/hunk boundary; the longer run leaves empty cells on
+ * the other side.
+ */
+export function buildSplitRows(lines: DiffFile["lines"]): SplitRow[] {
+  const rows: SplitRow[] = [];
+  let dels: string[] = [];
+  let adds: string[] = [];
+
+  const flush = () => {
+    const count = Math.max(dels.length, adds.length);
+    for (let i = 0; i < count; i++) {
+      rows.push({
+        kind: "pair",
+        left: dels[i] ?? null,
+        right: adds[i] ?? null,
+        leftKind: "del",
+        rightKind: "add",
+      });
+    }
+    dels = [];
+    adds = [];
+  };
+
+  for (const line of lines) {
+    switch (line.kind) {
+      case "del":
+        dels.push(stripMarker(line.text));
+        break;
+      case "add":
+        adds.push(stripMarker(line.text));
+        break;
+      case "hunk":
+        flush();
+        rows.push({ kind: "hunk", text: line.text });
+        break;
+      case "context": {
+        flush();
+        const text = stripMarker(line.text);
+        rows.push({
+          kind: "pair",
+          left: text,
+          right: text,
+          leftKind: "context",
+          rightKind: "context",
+        });
+        break;
+      }
+    }
+  }
+  flush();
+  return rows;
+}
+
+const SplitTable: FC<{ file: DiffFile }> = ({ file }) => (
+  <table class="diff-split">
+    <tbody>
+      {buildSplitRows(file.lines).map((row, index) =>
+        row.kind === "hunk" ? (
+          <tr key={index}>
+            <td class="diff-cell diff-hunk" colspan={2}>
+              {row.text}
+            </td>
+          </tr>
+        ) : (
+          <tr key={index}>
+            <td class={row.leftKind === "del" ? "diff-cell diff-del" : "diff-cell"}>
+              {row.left ?? ""}
+            </td>
+            <td class={row.rightKind === "add" ? "diff-cell diff-add" : "diff-cell"}>
+              {row.right ?? ""}
+            </td>
+          </tr>
+        ),
+      )}
+    </tbody>
+  </table>
+);
+
+/**
+ * The unified/split toggle is a hidden checkbox + CSS sibling selectors — the
+ * switch is instant and needs no client-side JavaScript, keeping the UI's
+ * server-rendered-only invariant. Both views are rendered; CSS shows one.
+ */
 export const DiffView: FC<{ files: DiffFile[] }> = ({ files }) => {
   if (files.length === 0) {
     return <p class="diff-empty">No changes between the workspace and the project.</p>;
   }
   return (
     <div class="diff-view">
+      <input type="checkbox" id="diff-split-toggle" class="diff-split-toggle" />
+      <label for="diff-split-toggle" class="diff-split-label">
+        <span class="diff-label-unified">Switch to split view</span>
+        <span class="diff-label-split">Switch to unified view</span>
+      </label>
       {files.map((file) => (
         <details class="diff-file" key={file.path} open={files.length <= 5}>
           <summary class="diff-file-header">
@@ -80,6 +188,7 @@ export const DiffView: FC<{ files: DiffFile[] }> = ({ files }) => {
               </span>
             ))}
           </pre>
+          <SplitTable file={file} />
         </details>
       ))}
     </div>

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -549,6 +549,14 @@ a:hover { text-decoration: underline; }
 .diff-add { background: rgba(74, 222, 128, 0.12); color: #b9f0cd; }
 .diff-del { background: rgba(248, 113, 113, 0.12); color: #f5c2c2; }
 .diff-hunk { color: #7cb7ff; background: #14181f; }
+.diff-meta { color: #666; font-style: italic; }
+
+/* Present for assistive tech, removed from the visual layout. */
+.visually-hidden {
+  position: absolute; width: 1px; height: 1px; margin: -1px;
+  padding: 0; border: 0; clip-path: inset(50%); overflow: hidden;
+  white-space: nowrap;
+}
 
 /* Unified/split toggle: hidden checkbox + sibling selectors, no client JS.
    The instant client-side switch (vs. GitHub's full reload) is deliberate. */

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -550,6 +550,34 @@ a:hover { text-decoration: underline; }
 .diff-del { background: rgba(248, 113, 113, 0.12); color: #f5c2c2; }
 .diff-hunk { color: #7cb7ff; background: #14181f; }
 
+/* Unified/split toggle: hidden checkbox + sibling selectors, no client JS.
+   The instant client-side switch (vs. GitHub's full reload) is deliberate. */
+.diff-split-toggle { position: absolute; opacity: 0; pointer-events: none; }
+.diff-split-label {
+  align-self: flex-end; cursor: pointer; user-select: none;
+  font-size: 0.8rem; color: #7cb7ff; border: 1px solid #2a2a2a;
+  border-radius: 6px; padding: 0.25rem 0.6rem; background: #181818;
+}
+.diff-split-label:hover { border-color: #7cb7ff; }
+.diff-split-toggle:focus-visible ~ .diff-split-label { outline: 2px solid #7cb7ff; outline-offset: 2px; }
+.diff-label-split { display: none; }
+.diff-split-toggle:checked ~ .diff-split-label .diff-label-unified { display: none; }
+.diff-split-toggle:checked ~ .diff-split-label .diff-label-split { display: inline; }
+
+/* Split view: hidden until the toggle is checked, then replaces unified. */
+.diff-split { display: none; }
+.diff-split-toggle:checked ~ .diff-file .diff-file-body { display: none; }
+.diff-split-toggle:checked ~ .diff-file .diff-split {
+  display: table; width: 100%; table-layout: fixed; border-collapse: collapse;
+  font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; line-height: 1.5;
+  background: #0d0d0d;
+}
+.diff-cell {
+  width: 50%; padding: 0 0.75rem; white-space: pre-wrap; word-break: break-all;
+  vertical-align: top; border-left: 1px solid #1c1c1c;
+}
+.diff-cell:first-child { border-left: none; }
+
 /* Settings */
 .settings-help { font-size: 0.85rem; color: #888; }
 .settings-token-reveal { border: 1px solid #2d4f2d; background: #101a10; }

--- a/tests/diff-split-view.test.tsx
+++ b/tests/diff-split-view.test.tsx
@@ -1,0 +1,155 @@
+import { renderToString } from "hono/jsx/dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  type DiffFile,
+  DiffView,
+  buildSplitRows,
+  parseUnifiedDiff,
+} from "../src/ui/components/diff-view";
+
+type Lines = DiffFile["lines"];
+
+describe("buildSplitRows", () => {
+  it("pairs a deletion run with an addition run", () => {
+    const lines: Lines = [
+      { kind: "hunk", text: "@@ -1,2 +1,2 @@" },
+      { kind: "del", text: "-const a = 1;" },
+      { kind: "del", text: "-const b = 2;" },
+      { kind: "add", text: "+const a = 10;" },
+      { kind: "add", text: "+const b = 20;" },
+    ];
+    const rows = buildSplitRows(lines);
+    expect(rows).toEqual([
+      { kind: "hunk", text: "@@ -1,2 +1,2 @@" },
+      {
+        kind: "pair",
+        left: "const a = 1;",
+        right: "const a = 10;",
+        leftKind: "del",
+        rightKind: "add",
+      },
+      {
+        kind: "pair",
+        left: "const b = 2;",
+        right: "const b = 20;",
+        leftKind: "del",
+        rightKind: "add",
+      },
+    ]);
+  });
+
+  it("leaves empty cells when runs have unequal length", () => {
+    const lines: Lines = [
+      { kind: "del", text: "-only removed" },
+      { kind: "add", text: "+replacement" },
+      { kind: "add", text: "+brand new line" },
+    ];
+    const rows = buildSplitRows(lines);
+    expect(rows).toEqual([
+      {
+        kind: "pair",
+        left: "only removed",
+        right: "replacement",
+        leftKind: "del",
+        rightKind: "add",
+      },
+      { kind: "pair", left: null, right: "brand new line", leftKind: "del", rightKind: "add" },
+    ]);
+  });
+
+  it("context lines appear on both sides and flush pending runs", () => {
+    const lines: Lines = [
+      { kind: "del", text: "-old" },
+      { kind: "context", text: " shared" },
+      { kind: "add", text: "+new" },
+    ];
+    const rows = buildSplitRows(lines);
+    expect(rows).toEqual([
+      { kind: "pair", left: "old", right: null, leftKind: "del", rightKind: "add" },
+      { kind: "pair", left: "shared", right: "shared", leftKind: "context", rightKind: "context" },
+      { kind: "pair", left: null, right: "new", leftKind: "del", rightKind: "add" },
+    ]);
+  });
+
+  it("handles a pure addition (new file) with no deletions", () => {
+    const lines: Lines = [
+      { kind: "add", text: "+line one" },
+      { kind: "add", text: "+line two" },
+    ];
+    const rows = buildSplitRows(lines);
+    expect(rows).toEqual([
+      { kind: "pair", left: null, right: "line one", leftKind: "del", rightKind: "add" },
+      { kind: "pair", left: null, right: "line two", leftKind: "del", rightKind: "add" },
+    ]);
+  });
+
+  it("round-trips through parseUnifiedDiff for a realistic hunk", () => {
+    const diff = [
+      "diff --git a/src/x.ts b/src/x.ts",
+      "--- a/src/x.ts",
+      "+++ b/src/x.ts",
+      "@@ -1,3 +1,3 @@",
+      " const keep = true;",
+      "-const version = 1;",
+      "+const version = 2;",
+      " export {};",
+    ].join("\n");
+    const [file] = parseUnifiedDiff(diff);
+    if (!file) throw new Error("diff did not parse");
+    const rows = buildSplitRows(file.lines);
+    expect(rows).toHaveLength(4);
+    expect(rows[1]).toEqual({
+      kind: "pair",
+      left: "const keep = true;",
+      right: "const keep = true;",
+      leftKind: "context",
+      rightKind: "context",
+    });
+    expect(rows[2]).toEqual({
+      kind: "pair",
+      left: "const version = 1;",
+      right: "const version = 2;",
+      leftKind: "del",
+      rightKind: "add",
+    });
+  });
+});
+
+describe("DiffView split toggle", () => {
+  const files: DiffFile[] = [
+    {
+      path: "src/x.ts",
+      additions: 1,
+      deletions: 1,
+      lines: [
+        { kind: "hunk", text: "@@ -1 +1 @@" },
+        { kind: "del", text: "-old line" },
+        { kind: "add", text: "+new line" },
+      ],
+    },
+  ];
+
+  it("renders both unified and split views with a CSS-only toggle", () => {
+    const html = renderToString(<DiffView files={files} />);
+    expect(html).toContain('class="diff-split-toggle"');
+    expect(html).toContain('type="checkbox"');
+    expect(html).toContain('class="diff-file-body"');
+    expect(html).toContain('class="diff-split"');
+    expect(html).toContain("Switch to split view");
+    expect(html).toContain("Switch to unified view");
+    // No client-side JavaScript may sneak in with the toggle.
+    expect(html).not.toContain("<script");
+  });
+
+  it("split cells carry the marker-stripped text", () => {
+    const html = renderToString(<DiffView files={files} />);
+    expect(html).toContain(">old line</td>");
+    expect(html).toContain(">new line</td>");
+  });
+
+  it("renders no toggle for an empty diff", () => {
+    const html = renderToString(<DiffView files={[]} />);
+    expect(html).toContain("No changes");
+    expect(html).not.toContain("diff-split-toggle");
+  });
+});

--- a/tests/diff-split-view.test.tsx
+++ b/tests/diff-split-view.test.tsx
@@ -113,6 +113,35 @@ describe("buildSplitRows", () => {
       rightKind: "add",
     });
   });
+
+  it("no-newline markers are metadata: never paired, never breaking alignment", () => {
+    const diff = [
+      "diff --git a/src/x.ts b/src/x.ts",
+      "--- a/src/x.ts",
+      "+++ b/src/x.ts",
+      "@@ -1 +1 @@",
+      "-old final line",
+      "\\ No newline at end of file",
+      "+new final line",
+      "\\ No newline at end of file",
+    ].join("\n");
+    const [file] = parseUnifiedDiff(diff);
+    if (!file) throw new Error("diff did not parse");
+    expect(file.lines.filter((l) => l.kind === "meta")).toHaveLength(2);
+    // The marker between del and add must not flush the pairing: the changed
+    // final line still renders as one aligned row, with no metadata rows.
+    const rows = buildSplitRows(file.lines);
+    expect(rows).toEqual([
+      { kind: "hunk", text: "@@ -1 +1 @@" },
+      {
+        kind: "pair",
+        left: "old final line",
+        right: "new final line",
+        leftKind: "del",
+        rightKind: "add",
+      },
+    ]);
+  });
 });
 
 describe("DiffView split toggle", () => {
@@ -151,5 +180,12 @@ describe("DiffView split toggle", () => {
     const html = renderToString(<DiffView files={[]} />);
     expect(html).toContain("No changes");
     expect(html).not.toContain("diff-split-toggle");
+  });
+
+  it("split table carries accessible caption and column headers", () => {
+    const html = renderToString(<DiffView files={files} />);
+    expect(html).toContain("Side-by-side diff of src/x.ts");
+    expect(html).toContain('<th scope="col">Original</th>');
+    expect(html).toContain('<th scope="col">Modified</th>');
   });
 });


### PR DESCRIPTION
## Summary

Carved out of #173 (3/6). Review-UX table stakes:

- Side-by-side diff view for change review: del/add runs are paired into aligned rows server-side (`buildSplitRows`), and a hidden-checkbox + CSS-sibling-selector toggle switches views **instantly with no client JavaScript** — preserving the server-rendered-only invariant. GitHub/GitLab need a full reload to switch views.
- Marks the deferred split-view recommendation in `docs/REMAINING_WORK.md` done.

(Diffs were already hunk-level via `createPatch` — pinned by the existing `buildUnifiedDiff` tests; the stale "full file rewrites" README claim is corrected in the docs PR.)

Independent of the sibling PRs; any merge order.

## Related issues

None filed; part of the Origin-response campaign (see #173).

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` (full unit suite on this branch; new suite covers pairing edge cases and renders both views)
- [x] `npm run lint`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (REMAINING_WORK)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (the toggle is pure CSS; the render test asserts no `<script>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiAwmc2tXjt6tHrGEpmnJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiAwmc2tXjt6tHrGEpmnJj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a side-by-side split view for comparing changes.
  * Added an instant toggle between unified and split diff views without reloading or refetching.
  * Preserved context and hunk information in both viewing modes.
  * Added accessible focus styling and clear toggle labels.

* **Bug Fixes**
  * Improved handling of uneven additions and deletions, including pure additions, empty diffs, and no-newline markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->