### PR TITLE
Gated git push to projects (ADR 005 slice 2b), staging-flagged

### DIFF
--- a/.stratum/policy.yaml
+++ b/.stratum/policy.yaml
@@ -1,0 +1,29 @@
+# Stratum's own merge policy — the dogfood configuration this repo runs under
+# when hosted on a Stratum instance (layer mode over GitHub, or as source of
+# truth). Inert on GitHub itself. The secret scan is always on and blocking and
+# needs no entry here.
+evaluators:
+  # Structural sanity: a Stratum change should be a reviewable unit, not a dump.
+  - type: diff
+    maxLines: 5000
+    maxFiles: 200
+  # LLM review as a gate, not a rubber stamp. An unparseable verdict fails
+  # closed; the diff window covers all but the largest changes.
+  - type: llm
+    threshold: 0.6
+    maxDiffChars: 48000
+
+requireAll: true
+minScore: 0.6
+
+merge:
+  # Approvals are a human gate; agents (including the ones building this repo)
+  # can never approve their own work.
+  requiredApprovals: 1
+  # The always-on secret scan must have passed on the evaluated revision.
+  requiredEvaluators: ["secret_scan"]
+  # No force-merge escape hatch on this repo. Deleting this line keeps force
+  # denied (deny-by-default); it is spelled out so the intent is explicit.
+  allowForce: false
+  # A change evaluated against a stale base must re-evaluate before merging.
+  requireFreshBase: true

--- a/docs/adr/005-git-smart-http-proxy.md
+++ b/docs/adr/005-git-smart-http-proxy.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-Partially accepted — **clone/fetch (slice 1) and workspace push (slice 2a)
-implemented**; the **gated default-branch push (slice 2b / Phase B) remains
-deferred**.
+Accepted — **clone/fetch (slice 1), workspace push (slice 2a), and the gated
+default-branch push (slice 2b) are implemented**; slice 2b ships behind
+`GIT_PUSH_GATED_ENABLED` (staging on, production off until validated against
+real Artifacts).
 
 - **Slice 1 — clone/fetch.** Authenticated `git-upload-pack` proxy: a project is
   a git remote for `git clone` / `git fetch` at `/@ns/slug.git`
@@ -121,10 +122,14 @@ funnels it through the existing change → eval → merge-queue pipeline, so a
 `git push` produces exactly the same artifacts as `stratum commit` followed by a
 change:
 
-- Push to the project's default branch → create (or update) a change against an
-  auto-named workspace, run evaluation, and either fast-forward or enqueue on the
-  `MergeQueue` per existing policy. A rejected eval surfaces to the client as a
-  non-zero `git push` exit with the reason in the sideband progress stream.
+- Push to the project's default branch → land the pack on a fresh auto-named
+  workspace fork, create a change, and run evaluation synchronously. The client
+  always receives a truthful per-ref `ng` carrying the change id and eval
+  verdict (with detail in the sideband progress stream): the default branch
+  only moves through the merge gate — under this repo's policy that includes a
+  human approval (`requiredApprovals: 1`). Answering `ok` by merging directly
+  when policy allows it (eval passed, zero required approvals) remains open
+  under #115.
 - Push to `refs/heads/<workspace>` → commit straight to that workspace ref
   (the workspace-commit path), no gate, matching `stratum commit`.
 

--- a/docs/adr/005-git-smart-http-proxy.md
+++ b/docs/adr/005-git-smart-http-proxy.md
@@ -26,13 +26,16 @@ real Artifacts).
   until validated against real Artifacts), a single-ref push to the project's
   configured default branch (`sourceDefaultBranch` → `githubDefaultBranch` →
   `main`) on the **project** URL is routed through the change gate:
-  the pack lands on a fresh server-managed workspace fork (whose `main` sits at
-  the project tip, so the client's old-oid lines up and the remote's own
-  fast-forward check stays truthful), then the shared change-flow service
+  the pack lands on a fresh server-managed workspace fork (a full-repository
+  fork whose default branch sits at the project tip; the original ref and
+  old-oid are forwarded unchanged, so the client's old-oid lines up and the
+  remote's own fast-forward check stays truthful), then the shared change-flow
+  service
   (`src/services/change-flow.ts` — the same pipeline the REST route runs)
   creates and synchronously evaluates a change. The client receives a
   **truthful `ng`** carrying the change id and eval verdict, with detail on the
-  side-band: `main` does not move until the change is approved and merged, and
+  side-band: the default branch does not move until the change is approved and
+  merged, and
   answering `ok` would corrupt the client's remote-tracking ref. Multi-ref
   pushes, deletions, and non-default refs keep the in-protocol refusal; a pack
   the workspace remote itself rejects is relayed verbatim. Evaluation runs

--- a/docs/adr/005-git-smart-http-proxy.md
+++ b/docs/adr/005-git-smart-http-proxy.md
@@ -20,14 +20,26 @@ deferred**.
   the client clones the workspace, ref/old-oid semantics line up and Artifacts'
   report-status is the truthful outcome — no pkt-line parsing or report-status
   synthesis needed. A streaming body cap bounds push size.
-- **Slice 2b — gated default-branch push (deferred, Phase B).** Pushing to the
-  **project** URL (`/@ns/slug.git`) is still refused (`403`). Routing a push
-  through the change → eval → MergeQueue gate requires: pinning the evaluated sha
-  and **merging by sha** (not the fork's mutable tip — TOCTOU/gate-bypass);
-  durable async eval (a queue + sweeper + dedupe, not `waitUntil`); idempotent
-  change creation under concurrent pushes (a DB uniqueness constraint); and
-  Gerrit-style `refs/for/main` → `ok` semantics with synthesized report-status.
-  Tracked in #115.
+- **Slice 2b — gated default-branch push (implemented, staging-flagged).**
+  Behind `GIT_PUSH_GATED_ENABLED` ("true" on staging, "false" in production
+  until validated against real Artifacts), a single-ref push to
+  `refs/heads/main` on the **project** URL is routed through the change gate:
+  the pack lands on a fresh server-managed workspace fork (whose `main` sits at
+  the project tip, so the client's old-oid lines up and the remote's own
+  fast-forward check stays truthful), then the shared change-flow service
+  (`src/services/change-flow.ts` — the same pipeline the REST route runs)
+  creates and synchronously evaluates a change. The client receives a
+  **truthful `ng`** carrying the change id and eval verdict, with detail on the
+  side-band: `main` does not move until the change is approved and merged, and
+  answering `ok` would corrupt the client's remote-tracking ref. Multi-ref
+  pushes, deletions, and non-default refs keep the in-protocol refusal; a pack
+  the workspace remote itself rejects is relayed verbatim. Evaluation runs
+  synchronously inside the push request — the same latency contract as
+  `POST /changes` — so the durable async-eval queue is an optimization, not a
+  prerequisite. Remaining for #115: answer `ok` by actually merging when policy
+  allows it (eval passed, zero required approvals) and change-per-push
+  idempotency under concurrent identical pushes (today each push opens its own
+  workspace + change, which is safe but can duplicate).
 
 ## Context
 

--- a/docs/adr/005-git-smart-http-proxy.md
+++ b/docs/adr/005-git-smart-http-proxy.md
@@ -33,9 +33,9 @@ real Artifacts).
   service
   (`src/services/change-flow.ts` — the same pipeline the REST route runs)
   creates and synchronously evaluates a change. The client receives a
-  **truthful `ng`** carrying the change id and eval verdict, with detail on the
-  side-band: the default branch does not move until the change is approved and
-  merged, and
+  **truthful `ng`** carrying the change id and eval verdict, with side-band
+  detail when the client negotiated it: the default branch does not move until
+  the change is approved and merged, and
   answering `ok` would corrupt the client's remote-tracking ref. Multi-ref
   pushes, deletions, and non-default refs keep the in-protocol refusal; a pack
   the workspace remote itself rejects is relayed verbatim. Evaluation runs

--- a/docs/adr/005-git-smart-http-proxy.md
+++ b/docs/adr/005-git-smart-http-proxy.md
@@ -23,8 +23,9 @@ real Artifacts).
   synthesis needed. A streaming body cap bounds push size.
 - **Slice 2b — gated default-branch push (implemented, staging-flagged).**
   Behind `GIT_PUSH_GATED_ENABLED` ("true" on staging, "false" in production
-  until validated against real Artifacts), a single-ref push to
-  `refs/heads/main` on the **project** URL is routed through the change gate:
+  until validated against real Artifacts), a single-ref push to the project's
+  configured default branch (`sourceDefaultBranch` → `githubDefaultBranch` →
+  `main`) on the **project** URL is routed through the change gate:
   the pack lands on a fresh server-managed workspace fork (whose `main` sits at
   the project tip, so the client's old-oid lines up and the remote's own
   fast-forward check stays truthful), then the shared change-flow service

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1,23 +1,17 @@
 import { type Context, Hono } from "hono";
-import {
-  CompositeEvaluator,
-  DiffEvaluator,
-  LLMEvaluator,
-  SandboxEvaluator,
-  SecretScanEvaluator,
-  WebhookEvaluator,
-  loadPolicy,
-} from "../evaluation";
-import type { EvalPolicy, EvalResult } from "../evaluation/types";
-import type { Evaluator } from "../evaluation/types";
+import { CompositeEvaluator, loadPolicy } from "../evaluation";
+import type { EvalPolicy } from "../evaluation/types";
 import { runPostMergeCheck } from "../merge/post-merge";
 import { checkMergeProtection } from "../merge/protection";
-import { type EventActor, emitEvent } from "../queue/events";
+import { emitEvent } from "../queue/events";
 import type { MergeOutcome } from "../queue/merge-queue";
-import { getAgent } from "../storage/agents";
+import {
+  buildEvaluators,
+  createChangeWithEvaluation,
+  resolveProjectHead,
+} from "../services/change-flow";
 import { recordAudit } from "../storage/audit";
 import {
-  createChange,
   getChange,
   getChangesByIds,
   listChanges,
@@ -41,11 +35,9 @@ import {
   parseStagedTree,
 } from "../storage/git-ops";
 import { recordProvenance } from "../storage/provenance";
-import { readRepoSnapshot } from "../storage/repo-snapshot";
 import { getProject, getWorkspace } from "../storage/state";
 import type { Change, Env, ProjectEntry } from "../types";
 import { canReadProject, canWriteProject } from "../utils/authz";
-import type { AppError } from "../utils/errors";
 import { newId } from "../utils/ids";
 import { createLogger } from "../utils/logger";
 import type { Logger } from "../utils/logger";
@@ -58,7 +50,6 @@ import {
   ok,
   unauthorized,
 } from "../utils/response";
-import { ok as okResult } from "../utils/result";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -149,25 +140,6 @@ function okOrFormRedirect<T>(c: Context<{ Bindings: Env }>, changeId: string, da
   return ok(data);
 }
 
-/** Current project HEAD: cheap KV snapshot first, single-commit clone as fallback. */
-async function resolveProjectHead(
-  env: Env,
-  project: ProjectEntry,
-  logger: Logger,
-): Promise<string | null> {
-  if (project.namespace && project.slug) {
-    const snapshotResult = await readRepoSnapshot(env.STATE, project, logger);
-    if (snapshotResult.success) {
-      const sha = snapshotResult.data?.commits[0]?.sha;
-      if (sha) return sha;
-    }
-  }
-  const readToken = await freshRepoToken(env.ARTIFACTS, project.remote, "read", logger);
-  if (!readToken.success) return null;
-  const logResult = await getCommitLog(project.remote, readToken.data, logger, 1);
-  return logResult.success ? (logResult.data[0]?.sha ?? null) : null;
-}
-
 /**
  * Resolve a workspace's current tip commit sha, or null if it can't be read.
  * Workspaces have no KV snapshot fast-path, so this clones the workspace remote.
@@ -182,25 +154,6 @@ async function resolveWorkspaceTip(
   if (!readToken.success) return null;
   const logResult = await getCommitLog(workspaceRemote, readToken.data, logger, 1);
   return logResult.success ? (logResult.data[0]?.sha ?? null) : null;
-}
-
-class UnavailableEvaluator implements Evaluator {
-  constructor(
-    private evaluatorType: string,
-    private reason: string,
-  ) {}
-
-  async evaluate(
-    _diff: string,
-    _policy: EvalPolicy,
-    _logger: Logger,
-  ): Promise<{ success: true; data: EvalResult } | { success: false; error: AppError }> {
-    return okResult({
-      score: 0,
-      passed: false,
-      reason: `${this.evaluatorType} unavailable: ${this.reason}`,
-    });
-  }
 }
 
 app.post("/projects/:name/changes", async (c) => {
@@ -259,231 +212,23 @@ app.post("/projects/:name/changes", async (c) => {
     return badRequest(`Workspace '${body.workspace}' does not belong to project '${projectName}'`);
   }
 
-  const baseSha = await resolveProjectHead(c.env, project, logger);
-
-  // Snapshot the authoring agent's model + prompt hash at creation, so
-  // provenance records the model that did the work rather than the agent's
-  // current (possibly later-changed) registration.
-  let agentModel: string | undefined;
-  let agentPromptHash: string | undefined;
-  if (agentId !== undefined) {
-    const agentResult = await getAgent(c.env.DB, agentId, logger);
-    if (agentResult.success) {
-      agentModel = agentResult.data.model;
-      agentPromptHash = agentResult.data.promptHash;
-    } else {
-      // Best effort: provenance metadata must not block change creation. Log so a
-      // persistent lookup failure is visible rather than silently dropping the
-      // model/prompt snapshot.
-      logger.warn("Could not load agent for provenance snapshot; continuing without it", {
-        agentId,
-        error: agentResult.error.message,
-      });
-    }
-  }
-
-  const changeResult = await createChange(c.env.DB, logger, {
-    project: projectName,
-    projectId: project.id,
-    workspace: body.workspace,
-    ...(agentId !== undefined ? { agentId } : {}),
-    ...(baseSha !== null ? { baseSha } : {}),
-    ...(agentModel !== undefined ? { agentModel } : {}),
-    ...(agentPromptHash !== undefined ? { agentPromptHash } : {}),
-  });
-  if (!changeResult.success) {
-    logger.error("Failed to create change", changeResult.error);
-    return badRequest(changeResult.error.message);
-  }
-  const change = changeResult.data;
-
-  const actor: EventActor = agentId
-    ? { type: "agent", id: agentId }
-    : { type: "user", ...(userId !== undefined ? { id: userId } : {}) };
-
-  await emitEvent(
-    c.env.DB,
-    c.env.EVENTS_QUEUE,
-    {
-      type: "change.created",
-      project: projectName,
-      changeId: change.id,
-      workspace: body.workspace,
+  const outcome = await createChangeWithEvaluation(c.env, logger, {
+    project,
+    projectName,
+    workspaceName: body.workspace,
+    workspaceRemote: workspace.remote,
+    actor: {
+      ...(userId !== undefined ? { userId } : {}),
+      ...(agentId !== undefined ? { agentId } : {}),
     },
-    actor,
-    logger,
-    project.id,
-  );
-
-  const [projectReadToken, workspaceReadToken] = await Promise.all([
-    freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger),
-    freshRepoToken(c.env.ARTIFACTS, workspace.remote, "read", logger),
-  ]);
-  if (!projectReadToken.success) return internalError(projectReadToken.error.message);
-  if (!workspaceReadToken.success) return internalError(workspaceReadToken.error.message);
-
-  const policy = await loadPolicy(project.remote, projectReadToken.data, logger);
-
-  const diffResult = await getDiffBetweenRepos(
-    project.remote,
-    projectReadToken.data,
-    workspace.remote,
-    workspaceReadToken.data,
-    logger,
-  );
-  if (!diffResult.success) {
-    logger.error("Failed to get diff between repos", diffResult.error);
-    return badRequest(diffResult.error.message);
-  }
-  // workspaceOid === workspaceSha (same evaluated tip): #133 pins evaluatedSha +
-  // tree oid for content-addressing, #115 pins workspaceHeadSha for the merge.
-  const {
-    diff,
-    workspaceOid: evaluatedSha,
-    workspaceTreeOid: evaluatedTreeOid,
-    workspaceSha: workspaceHeadSha,
-  } = diffResult.data;
-
-  const evaluators: Array<{ type: string; evaluator: Evaluator }> = [
-    { type: "secret_scan", evaluator: new SecretScanEvaluator() },
-  ];
-
-  evaluators.push(
-    ...policy.evaluators.flatMap((cfg): Array<{ type: string; evaluator: Evaluator }> => {
-      switch (cfg.type) {
-        case "diff":
-          return [{ type: "diff", evaluator: new DiffEvaluator() }];
-        case "webhook":
-          return [{ type: "webhook", evaluator: new WebhookEvaluator() }];
-        case "llm":
-          if (c.env.AI) return [{ type: "llm", evaluator: new LLMEvaluator(c.env.AI) }];
-          return [
-            {
-              type: "llm",
-              evaluator: new UnavailableEvaluator("llm", "AI binding is not configured"),
-            },
-          ];
-        case "sandbox":
-          if (c.env.SANDBOX) {
-            return [{ type: "sandbox", evaluator: new SandboxEvaluator(c.env.SANDBOX) }];
-          }
-          return [
-            {
-              type: "sandbox",
-              evaluator: new UnavailableEvaluator("sandbox", "SANDBOX binding is not configured"),
-            },
-          ];
-        default:
-          logger.warn(
-            `Unknown evaluator type "${(cfg as { type: string }).type}" in policy for project ${projectName}`,
-            { evaluatorType: (cfg as { type: string }).type, projectName },
-          );
-          return [];
-      }
-    }),
-  );
-
-  const evalRuns = await Promise.all(
-    evaluators.map(async ({ type, evaluator }) => {
-      const result = await evaluator.evaluate(diff, policy, logger);
-      return {
-        evaluatorType: type,
-        result: result.success
-          ? result.data
-          : { score: 0, passed: false, reason: result.error.message },
-      };
-    }),
-  );
-
-  const composite = new CompositeEvaluator(evaluators.map(({ evaluator }) => evaluator));
-  const aggregateResult = composite.aggregate(
-    evalRuns.map(({ result }) => result),
-    policy,
-    logger,
-  );
-  const blockingFailure = evalRuns.find(
-    ({ evaluatorType, result }) => evaluatorType === "secret_scan" && !result.passed,
-  );
-  const evalResult =
-    blockingFailure === undefined
-      ? aggregateResult
-      : {
-          score: Math.min(aggregateResult.score, blockingFailure.result.score),
-          passed: false,
-          reason:
-            aggregateResult.reason === blockingFailure.result.reason
-              ? blockingFailure.result.reason
-              : `${blockingFailure.result.reason} ${aggregateResult.reason}`,
-          issues: aggregateResult.issues,
-        };
-
-  const newStatus: Change["status"] = evalResult.passed ? "accepted" : "needs_changes";
-
-  const recordResult = await recordEvalRuns(c.env.DB, logger, change.id, evalRuns);
-  if (!recordResult.success) {
-    logger.error("Failed to record eval runs", recordResult.error);
-    return badRequest(recordResult.error.message);
-  }
-
-  // Best-effort cost tracking: the diff clones both repos, evaluators self-report.
-  const createCostSamples: CostSample[] = [
-    { kind: "git_ops", quantity: 2 },
-    ...evalRuns.flatMap(({ result }) => result.costs ?? []),
-  ];
-  await recordCosts(
-    c.env.DB,
-    logger,
-    { project: projectName, projectId: project.id, changeId: change.id, workspace: body.workspace },
-    createCostSamples,
-  );
-
-  const updateResult = await updateChangeStatus(c.env.DB, logger, change.id, newStatus, {
-    evalScore: evalResult.score,
-    evalPassed: evalResult.passed,
-    evalReason: evalResult.reason,
-    evaluatedSha,
-    evaluatedTreeOid,
-    ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
   });
-  if (!updateResult.success) {
-    logger.error("Failed to update change status", updateResult.error);
-    return badRequest(updateResult.error.message);
+  if (!outcome.success) {
+    return outcome.error.statusCode >= 500
+      ? internalError(outcome.error.message)
+      : badRequest(outcome.error.message);
   }
-
-  await emitEvent(
-    c.env.DB,
-    c.env.EVENTS_QUEUE,
-    {
-      type: "change.evaluated",
-      project: projectName,
-      changeId: change.id,
-      score: evalResult.score,
-      passed: evalResult.passed,
-    },
-    { type: "system" },
-    logger,
-    project.id,
-  );
-
-  const updatedChange: Change = {
-    ...change,
-    status: newStatus,
-    evalScore: evalResult.score,
-    evalPassed: evalResult.passed,
-    evalReason: evalResult.reason,
-    evaluatedSha,
-    evaluatedTreeOid,
-    ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
-  };
-
-  logger.info("Change created and evaluated", {
-    changeId: change.id,
-    project: projectName,
-    workspace: body.workspace,
-    status: newStatus,
-    evalScore: evalResult.score,
-  });
-  return created({ change: updatedChange, eval: evalResult, evalRuns: recordResult.data });
+  const { change: updatedChange, evalResult, evalRuns: recordedRuns } = outcome.data;
+  return created({ change: updatedChange, eval: evalResult, evalRuns: recordedRuns });
 });
 
 app.get("/projects/:name/changes", async (c) => {
@@ -1490,40 +1235,7 @@ app.post("/changes/:id/evaluate", async (c) => {
     workspaceSha: workspaceHeadSha,
   } = diffResult.data;
 
-  const evaluators: Array<{ type: string; evaluator: Evaluator }> = [
-    { type: "secret_scan", evaluator: new SecretScanEvaluator() },
-    ...policy.evaluators.flatMap((cfg): Array<{ type: string; evaluator: Evaluator }> => {
-      switch (cfg.type) {
-        case "diff":
-          return [{ type: "diff", evaluator: new DiffEvaluator() }];
-        case "webhook":
-          return [{ type: "webhook", evaluator: new WebhookEvaluator() }];
-        case "llm":
-          return c.env.AI
-            ? [{ type: "llm", evaluator: new LLMEvaluator(c.env.AI) }]
-            : [
-                {
-                  type: "llm",
-                  evaluator: new UnavailableEvaluator("llm", "AI binding is not configured"),
-                },
-              ];
-        case "sandbox":
-          return c.env.SANDBOX
-            ? [{ type: "sandbox", evaluator: new SandboxEvaluator(c.env.SANDBOX) }]
-            : [
-                {
-                  type: "sandbox",
-                  evaluator: new UnavailableEvaluator(
-                    "sandbox",
-                    "SANDBOX binding is not configured",
-                  ),
-                },
-              ];
-        default:
-          return [];
-      }
-    }),
-  ];
+  const evaluators = buildEvaluators(c.env, policy, change.project, logger);
 
   const evalRuns = await Promise.all(
     evaluators.map(async ({ type, evaluator }) => {

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -224,9 +224,14 @@ app.post("/projects/:name/changes", async (c) => {
     },
   });
   if (!outcome.success) {
-    return outcome.error.statusCode >= 500
-      ? internalError(outcome.error.message)
-      : badRequest(outcome.error.message);
+    // Post-creation failures leave an open change row; name it so the caller
+    // can re-evaluate or reject that change instead of losing track of it.
+    const stuckChangeId = outcome.error.context?.changeId;
+    const message =
+      typeof stuckChangeId === "string"
+        ? `${outcome.error.message} (change ${stuckChangeId})`
+        : outcome.error.message;
+    return outcome.error.statusCode >= 500 ? internalError(message) : badRequest(message);
   }
   const { change: updatedChange, evalResult, evalRuns: recordedRuns } = outcome.data;
   return created({ change: updatedChange, eval: evalResult, evalRuns: recordedRuns });

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1,5 +1,5 @@
 import { type Context, Hono } from "hono";
-import { CompositeEvaluator, loadPolicy } from "../evaluation";
+import { loadPolicy } from "../evaluation";
 import type { EvalPolicy } from "../evaluation/types";
 import { runPostMergeCheck } from "../merge/post-merge";
 import { checkMergeProtection } from "../merge/protection";
@@ -9,6 +9,7 @@ import {
   buildEvaluators,
   createChangeWithEvaluation,
   resolveProjectHead,
+  runEvaluation,
 } from "../services/change-flow";
 import { recordAudit } from "../storage/audit";
 import {
@@ -1236,40 +1237,7 @@ app.post("/changes/:id/evaluate", async (c) => {
   } = diffResult.data;
 
   const evaluators = buildEvaluators(c.env, policy, change.project, logger);
-
-  const evalRuns = await Promise.all(
-    evaluators.map(async ({ type, evaluator }) => {
-      const result = await evaluator.evaluate(diff, policy, logger);
-      return {
-        evaluatorType: type,
-        result: result.success
-          ? result.data
-          : { score: 0, passed: false, reason: result.error.message },
-      };
-    }),
-  );
-
-  const composite = new CompositeEvaluator(evaluators.map(({ evaluator }) => evaluator));
-  const aggregateResult = composite.aggregate(
-    evalRuns.map(({ result }) => result),
-    policy,
-    logger,
-  );
-  const blockingFailure = evalRuns.find(
-    ({ evaluatorType, result }) => evaluatorType === "secret_scan" && !result.passed,
-  );
-  const evalResult =
-    blockingFailure === undefined
-      ? aggregateResult
-      : {
-          score: Math.min(aggregateResult.score, blockingFailure.result.score),
-          passed: false,
-          reason:
-            aggregateResult.reason === blockingFailure.result.reason
-              ? blockingFailure.result.reason
-              : `${blockingFailure.result.reason} ${aggregateResult.reason}`,
-          issues: aggregateResult.issues,
-        };
+  const { evalRuns, evalResult } = await runEvaluation(evaluators, diff, policy, logger);
 
   const recordResult = await recordEvalRuns(c.env.DB, logger, id, evalRuns);
   if (!recordResult.success) {

--- a/src/routes/git-http.ts
+++ b/src/routes/git-http.ts
@@ -469,7 +469,7 @@ async function forwardPackToWorkspace(
   workspaceRemote: string,
   body: ArrayBuffer,
   logger: ReturnType<typeof createLogger>,
-): Promise<{ ok: boolean; body: Uint8Array } | null> {
+): Promise<{ ok: boolean; landed: boolean; body: Uint8Array } | null> {
   const tokenResult = await freshRepoToken(c.env.ARTIFACTS, workspaceRemote, "write", logger);
   if (!tokenResult.success) {
     logger.error("Failed to mint Artifacts token for gated push", tokenResult.error);
@@ -504,10 +504,16 @@ async function forwardPackToWorkspace(
   const report = parseReportStatus(responseBody);
   if (!report.success) {
     logger.error("Gated push: unparseable workspace report-status", report.error);
-    return { ok: false, body: responseBody };
+    // HTTP 200 means Artifacts processed the request, so the pack may already
+    // be in the fork even though the verdict is unreadable. Fail closed on
+    // success, but flag the outcome as "may have landed" so the caller never
+    // treats it as a proven rejection and deletes the client's commits.
+    return { ok: false, landed: true, body: responseBody };
   }
   const pushOk = report.data.unpack === "ok" && report.data.results.every((r) => r.ok);
-  return { ok: pushOk, body: responseBody };
+  // A parsed `ng`/failed-unpack proves the ref never moved, so the fork holds
+  // nothing of the client's; only then is `landed` false.
+  return { ok: pushOk, landed: pushOk, body: responseBody };
 }
 
 /**
@@ -623,7 +629,9 @@ gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
   // Land the pack on a fresh server-managed workspace fork. The fork's main is
   // at the project tip, so the client's old-oid (computed against the project
   // advertisement) lines up and Artifacts' own ref check stays truthful.
-  const workspaceName = `push-${crypto.randomUUID().slice(0, 8)}`;
+  // Full UUID: an 8-hex prefix is only 32 bits, and a name collision would
+  // make setWorkspace overwrite an existing workspace entry with this fork.
+  const workspaceName = `push-${crypto.randomUUID()}`;
   const actor = {
     ...(identity?.userId !== undefined ? { userId: identity.userId } : {}),
     ...(identity?.agentId !== undefined ? { agentId: identity.agentId } : {}),
@@ -650,12 +658,23 @@ gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
     return refuseAll("upstream git error while landing the pack — try again", []);
   }
   if (!forwarded.ok) {
-    // Artifacts rejected the pack (non-fast-forward, corrupt pack, …). Its own
-    // report-status is the truthful outcome; relay it verbatim — the upstream
-    // negotiated the same capabilities we were sent, so the framing matches.
-    // The empty fork is torn down: the pack never landed, nothing references it.
     logger.warn("Gated push rejected by workspace remote", { workspaceName: forkedName });
-    await cleanupPushWorkspace(c.env, project.id, forkedName, forkResult.data.remote, logger);
+    if (forwarded.landed) {
+      // Unknown outcome (HTTP 200, unreadable verdict): the pack may be in the
+      // fork, so deleting it could destroy the client's commits. Preserve it
+      // and log its coordinates for manual triage.
+      logger.error("Gated push: unknown upstream outcome; preserving fork", undefined, {
+        workspaceName: forkedName,
+        remote: forkResult.data.remote,
+        projectId: project.id,
+      });
+    } else {
+      // A parsed rejection (non-fast-forward, corrupt pack, …) proves the ref
+      // never moved — the empty fork can be torn down. The upstream's own
+      // report-status is relayed verbatim below; the framing matches because
+      // it negotiated the same capabilities we were sent.
+      await cleanupPushWorkspace(c.env, project.id, forkedName, forkResult.data.remote, logger);
+    }
     return receivePackResult(forwarded.body);
   }
 
@@ -668,6 +687,18 @@ gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
   });
   if (!outcome.success) {
     logger.error("Gated push change creation failed", outcome.error);
+    // Post-creation failures carry the open change's id in the error context;
+    // naming it steers the user to re-evaluate rather than open a duplicate.
+    const stuckChangeId = outcome.error.context?.changeId;
+    if (typeof stuckChangeId === "string") {
+      return refuseAll(
+        `change ${stuckChangeId} created but processing failed: ${outcome.error.message} — re-evaluate it in Stratum`,
+        [
+          `Change ${stuckChangeId} exists (workspace '${forkedName}') but evaluation/recording did not complete.`,
+          `Re-run evaluation at /changes/${stuckChangeId} — do not open a duplicate change.`,
+        ],
+      );
+    }
     return refuseAll(
       `pack landed in workspace ${forkedName} but change creation failed: ${outcome.error.message}`,
       [`Your commits are safe in workspace '${forkedName}' — open a change from it manually.`],

--- a/src/routes/git-http.ts
+++ b/src/routes/git-http.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
+import { createChangeWithEvaluation, createWorkspaceFork } from "../services/change-flow";
 import { getAgentByToken } from "../storage/agents";
+import { isTargetDeleting } from "../storage/deletion";
 import {
   artifactsRepoNameFromRemote,
   extractTokenSecret,
@@ -9,15 +11,20 @@ import { getProjectByPath, getWorkspace } from "../storage/state";
 import { getUserByToken } from "../storage/users";
 import type { Env, ProjectEntry } from "../types";
 import { canReadProject, canWriteProject, canWriteWorkspace } from "../utils/authz";
+import { buildReportStatus, parseReceivePackRequest, wantsSideband } from "../utils/git-protocol";
 import { createLogger } from "../utils/logger";
 
 /**
  * Git smart-HTTP proxy (ADR 005).
  *
  * Lets a Stratum project be used as a git remote. Two surfaces:
- *  - Project URL `/@ns/slug.git` — clone/fetch (read). Pushing to the project
- *    URL is refused (`pushNotSupported`); the gated `push → change → eval →
- *    merge` path is a separate slice (Phase B / #115).
+ *  - Project URL `/@ns/slug.git` — clone/fetch (read). A push to the default
+ *    branch is routed through the change gate when GIT_PUSH_GATED_ENABLED
+ *    (ADR 005 slice 2b): pack lands on a server-managed workspace fork, a
+ *    change is created + evaluated, and the client gets a truthful per-ref
+ *    `ng` carrying the change id (main only moves through the merge gate).
+ *    With the flag off — and for multi-ref/delete/non-default pushes — the
+ *    push is refused in-protocol with sideband guidance.
  *  - Workspace URL `/@ns/slug/workspaces/<ws>.git` — clone/fetch (read) AND
  *    `git push` (write), proxied verbatim to the workspace's Artifacts fork.
  *    The client clones the workspace, so ref/old-oid semantics line up and
@@ -123,6 +130,7 @@ function parseBasicToken(header: string | undefined): string | null {
 
 interface Identity {
   userId?: string;
+  agentId?: string;
   agentOwnerId?: string;
 }
 
@@ -143,7 +151,7 @@ async function authenticate(
     return result.success ? { userId: result.data.id } : null;
   }
   const result = await getAgentByToken(c.env.DB, token, logger);
-  return result.success ? { agentOwnerId: result.data.ownerId } : null;
+  return result.success ? { agentId: result.data.id, agentOwnerId: result.data.ownerId } : null;
 }
 
 function basicAuthHeader(artifactsToken: string): string {
@@ -210,11 +218,18 @@ async function proxyUpstream(
   return new Response(upstream.body, { status: 200, headers: responseHeaders });
 }
 
-function pushNotSupported(): Response {
-  return new Response(
-    "push over git is not yet supported — use 'stratum commit' or the change flow\n",
-    { status: 403, headers: { "Content-Type": "text/plain" } },
-  );
+/**
+ * Guidance streamed to a pushing client (as `remote:` lines) when it pushes to
+ * the project URL. The gated default-branch push (slice 2b, #115) will replace
+ * the rejection with the change/eval pipeline; until then the refusal happens
+ * in-protocol so `git push` fails legibly instead of with an opaque HTTP 403.
+ */
+function pushGuidance(namespace: string, slug: string): string[] {
+  return [
+    "Pushes to a project's protected refs are gated by Stratum's change flow.",
+    `Push to a workspace remote instead: /${namespace}/${slug}/workspaces/<ws>.git`,
+    "then open a change (stratum change create) to run evaluations and merge.",
+  ];
 }
 
 /** Strip a trailing `.git` so both `/@ns/slug.git` and `/@ns/slug` resolve. */
@@ -223,13 +238,15 @@ function normalizeSlug(slug: string): string {
 }
 
 /**
- * Resolve + authorize a project for a read, applying the no-leak truth table.
- * Returns the project on success, or a `Response` to return as-is.
+ * Resolve + authorize a project for a read (clone/fetch) or write (push),
+ * applying the no-leak truth table. Returns the project on success, or a
+ * `Response` to return as-is.
  */
-async function authorizeRead(
+async function authorizeProject(
   c: { req: { header(name: string): string | undefined; param(name: string): string }; env: Env },
+  scope: "read" | "write",
   logger: ReturnType<typeof createLogger>,
-): Promise<ProjectEntry | Response> {
+): Promise<{ project: ProjectEntry; identity: Identity | null } | Response> {
   const namespace = c.req.param("namespace");
   const slug = normalizeSlug(c.req.param("slug"));
 
@@ -251,8 +268,11 @@ async function authorizeRead(
   }
 
   const project = projectResult.data;
-  const canRead = await canReadProject(c.env.DB, project, identity?.userId, identity?.agentOwnerId);
-  if (!canRead) {
+  const allowed =
+    scope === "write"
+      ? await canWriteProject(c.env.DB, project, identity?.userId, identity?.agentOwnerId)
+      : await canReadProject(c.env.DB, project, identity?.userId, identity?.agentOwnerId);
+  if (!allowed) {
     return isAnonymous ? authChallenge() : gitNotFound();
   }
 
@@ -265,7 +285,7 @@ async function authorizeRead(
     return gitUnavailable("project");
   }
 
-  return project;
+  return { project, identity };
 }
 
 const gitUnavailable = (resource: "project" | "workspace"): Response =>
@@ -276,7 +296,7 @@ const gitUnavailable = (resource: "project" | "workspace"): Response =>
 
 /**
  * Resolve + authorize a workspace for clone/fetch (read) or push (write),
- * applying the same no-leak truth table as `authorizeRead`. Returns the
+ * applying the same no-leak truth table as `authorizeProject`. Returns the
  * workspace's Artifacts remote on success, or a `Response` to return as-is.
  */
 async function authorizeWorkspace(
@@ -393,37 +413,227 @@ export const gitHttpRouter = new Hono<{ Bindings: Env }>();
 gitHttpRouter.get("/:namespace/:slug/info/refs", async (c) => {
   const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path, method: "GET" });
   const service = c.req.query("service");
-  if (service === RECEIVE_PACK) return pushNotSupported();
-  if (service !== UPLOAD_PACK) {
-    return new Response("only the smart-HTTP git-upload-pack service is supported\n", {
+  const scope = service === RECEIVE_PACK ? "write" : service === UPLOAD_PACK ? "read" : null;
+  if (!scope) {
+    return new Response("unsupported git service\n", {
       status: 400,
       headers: { "Content-Type": "text/plain" },
     });
   }
 
-  const result = await authorizeRead(c, logger);
+  // The receive-pack advertisement is proxied (write-authorized) so `git push`
+  // proceeds to the RPC below, where the outcome is delivered in-protocol
+  // instead of as an opaque HTTP error at the advertise step.
+  const result = await authorizeProject(c, scope, logger);
   if (result instanceof Response) return result;
 
-  const upstreamUrl = `${result.remote}/info/refs?service=${UPLOAD_PACK}`;
-  return proxyUpstream(c, result.remote, "read", upstreamUrl, "GET", undefined, logger);
+  const upstreamUrl = `${result.project.remote}/info/refs?service=${service}`;
+  return proxyUpstream(c, result.project.remote, scope, upstreamUrl, "GET", undefined, logger);
 });
 
 // POST /@:namespace/:slug.git/git-upload-pack — clone/fetch RPC
 gitHttpRouter.post("/:namespace/:slug/git-upload-pack", async (c) => {
   const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path, method: "POST" });
-  const result = await authorizeRead(c, logger);
+  const result = await authorizeProject(c, "read", logger);
   if (result instanceof Response) return result;
 
   const body = await readCappedBody(c, logger);
   if (body instanceof Response) return body;
-  const upstreamUrl = `${result.remote}/${UPLOAD_PACK}`;
-  return proxyUpstream(c, result.remote, "read", upstreamUrl, "POST", body, logger);
+  const upstreamUrl = `${result.project.remote}/${UPLOAD_PACK}`;
+  return proxyUpstream(c, result.project.remote, "read", upstreamUrl, "POST", body, logger);
 });
 
+const ZERO_OID = "0".repeat(40);
+
+/** The report-status Content-Type git expects on the receive-pack reply. */
+function receivePackResult(body: Uint8Array): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/x-git-receive-pack-result" },
+  });
+}
+
+/**
+ * Forward a buffered receive-pack request to a workspace fork's remote and
+ * return the buffered upstream result, or null on transport failure. The
+ * response is buffered (not streamed) because the gated flow must inspect the
+ * outcome before deciding what to tell the client.
+ */
+async function forwardPackToWorkspace(
+  c: { req: { header(name: string): string | undefined }; env: Env },
+  workspaceRemote: string,
+  body: ArrayBuffer,
+  logger: ReturnType<typeof createLogger>,
+): Promise<{ ok: boolean; body: Uint8Array } | null> {
+  const tokenResult = await freshRepoToken(c.env.ARTIFACTS, workspaceRemote, "write", logger);
+  if (!tokenResult.success) {
+    logger.error("Failed to mint Artifacts token for gated push", tokenResult.error);
+    return null;
+  }
+  const headers: Record<string, string> = { Authorization: basicAuthHeader(tokenResult.data) };
+  for (const name of ["Git-Protocol", "Content-Type", "Content-Encoding"]) {
+    const value = c.req.header(name);
+    if (value) headers[name] = value;
+  }
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${workspaceRemote}/${RECEIVE_PACK}`, {
+      method: "POST",
+      headers,
+      body,
+      redirect: "manual",
+    });
+  } catch (error) {
+    logger.error("Gated push upstream fetch failed", error instanceof Error ? error : undefined);
+    return null;
+  }
+  if (upstream.status < 200 || upstream.status >= 300) {
+    logger.error("Gated push upstream returned non-2xx", undefined, { status: upstream.status });
+    return null;
+  }
+  const responseBody = new Uint8Array(await upstream.arrayBuffer());
+  // The receive-pack result carries only status protocol (no pack data), so a
+  // byte-level scan is a faithful success check whether or not it is
+  // sideband-wrapped: success = an "unpack ok" with no "ng " ref lines.
+  const text = new TextDecoder().decode(responseBody);
+  const pushOk = text.includes("unpack ok") && !text.includes("ng ");
+  return { ok: pushOk, body: responseBody };
+}
+
 // POST /@:namespace/:slug.git/git-receive-pack — push to the project ref.
-// Refused: the gated push path (open a change + eval + merge) is a separate
-// slice (#115 / ADR 005 Phase B). Push to a workspace URL instead.
-gitHttpRouter.post("/:namespace/:slug/git-receive-pack", () => pushNotSupported());
+//
+// With GIT_PUSH_GATED_ENABLED, a single-ref push to refs/heads/main is routed
+// through the change gate (ADR 005 slice 2b): the pack lands on a fresh
+// server-managed workspace fork, a change is created and evaluated, and the
+// client gets a truthful per-ref `ng` — main does NOT move until the change is
+// approved and merged, so reporting `ok` would corrupt the client's
+// remote-tracking ref. The change id and eval verdict stream back as sideband
+// messages. Everything else (flag off, multi-ref, deletes, non-default refs)
+// is refused in-protocol as before.
+gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
+  const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path, method: "POST" });
+  const result = await authorizeProject(c, "write", logger);
+  if (result instanceof Response) return result;
+  const { project, identity } = result;
+
+  const body = await readCappedBody(c, logger);
+  if (body instanceof Response) return body;
+
+  const parsed = parseReceivePackRequest(new Uint8Array(body));
+  if (!parsed.success) {
+    logger.warn("Malformed receive-pack request", { error: parsed.error.message });
+    return new Response(`${parsed.error.message}\n`, {
+      status: 400,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+
+  const { commands, capabilities } = parsed.data;
+  const sideband = wantsSideband(capabilities);
+  const namespace = c.req.param("namespace");
+  const slug = normalizeSlug(c.req.param("slug"));
+
+  const refuseAll = (reason: string, messages: string[]): Response =>
+    receivePackResult(
+      buildReportStatus({
+        unpack: "ok",
+        results: commands.map((cmd) => ({ ref: cmd.ref, ok: false, reason })),
+        messages,
+        sideband,
+      }),
+    );
+
+  const gatedEnabled = c.env.GIT_PUSH_GATED_ENABLED === "true";
+  const command = commands[0];
+  const isGateablePush =
+    gatedEnabled &&
+    commands.length === 1 &&
+    command !== undefined &&
+    command.ref === "refs/heads/main" &&
+    command.newOid !== ZERO_OID;
+
+  if (!isGateablePush) {
+    logger.info("Refusing project push in-protocol", {
+      gatedEnabled,
+      refs: commands.map((cmd) => cmd.ref),
+    });
+    return refuseAll(
+      gatedEnabled
+        ? "only a single push to refs/heads/main can be gated — push other refs to a workspace remote"
+        : "project pushes are gated — push to a workspace remote and open a change",
+      pushGuidance(namespace, slug),
+    );
+  }
+
+  if (await isTargetDeleting(c.env, project, logger)) {
+    return refuseAll("project is being deleted", []);
+  }
+
+  // Land the pack on a fresh server-managed workspace fork. The fork's main is
+  // at the project tip, so the client's old-oid (computed against the project
+  // advertisement) lines up and Artifacts' own ref check stays truthful.
+  const workspaceName = `push-${crypto.randomUUID().slice(0, 8)}`;
+  const actor = {
+    ...(identity?.userId !== undefined ? { userId: identity.userId } : {}),
+    ...(identity?.agentId !== undefined ? { agentId: identity.agentId } : {}),
+    ...(identity?.agentOwnerId !== undefined ? { agentOwnerId: identity.agentOwnerId } : {}),
+  };
+  const forkResult = await createWorkspaceFork(c.env, logger, {
+    project,
+    workspaceName,
+    actor,
+  });
+  if (!forkResult.success) {
+    logger.error("Gated push could not fork workspace", forkResult.error);
+    return refuseAll(`could not create workspace for push: ${forkResult.error.message}`, []);
+  }
+
+  // The service's returned name is authoritative from here on.
+  const forkedName = forkResult.data.name;
+
+  const forwarded = await forwardPackToWorkspace(c, forkResult.data.remote, body, logger);
+  if (forwarded === null) {
+    return refuseAll("upstream git error while landing the pack — try again", []);
+  }
+  if (!forwarded.ok) {
+    // Artifacts rejected the pack (non-fast-forward, corrupt pack, …). Its own
+    // report-status is the truthful outcome; relay it verbatim — the upstream
+    // negotiated the same capabilities we were sent, so the framing matches.
+    logger.warn("Gated push rejected by workspace remote", { workspaceName: forkedName });
+    return receivePackResult(forwarded.body);
+  }
+
+  const outcome = await createChangeWithEvaluation(c.env, logger, {
+    project,
+    projectName: `${namespace}/${slug}`,
+    workspaceName: forkedName,
+    workspaceRemote: forkResult.data.remote,
+    actor,
+  });
+  if (!outcome.success) {
+    logger.error("Gated push change creation failed", outcome.error);
+    return refuseAll(
+      `pack landed in workspace ${forkedName} but change creation failed: ${outcome.error.message}`,
+      [`Your commits are safe in workspace '${forkedName}' — open a change from it manually.`],
+    );
+  }
+
+  const { change, evalResult } = outcome.data;
+  logger.info("Gated push created change", {
+    changeId: change.id,
+    workspaceName: forkedName,
+    evalPassed: evalResult.passed,
+  });
+  return refuseAll(
+    `gated: change ${change.id} created (eval ${evalResult.passed ? "passed" : "failed"}) — review and merge in Stratum`,
+    [
+      `Change ${change.id} created from this push (workspace '${forkedName}').`,
+      `Evaluation ${evalResult.passed ? "PASSED" : "FAILED"}: ${evalResult.reason}`,
+      `Review and merge: /changes/${change.id}`,
+      "main is updated by the merge gate, not the push — your local branch is unchanged.",
+    ],
+  );
+});
 
 // ── Workspace URLs: /@:namespace/:slug/workspaces/:workspace.git ─────────────
 // Clone/fetch (read) and push (write), proxied verbatim to the workspace fork.

--- a/src/routes/git-http.ts
+++ b/src/routes/git-http.ts
@@ -7,11 +7,16 @@ import {
   extractTokenSecret,
   freshRepoToken,
 } from "../storage/git-ops";
-import { getProjectByPath, getWorkspace } from "../storage/state";
+import { deleteWorkspace, getProjectByPath, getWorkspace } from "../storage/state";
 import { getUserByToken } from "../storage/users";
 import type { Env, ProjectEntry } from "../types";
 import { canReadProject, canWriteProject, canWriteWorkspace } from "../utils/authz";
-import { buildReportStatus, parseReceivePackRequest, wantsSideband } from "../utils/git-protocol";
+import {
+  buildReportStatus,
+  parseReceivePackRequest,
+  parseReportStatus,
+  wantsSideband,
+} from "../utils/git-protocol";
 import { createLogger } from "../utils/logger";
 
 /**
@@ -219,10 +224,10 @@ async function proxyUpstream(
 }
 
 /**
- * Guidance streamed to a pushing client (as `remote:` lines) when it pushes to
- * the project URL. The gated default-branch push (slice 2b, #115) will replace
- * the rejection with the change/eval pipeline; until then the refusal happens
- * in-protocol so `git push` fails legibly instead of with an opaque HTTP 403.
+ * Guidance streamed to a pushing client (as `remote:` lines) when its push to
+ * the project URL cannot be gated (flag off, multi-ref, delete, non-default
+ * ref). The refusal happens in-protocol so `git push` fails legibly instead of
+ * with an opaque HTTP error.
  */
 function pushGuidance(namespace: string, slug: string): string[] {
   return [
@@ -492,24 +497,64 @@ async function forwardPackToWorkspace(
     return null;
   }
   const responseBody = new Uint8Array(await upstream.arrayBuffer());
-  // The receive-pack result carries only status protocol (no pack data), so a
-  // byte-level scan is a faithful success check whether or not it is
-  // sideband-wrapped: success = an "unpack ok" with no "ng " ref lines.
-  const text = new TextDecoder().decode(responseBody);
-  const pushOk = text.includes("unpack ok") && !text.includes("ng ");
+  // Parse the report-status properly rather than substring-scanning the body:
+  // sideband progress text ("Counting objects…", or anything containing "ng ")
+  // is not a ref verdict, and misreading it would tell the pusher their pack
+  // failed after it had already landed. An unparseable reply fails closed.
+  const report = parseReportStatus(responseBody);
+  if (!report.success) {
+    logger.error("Gated push: unparseable workspace report-status", report.error);
+    return { ok: false, body: responseBody };
+  }
+  const pushOk = report.data.unpack === "ok" && report.data.results.every((r) => r.ok);
   return { ok: pushOk, body: responseBody };
+}
+
+/**
+ * Best-effort teardown of the server-managed fork when a gated push dies
+ * before its change exists: nothing references the workspace yet, so leaving
+ * it would leak an Artifacts repo + KV entry per failed push. Failures are
+ * logged with enough coordinates to find the orphan by hand.
+ */
+async function cleanupPushWorkspace(
+  env: Env,
+  projectId: string,
+  workspaceName: string,
+  remote: string,
+  logger: ReturnType<typeof createLogger>,
+): Promise<void> {
+  const repoName = artifactsRepoNameFromRemote(remote);
+  if (repoName) {
+    await env.ARTIFACTS.delete(repoName).catch((error: unknown) => {
+      logger.warn("Gated push cleanup: could not delete Artifacts fork", {
+        repoName,
+        remote,
+        workspaceName,
+        projectId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+  const deleteResult = await deleteWorkspace(env.STATE, projectId, workspaceName, logger);
+  if (!deleteResult.success) {
+    logger.warn("Gated push cleanup: could not delete workspace entry", {
+      workspaceName,
+      projectId,
+      error: deleteResult.error.message,
+    });
+  }
 }
 
 // POST /@:namespace/:slug.git/git-receive-pack — push to the project ref.
 //
-// With GIT_PUSH_GATED_ENABLED, a single-ref push to refs/heads/main is routed
-// through the change gate (ADR 005 slice 2b): the pack lands on a fresh
-// server-managed workspace fork, a change is created and evaluated, and the
-// client gets a truthful per-ref `ng` — main does NOT move until the change is
-// approved and merged, so reporting `ok` would corrupt the client's
-// remote-tracking ref. The change id and eval verdict stream back as sideband
-// messages. Everything else (flag off, multi-ref, deletes, non-default refs)
-// is refused in-protocol as before.
+// With GIT_PUSH_GATED_ENABLED, a single-ref push to the project's default
+// branch is routed through the change gate (ADR 005 slice 2b): the pack lands
+// on a fresh server-managed workspace fork, a change is created and evaluated,
+// and the client gets a truthful per-ref `ng` — the default branch does NOT
+// move until the change is approved and merged, so reporting `ok` would
+// corrupt the client's remote-tracking ref. The change id and eval verdict
+// stream back as sideband messages. Everything else (flag off, multi-ref,
+// deletes, non-default refs) is refused in-protocol as before.
 gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
   const logger = createLogger({ requestId: crypto.randomUUID(), path: c.req.path, method: "POST" });
   const result = await authorizeProject(c, "write", logger);
@@ -544,22 +589,28 @@ gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
     );
 
   const gatedEnabled = c.env.GIT_PUSH_GATED_ENABLED === "true";
+  // Same default-branch resolution the merge/sync paths use — a repo imported
+  // with a `master` or `trunk` default must gate pushes to THAT ref, not to a
+  // literal refs/heads/main it doesn't have.
+  const defaultBranch = project.sourceDefaultBranch || project.githubDefaultBranch || "main";
+  const defaultRef = `refs/heads/${defaultBranch}`;
   const command = commands[0];
   const isGateablePush =
     gatedEnabled &&
     commands.length === 1 &&
     command !== undefined &&
-    command.ref === "refs/heads/main" &&
+    command.ref === defaultRef &&
     command.newOid !== ZERO_OID;
 
   if (!isGateablePush) {
     logger.info("Refusing project push in-protocol", {
       gatedEnabled,
+      defaultRef,
       refs: commands.map((cmd) => cmd.ref),
     });
     return refuseAll(
       gatedEnabled
-        ? "only a single push to refs/heads/main can be gated — push other refs to a workspace remote"
+        ? `only a single push to ${defaultRef} can be gated — push other refs to a workspace remote`
         : "project pushes are gated — push to a workspace remote and open a change",
       pushGuidance(namespace, slug),
     );
@@ -593,13 +644,18 @@ gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
 
   const forwarded = await forwardPackToWorkspace(c, forkResult.data.remote, body, logger);
   if (forwarded === null) {
+    // No change exists yet, so the fresh fork has no owner-visible value —
+    // tear it down rather than leaking one per failed push.
+    await cleanupPushWorkspace(c.env, project.id, forkedName, forkResult.data.remote, logger);
     return refuseAll("upstream git error while landing the pack — try again", []);
   }
   if (!forwarded.ok) {
     // Artifacts rejected the pack (non-fast-forward, corrupt pack, …). Its own
     // report-status is the truthful outcome; relay it verbatim — the upstream
     // negotiated the same capabilities we were sent, so the framing matches.
+    // The empty fork is torn down: the pack never landed, nothing references it.
     logger.warn("Gated push rejected by workspace remote", { workspaceName: forkedName });
+    await cleanupPushWorkspace(c.env, project.id, forkedName, forkResult.data.remote, logger);
     return receivePackResult(forwarded.body);
   }
 
@@ -630,7 +686,7 @@ gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
       `Change ${change.id} created from this push (workspace '${forkedName}').`,
       `Evaluation ${evalResult.passed ? "PASSED" : "FAILED"}: ${evalResult.reason}`,
       `Review and merge: /changes/${change.id}`,
-      "main is updated by the merge gate, not the push — your local branch is unchanged.",
+      `'${defaultBranch}' is updated by the merge gate, not the push — your local branch is unchanged.`,
     ],
   );
 });

--- a/src/routes/workspaces.ts
+++ b/src/routes/workspaces.ts
@@ -111,7 +111,9 @@ app.post("/:namespace/:slug/workspaces", async (c) => {
   await emitEvent(
     c.env.DB,
     c.env.EVENTS_QUEUE,
-    { type: "workspace.created", project: project.name, workspace: workspaceName },
+    // Canonical `namespace/slug` (the route's own params), matching the other
+    // producer in services/change-flow.ts — not the mutable display name.
+    { type: "workspace.created", project: `${namespace}/${slug}`, workspace: workspaceName },
     actor,
     logger,
     project.id,

--- a/src/services/change-flow.ts
+++ b/src/services/change-flow.ts
@@ -1,0 +1,423 @@
+import {
+  CompositeEvaluator,
+  DiffEvaluator,
+  LLMEvaluator,
+  SandboxEvaluator,
+  SecretScanEvaluator,
+  WebhookEvaluator,
+  loadPolicy,
+} from "../evaluation";
+import type { EvalPolicy, EvalResult, Evaluator } from "../evaluation/types";
+import { type EventActor, emitEvent } from "../queue/events";
+import { getAgent } from "../storage/agents";
+import { createChange, updateChangeStatus } from "../storage/changes";
+import { type CostSample, recordCosts } from "../storage/costs";
+import { recordEvalRuns } from "../storage/eval-runs";
+import { freshRepoToken, getCommitLog, getDiffBetweenRepos } from "../storage/git-ops";
+import { readRepoSnapshot } from "../storage/repo-snapshot";
+import { setWorkspace } from "../storage/state";
+import { type Change, type Env, type ProjectEntry, getArtifactsRepoName } from "../types";
+import { AppError } from "../utils/errors";
+import type { Logger } from "../utils/logger";
+import type { Result } from "../utils/result";
+import { err, ok } from "../utils/result";
+
+/**
+ * The create-change + evaluate pipeline, extracted from the REST route so every
+ * front door (REST `POST /changes`, gated `git push`, future queue consumers)
+ * runs the identical gate. Behavior must stay in lockstep with what the route
+ * historically did — the route's test suite is the contract.
+ */
+
+/** Current project HEAD: cheap KV snapshot first, single-commit clone as fallback. */
+export async function resolveProjectHead(
+  env: Env,
+  project: ProjectEntry,
+  logger: Logger,
+): Promise<string | null> {
+  if (project.namespace && project.slug) {
+    const snapshotResult = await readRepoSnapshot(env.STATE, project, logger);
+    if (snapshotResult.success) {
+      const sha = snapshotResult.data?.commits[0]?.sha;
+      if (sha) return sha;
+    }
+  }
+  const readToken = await freshRepoToken(env.ARTIFACTS, project.remote, "read", logger);
+  if (!readToken.success) return null;
+  const logResult = await getCommitLog(project.remote, readToken.data, logger, 1);
+  return logResult.success ? (logResult.data[0]?.sha ?? null) : null;
+}
+
+export class UnavailableEvaluator implements Evaluator {
+  constructor(
+    private evaluatorType: string,
+    private reason: string,
+  ) {}
+
+  async evaluate(
+    _diff: string,
+    _policy: EvalPolicy,
+    _logger: Logger,
+  ): Promise<Result<EvalResult, AppError>> {
+    return ok({
+      score: 0,
+      passed: false,
+      reason: `${this.evaluatorType} unavailable: ${this.reason}`,
+    });
+  }
+}
+
+/**
+ * Build the evaluator set for a policy: the always-on blocking secret scan plus
+ * whatever the policy configures. Evaluators whose binding is missing become
+ * UnavailableEvaluator (score 0, fail) rather than silently vanishing.
+ */
+export function buildEvaluators(
+  env: Env,
+  policy: EvalPolicy,
+  projectName: string,
+  logger: Logger,
+): Array<{ type: string; evaluator: Evaluator }> {
+  const evaluators: Array<{ type: string; evaluator: Evaluator }> = [
+    { type: "secret_scan", evaluator: new SecretScanEvaluator() },
+  ];
+
+  evaluators.push(
+    ...policy.evaluators.flatMap((cfg): Array<{ type: string; evaluator: Evaluator }> => {
+      switch (cfg.type) {
+        case "diff":
+          return [{ type: "diff", evaluator: new DiffEvaluator() }];
+        case "webhook":
+          return [{ type: "webhook", evaluator: new WebhookEvaluator() }];
+        case "llm":
+          if (env.AI) return [{ type: "llm", evaluator: new LLMEvaluator(env.AI) }];
+          return [
+            {
+              type: "llm",
+              evaluator: new UnavailableEvaluator("llm", "AI binding is not configured"),
+            },
+          ];
+        case "sandbox":
+          if (env.SANDBOX) {
+            return [{ type: "sandbox", evaluator: new SandboxEvaluator(env.SANDBOX) }];
+          }
+          return [
+            {
+              type: "sandbox",
+              evaluator: new UnavailableEvaluator("sandbox", "SANDBOX binding is not configured"),
+            },
+          ];
+        default:
+          logger.warn(
+            `Unknown evaluator type "${(cfg as { type: string }).type}" in policy for project ${projectName}`,
+            { evaluatorType: (cfg as { type: string }).type, projectName },
+          );
+          return [];
+      }
+    }),
+  );
+
+  return evaluators;
+}
+
+type RecordedEvalRuns = Extract<
+  Awaited<ReturnType<typeof recordEvalRuns>>,
+  { success: true }
+>["data"];
+
+export interface ChangeCreationActor {
+  userId?: string;
+  agentId?: string;
+}
+
+export interface ChangeCreationOutcome {
+  change: Change;
+  evalResult: EvalResult;
+  evalRuns: RecordedEvalRuns;
+}
+
+/**
+ * Create a change from a workspace and synchronously run the full evaluation
+ * suite, recording eval runs, costs, status, and events. Callers must have
+ * already authorized the actor for project write and verified the workspace
+ * belongs to the project and the project is not being deleted.
+ *
+ * Errors carry statusCode 500 for infrastructure failures (token minting) and
+ * 400 otherwise, so HTTP front doors can map them faithfully.
+ */
+export async function createChangeWithEvaluation(
+  env: Env,
+  logger: Logger,
+  args: {
+    project: ProjectEntry;
+    projectName: string;
+    workspaceName: string;
+    workspaceRemote: string;
+    actor: ChangeCreationActor;
+  },
+): Promise<Result<ChangeCreationOutcome, AppError>> {
+  const { project, projectName, workspaceName, workspaceRemote, actor } = args;
+  const { userId, agentId } = actor;
+
+  const baseSha = await resolveProjectHead(env, project, logger);
+
+  // Snapshot the authoring agent's model + prompt hash at creation, so
+  // provenance records the model that did the work rather than the agent's
+  // current (possibly later-changed) registration.
+  let agentModel: string | undefined;
+  let agentPromptHash: string | undefined;
+  if (agentId !== undefined) {
+    const agentResult = await getAgent(env.DB, agentId, logger);
+    if (agentResult.success) {
+      agentModel = agentResult.data.model;
+      agentPromptHash = agentResult.data.promptHash;
+    } else {
+      // Best effort: provenance metadata must not block change creation. Log so a
+      // persistent lookup failure is visible rather than silently dropping the
+      // model/prompt snapshot.
+      logger.warn("Could not load agent for provenance snapshot; continuing without it", {
+        agentId,
+        error: agentResult.error.message,
+      });
+    }
+  }
+
+  const changeResult = await createChange(env.DB, logger, {
+    project: projectName,
+    projectId: project.id,
+    workspace: workspaceName,
+    ...(agentId !== undefined ? { agentId } : {}),
+    ...(baseSha !== null ? { baseSha } : {}),
+    ...(agentModel !== undefined ? { agentModel } : {}),
+    ...(agentPromptHash !== undefined ? { agentPromptHash } : {}),
+  });
+  if (!changeResult.success) {
+    logger.error("Failed to create change", changeResult.error);
+    return err(new AppError(changeResult.error.message, changeResult.error.code, 400));
+  }
+  const change = changeResult.data;
+
+  const actorEvent: EventActor = agentId
+    ? { type: "agent", id: agentId }
+    : { type: "user", ...(userId !== undefined ? { id: userId } : {}) };
+
+  await emitEvent(
+    env.DB,
+    env.EVENTS_QUEUE,
+    {
+      type: "change.created",
+      project: projectName,
+      changeId: change.id,
+      workspace: workspaceName,
+    },
+    actorEvent,
+    logger,
+    project.id,
+  );
+
+  const [projectReadToken, workspaceReadToken] = await Promise.all([
+    freshRepoToken(env.ARTIFACTS, project.remote, "read", logger),
+    freshRepoToken(env.ARTIFACTS, workspaceRemote, "read", logger),
+  ]);
+  if (!projectReadToken.success) {
+    return err(new AppError(projectReadToken.error.message, projectReadToken.error.code, 500));
+  }
+  if (!workspaceReadToken.success) {
+    return err(new AppError(workspaceReadToken.error.message, workspaceReadToken.error.code, 500));
+  }
+
+  const policy = await loadPolicy(project.remote, projectReadToken.data, logger);
+
+  const diffResult = await getDiffBetweenRepos(
+    project.remote,
+    projectReadToken.data,
+    workspaceRemote,
+    workspaceReadToken.data,
+    logger,
+  );
+  if (!diffResult.success) {
+    logger.error("Failed to get diff between repos", diffResult.error);
+    return err(new AppError(diffResult.error.message, diffResult.error.code, 400));
+  }
+  // workspaceOid === workspaceSha (same evaluated tip): #133 pins evaluatedSha +
+  // tree oid for content-addressing, #115 pins workspaceHeadSha for the merge.
+  const {
+    diff,
+    workspaceOid: evaluatedSha,
+    workspaceTreeOid: evaluatedTreeOid,
+    workspaceSha: workspaceHeadSha,
+  } = diffResult.data;
+
+  const evaluators = buildEvaluators(env, policy, projectName, logger);
+
+  const evalRuns = await Promise.all(
+    evaluators.map(async ({ type, evaluator }) => {
+      const result = await evaluator.evaluate(diff, policy, logger);
+      return {
+        evaluatorType: type,
+        result: result.success
+          ? result.data
+          : { score: 0, passed: false, reason: result.error.message },
+      };
+    }),
+  );
+
+  const composite = new CompositeEvaluator(evaluators.map(({ evaluator }) => evaluator));
+  const aggregateResult = composite.aggregate(
+    evalRuns.map(({ result }) => result),
+    policy,
+    logger,
+  );
+  const blockingFailure = evalRuns.find(
+    ({ evaluatorType, result }) => evaluatorType === "secret_scan" && !result.passed,
+  );
+  const evalResult =
+    blockingFailure === undefined
+      ? aggregateResult
+      : {
+          score: Math.min(aggregateResult.score, blockingFailure.result.score),
+          passed: false,
+          reason:
+            aggregateResult.reason === blockingFailure.result.reason
+              ? blockingFailure.result.reason
+              : `${blockingFailure.result.reason} ${aggregateResult.reason}`,
+          issues: aggregateResult.issues,
+        };
+
+  const newStatus: Change["status"] = evalResult.passed ? "accepted" : "needs_changes";
+
+  const recordResult = await recordEvalRuns(env.DB, logger, change.id, evalRuns);
+  if (!recordResult.success) {
+    logger.error("Failed to record eval runs", recordResult.error);
+    return err(new AppError(recordResult.error.message, "DATABASE_ERROR", 400));
+  }
+
+  // Best-effort cost tracking: the diff clones both repos, evaluators self-report.
+  const createCostSamples: CostSample[] = [
+    { kind: "git_ops", quantity: 2 },
+    ...evalRuns.flatMap(({ result }) => result.costs ?? []),
+  ];
+  await recordCosts(
+    env.DB,
+    logger,
+    { project: projectName, projectId: project.id, changeId: change.id, workspace: workspaceName },
+    createCostSamples,
+  );
+
+  const updateResult = await updateChangeStatus(env.DB, logger, change.id, newStatus, {
+    evalScore: evalResult.score,
+    evalPassed: evalResult.passed,
+    evalReason: evalResult.reason,
+    evaluatedSha,
+    evaluatedTreeOid,
+    ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
+  });
+  if (!updateResult.success) {
+    logger.error("Failed to update change status", updateResult.error);
+    return err(new AppError(updateResult.error.message, updateResult.error.code, 400));
+  }
+
+  await emitEvent(
+    env.DB,
+    env.EVENTS_QUEUE,
+    {
+      type: "change.evaluated",
+      project: projectName,
+      changeId: change.id,
+      score: evalResult.score,
+      passed: evalResult.passed,
+    },
+    { type: "system" },
+    logger,
+    project.id,
+  );
+
+  const updatedChange: Change = {
+    ...change,
+    status: newStatus,
+    evalScore: evalResult.score,
+    evalPassed: evalResult.passed,
+    evalReason: evalResult.reason,
+    evaluatedSha,
+    evaluatedTreeOid,
+    ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
+  };
+
+  logger.info("Change created and evaluated", {
+    changeId: change.id,
+    project: projectName,
+    workspace: workspaceName,
+    status: newStatus,
+    evalScore: evalResult.score,
+  });
+
+  return ok({ change: updatedChange, evalResult, evalRuns: recordResult.data });
+}
+
+/**
+ * Fork a server-managed workspace from a project (used by the gated git push,
+ * which needs a workspace to land the incoming pack on). Mirrors the REST
+ * workspace-creation route's fork + KV registration + event; callers must have
+ * already authorized write and checked the project isn't being deleted.
+ */
+export async function createWorkspaceFork(
+  env: Env,
+  logger: Logger,
+  args: {
+    project: ProjectEntry;
+    workspaceName: string;
+    actor: ChangeCreationActor & { agentOwnerId?: string };
+  },
+): Promise<Result<{ name: string; remote: string }, AppError>> {
+  const { project, workspaceName, actor } = args;
+  if (!project.namespace || !project.slug) {
+    return err(new AppError("Project has no namespace/slug", "INVALID_PROJECT", 400));
+  }
+
+  const artifactsRepoName = getArtifactsRepoName(project.namespace, project.slug);
+  let remote: string;
+  try {
+    const projectRepo = await env.ARTIFACTS.get(artifactsRepoName);
+    const forked = await projectRepo.fork(workspaceName);
+    remote = forked.remote;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error("Failed to fork workspace for push", error instanceof Error ? error : undefined, {
+      workspaceName,
+    });
+    return err(new AppError(message, "ARTIFACTS_ERROR", 502));
+  }
+
+  const setResult = await setWorkspace(
+    env.STATE,
+    project.id,
+    {
+      name: workspaceName,
+      remote,
+      parent: project.id,
+      createdAt: new Date().toISOString(),
+      branchName: workspaceName,
+      createdByUserId: actor.userId ?? actor.agentOwnerId,
+      ...(actor.agentId !== undefined ? { createdByAgentId: actor.agentId } : {}),
+    },
+    logger,
+  );
+  if (!setResult.success) {
+    logger.error("Failed to set workspace", setResult.error);
+    return err(new AppError(setResult.error.message, setResult.error.code, 400));
+  }
+
+  const actorEvent: EventActor = actor.agentId
+    ? { type: "agent", id: actor.agentId }
+    : { type: "user", ...(actor.userId !== undefined ? { id: actor.userId } : {}) };
+  await emitEvent(
+    env.DB,
+    env.EVENTS_QUEUE,
+    { type: "workspace.created", project: project.name, workspace: workspaceName },
+    actorEvent,
+    logger,
+    project.id,
+  );
+
+  return ok({ name: workspaceName, remote });
+}

--- a/src/services/change-flow.ts
+++ b/src/services/change-flow.ts
@@ -13,7 +13,12 @@ import { getAgent } from "../storage/agents";
 import { createChange, updateChangeStatus } from "../storage/changes";
 import { type CostSample, recordCosts } from "../storage/costs";
 import { recordEvalRuns } from "../storage/eval-runs";
-import { freshRepoToken, getCommitLog, getDiffBetweenRepos } from "../storage/git-ops";
+import {
+  artifactsRepoNameFromRemote,
+  freshRepoToken,
+  getCommitLog,
+  getDiffBetweenRepos,
+} from "../storage/git-ops";
 import { readRepoSnapshot } from "../storage/repo-snapshot";
 import { setWorkspace } from "../storage/state";
 import { type Change, type Env, type ProjectEntry, getArtifactsRepoName } from "../types";
@@ -120,6 +125,59 @@ export function buildEvaluators(
   return evaluators;
 }
 
+export interface EvaluationRun {
+  evaluatorType: string;
+  result: EvalResult;
+}
+
+/**
+ * Run every evaluator over a diff and aggregate the verdict, applying the
+ * blocking secret-scan override (a failed secret scan fails the aggregate and
+ * caps its score regardless of policy weighting). Shared by change creation
+ * and the re-evaluate route so the two verdicts can't drift.
+ */
+export async function runEvaluation(
+  evaluators: Array<{ type: string; evaluator: Evaluator }>,
+  diff: string,
+  policy: EvalPolicy,
+  logger: Logger,
+): Promise<{ evalRuns: EvaluationRun[]; evalResult: EvalResult }> {
+  const evalRuns = await Promise.all(
+    evaluators.map(async ({ type, evaluator }) => {
+      const result = await evaluator.evaluate(diff, policy, logger);
+      return {
+        evaluatorType: type,
+        result: result.success
+          ? result.data
+          : { score: 0, passed: false, reason: result.error.message },
+      };
+    }),
+  );
+
+  const composite = new CompositeEvaluator(evaluators.map(({ evaluator }) => evaluator));
+  const aggregateResult = composite.aggregate(
+    evalRuns.map(({ result }) => result),
+    policy,
+    logger,
+  );
+  const blockingFailure = evalRuns.find(
+    ({ evaluatorType, result }) => evaluatorType === "secret_scan" && !result.passed,
+  );
+  const evalResult =
+    blockingFailure === undefined
+      ? aggregateResult
+      : {
+          score: Math.min(aggregateResult.score, blockingFailure.result.score),
+          passed: false,
+          reason:
+            aggregateResult.reason === blockingFailure.result.reason
+              ? blockingFailure.result.reason
+              : `${blockingFailure.result.reason} ${aggregateResult.reason}`,
+          issues: aggregateResult.issues,
+        };
+  return { evalRuns, evalResult };
+}
+
 type RecordedEvalRuns = Extract<
   Awaited<ReturnType<typeof recordEvalRuns>>,
   { success: true }
@@ -142,8 +200,9 @@ export interface ChangeCreationOutcome {
  * already authorized the actor for project write and verified the workspace
  * belongs to the project and the project is not being deleted.
  *
- * Errors carry statusCode 500 for infrastructure failures (token minting) and
- * 400 otherwise, so HTTP front doors can map them faithfully.
+ * Errors preserve the underlying failure's statusCode (5xx for infrastructure
+ * — D1 writes, token minting — 4xx otherwise) so HTTP front doors can map them
+ * faithfully; once the change row exists, its id rides in the error context.
  */
 export async function createChangeWithEvaluation(
   env: Env,
@@ -193,7 +252,16 @@ export async function createChangeWithEvaluation(
   });
   if (!changeResult.success) {
     logger.error("Failed to create change", changeResult.error);
-    return err(new AppError(changeResult.error.message, changeResult.error.code, 400));
+    // Preserve the storage layer's statusCode: a D1 failure is a 500, not the
+    // caller's fault — flattening it to 400 misleads clients into retrying
+    // with "fixed" input.
+    return err(
+      new AppError(
+        changeResult.error.message,
+        changeResult.error.code,
+        changeResult.error.statusCode,
+      ),
+    );
   }
   const change = changeResult.data;
 
@@ -220,10 +288,18 @@ export async function createChangeWithEvaluation(
     freshRepoToken(env.ARTIFACTS, workspaceRemote, "read", logger),
   ]);
   if (!projectReadToken.success) {
-    return err(new AppError(projectReadToken.error.message, projectReadToken.error.code, 500));
+    return err(
+      new AppError(projectReadToken.error.message, projectReadToken.error.code, 500, {
+        changeId: change.id,
+      }),
+    );
   }
   if (!workspaceReadToken.success) {
-    return err(new AppError(workspaceReadToken.error.message, workspaceReadToken.error.code, 500));
+    return err(
+      new AppError(workspaceReadToken.error.message, workspaceReadToken.error.code, 500, {
+        changeId: change.id,
+      }),
+    );
   }
 
   const policy = await loadPolicy(project.remote, projectReadToken.data, logger);
@@ -237,7 +313,9 @@ export async function createChangeWithEvaluation(
   );
   if (!diffResult.success) {
     logger.error("Failed to get diff between repos", diffResult.error);
-    return err(new AppError(diffResult.error.message, diffResult.error.code, 400));
+    return err(
+      new AppError(diffResult.error.message, diffResult.error.code, 400, { changeId: change.id }),
+    );
   }
   // workspaceOid === workspaceSha (same evaluated tip): #133 pins evaluatedSha +
   // tree oid for content-addressing, #115 pins workspaceHeadSha for the merge.
@@ -249,47 +327,16 @@ export async function createChangeWithEvaluation(
   } = diffResult.data;
 
   const evaluators = buildEvaluators(env, policy, projectName, logger);
-
-  const evalRuns = await Promise.all(
-    evaluators.map(async ({ type, evaluator }) => {
-      const result = await evaluator.evaluate(diff, policy, logger);
-      return {
-        evaluatorType: type,
-        result: result.success
-          ? result.data
-          : { score: 0, passed: false, reason: result.error.message },
-      };
-    }),
-  );
-
-  const composite = new CompositeEvaluator(evaluators.map(({ evaluator }) => evaluator));
-  const aggregateResult = composite.aggregate(
-    evalRuns.map(({ result }) => result),
-    policy,
-    logger,
-  );
-  const blockingFailure = evalRuns.find(
-    ({ evaluatorType, result }) => evaluatorType === "secret_scan" && !result.passed,
-  );
-  const evalResult =
-    blockingFailure === undefined
-      ? aggregateResult
-      : {
-          score: Math.min(aggregateResult.score, blockingFailure.result.score),
-          passed: false,
-          reason:
-            aggregateResult.reason === blockingFailure.result.reason
-              ? blockingFailure.result.reason
-              : `${blockingFailure.result.reason} ${aggregateResult.reason}`,
-          issues: aggregateResult.issues,
-        };
+  const { evalRuns, evalResult } = await runEvaluation(evaluators, diff, policy, logger);
 
   const newStatus: Change["status"] = evalResult.passed ? "accepted" : "needs_changes";
 
   const recordResult = await recordEvalRuns(env.DB, logger, change.id, evalRuns);
   if (!recordResult.success) {
     logger.error("Failed to record eval runs", recordResult.error);
-    return err(new AppError(recordResult.error.message, "DATABASE_ERROR", 400));
+    return err(
+      new AppError(recordResult.error.message, "DATABASE_ERROR", 500, { changeId: change.id }),
+    );
   }
 
   // Best-effort cost tracking: the diff clones both repos, evaluators self-report.
@@ -314,7 +361,16 @@ export async function createChangeWithEvaluation(
   });
   if (!updateResult.success) {
     logger.error("Failed to update change status", updateResult.error);
-    return err(new AppError(updateResult.error.message, updateResult.error.code, 400));
+    return err(
+      new AppError(
+        updateResult.error.message,
+        updateResult.error.code,
+        updateResult.error.statusCode,
+        {
+          changeId: change.id,
+        },
+      ),
+    );
   }
 
   await emitEvent(
@@ -403,8 +459,29 @@ export async function createWorkspaceFork(
     logger,
   );
   if (!setResult.success) {
-    logger.error("Failed to set workspace", setResult.error);
-    return err(new AppError(setResult.error.message, setResult.error.code, 400));
+    // The fork exists but was never registered — deleting it here stops each
+    // failed push from leaking an Artifacts repo. Log the coordinates either
+    // way so a failed delete leaves a findable orphan, not a silent one.
+    logger.error("Failed to register pushed workspace; removing orphaned fork", setResult.error, {
+      remote,
+      workspaceName,
+      projectId: project.id,
+    });
+    const orphanRepoName = artifactsRepoNameFromRemote(remote);
+    if (orphanRepoName) {
+      await env.ARTIFACTS.delete(orphanRepoName).catch((error: unknown) => {
+        logger.warn("Could not delete orphaned workspace fork", {
+          repoName: orphanRepoName,
+          remote,
+          workspaceName,
+          projectId: project.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }
+    return err(
+      new AppError(setResult.error.message, setResult.error.code, setResult.error.statusCode),
+    );
   }
 
   const actorEvent: EventActor = actor.agentId
@@ -413,7 +490,13 @@ export async function createWorkspaceFork(
   await emitEvent(
     env.DB,
     env.EVENTS_QUEUE,
-    { type: "workspace.created", project: project.name, workspace: workspaceName },
+    // Canonical `namespace/slug` (guaranteed by the guard above), matching the
+    // change.* events this flow emits — not the mutable display name.
+    {
+      type: "workspace.created",
+      project: `${project.namespace}/${project.slug}`,
+      workspace: workspaceName,
+    },
     actorEvent,
     logger,
     project.id,

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,6 +150,10 @@ export interface Env {
   MAX_BACKUP_BYTES?: string;
   /** Gates the RepoDO fast-forward path (ADR 004). Off -> classic cold merge. */
   REPO_DO_ENABLED?: string;
+  /** "true" routes a `git push` to a project's default branch through the
+   * change/eval gate (ADR 005 slice 2b) instead of refusing it. Staging-first
+   * rollout flag; off in production until validated end-to-end. */
+  GIT_PUSH_GATED_ENABLED?: string;
   /** Deploy environment: "development" | "staging" | "production". Gates dev-only
    * routes and toggles HSTS. Defaults to production-safe behavior when unset. */
   ENVIRONMENT?: string;

--- a/src/utils/git-protocol.ts
+++ b/src/utils/git-protocol.ts
@@ -157,9 +157,12 @@ export function buildReportStatus(report: ReportStatus): Uint8Array {
   for (const result of report.results) {
     statusLines.push(
       encodePktLine(
+        // The ref is echoed from the client's own command line and can carry
+        // arbitrary bytes/length — sanitize it too, or a hostile ref would
+        // make encodePktLine throw and turn the refusal into an HTTP 500.
         result.ok
-          ? `ok ${result.ref}\n`
-          : `ng ${result.ref} ${sanitizeStatusText(result.reason ?? "rejected")}\n`,
+          ? `ok ${sanitizeStatusText(result.ref)}\n`
+          : `ng ${sanitizeStatusText(result.ref)} ${sanitizeStatusText(result.reason ?? "rejected")}\n`,
       ),
     );
   }

--- a/src/utils/git-protocol.ts
+++ b/src/utils/git-protocol.ts
@@ -135,6 +135,18 @@ export interface ReportStatus {
   sideband: boolean;
 }
 
+// Reasons and messages can carry arbitrary upstream/evaluator text. pkt-line
+// framing is line-oriented with a 16-bit length, so an embedded newline would
+// smuggle extra protocol lines and an oversized payload would make
+// encodePktLine throw mid-response. Flatten and bound at the encoding boundary.
+const MAX_STATUS_TEXT_CHARS = 512;
+
+/** Collapse newlines and cap length so text is safe inside one pkt-line. */
+export function sanitizeStatusText(text: string): string {
+  const flat = text.replace(/[\r\n]+/g, " ").trim();
+  return flat.length > MAX_STATUS_TEXT_CHARS ? `${flat.slice(0, MAX_STATUS_TEXT_CHARS)}…` : flat;
+}
+
 /**
  * Build a git-receive-pack result body carrying report-status (and optional
  * progress messages when side-band-64k was negotiated — without side-band there
@@ -145,7 +157,9 @@ export function buildReportStatus(report: ReportStatus): Uint8Array {
   for (const result of report.results) {
     statusLines.push(
       encodePktLine(
-        result.ok ? `ok ${result.ref}\n` : `ng ${result.ref} ${result.reason ?? "rejected"}\n`,
+        result.ok
+          ? `ok ${result.ref}\n`
+          : `ng ${result.ref} ${sanitizeStatusText(result.reason ?? "rejected")}\n`,
       ),
     );
   }
@@ -156,7 +170,7 @@ export function buildReportStatus(report: ReportStatus): Uint8Array {
 
   const parts: Uint8Array[] = [];
   for (const message of report.messages ?? []) {
-    parts.push(encodeSideband(2, encoder.encode(`${message}\n`)));
+    parts.push(encodeSideband(2, encoder.encode(`${sanitizeStatusText(message)}\n`)));
   }
   parts.push(encodeSideband(1, status));
   parts.push(FLUSH_PKT);
@@ -165,4 +179,103 @@ export function buildReportStatus(report: ReportStatus): Uint8Array {
 
 export function wantsSideband(capabilities: string[]): boolean {
   return capabilities.includes("side-band-64k");
+}
+
+/** Split a buffer into pkt-line payloads, tolerating interleaved flush-pkts. */
+function readPktLines(body: Uint8Array): Result<Uint8Array[], AppError> {
+  const lines: Uint8Array[] = [];
+  let offset = 0;
+  while (offset < body.byteLength) {
+    if (offset + 4 > body.byteLength) {
+      return err(new AppError("truncated pkt-line header", "GIT_PROTOCOL", 502));
+    }
+    const lengthHex = decoder.decode(body.subarray(offset, offset + 4));
+    if (!/^[0-9a-f]{4}$/.test(lengthHex)) {
+      return err(new AppError("malformed pkt-line length", "GIT_PROTOCOL", 502));
+    }
+    const length = Number.parseInt(lengthHex, 16);
+    if (length === 0) {
+      offset += 4; // flush-pkt: section boundary, keep reading
+      continue;
+    }
+    if (length < 4 || offset + length > body.byteLength) {
+      return err(new AppError("pkt-line length out of range", "GIT_PROTOCOL", 502));
+    }
+    lines.push(body.subarray(offset + 4, offset + length));
+    offset += length;
+  }
+  return ok(lines);
+}
+
+export interface ParsedReportStatus {
+  /** "ok" or the unpack error description. */
+  unpack: string;
+  results: Array<{ ref: string; ok: boolean; reason?: string }>;
+}
+
+/**
+ * Parse a git-receive-pack result body into its report-status, handling both
+ * plain and side-band-64k framing. Only band 1 carries the status stream;
+ * bands 2/3 are free-form progress/error text and are deliberately ignored —
+ * substring-scanning the whole body would misread progress like
+ * "Counting objects" (or any text containing "ng ") as a ref verdict.
+ */
+export function parseReportStatus(body: Uint8Array): Result<ParsedReportStatus, AppError> {
+  const framesResult = readPktLines(body);
+  if (!framesResult.success) return framesResult;
+  const frames = framesResult.data;
+  if (frames.length === 0) {
+    return err(new AppError("empty receive-pack result", "GIT_PROTOCOL", 502));
+  }
+
+  // Sideband framing iff every frame leads with a band byte (1-3); a plain
+  // status stream leads with ASCII text ("unpack …"), which can't collide.
+  const isSideband = frames.every((f) => {
+    const band = f[0];
+    return band !== undefined && band >= 1 && band <= 3;
+  });
+  let statusFrames: Uint8Array[];
+  if (isSideband) {
+    const band1 = concat(frames.filter((f) => f[0] === 1).map((f) => f.subarray(1)));
+    const inner = readPktLines(band1);
+    if (!inner.success) return inner;
+    statusFrames = inner.data;
+  } else {
+    statusFrames = frames;
+  }
+
+  const lines = statusFrames.map((f) => {
+    const text = decoder.decode(f);
+    return text.endsWith("\n") ? text.slice(0, -1) : text;
+  });
+
+  const first = lines[0];
+  if (first === undefined || !first.startsWith("unpack ")) {
+    return err(new AppError("receive-pack result missing unpack status", "GIT_PROTOCOL", 502));
+  }
+  const unpack = first.slice("unpack ".length);
+
+  const results: ParsedReportStatus["results"] = [];
+  for (const line of lines.slice(1)) {
+    if (line.startsWith("ok ")) {
+      results.push({ ref: line.slice("ok ".length), ok: true });
+    } else if (line.startsWith("ng ")) {
+      const rest = line.slice("ng ".length);
+      const space = rest.indexOf(" ");
+      results.push(
+        space >= 0
+          ? { ref: rest.slice(0, space), ok: false, reason: rest.slice(space + 1) }
+          : { ref: rest, ok: false },
+      );
+    } else {
+      return err(
+        new AppError(
+          `unexpected receive-pack status line: ${line.slice(0, 80)}`,
+          "GIT_PROTOCOL",
+          502,
+        ),
+      );
+    }
+  }
+  return ok({ unpack, results });
 }

--- a/src/utils/git-protocol.ts
+++ b/src/utils/git-protocol.ts
@@ -1,0 +1,168 @@
+import { AppError } from "./errors";
+import type { Result } from "./result";
+import { err, ok } from "./result";
+
+/**
+ * Minimal git pack-protocol encoding for the smart-HTTP proxy (ADR 005).
+ *
+ * Covers exactly what the receive-pack surface needs: pkt-line framing, parsing
+ * a client's ref-update command list, and synthesizing a report-status reply —
+ * optionally wrapped in side-band-64k — so `git push` outcomes render legibly
+ * in the client ("remote: …" messages and per-ref ok/ng status) instead of an
+ * opaque HTTP error. This is the foundation the gated default-branch push
+ * (slice 2b, #115) plugs into.
+ */
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/** A single ref update requested by the client. */
+export interface ReceivePackCommand {
+  oldOid: string;
+  newOid: string;
+  ref: string;
+}
+
+export interface ReceivePackRequest {
+  commands: ReceivePackCommand[];
+  capabilities: string[];
+}
+
+export const FLUSH_PKT = encoder.encode("0000");
+
+/** Frame one pkt-line: 4-hex length (self-inclusive) + payload. */
+export function encodePktLine(payload: string | Uint8Array): Uint8Array {
+  const data = typeof payload === "string" ? encoder.encode(payload) : payload;
+  const length = data.byteLength + 4;
+  if (length > 0xffff) {
+    throw new RangeError(`pkt-line payload too large: ${data.byteLength} bytes`);
+  }
+  const header = encoder.encode(length.toString(16).padStart(4, "0"));
+  const out = new Uint8Array(length);
+  out.set(header, 0);
+  out.set(data, 4);
+  return out;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.byteLength;
+  }
+  return out;
+}
+
+const OID_RE = /^[0-9a-f]{40}$/;
+
+/**
+ * Parse the command section of a git-receive-pack request body: pkt-lines of
+ * `old-oid new-oid refname` (the first carrying `\0capability…`), terminated by
+ * a flush-pkt; the packfile that follows is not consumed. Returns an error for
+ * malformed framing rather than guessing — the caller fails the push closed.
+ */
+export function parseReceivePackRequest(body: Uint8Array): Result<ReceivePackRequest, AppError> {
+  const commands: ReceivePackCommand[] = [];
+  let capabilities: string[] = [];
+  let offset = 0;
+
+  while (true) {
+    if (offset + 4 > body.byteLength) {
+      return err(new AppError("receive-pack request ended before flush-pkt", "GIT_PROTOCOL", 400));
+    }
+    const lengthHex = decoder.decode(body.subarray(offset, offset + 4));
+    if (!/^[0-9a-f]{4}$/.test(lengthHex)) {
+      return err(new AppError("malformed pkt-line length", "GIT_PROTOCOL", 400));
+    }
+    const length = Number.parseInt(lengthHex, 16);
+    if (length === 0) break; // flush-pkt: end of command section
+    if (length < 4 || offset + length > body.byteLength) {
+      return err(new AppError("pkt-line length out of range", "GIT_PROTOCOL", 400));
+    }
+
+    let line = decoder.decode(body.subarray(offset + 4, offset + length));
+    offset += length;
+    if (line.endsWith("\n")) line = line.slice(0, -1);
+
+    const nul = line.indexOf("\0");
+    if (nul >= 0) {
+      capabilities = line
+        .slice(nul + 1)
+        .split(" ")
+        .filter((c) => c.length > 0);
+      line = line.slice(0, nul);
+    }
+
+    const [oldOid, newOid, ...refParts] = line.split(" ");
+    const ref = refParts.join(" ");
+    if (!oldOid || !newOid || !ref || !OID_RE.test(oldOid) || !OID_RE.test(newOid)) {
+      return err(new AppError("malformed receive-pack command", "GIT_PROTOCOL", 400));
+    }
+    commands.push({ oldOid, newOid, ref });
+  }
+
+  if (commands.length === 0) {
+    return err(new AppError("receive-pack request contains no commands", "GIT_PROTOCOL", 400));
+  }
+  return ok({ commands, capabilities });
+}
+
+// side-band-64k caps a packet's payload at 65519 bytes; one byte carries the band.
+const SIDEBAND_MAX_DATA = 65515;
+
+/** Wrap raw bytes in side-band packets on the given band (1=data, 2=progress, 3=error). */
+export function encodeSideband(band: 1 | 2 | 3, data: Uint8Array): Uint8Array {
+  const parts: Uint8Array[] = [];
+  for (let i = 0; i < data.byteLength; i += SIDEBAND_MAX_DATA) {
+    const chunk = data.subarray(i, Math.min(i + SIDEBAND_MAX_DATA, data.byteLength));
+    const framed = new Uint8Array(chunk.byteLength + 1);
+    framed[0] = band;
+    framed.set(chunk, 1);
+    parts.push(encodePktLine(framed));
+  }
+  return concat(parts);
+}
+
+export interface ReportStatus {
+  /** "ok" or an unpack error description. */
+  unpack: string;
+  results: Array<{ ref: string; ok: boolean; reason?: string }>;
+  /** Human guidance streamed to the client as `remote: …` lines. */
+  messages?: string[];
+  /** Whether the client negotiated side-band-64k (wrap report + messages). */
+  sideband: boolean;
+}
+
+/**
+ * Build a git-receive-pack result body carrying report-status (and optional
+ * progress messages when side-band-64k was negotiated — without side-band there
+ * is no channel for messages, so only the status section is sent).
+ */
+export function buildReportStatus(report: ReportStatus): Uint8Array {
+  const statusLines: Uint8Array[] = [encodePktLine(`unpack ${report.unpack}\n`)];
+  for (const result of report.results) {
+    statusLines.push(
+      encodePktLine(
+        result.ok ? `ok ${result.ref}\n` : `ng ${result.ref} ${result.reason ?? "rejected"}\n`,
+      ),
+    );
+  }
+  statusLines.push(FLUSH_PKT);
+  const status = concat(statusLines);
+
+  if (!report.sideband) return status;
+
+  const parts: Uint8Array[] = [];
+  for (const message of report.messages ?? []) {
+    parts.push(encodeSideband(2, encoder.encode(`${message}\n`)));
+  }
+  parts.push(encodeSideband(1, status));
+  parts.push(FLUSH_PKT);
+  return concat(parts);
+}
+
+export function wantsSideband(capabilities: string[]): boolean {
+  return capabilities.includes("side-band-64k");
+}

--- a/tests/git-http.test.ts
+++ b/tests/git-http.test.ts
@@ -914,7 +914,7 @@ describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
     );
     expect(vi.mocked(createWorkspaceFork)).toHaveBeenCalledTimes(1);
     const forkArgs = vi.mocked(createWorkspaceFork).mock.calls[0]?.[2];
-    expect(forkArgs?.workspaceName).toMatch(/^push-[0-9a-f-]{8}$/);
+    expect(forkArgs?.workspaceName).toMatch(/^push-[0-9a-f-]{36}$/);
     expect(forkArgs?.actor.userId).toBe("user_owner");
 
     const changeArgs = vi.mocked(createChangeWithEvaluation).mock.calls[0]?.[2];
@@ -1061,6 +1061,58 @@ describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
     // The pack landed → the change flow ran and reported its id.
     expect(text).toContain("chg_push1");
     expect(vi.mocked(createChangeWithEvaluation)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(env.ARTIFACTS.delete)).not.toHaveBeenCalled();
+  });
+
+  it("preserves the fork when an HTTP 200 report-status cannot be parsed", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    // HTTP 200 with an unknown status line: Artifacts processed the request,
+    // so the pack may have landed — deleting the fork could destroy commits.
+    stubFetch(
+      () =>
+        new Response("000eunpack ok\n0017weird refs/heads/x\n0000", {
+          status: 200,
+          headers: { "Content-Type": "application/x-git-receive-pack-result" },
+        }),
+    );
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(vi.mocked(env.ARTIFACTS.delete)).not.toHaveBeenCalled();
+    expect(vi.mocked(createChangeWithEvaluation)).not.toHaveBeenCalled();
+  });
+
+  it("names the stuck change when post-creation processing fails with a changeId", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    stubFetch(() => upstreamPushOk());
+    vi.mocked(createChangeWithEvaluation).mockResolvedValueOnce({
+      success: false,
+      error: Object.assign(new Error("record eval runs failed"), {
+        code: "DATABASE_ERROR",
+        statusCode: 500,
+        context: { changeId: "chg_stuck1" },
+      }),
+    } as never);
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    const text = await res.text();
+    // The existing change is named so the pusher re-evaluates it, not duplicates it.
+    expect(text).toContain("chg_stuck1");
+    expect(text).toContain("re-evaluate");
     expect(vi.mocked(env.ARTIFACTS.delete)).not.toHaveBeenCalled();
   });
 

--- a/tests/git-http.test.ts
+++ b/tests/git-http.test.ts
@@ -1108,9 +1108,11 @@ describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
     // A real AppError (not a shape-alike cast) so the test binds to the same
     // context contract createChangeWithEvaluation actually produces.
     vi.mocked(createChangeWithEvaluation).mockResolvedValueOnce(
-      err(new AppError("record eval runs failed", "DATABASE_ERROR", 500, {
-        changeId: "chg_stuck1",
-      })),
+      err(
+        new AppError("record eval runs failed", "DATABASE_ERROR", 500, {
+          changeId: "chg_stuck1",
+        }),
+      ),
     );
     const res = await app.fetch(
       req("/@owner/repo.git/git-receive-pack", {

--- a/tests/git-http.test.ts
+++ b/tests/git-http.test.ts
@@ -20,6 +20,31 @@ const OTHER_TOKEN = "stratum_user_other000000000000000000";
 const AGENT_TOKEN = "stratum_agent_agent00000000000000000";
 const INVALID_TOKEN = "stratum_user_invalid0000000000000000";
 
+// The gated-push handler calls the change-flow service; mock its two entry
+// points so these tests exercise the wire protocol, not the eval pipeline
+// (which has its own suite via the REST route).
+vi.mock("../src/services/change-flow", async (importActual) => {
+  const actual = await importActual<typeof import("../src/services/change-flow")>();
+  return {
+    ...actual,
+    createWorkspaceFork: vi.fn(async () => ({
+      success: true,
+      data: {
+        name: "push-abcd1234",
+        remote: "https://acct.artifacts.cloudflare.net/git/@owner/push-abcd1234.git",
+      },
+    })),
+    createChangeWithEvaluation: vi.fn(async () => ({
+      success: true,
+      data: {
+        change: { id: "chg_push1", status: "accepted" },
+        evalResult: { score: 0.9, passed: true, reason: "clean" },
+        evalRuns: [],
+      },
+    })),
+  };
+});
+
 vi.mock("../src/storage/users", () => ({
   getUserByToken: vi.fn(async (_db: unknown, token: string) => {
     if (token === OWNER_TOKEN)
@@ -410,22 +435,121 @@ describe("git smart-HTTP proxy — upstream proxy (Task 3)", () => {
   });
 });
 
-describe("git smart-HTTP proxy — receive-pack rejection (Task 4)", () => {
-  it("POST git-receive-pack → 403 naming stratum commit, no upstream call", async () => {
+describe("git smart-HTTP proxy — receive-pack in-protocol rejection (Task 4)", () => {
+  const OID_A = "a".repeat(40);
+  const OID_B = "b".repeat(40);
+
+  function pktLine(payload: string): Uint8Array {
+    const data = new TextEncoder().encode(payload);
+    const header = new TextEncoder().encode((data.byteLength + 4).toString(16).padStart(4, "0"));
+    const out = new Uint8Array(data.byteLength + 4);
+    out.set(header, 0);
+    out.set(data, 4);
+    return out;
+  }
+
+  function pushBody(caps: string): Uint8Array {
+    const line = pktLine(`${OID_A} ${OID_B} refs/heads/main\0${caps}`);
+    const flush = new TextEncoder().encode("0000");
+    const out = new Uint8Array(line.byteLength + flush.byteLength);
+    out.set(line, 0);
+    out.set(flush, line.byteLength);
+    return out;
+  }
+
+  it("POST git-receive-pack → 200 report-status with per-ref ng, pack never forwarded", async () => {
     const env = makeEnv();
-    await seedProject(env, { visibility: "public" });
+    await seedProject(env);
     const fetchMock = stubFetch(() => okUpstream());
-    const res = await app.fetch(req("/@owner/repo.git/git-receive-pack", { method: "POST" }), env);
-    expect(res.status).toBe(403);
-    expect(await res.text()).toContain("stratum commit");
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: pushBody("report-status"),
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/x-git-receive-pack-result");
+    const text = await res.text();
+    expect(text).toContain("unpack ok\n");
+    expect(text).toContain("ng refs/heads/main");
+    expect(text).toContain("gated");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("info/refs?service=git-receive-pack → 403", async () => {
+  it("sideband push gets remote guidance messages naming the workspace remote", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    stubFetch(() => okUpstream());
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: pushBody("report-status side-band-64k"),
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("workspaces/<ws>.git");
+    expect(text).toContain("ng refs/heads/main");
+  });
+
+  it("push requires write: anonymous → 401 challenge, non-writer → 404", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    stubFetch(() => okUpstream());
+    const anon = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", { method: "POST", body: pushBody("") }),
+      env,
+    );
+    expect(anon.status).toBe(401);
+    const other = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OTHER_TOKEN),
+        body: pushBody("report-status"),
+      }),
+      env,
+    );
+    expect(other.status).toBe(404);
+  });
+
+  it("malformed push body → 400, not a synthesized report", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    stubFetch(() => okUpstream());
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: "zzzz garbage",
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("info/refs?service=git-receive-pack advertises for a writer (write-scoped proxy)", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    const fetchMock = stubFetch(() => okUpstream());
+    const res = await app.fetch(
+      req("/@owner/repo.git/info/refs?service=git-receive-pack", { headers: basic(OWNER_TOKEN) }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("service=git-receive-pack");
+    expect(vi.mocked(freshRepoToken).mock.calls[0]?.[2]).toBe("write");
+  });
+
+  it("info/refs?service=git-receive-pack challenges the anonymous caller", async () => {
     const env = makeEnv();
     await seedProject(env, { visibility: "public" });
+    stubFetch(() => okUpstream());
     const res = await app.fetch(req("/@owner/repo.git/info/refs?service=git-receive-pack"), env);
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
   });
 });
 
@@ -714,5 +838,204 @@ describe("git smart-HTTP proxy — workspace write ownership (S1)", () => {
     stubFetch(() => okUpstream());
     const res = await app.fetch(req(WS_UPLOAD_ADV, { headers: basic(OTHER_TOKEN) }), env);
     expect(res.status).toBe(200);
+  });
+});
+
+// ── Gated push (ADR 005 slice 2b, GIT_PUSH_GATED_ENABLED) ────────────────────
+
+import { createChangeWithEvaluation, createWorkspaceFork } from "../src/services/change-flow";
+
+describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
+  const OID_A = "a".repeat(40);
+  const OID_B = "b".repeat(40);
+  const ZEROS = "0".repeat(40);
+
+  function pktLine(payload: string): Uint8Array {
+    const data = new TextEncoder().encode(payload);
+    const header = new TextEncoder().encode((data.byteLength + 4).toString(16).padStart(4, "0"));
+    const out = new Uint8Array(data.byteLength + 4);
+    out.set(header, 0);
+    out.set(data, 4);
+    return out;
+  }
+
+  function pushBody(lines: string[]): Uint8Array {
+    const parts = lines.map((l) => pktLine(l));
+    const flush = new TextEncoder().encode("0000");
+    const total = parts.reduce((n, p) => n + p.byteLength, 0) + flush.byteLength;
+    const out = new Uint8Array(total);
+    let off = 0;
+    for (const p of parts) {
+      out.set(p, off);
+      off += p.byteLength;
+    }
+    out.set(flush, off);
+    return out;
+  }
+
+  const MAIN_PUSH = pushBody([`${OID_A} ${OID_B} refs/heads/main\0report-status`]);
+
+  function gatedEnv(): Env {
+    return { ...makeEnv(), GIT_PUSH_GATED_ENABLED: "true" } as Env;
+  }
+
+  function upstreamPushOk(): Response {
+    return new Response("000eunpack ok\n0000", {
+      status: 200,
+      headers: { "Content-Type": "application/x-git-receive-pack-result" },
+    });
+  }
+
+  it("routes a main push through fork → land pack → change, answering a truthful ng", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    const fetchMock = stubFetch(() => upstreamPushOk());
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    // Truthful outcome: main did not move, so the ref reports ng…
+    expect(text).toContain("ng refs/heads/main");
+    // …but the reason carries the created change and its verdict.
+    expect(text).toContain("chg_push1");
+    expect(text).toContain("eval passed");
+
+    // The pack was forwarded to the fork's receive-pack, not the project's.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "https://acct.artifacts.cloudflare.net/git/@owner/push-abcd1234.git/git-receive-pack",
+    );
+    expect(vi.mocked(createWorkspaceFork)).toHaveBeenCalledTimes(1);
+    const forkArgs = vi.mocked(createWorkspaceFork).mock.calls[0]?.[2];
+    expect(forkArgs?.workspaceName).toMatch(/^push-[0-9a-f-]{8}$/);
+    expect(forkArgs?.actor.userId).toBe("user_owner");
+
+    const changeArgs = vi.mocked(createChangeWithEvaluation).mock.calls[0]?.[2];
+    expect(changeArgs?.projectName).toBe("@owner/repo");
+    expect(changeArgs?.workspaceRemote).toContain("push-abcd1234");
+  });
+
+  it("an agent push carries the agent identity into the change flow", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    stubFetch(() => upstreamPushOk());
+    await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(AGENT_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    const changeArgs = vi.mocked(createChangeWithEvaluation).mock.calls[0]?.[2];
+    expect(changeArgs?.actor.agentId).toBe("agent_1");
+    expect(changeArgs?.actor.userId).toBeUndefined();
+  });
+
+  it("refuses multi-ref pushes even with the flag on", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    const fetchMock = stubFetch(() => upstreamPushOk());
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: pushBody([
+          `${OID_A} ${OID_B} refs/heads/main\0report-status`,
+          `${OID_A} ${OID_B} refs/heads/dev`,
+        ]),
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("only a single push to refs/heads/main");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(vi.mocked(createWorkspaceFork)).not.toHaveBeenCalled();
+  });
+
+  it("refuses a ref deletion even with the flag on", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    stubFetch(() => upstreamPushOk());
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: pushBody([`${OID_A} ${ZEROS} refs/heads/main\0report-status`]),
+      }),
+      env,
+    );
+    expect(await res.text()).toContain("only a single push to refs/heads/main");
+    expect(vi.mocked(createWorkspaceFork)).not.toHaveBeenCalled();
+  });
+
+  it("relays the workspace remote's own rejection verbatim (non-fast-forward)", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    stubFetch(
+      () =>
+        new Response("0027unpack ok\n002bng refs/heads/main non-fast-forward\n0000", {
+          status: 200,
+          headers: { "Content-Type": "application/x-git-receive-pack-result" },
+        }),
+    );
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("non-fast-forward");
+    expect(vi.mocked(createChangeWithEvaluation)).not.toHaveBeenCalled();
+  });
+
+  it("preserves the workspace pointer when change creation fails after the pack landed", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    stubFetch(() => upstreamPushOk());
+    vi.mocked(createChangeWithEvaluation).mockResolvedValueOnce({
+      success: false,
+      error: Object.assign(new Error("db unavailable"), {
+        code: "DATABASE_ERROR",
+        statusCode: 400,
+      }),
+    } as never);
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("change creation failed");
+    expect(text).toContain("push-abcd1234");
+  });
+
+  it("flag off → the plain in-protocol refusal, no fork", async () => {
+    const env = makeEnv(); // no GIT_PUSH_GATED_ENABLED
+    await seedProject(env);
+    stubFetch(() => upstreamPushOk());
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("project pushes are gated");
+    expect(vi.mocked(createWorkspaceFork)).not.toHaveBeenCalled();
   });
 });

--- a/tests/git-http.test.ts
+++ b/tests/git-http.test.ts
@@ -99,7 +99,8 @@ function makeKV(): KVNamespace {
 
 function makeEnv(): Env {
   return {
-    ARTIFACTS: {} as unknown as Env["ARTIFACTS"],
+    // `delete` is real-ish so gated-push cleanup paths can run and be asserted.
+    ARTIFACTS: { delete: vi.fn(async () => {}) } as unknown as Env["ARTIFACTS"],
     STATE: makeKV(),
     DB: {} as D1Database,
   } as Env;
@@ -975,12 +976,14 @@ describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
     expect(vi.mocked(createWorkspaceFork)).not.toHaveBeenCalled();
   });
 
-  it("relays the workspace remote's own rejection verbatim (non-fast-forward)", async () => {
+  it("relays the workspace remote's own rejection verbatim and cleans up the fork", async () => {
     const env = gatedEnv();
     await seedProject(env);
+    // Correctly framed report-status: "unpack ok\n" (14=0x000e) and the 40-byte
+    // (0x0028) ng line — the handler now PARSES this instead of substring-scanning.
     stubFetch(
       () =>
-        new Response("0027unpack ok\n002bng refs/heads/main non-fast-forward\n0000", {
+        new Response("000eunpack ok\n0028ng refs/heads/main non-fast-forward\n0000", {
           status: 200,
           headers: { "Content-Type": "application/x-git-receive-pack-result" },
         }),
@@ -996,6 +999,119 @@ describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
     const text = await res.text();
     expect(text).toContain("non-fast-forward");
     expect(vi.mocked(createChangeWithEvaluation)).not.toHaveBeenCalled();
+    // The pack never landed as a change, so the empty fork must not leak.
+    expect(vi.mocked(env.ARTIFACTS.delete)).toHaveBeenCalledWith("push-abcd1234");
+  });
+
+  it("treats a sideband success reply with 'Counting objects' progress as success (regression)", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    // Sideband-framed success: band-2 progress whose text contains "ng "
+    // ("Counting objects…") plus a band-1 status stream. The old substring
+    // scan misread this as a rejection after the pack had already landed.
+    function pkt(payload: Uint8Array): Uint8Array {
+      const header = new TextEncoder().encode(
+        (payload.byteLength + 4).toString(16).padStart(4, "0"),
+      );
+      const out = new Uint8Array(payload.byteLength + 4);
+      out.set(header, 0);
+      out.set(payload, 4);
+      return out;
+    }
+    function band(b: number, text: string): Uint8Array {
+      const data = new TextEncoder().encode(text);
+      const framed = new Uint8Array(data.byteLength + 1);
+      framed[0] = b;
+      framed.set(data, 1);
+      return pkt(framed);
+    }
+    const status = "000eunpack ok\n0017ok refs/heads/main\n0000";
+    const statusBytes = new TextEncoder().encode(status);
+    const statusFrame = new Uint8Array(statusBytes.byteLength + 1);
+    statusFrame[0] = 1;
+    statusFrame.set(statusBytes, 1);
+    const bodyParts = [
+      band(2, "Counting objects: 100% (3/3), done.\n"),
+      pkt(statusFrame),
+      new TextEncoder().encode("0000"),
+    ];
+    const total = bodyParts.reduce((n, p) => n + p.byteLength, 0);
+    const upstreamBody = new Uint8Array(total);
+    let off = 0;
+    for (const p of bodyParts) {
+      upstreamBody.set(p, off);
+      off += p.byteLength;
+    }
+    stubFetch(
+      () =>
+        new Response(upstreamBody, {
+          status: 200,
+          headers: { "Content-Type": "application/x-git-receive-pack-result" },
+        }),
+    );
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    const text = await res.text();
+    // The pack landed → the change flow ran and reported its id.
+    expect(text).toContain("chg_push1");
+    expect(vi.mocked(createChangeWithEvaluation)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(env.ARTIFACTS.delete)).not.toHaveBeenCalled();
+  });
+
+  it("cleans up the fork when the upstream transport fails", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    stubFetch(() => new Response("boom", { status: 500 }));
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("upstream git error");
+    expect(vi.mocked(env.ARTIFACTS.delete)).toHaveBeenCalledWith("push-abcd1234");
+    expect(vi.mocked(createChangeWithEvaluation)).not.toHaveBeenCalled();
+  });
+
+  it("gates the push against the project's actual default branch, not literal main", async () => {
+    const env = gatedEnv();
+    await seedProject(env, { sourceDefaultBranch: "trunk" });
+    const fetchMock = stubFetch(() => upstreamPushOk());
+
+    // A push to refs/heads/main is NOT the default branch here → refused, named.
+    const mainRes = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    expect(await mainRes.text()).toContain("only a single push to refs/heads/trunk");
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // A push to refs/heads/trunk IS gated.
+    const trunkRes = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: pushBody([`${OID_A} ${OID_B} refs/heads/trunk\0report-status`]),
+      }),
+      env,
+    );
+    const text = await trunkRes.text();
+    expect(text).toContain("ng refs/heads/trunk");
+    expect(text).toContain("chg_push1");
+    expect(vi.mocked(createChangeWithEvaluation)).toHaveBeenCalledTimes(1);
   });
 
   it("preserves the workspace pointer when change creation fails after the pack landed", async () => {
@@ -1020,6 +1136,8 @@ describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
     const text = await res.text();
     expect(text).toContain("change creation failed");
     expect(text).toContain("push-abcd1234");
+    // The pack DID land: the workspace holds the user's commits and must survive.
+    expect(vi.mocked(env.ARTIFACTS.delete)).not.toHaveBeenCalled();
   });
 
   it("flag off → the plain in-protocol refusal, no fork", async () => {

--- a/tests/git-http.test.ts
+++ b/tests/git-http.test.ts
@@ -3,6 +3,8 @@ import app from "../src/index";
 import { isGitHttpPath } from "../src/routes/git-http";
 import { freshRepoToken } from "../src/storage/git-ops";
 import type { Env, ProjectEntry } from "../src/types";
+import { AppError } from "../src/utils/errors";
+import { err } from "../src/utils/result";
 
 // Real `artifactsRepoNameFromRemote` + `extractTokenSecret` (pure) are kept so
 // the tests exercise the genuine URL validation; only `freshRepoToken` (which
@@ -999,8 +1001,10 @@ describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
     const text = await res.text();
     expect(text).toContain("non-fast-forward");
     expect(vi.mocked(createChangeWithEvaluation)).not.toHaveBeenCalled();
-    // The pack never landed as a change, so the empty fork must not leak.
+    // The pack never landed as a change, so the empty fork must not leak —
+    // both the Artifacts repo and the workspace KV entry go.
     expect(vi.mocked(env.ARTIFACTS.delete)).toHaveBeenCalledWith("push-abcd1234");
+    expect(await env.STATE.get("workspace:proj_1:push-abcd1234")).toBeNull();
   });
 
   it("treats a sideband success reply with 'Counting objects' progress as success (regression)", async () => {
@@ -1076,6 +1080,13 @@ describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
           headers: { "Content-Type": "application/x-git-receive-pack-result" },
         }),
     );
+    // Pre-seed the fork's KV entry (createWorkspaceFork is mocked, so the
+    // real registration never runs) to prove cleanup leaves BOTH resources.
+    await seedWorkspace(
+      env,
+      "push-abcd1234",
+      "https://acct.artifacts.cloudflare.net/git/@owner/push-abcd1234.git",
+    );
     const res = await app.fetch(
       req("/@owner/repo.git/git-receive-pack", {
         method: "POST",
@@ -1086,6 +1097,7 @@ describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
     );
     expect(res.status).toBe(200);
     expect(vi.mocked(env.ARTIFACTS.delete)).not.toHaveBeenCalled();
+    expect(await env.STATE.get("workspace:proj_1:push-abcd1234")).not.toBeNull();
     expect(vi.mocked(createChangeWithEvaluation)).not.toHaveBeenCalled();
   });
 
@@ -1093,14 +1105,13 @@ describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
     const env = gatedEnv();
     await seedProject(env);
     stubFetch(() => upstreamPushOk());
-    vi.mocked(createChangeWithEvaluation).mockResolvedValueOnce({
-      success: false,
-      error: Object.assign(new Error("record eval runs failed"), {
-        code: "DATABASE_ERROR",
-        statusCode: 500,
-        context: { changeId: "chg_stuck1" },
-      }),
-    } as never);
+    // A real AppError (not a shape-alike cast) so the test binds to the same
+    // context contract createChangeWithEvaluation actually produces.
+    vi.mocked(createChangeWithEvaluation).mockResolvedValueOnce(
+      err(new AppError("record eval runs failed", "DATABASE_ERROR", 500, {
+        changeId: "chg_stuck1",
+      })),
+    );
     const res = await app.fetch(
       req("/@owner/repo.git/git-receive-pack", {
         method: "POST",
@@ -1170,13 +1181,9 @@ describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
     const env = gatedEnv();
     await seedProject(env);
     stubFetch(() => upstreamPushOk());
-    vi.mocked(createChangeWithEvaluation).mockResolvedValueOnce({
-      success: false,
-      error: Object.assign(new Error("db unavailable"), {
-        code: "DATABASE_ERROR",
-        statusCode: 400,
-      }),
-    } as never);
+    vi.mocked(createChangeWithEvaluation).mockResolvedValueOnce(
+      err(new AppError("db unavailable", "DATABASE_ERROR", 400)),
+    );
     const res = await app.fetch(
       req("/@owner/repo.git/git-receive-pack", {
         method: "POST",

--- a/tests/git-protocol.test.ts
+++ b/tests/git-protocol.test.ts
@@ -5,6 +5,8 @@ import {
   encodePktLine,
   encodeSideband,
   parseReceivePackRequest,
+  parseReportStatus,
+  sanitizeStatusText,
   wantsSideband,
 } from "../src/utils/git-protocol";
 
@@ -120,6 +122,121 @@ describe("encodeSideband", () => {
   });
 });
 
+describe("sanitizeStatusText", () => {
+  it("flattens newlines so text cannot smuggle extra pkt-lines", () => {
+    expect(sanitizeStatusText("line one\nng refs/heads/main injected\r\nline three")).toBe(
+      "line one ng refs/heads/main injected line three",
+    );
+  });
+
+  it("caps length so encodePktLine cannot overflow", () => {
+    const long = sanitizeStatusText("x".repeat(100_000));
+    expect(long.length).toBeLessThanOrEqual(513); // cap + ellipsis
+    expect(() => encodePktLine(`ng refs/heads/main ${long}\n`)).not.toThrow();
+  });
+
+  it("leaves ordinary text alone", () => {
+    expect(sanitizeStatusText("gated: change chg_1 created")).toBe("gated: change chg_1 created");
+  });
+});
+
+describe("parseReportStatus", () => {
+  it("parses a plain successful report", () => {
+    const body = concat(pktLine("unpack ok\n"), pktLine("ok refs/heads/main\n"), FLUSH_PKT);
+    const result = parseReportStatus(body);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.unpack).toBe("ok");
+      expect(result.data.results).toEqual([{ ref: "refs/heads/main", ok: true }]);
+    }
+  });
+
+  it("parses a plain rejection with the reason", () => {
+    const body = concat(
+      pktLine("unpack ok\n"),
+      pktLine("ng refs/heads/main non-fast-forward\n"),
+      FLUSH_PKT,
+    );
+    const result = parseReportStatus(body);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.results).toEqual([
+        { ref: "refs/heads/main", ok: false, reason: "non-fast-forward" },
+      ]);
+    }
+  });
+
+  it("ignores band-2 progress — 'Counting objects' contains 'ng ' and must not read as a verdict", () => {
+    const status = concat(pktLine("unpack ok\n"), pktLine("ok refs/heads/main\n"), FLUSH_PKT);
+    const body = concat(
+      encodeSideband(2, encoder.encode("Counting objects: 100% (3/3), done.\n")),
+      encodeSideband(1, status),
+      FLUSH_PKT,
+    );
+    const result = parseReportStatus(body);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.unpack).toBe("ok");
+      expect(result.data.results.every((r) => r.ok)).toBe(true);
+    }
+  });
+
+  it("surfaces a sideband-wrapped rejection", () => {
+    const status = concat(
+      pktLine("unpack ok\n"),
+      pktLine("ng refs/heads/main hook declined\n"),
+      FLUSH_PKT,
+    );
+    const body = concat(encodeSideband(1, status), FLUSH_PKT);
+    const result = parseReportStatus(body);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.results[0]).toEqual({
+        ref: "refs/heads/main",
+        ok: false,
+        reason: "hook declined",
+      });
+    }
+  });
+
+  it("reports a failed unpack verbatim", () => {
+    const body = concat(pktLine("unpack index-pack failed\n"), FLUSH_PKT);
+    const result = parseReportStatus(body);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.unpack).toBe("index-pack failed");
+  });
+
+  it("rejects a body without an unpack line", () => {
+    const body = concat(pktLine("ok refs/heads/main\n"), FLUSH_PKT);
+    const result = parseReportStatus(body);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects garbage framing and empty bodies", () => {
+    expect(parseReportStatus(encoder.encode("zzzz not a pkt")).success).toBe(false);
+    expect(parseReportStatus(new Uint8Array(0)).success).toBe(false);
+    expect(parseReportStatus(FLUSH_PKT).success).toBe(false);
+  });
+
+  it("round-trips buildReportStatus output, both framings", () => {
+    for (const sideband of [false, true]) {
+      const body = buildReportStatus({
+        unpack: "ok",
+        results: [{ ref: "refs/heads/main", ok: false, reason: "gated" }],
+        messages: ["review the change"],
+        sideband,
+      });
+      const result = parseReportStatus(body);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.results).toEqual([
+          { ref: "refs/heads/main", ok: false, reason: "gated" },
+        ]);
+      }
+    }
+  });
+});
+
 describe("buildReportStatus", () => {
   it("without sideband: plain pkt-line status section", () => {
     const body = buildReportStatus({
@@ -153,5 +270,28 @@ describe("buildReportStatus", () => {
     expect(text).toContain("ok refs/heads/main\n");
     expect(text).toContain("ng refs/heads/dev no\n");
     expect(text.endsWith("0000")).toBe(true);
+  });
+
+  it("sanitizes reasons and messages: no injected lines, no pkt-line overflow", () => {
+    const body = buildReportStatus({
+      unpack: "ok",
+      results: [
+        {
+          ref: "refs/heads/main",
+          ok: false,
+          reason: `bad\nok refs/heads/main\n${"y".repeat(80_000)}`,
+        },
+      ],
+      messages: ["multi\nline\nmessage"],
+      sideband: true,
+    });
+    const parsed = parseReportStatus(body);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      // Still exactly one ng result — the embedded "ok refs/heads/main" line
+      // was flattened into the reason text, not parsed as a second verdict.
+      expect(parsed.data.results).toHaveLength(1);
+      expect(parsed.data.results[0]?.ok).toBe(false);
+    }
   });
 });

--- a/tests/git-protocol.test.ts
+++ b/tests/git-protocol.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  FLUSH_PKT,
+  buildReportStatus,
+  encodePktLine,
+  encodeSideband,
+  parseReceivePackRequest,
+  wantsSideband,
+} from "../src/utils/git-protocol";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const OID_A = "a".repeat(40);
+const OID_B = "b".repeat(40);
+
+function pktLine(payload: string): Uint8Array {
+  const data = encoder.encode(payload);
+  const header = encoder.encode((data.byteLength + 4).toString(16).padStart(4, "0"));
+  const out = new Uint8Array(data.byteLength + 4);
+  out.set(header, 0);
+  out.set(data, 4);
+  return out;
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.byteLength;
+  }
+  return out;
+}
+
+describe("encodePktLine", () => {
+  it("frames a payload with a self-inclusive hex length", () => {
+    const line = encodePktLine("unpack ok\n");
+    // "unpack ok\n" is 10 bytes; 10 + 4 = 14 = 0x000e.
+    expect(decoder.decode(line)).toBe("000eunpack ok\n");
+  });
+
+  it("rejects payloads beyond the pkt-line maximum", () => {
+    expect(() => encodePktLine("x".repeat(0x10000))).toThrow(RangeError);
+  });
+});
+
+describe("parseReceivePackRequest", () => {
+  it("parses a single command with capabilities after NUL", () => {
+    const body = concat(
+      pktLine(`${OID_A} ${OID_B} refs/heads/main\0report-status side-band-64k agent=git/2.44`),
+      FLUSH_PKT,
+      encoder.encode("PACKdata-not-parsed"),
+    );
+    const result = parseReceivePackRequest(body);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.commands).toEqual([
+        { oldOid: OID_A, newOid: OID_B, ref: "refs/heads/main" },
+      ]);
+      expect(result.data.capabilities).toContain("side-band-64k");
+      expect(result.data.capabilities).toContain("report-status");
+      expect(wantsSideband(result.data.capabilities)).toBe(true);
+    }
+  });
+
+  it("parses multiple commands; only the first line carries capabilities", () => {
+    const body = concat(
+      pktLine(`${OID_A} ${OID_B} refs/heads/main\0report-status`),
+      pktLine(`${OID_A} ${OID_B} refs/heads/dev\n`),
+      FLUSH_PKT,
+    );
+    const result = parseReceivePackRequest(body);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.commands).toHaveLength(2);
+      expect(result.data.commands[1]?.ref).toBe("refs/heads/dev");
+      expect(wantsSideband(result.data.capabilities)).toBe(false);
+    }
+  });
+
+  it("rejects a body with no flush-pkt", () => {
+    const result = parseReceivePackRequest(pktLine(`${OID_A} ${OID_B} refs/heads/main`));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toContain("flush-pkt");
+  });
+
+  it("rejects malformed oids", () => {
+    const body = concat(pktLine(`not-an-oid ${OID_B} refs/heads/main`), FLUSH_PKT);
+    const result = parseReceivePackRequest(body);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty command section", () => {
+    const result = parseReceivePackRequest(FLUSH_PKT);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toContain("no commands");
+  });
+
+  it("rejects garbage framing", () => {
+    const result = parseReceivePackRequest(encoder.encode("zzzz not a pkt line"));
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("encodeSideband", () => {
+  it("prefixes the band byte inside the pkt-line", () => {
+    const packet = encodeSideband(2, encoder.encode("hello"));
+    // length = 4 (header) + 1 (band) + 5 (payload) = 10 = 0x000a
+    expect(decoder.decode(packet.subarray(0, 4))).toBe("000a");
+    expect(packet[4]).toBe(2);
+    expect(decoder.decode(packet.subarray(5))).toBe("hello");
+  });
+
+  it("chunks payloads larger than the sideband maximum", () => {
+    const packet = encodeSideband(1, new Uint8Array(70_000));
+    // Two packets: 65515 bytes + remainder, each with 4-byte header + band byte.
+    expect(packet.byteLength).toBe(70_000 + 2 * 5);
+  });
+});
+
+describe("buildReportStatus", () => {
+  it("without sideband: plain pkt-line status section", () => {
+    const body = buildReportStatus({
+      unpack: "ok",
+      results: [{ ref: "refs/heads/main", ok: false, reason: "gated" }],
+      messages: ["ignored without sideband"],
+      sideband: false,
+    });
+    const text = decoder.decode(body);
+    expect(text).toContain("unpack ok\n");
+    expect(text).toContain("ng refs/heads/main gated\n");
+    expect(text.endsWith("0000")).toBe(true);
+    expect(text).not.toContain("ignored");
+  });
+
+  it("with sideband: wraps status in band 1 and messages in band 2", () => {
+    const body = buildReportStatus({
+      unpack: "ok",
+      results: [
+        { ref: "refs/heads/main", ok: true },
+        { ref: "refs/heads/dev", ok: false, reason: "no" },
+      ],
+      messages: ["use a workspace remote"],
+      sideband: true,
+    });
+    // Band bytes appear right after each 4-byte pkt header.
+    expect(body[4]).toBe(2); // first packet: progress message
+    const text = decoder.decode(body);
+    expect(text).toContain("use a workspace remote");
+    expect(text).toContain("unpack ok\n");
+    expect(text).toContain("ok refs/heads/main\n");
+    expect(text).toContain("ng refs/heads/dev no\n");
+    expect(text.endsWith("0000")).toBe(true);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -235,6 +235,9 @@ DEV_LOGIN_ENABLED = "false"
 # bound" at merge time and workspace staging silently no-ops. The config-guard
 # middleware logs an error if this is set "true" with no bucket bound.
 REPO_DO_ENABLED = "false"
+# Gated git push (ADR 005 slice 2b) — off until validated on staging; pushes to
+# a project URL keep getting the in-protocol refusal pointing at workspaces.
+GIT_PUSH_GATED_ENABLED = "false"
 # Production OAuth callbacks. The matching callback URLs must also be registered
 # in the GitHub and Google OAuth app settings.
 OAUTH_REDIRECT_URI = "https://app.usestratum.dev/auth/github/callback"
@@ -343,6 +346,10 @@ DEV_LOGIN_ENABLED = "false"
 # RepoDO + R2 merge path (ADR 004). "true" on staging: workspace commits stage to
 # R2 and merges route through the fetch-free R2 path (cold path as fallback).
 REPO_DO_ENABLED = "true"
+# Gated git push (ADR 005 slice 2b): a push to a project's default branch lands
+# on a server-managed workspace and opens an eval-gated change. Staging-first;
+# flip production once validated end-to-end against real Artifacts.
+GIT_PUSH_GATED_ENABLED = "true"
 OAUTH_REDIRECT_URI = "https://staging.app.usestratum.dev/auth/github/callback"
 EMAIL_FROM_ADDRESS = "noreply@staging.app.usestratum.dev"
 # Closed beta — validate the invite gate on staging before prod. Points at the


### PR DESCRIPTION
## Summary

Carved out of #173 (4/6). `git push` becomes a first-class, gated front door.

**Wire protocol** (`src/utils/git-protocol.ts`, fully tested): pkt-line parsing of receive-pack commands + capabilities, sideband encoding with 64k chunking, synthesized report-status. Pushes to a project URL now fail **in-protocol** with per-ref `ng` + sideband guidance instead of an opaque HTTP 403; the receive-pack advertisement is proxied write-authorized under the existing no-leak truth table.

**Gated push** (behind `GIT_PUSH_GATED_ENABLED` — "true" on staging, "false" in production until validated against real Artifacts): a single-ref push to `refs/heads/main` lands the pack on a fresh server-managed workspace fork (fork `main` sits at the project tip, so the client's old-oid lines up), then the shared change-flow service creates and synchronously evaluates a change. The client gets a **truthful per-ref `ng`** carrying the change id and eval verdict — `main` only moves through the merge gate, so answering `ok` would corrupt the client's remote-tracking ref. Non-fast-forward rejections relay verbatim; a change-creation failure after the pack lands names the workspace so commits are recoverable.

**Refactor**: the change-creation + eval pipeline moves from the REST route into `src/services/change-flow.ts` so every front door runs the identical gate; the route becomes a thin wrapper and the re-evaluate route shares `buildEvaluators`. The existing 62-test route suite pins behavior parity.

**Dogfood**: adds `.stratum/policy.yaml` — this repo's own merge policy (diff limits, LLM review at 0.6, one human approval, fresh-base required, force-merge denied). Inert on GitHub.

Remaining for #115 (noted in the ADR): answer `ok` by actually merging when policy allows (eval passed, zero required approvals), and change-per-push idempotency under concurrent identical pushes.

Independent of the sibling PRs; any merge order.

## Related issues

Advances #115.

## Type of change

- [x] New feature
- [ ] Bug fix
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` (full unit suite on this branch; new git-protocol suite + 7 gated-push cases; changes route suite pins the extraction)
- [x] `npm run lint`
- Staging validation against real Artifacts is the flag-flip criterion — the flag ships off in production

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (ADR 005 status rewritten; CHANGELOG rides in the docs PR)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (no UI changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiAwmc2tXjt6tHrGEpmnJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiAwmc2tXjt6tHrGEpmnJj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added gated pushes to the default branch, evaluating changes before approval and merge.
  - Added clear Git status and rejection responses for supported push workflows.
  - Added configurable gated-push enablement, enabled in staging and disabled in production.
  - Added policy enforcement for evaluator completion, minimum scores, human approval, secret scanning, and fresh-base re-evaluation.
  - Added validation and guidance for unsupported push types, malformed requests, and upstream failures.

- **Documentation**
  - Documented the gated default-branch push workflow and current limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->