### PR TITLE
CI resilience: retry github-script 5xx, widen sync-test timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,9 +204,6 @@ jobs:
         if: success()
         uses: actions/github-script@v7
         with:
-          # Ride out transient GitHub API 5xx (503 brownouts have failed
-          # otherwise-green runs on nothing but the status comment).
-          retries: 3
           script: |
             const deploymentUrl = '${{ steps.deploy.outputs.url }}';
             const commitSha = context.sha.substring(0, 7);
@@ -231,8 +228,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           # Ride out transient GitHub API 5xx (503 brownouts have failed
-          # otherwise-green runs on nothing but the status comment).
+          # otherwise-green runs on nothing but the status comment). A retried
+          # POST can rarely duplicate a status comment — accepted trade-off vs.
+          # red runs. Every non-transient 4xx is exempt; 429 stays retryable.
           retries: 3
+          retry-exempt-status-codes: 400,401,402,403,404,405,406,407,409,410,411,412,413,414,415,416,417,418,421,422,423,424,426,428,431,451
           script: |
             await github.rest.issues.create({
               owner: context.repo.owner,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,9 @@ jobs:
         if: success()
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             const deploymentUrl = '${{ steps.deploy.outputs.url }}';
             const commitSha = context.sha.substring(0, 7);
@@ -227,6 +230,9 @@ jobs:
         if: failure()
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             await github.rest.issues.create({
               owner: context.repo.owner,

--- a/.github/workflows/d1-migrate.yml
+++ b/.github/workflows/d1-migrate.yml
@@ -59,6 +59,9 @@ jobs:
         if: failure()
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             await github.rest.issues.create({
               owner: context.repo.owner,

--- a/.github/workflows/d1-migrate.yml
+++ b/.github/workflows/d1-migrate.yml
@@ -60,8 +60,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           # Ride out transient GitHub API 5xx (503 brownouts have failed
-          # otherwise-green runs on nothing but the status comment).
+          # otherwise-green runs on nothing but the status comment). A retried
+          # POST can rarely duplicate a status comment — accepted trade-off vs.
+          # red runs. Every non-transient 4xx is exempt; 429 stays retryable.
           retries: 3
+          retry-exempt-status-codes: 400,401,402,403,404,405,406,407,409,410,411,412,413,414,415,416,417,418,421,422,423,424,426,428,431,451
           script: |
             await github.rest.issues.create({
               owner: context.repo.owner,

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -58,8 +58,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           # Ride out transient GitHub API 5xx (503 brownouts have failed
-          # otherwise-green runs on nothing but the status comment).
+          # otherwise-green runs on nothing but the status comment). A retried
+          # POST can rarely duplicate a status comment — accepted trade-off vs.
+          # red runs. Every non-transient 4xx is exempt; 429 stays retryable.
           retries: 3
+          retry-exempt-status-codes: 400,401,402,403,404,405,406,407,409,410,411,412,413,414,415,416,417,418,421,422,423,424,426,428,431,451
           script: |
             await github.rest.issues.create({
               owner: context.repo.owner,

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -57,6 +57,9 @@ jobs:
         if: failure()
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             await github.rest.issues.create({
               owner: context.repo.owner,

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -197,8 +197,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           # Ride out transient GitHub API 5xx (503 brownouts have failed
-          # otherwise-green runs on nothing but the status comment).
+          # otherwise-green runs on nothing but the status comment). A retried
+          # POST can rarely duplicate a status comment — accepted trade-off vs.
+          # red runs. Every non-transient 4xx is exempt; 429 stays retryable.
           retries: 3
+          retry-exempt-status-codes: 400,401,402,403,404,405,406,407,409,410,411,412,413,414,415,416,417,418,421,422,423,424,426,428,431,451
           script: |
             const stagingUrl = '${{ steps.deploy.outputs.url }}';
             const workflowRunUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
@@ -266,8 +269,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           # Ride out transient GitHub API 5xx (503 brownouts have failed
-          # otherwise-green runs on nothing but the status comment).
+          # otherwise-green runs on nothing but the status comment). A retried
+          # POST can rarely duplicate a status comment — accepted trade-off vs.
+          # red runs. Every non-transient 4xx is exempt; 429 stays retryable.
           retries: 3
+          retry-exempt-status-codes: 400,401,402,403,404,405,406,407,409,410,411,412,413,414,415,416,417,418,421,422,423,424,426,428,431,451
           script: |
             const workflowRunUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
             await github.rest.issues.createComment({
@@ -299,8 +305,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           # Ride out transient GitHub API 5xx (503 brownouts have failed
-          # otherwise-green runs on nothing but the status comment).
+          # otherwise-green runs on nothing but the status comment). A retried
+          # POST can rarely duplicate a status comment — accepted trade-off vs.
+          # red runs. Every non-transient 4xx is exempt; 429 stays retryable.
           retries: 3
+          retry-exempt-status-codes: 400,401,402,403,404,405,406,407,409,410,411,412,413,414,415,416,417,418,421,422,423,424,426,428,431,451
           script: |
             const jobs = {
               lint: '${{ needs.lint.result }}',

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -196,6 +196,9 @@ jobs:
         if: success()
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             const stagingUrl = '${{ steps.deploy.outputs.url }}';
             const workflowRunUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
@@ -262,6 +265,9 @@ jobs:
         if: failure()
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             const workflowRunUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
             await github.rest.issues.createComment({
@@ -292,6 +298,9 @@ jobs:
       - name: Update PR status
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             const jobs = {
               lint: '${{ needs.lint.result }}',

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -392,6 +395,9 @@ jobs:
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
+          # Ride out transient GitHub API 5xx (503 brownouts have failed
+          # otherwise-green runs on nothing but the status comment).
+          retries: 3
           script: |
             const previewUrl = '${{ steps.deploy.outputs.preview_url }}';
             const dbId = '${{ steps.db.outputs.db_id }}';

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -115,8 +115,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           # Ride out transient GitHub API 5xx (503 brownouts have failed
-          # otherwise-green runs on nothing but the status comment).
+          # otherwise-green runs on nothing but the status comment). A retried
+          # POST can rarely duplicate a status comment — accepted trade-off vs.
+          # red runs. Every non-transient 4xx is exempt; 429 stays retryable.
           retries: 3
+          retry-exempt-status-codes: 400,401,402,403,404,405,406,407,409,410,411,412,413,414,415,416,417,418,421,422,423,424,426,428,431,451
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -396,8 +399,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           # Ride out transient GitHub API 5xx (503 brownouts have failed
-          # otherwise-green runs on nothing but the status comment).
+          # otherwise-green runs on nothing but the status comment). A retried
+          # POST can rarely duplicate a status comment — accepted trade-off vs.
+          # red runs. Every non-transient 4xx is exempt; 429 stays retryable.
           retries: 3
+          retry-exempt-status-codes: 400,401,402,403,404,405,406,407,409,410,411,412,413,414,415,416,417,418,421,422,423,424,426,428,431,451
           script: |
             const previewUrl = '${{ steps.deploy.outputs.preview_url }}';
             const dbId = '${{ steps.db.outputs.db_id }}';

--- a/tests/integration/import-flow.test.ts
+++ b/tests/integration/import-flow.test.ts
@@ -557,7 +557,9 @@ describe("End-to-End Import Flow", () => {
   });
 
   describe("Sync Job Flow", () => {
-    it("should process a sync job successfully", async () => {
+    // Generous timeout: the full queue round-trip is fast locally but has
+    // blown the default 5s budget on contended CI runners.
+    it("should process a sync job successfully", { timeout: 20_000 }, async () => {
       const { importFromGitHub } = await import("../../src/storage/git-ops");
       vi.mocked(importFromGitHub).mockResolvedValue({
         success: true,

--- a/tests/integration/queue.test.ts
+++ b/tests/integration/queue.test.ts
@@ -474,7 +474,9 @@ describe("Queue Processing Integration Tests", () => {
   });
 
   describe("Sync Job Processing", () => {
-    it("should process a valid sync job", async () => {
+    // Generous timeout: the full queue round-trip is fast locally but has
+    // blown the default 5s budget on contended CI runners.
+    it("should process a valid sync job", { timeout: 20_000 }, async () => {
       const { importFromGitHub } = await import("../../src/storage/git-ops");
       vi.mocked(importFromGitHub).mockResolvedValue({
         success: true,


### PR DESCRIPTION
## Summary

Carved out of #173 (5/6). Two CI-stability fixes observed failing real runs today:

- **`github-script` retries**: multiple otherwise-green runs went red only because a comment/check-run POST hit a transient GitHub API 503 ("No server is currently available") — one even posted a spurious "Staging Deployment Failed" comment after the deploy had succeeded. All nine `github-script` steps across the five workflows now run with `retries: 3`; 4xx stay exempt so real permission/validation errors still fail fast.
- **Sync-test timeouts**: the two sync-job integration tests pass locally in ~150ms but blew the default 5s budget on contended CI runners; they get explicit generous timeouts.

Independent of the sibling PRs; any merge order (workflow hunks don't overlap the MCP PR's package-job additions).

## Related issues

None filed; part of the Origin-response campaign (see #173).

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

- [x] `npm run typecheck` (untouched by this diff)
- [x] `npm test` (the two integration suites re-run green on this branch)
- [x] `npm run lint` (workflows are outside biome scope)
- All five workflow files re-validated as parseable YAML

## Checklist

- [x] Tests added or updated for the change (timeout options only; coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (none needed)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (no UI changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiAwmc2tXjt6tHrGEpmnJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiAwmc2tXjt6tHrGEpmnJj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Improved deployment, preview, migration, and pull request workflow resilience by retrying transient API failures up to three times.
  * Non-transient client errors are excluded from retries, while rate-limit responses remain retryable.
  * Reduced the chance of missed deployment updates, notifications, and status comments.

* **Tests**
  * Increased integration test timeouts to 20 seconds for longer-running synchronization and queue operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->