### PR TITLE
Docs & GTM: OpenAPI spec, user guide, open signup, control-plane positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same pipeline as the REST route (now extracted to
   `src/services/change-flow.ts`); the client gets a truthful per-ref `ng`
   carrying the change id and eval verdict — main only moves through the merge
-  gate. On on staging, off in production until validated end-to-end.
+  gate. On staging, off in production until validated end-to-end.
 - `.stratum/policy.yaml` for this repository — the dogfood merge policy (diff
   limits, LLM review at 0.6, one human approval, fresh-base required,
   force-merge denied).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to restore it.
 
 ### Added
+- **Gated `git push` (ADR 005 slice 2b), staging-flagged.** With
+  `GIT_PUSH_GATED_ENABLED`, pushing to a project's default branch lands the pack
+  on a server-managed workspace fork and opens an eval-gated change through the
+  same pipeline as the REST route (now extracted to
+  `src/services/change-flow.ts`); the client gets a truthful per-ref `ng`
+  carrying the change id and eval verdict — main only moves through the merge
+  gate. On on staging, off in production until validated end-to-end.
+- `.stratum/policy.yaml` for this repository — the dogfood merge policy (diff
+  limits, LLM review at 0.6, one human approval, fresh-base required,
+  force-merge denied).
+- Split/unified diff toggle on the change review page — instant, pure-CSS switch
+  (no client-side JavaScript, no reload; GitHub/GitLab need a full reload).
+- `git push` to a project URL now fails **in-protocol**: the receive-pack
+  advertisement is served, and each ref update is answered with a legible `ng`
+  report-status plus sideband guidance pointing at workspace remotes — instead of
+  an opaque HTTP 403. The pkt-line/report-status machinery
+  (`src/utils/git-protocol.ts`) is the groundwork for the gated default-branch
+  push (ADR 005 slice 2b, #115).
+- Complete OpenAPI 3.1 specification (`docs/api/openapi.yml`): 72 paths / 91
+  operations generated from the route code, replacing the 4-path stub.
+- Real user documentation: a full getting-started walkthrough and a 15-question
+  FAQ (`docs/user-guide/`).
+- `@stratum/mcp` (`mcp/`): MCP server exposing the full eval-gated change flow —
+  projects, workspaces, commits, changes, reviews, merges, and issues — so any
+  MCP-capable agent or editor (Claude Code, Cursor, Zed, Copilot, custom agents)
+  can work against Stratum without a bespoke integration.
+- Secret scanner now covers 25+ credential patterns (GitHub fine-grained PATs, GitLab,
+  Slack, Stripe, OpenAI, Anthropic, Google, npm, PyPI, Hugging Face, SendGrid, Twilio,
+  Azure, private-key blocks, JWTs, connection-string credentials) plus Shannon-entropy
+  detection for generic high-entropy credentials in keyword context.
+- LLM evaluator: review window is configurable via `maxDiffChars` in the policy
+  (default raised 8k → 24k chars, capped at 100k); truncated evaluations say so in
+  their result issues; the evaluator now sends a real reviewer system prompt.
+
 - Open-source onboarding: `LICENSE` (MIT), `CONTRIBUTING.md`, `SECURITY.md`, `AGENTS.md`,
   issue and pull-request templates.
 - Enforced test-coverage thresholds in `vitest.config.ts`.
 - High-frequency agent commits via the Durable-Object SQLite hot index (ADR 004).
+
+### Changed
+
+- **Production signup is open.** The closed-beta invite gate is off in the
+  production config (`BETA_GATE = "0"`); staging keeps it on so the invite path
+  stays exercised. Takes effect on the next production deploy.
+- **LLM evaluator fails closed.** An unparseable model response now scores 0 and blocks,
+  instead of inferring a 0.8 score from "LGTM" prose. Non-finite scores (JSON
+  `1e999`) fail closed rather than clamping to a pass, and `maxDiffChars` is
+  floored/bounded to [1000, 100k] so a tiny or fractional window can never send
+  the model an empty diff.
+- README repositioned around the control plane: Stratum is the governance layer
+  for AI-written code on top of wherever code lives, usable from any agent or
+  editor.
+- CLI and MCP clients reject project references with extra path segments instead
+  of silently truncating; the MCP client enforces a request deadline (default
+  120s) so a stalled API can't hang a tool call forever.
 
 ## [0.1.0] - 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,21 @@ below use `https://your-instance.workers.dev` as a placeholder for your deployme
 
 ## What is Stratum?
 
-Stratum is a GitHub alternative where both humans and AI agents are first-class citizens. It provides:
+Stratum is the **governance layer for AI-written code** — the control plane that decides
+what agent output is allowed to merge, wherever your code lives. Humans and AI agents are
+both first-class citizens, with different powers by design:
 
-- **Git repository hosting** via Cloudflare Artifacts (fast, serverless Git)
-- **Workspace forking** - Create isolated branches for changes
-- **Evaluation-gated merges** - Automated code review before merging
-- **Agent identities** - Register and authenticate AI agents
-- **Provenance tracking** - Know which AI model made what change
-- **Read-only web UI** - Browse repos, changes, and evaluation results
+- **Evaluation-gated merges** - Policy-as-code (`.stratum/policy.yaml`) blocks merges on
+  secret scans, diff rules, sandboxed tests, external CI, and LLM review
+- **Provenance & cost tracking** - Every merged commit records which agent, model, and
+  prompt produced it, its evaluation score, and what it cost (LLM tokens, sandbox time)
+- **Agent identities with a hard invariant** - Agents authenticate as themselves and can
+  never approve work; approvals are a human gate
+- **Any agent, any editor** - REST API, CLI, and MCP server: Claude Code, Cursor, Copilot,
+  or your own agents all speak to the same gate. No editor subscription required
+- **Two ways to run it** - As a **layer over GitHub** (keep your repos and PRs; eval
+  verdicts land as PR comments and commit statuses) or as a **standalone forge** (Git
+  hosting on Cloudflare Artifacts, workspace forking, issues, orgs, server-rendered UI)
 
 ## Features
 
@@ -54,6 +61,7 @@ Stratum is a GitHub alternative where both humans and AI agents are first-class 
 | Issue Tracker | ✅ | Per-project issues, auto-close on linked-change merge |
 | Bidirectional GitHub Sync | ✅ | Inbound webhooks + outbound PR promotion |
 | CLI Tool | 🚧 | `@stratum/cli` at full API parity; install from `cli/` (not yet published to npm) |
+| MCP Server | 🚧 | `@stratum/mcp` — any MCP-capable agent or editor can drive the eval-gated change flow; install from `mcp/` (not yet published to npm) |
 
 **Legend:** ✅ Working | 🚧 In Progress | 📋 Planned
 
@@ -335,7 +343,7 @@ See [Deployment Guide](docs/developer/deployment.md) for detailed instructions.
 
 - **Authorization**: Project-level access control is minimal; auth middleware resolves users but doesn't enforce ownership on all routes
 - **Merge semantics**: Squash merge only; true merge commits not yet supported
-- **Diff accuracy**: Current diff format shows full file rewrites rather than precise hunks
+- **Diff limits**: Diffs are hunk-level with unified and split views, but binary files are not diffed and very large files are rendered whole
 - **Scale**: Git operations run in-memory; large repos will hit Worker limits
 
 See [CURRENT_CAPABILITIES.md](docs/CURRENT_CAPABILITIES.md) for more details.

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.
 Key areas needing work:
 
 1. **Authorization**: Enforce project-level access control
-2. **Diff accuracy**: Produce real unified diffs instead of full-file comparisons
+2. **Diff depth**: Per-line intra-hunk highlighting and binary-file diffs (hunk-level unified/split views ship already)
 3. **Merge semantics**: Handle conflicts properly, support true merges
 4. **Scale**: Move git operations off the Worker to Containers or a backend service
 

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -1,56 +1,239 @@
 openapi: 3.1.0
 info:
   title: Stratum API
-  description: A code collaboration platform for the AI engineering era
+  description: |
+    A code collaboration platform for the AI engineering era.
+
+    This specification is generated from the route code (`src/index.ts` and
+    `src/routes/*.ts`) and covers every `/api/*` route, the root health check,
+    and the GitHub webhook receiver.
+
+    Not covered here:
+    - HTML page routes (`/`, `/p/*`, `/changes/*`, `/auth/*`, `/dev-login`, `/ui.css`, ...).
+    - The git smart-HTTP endpoints (`/@{namespace}/{slug}/info/refs`,
+      `git-upload-pack`, `git-receive-pack`) — documented separately in
+      `docs/adr/005`.
+
+    Authentication: most endpoints accept a Stratum API token (user or agent)
+    as a `Authorization: Bearer <token>` header. Browser requests may instead be
+    authenticated by the `stratum_session` cookie. Read endpoints on projects
+    with `visibility: public` also accept anonymous requests. Admin endpoints
+    additionally accept an `X-Admin-API-Key` header.
+
+    Several form-friendly endpoints return a `302` redirect instead of JSON when
+    the request body is form-encoded rather than `application/json`; this spec
+    documents the JSON behaviour.
   version: 1.0.0
 
 servers:
   - url: https://your-instance.workers.dev
     description: Production
 
+security:
+  - bearerAuth: []
+
+tags:
+  - name: health
+    description: Liveness and dependency health checks
+  - name: projects
+    description: Project creation, metadata, files, and history
+  - name: imports
+    description: Importing repositories from GitHub/GitLab/Bitbucket
+  - name: sync
+    description: Keeping imported projects in sync with their source repository
+  - name: workspaces
+    description: Workspace (fork) lifecycle and commits
+  - name: changes
+    description: Changes (evaluated merge proposals) and merge operations
+  - name: reviews
+    description: Human review verdicts and comments on changes
+  - name: issues
+    description: Project issues
+  - name: webhooks
+    description: Outbound project webhooks
+  - name: orgs
+    description: Organizations, members, and teams
+  - name: users
+    description: The authenticated user's account
+  - name: agents
+    description: Agent registration and tokens
+  - name: bulk-import
+    description: Importing many repositories at once
+  - name: github
+    description: Inbound GitHub webhook receiver
+  - name: admin
+    description: Administrator-only operations (metrics, audit, backup, restore, deletion jobs)
+
 paths:
   /health:
     get:
-      summary: Health check
+      operationId: rootHealth
+      tags: [health]
+      summary: Basic health check
+      security: []
       responses:
-        '200':
-          description: OK
+        "200":
+          description: Service is up
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: ok }
+                  service: { type: string, example: stratum }
+
+  /api/health:
+    get:
+      operationId: healthCheck
+      tags: [health]
+      summary: Comprehensive health check of all system dependencies
+      security: []
+      responses:
+        "200":
+          description: Healthy or degraded (queue-only failure)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthCheckResponse"
+        "503":
+          description: Unhealthy — a critical dependency (database, KV, artifacts) failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthCheckResponse"
+
+  /api/health/simple:
+    get:
+      operationId: healthSimple
+      tags: [health]
+      summary: Simple liveness check
+      security: []
+      responses:
+        "200":
+          description: Service is up
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: ok }
+                  service: { type: string, example: stratum }
+                  timestamp: { type: string, format: date-time }
 
   /api/projects:
-    get:
-      summary: List projects
-      responses:
-        '200':
-          description: List of projects
     post:
-      summary: Create project
+      operationId: createProject
+      tags: [projects]
+      summary: Create a project
+      description: |
+        Creates a project (and its backing Artifacts git repo) in the caller's
+        namespace, or in an organization's namespace when `org` is given (the
+        caller needs org write access). Also accepts form-encoded bodies.
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
+              required: [name]
               properties:
                 name:
                   type: string
+                  description: 1-64 char alphanumeric slug
+                visibility:
+                  type: string
+                  enum: [private, public]
+                  default: private
+                files:
+                  type: object
+                  additionalProperties: { type: string }
+                  description: Initial file map (path -> contents). Defaults to a single `.gitkeep`, or starter files when `seed` is true.
+                seed:
+                  type: boolean
+                  description: Seed the repo with default starter files
+                org:
+                  type: string
+                  description: Organization slug to own the project
       responses:
-        '201':
+        "201":
           description: Project created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, name, namespace, slug]
+                properties:
+                  id: { type: string, format: uuid }
+                  name: { type: string }
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  remote: { type: string }
+                  commit:
+                    type: string
+                    description: SHA of the initial commit
+                  visibility: { type: string, enum: [private, public] }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Organization not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listProjects
+      tags: [projects]
+      summary: List projects in the caller's namespace
+      description: Returns an empty list for unauthenticated callers. Results are filtered to projects the caller can read.
+      responses:
+        "200":
+          description: Projects the caller can read
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [projects]
+                properties:
+                  projects:
+                    type: array
+                    items: { $ref: "#/components/schemas/Project" }
+        "500":
+          $ref: "#/components/responses/InternalError"
 
   /api/projects/{namespace}/{slug}:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: getProject
+      tags: [projects]
+      summary: Get a project
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Project details
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Project" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
     delete:
+      operationId: deleteProject
+      tags: [projects]
       summary: Delete project (owner-only, cascading, async)
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: slug
-          in: path
-          required: true
-          schema:
-            type: string
+      description: |
+        Owner-only. Requires a confirm token that EXACTLY equals
+        `@namespace/slug`. Enqueues a durable deletion job; a repeated request
+        while a cascade is in flight returns the same in-flight job.
+        Non-owners receive a 404 (existence is not disclosed).
       requestBody:
         required: true
         content:
@@ -63,28 +246,1952 @@ paths:
                   type: string
                   description: Must exactly equal "@namespace/slug".
       responses:
-        '202':
+        "202":
           description: Deletion enqueued
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/DeletionAccepted" }
+        "400":
+          description: Confirmation mismatch
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Not found or not the owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/delete:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: deleteProjectForm
+      tags: [projects]
+      summary: Delete project (form-friendly alias of DELETE)
+      description: Same semantics as `DELETE /api/projects/{namespace}/{slug}` for HTML forms that cannot send DELETE.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [confirm]
+              properties:
+                confirm: { type: string }
+      responses:
+        "202":
+          description: Deletion enqueued (JSON callers)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/DeletionAccepted" }
+        "302":
+          description: Redirect to home (form callers)
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/projects/{namespace}/{slug}/import:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: importProject
+      tags: [imports]
+      summary: Import a repository from GitHub/GitLab/Bitbucket
+      description: |
+        Creates the project and queues a background import. Rate limited
+        (3 imports/minute per user, 1 concurrent import per project). Imports
+        are only allowed into the caller's own namespace. If the project
+        already exists with an incomplete import, the import is re-triggered
+        and a 200 is returned.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [url]
+              properties:
+                url:
+                  type: string
+                  description: Repository URL (GitHub, GitLab, or Bitbucket)
+                branch:
+                  type: string
+                  default: main
+                depth:
+                  type: integer
+                  description: Clone depth
+                visibility:
+                  type: string
+                  enum: [private, public]
+                  default: private
+      responses:
+        "201":
+          description: Import queued
           content:
             application/json:
               schema:
                 type: object
-                required: [status, jobId]
                 properties:
-                  status:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  importId: { type: string }
+                  path: { type: string }
+                  status: { type: string, example: queued }
+                  source: { type: string }
+                  visibility: { type: string, enum: [private, public] }
+        "200":
+          description: Project already exists (incomplete imports are re-triggered)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  remote: { type: string }
+                  source: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          description: Import rate limit exceeded
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/import/status:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: getImportStatus
+      tags: [imports]
+      summary: Get import progress (for polling)
+      description: Also detects and recovers imports stalled for more than 5 minutes.
+      responses:
+        "200":
+          description: Import progress
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ImportProgress" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/import/stream:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: streamImportStatus
+      tags: [imports]
+      summary: Import progress as Server-Sent Events
+      description: Emits an `ImportProgress` JSON object as an SSE `data:` line every 2 seconds until the import completes, fails, or is cancelled.
+      responses:
+        "200":
+          description: SSE stream of import progress
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/projects/{namespace}/{slug}/import/retry:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: retryImport
+      tags: [imports]
+      summary: Retry a failed import
+      description: Rate limited like the initial import. Only allowed in the caller's own namespace.
+      responses:
+        "200":
+          description: Retry initiated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+                  namespace: { type: string }
+                  slug: { type: string }
+                  status: { type: string, example: queued }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/import/cancel:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: cancelImport
+      tags: [imports]
+      summary: Cancel an ongoing import
+      responses:
+        "200":
+          description: Cancellation requested or completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+                  namespace: { type: string }
+                  slug: { type: string }
+                  status: { type: string, enum: [cancelled, cancelling] }
+        "400":
+          description: Import is not in a cancellable state
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/files:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: listProjectFiles
+      tags: [projects]
+      summary: List files in the project repository
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: File listing
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  files:
+                    type: array
+                    items: { type: string }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/content:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: getFileContent
+      tags: [projects]
+      summary: Get file content by path
+      security: [{ bearerAuth: [] }, {}]
+      parameters:
+        - name: path
+          in: query
+          required: true
+          schema: { type: string }
+          description: File path within the repository
+      responses:
+        "200":
+          description: File content, or a marker for binary/oversized files
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [namespace, slug, path, kind]
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  kind:
                     type: string
-                    example: deleting
-                  jobId:
+                    description: '"content" when `value` carries the text; other kinds (e.g. binary/too-large) omit `value`.'
+                  value:
                     type: string
-                    example: del_abc123
-        '400':
-          description: Confirmation mismatch
-        '404':
-          description: Not found or not the owner
+                    description: Present only when kind is "content"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/log:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: getCommitLog
+      tags: [projects]
+      summary: Get the project's commit log
+      security: [{ bearerAuth: [] }, {}]
+      parameters:
+        - name: depth
+          in: query
+          schema: { type: integer, default: 20 }
+          description: Number of commits to return
+      responses:
+        "200":
+          description: Commit log
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  log:
+                    type: array
+                    items: { $ref: "#/components/schemas/CommitLogEntry" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/provenance:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: listProvenance
+      tags: [projects]
+      summary: List provenance records (which agent/model produced each merged commit)
+      security: [{ bearerAuth: [] }, {}]
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer }
+      responses:
+        "200":
+          description: Provenance records
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  records:
+                    type: array
+                    items: { $ref: "#/components/schemas/ProvenanceRecord" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/activity:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: listActivity
+      tags: [projects]
+      summary: Project activity feed (domain events)
+      security: [{ bearerAuth: [] }, {}]
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer, default: 50, maximum: 200 }
+      responses:
+        "200":
+          description: Activity events, newest first
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  events:
+                    type: array
+                    items: { $ref: "#/components/schemas/ActivityEvent" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/sync:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: syncProject
+      tags: [sync]
+      summary: Re-sync the project with its source repository
+      description: |
+        Checks the source remote (GitHub/GitLab/Bitbucket) for new commits and,
+        when updates exist, queues a background sync. Only allowed in the
+        caller's own namespace.
+      responses:
+        "200":
+          description: Sync initiated, or already up to date
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+                  namespace: { type: string }
+                  slug: { type: string }
+                  importId: { type: string }
+                  status: { type: string, example: queued }
+                  hasUpdates: { type: boolean }
+                  commitsBehind: { type: integer }
+                  latestCommit: { type: string }
+                  lastSyncedCommit: { type: string }
+        "400":
+          description: Not connected to a remote, unsupported provider, or a sync is already in progress
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/sync/status:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: getSyncStatus
+      tags: [sync]
+      summary: Get sync status for a project
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Sync status
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SyncStatus" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/sync/settings:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: updateSyncSettings
+      tags: [sync]
+      summary: Update sync settings (auto-sync, frequency)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                autoSyncEnabled: { type: boolean }
+                syncFrequency:
+                  type: integer
+                  description: Minutes between auto-syncs
+      responses:
+        "200":
+          description: Settings saved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
+                  autoSyncEnabled: { type: boolean }
+                  syncFrequency: { type: integer }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/sync/history:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: getSyncHistory
+      tags: [sync]
+      summary: Get sync history for a project
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer, default: 50 }
+        - name: offset
+          in: query
+          schema: { type: integer, default: 0 }
+      responses:
+        "200":
+          description: Sync history entries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  history:
+                    type: array
+                    items:
+                      type: object
+                      description: Recorded sync run (trigger, status, synced commit, timings)
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/projects/{namespace}/{slug}/sync/stream:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: streamSyncStatus
+      tags: [sync]
+      summary: Sync status as Server-Sent Events
+      description: Emits the sync-status object every 2 seconds until the sync succeeds or fails; the stream self-closes after 5 minutes.
+      responses:
+        "200":
+          description: SSE stream of sync status
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/projects/conflicts/{id}/resolve:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+        description: Conflict id returned by a merge that failed with MERGE_CONFLICT
+    post:
+      operationId: resolveConflict
+      tags: [sync, changes]
+      summary: Resolve a recorded merge conflict
+      description: |
+        Applies a resolution strategy to a conflict previously recorded by a
+        failed merge and commits the result to the project. Requires project
+        write access.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [strategy]
+              properties:
+                strategy:
+                  type: string
+                  enum: [accept-project, accept-workspace, manual]
+                resolutions:
+                  type: array
+                  description: Required for the manual strategy
+                  items:
+                    type: object
+                    required: [file, content]
+                    properties:
+                      file: { type: string }
+                      content: { type: string }
+      responses:
+        "200":
+          description: Conflict resolved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: resolved }
+                  commitSha: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "410":
+          description: Conflict not found or already resolved
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "422":
+          description: Resolution failed to apply (or invalid file path)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "502":
+          description: Failed to mint repository tokens
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/projects/{namespace}/{slug}/webhooks:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: createWebhook
+      tags: [webhooks]
+      summary: Create an outbound webhook
+      description: |
+        Requires project write access. The webhook `secret` is returned only on
+        creation; receivers verify the `X-Stratum-Signature` header with it.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [url]
+              properties:
+                url: { type: string, format: uri }
+                events:
+                  type: string
+                  description: |
+                    "*" (default) or a comma-separated subset of:
+                    change.created, change.evaluated, change.merged,
+                    change.rejected, change.reverted, change.commented,
+                    change.reviewed, project.created, project.imported,
+                    workspace.created, sync.completed, issue.opened, issue.closed
+      responses:
+        "201":
+          description: Webhook created (includes the secret, shown once)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  webhook: { $ref: "#/components/schemas/Webhook" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listWebhooks
+      tags: [webhooks]
+      summary: List webhooks (secrets omitted)
+      description: Requires project write access — webhook URLs are sensitive.
+      responses:
+        "200":
+          description: Webhooks without secrets
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  webhooks:
+                    type: array
+                    items: { $ref: "#/components/schemas/Webhook" }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/webhooks/{id}:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    delete:
+      operationId: deleteWebhook
+      tags: [webhooks]
+      summary: Delete a webhook
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+                  id: { type: string }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/webhooks/{id}/deliveries:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      operationId: listWebhookDeliveries
+      tags: [webhooks]
+      summary: List recent webhook deliveries
+      responses:
+        "200":
+          description: Delivery log
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deliveries:
+                    type: array
+                    items: { $ref: "#/components/schemas/WebhookDelivery" }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/webhooks/{id}/toggle:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      operationId: toggleWebhook
+      tags: [webhooks]
+      summary: Enable or disable a webhook (flips the current state)
+      responses:
+        "200":
+          description: New state
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  active: { type: boolean }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/webhooks/{id}/delete:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      operationId: deleteWebhookForm
+      tags: [webhooks]
+      summary: Delete a webhook (form-friendly alias)
+      responses:
+        "302":
+          description: Redirect back to the project's webhooks page
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/projects/{namespace}/{slug}/issues:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: createIssue
+      tags: [issues]
+      summary: Open an issue
+      description: Anyone who can read the project can open issues. Also accepts form bodies (which redirect on success).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title]
+              properties:
+                title: { type: string, maxLength: 200 }
+                body: { type: string, maxLength: 20000 }
+                linkedChangeId:
+                  type: string
+                  description: Must reference a change in this project
+      responses:
+        "201":
+          description: Issue created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  issue: { $ref: "#/components/schemas/Issue" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/TargetDeleting"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listIssues
+      tags: [issues]
+      summary: List issues
+      security: [{ bearerAuth: [] }, {}]
+      parameters:
+        - name: status
+          in: query
+          schema: { type: string, enum: [open, closed] }
+        - name: limit
+          in: query
+          schema: { type: integer, default: 100, maximum: 500 }
+      responses:
+        "200":
+          description: Issues
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  issues:
+                    type: array
+                    items: { $ref: "#/components/schemas/Issue" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/issues/{number}:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: number
+        in: path
+        required: true
+        schema: { type: integer, minimum: 1 }
+    get:
+      operationId: getIssue
+      tags: [issues]
+      summary: Issue detail
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Issue
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  issue: { $ref: "#/components/schemas/Issue" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    patch:
+      operationId: updateIssue
+      tags: [issues]
+      summary: Edit, close, or reopen an issue
+      description: Requires project write access. Users only (agent tokens cannot edit issues).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title: { type: string, maxLength: 200 }
+                body: { type: string, maxLength: 20000 }
+                status: { type: string, enum: [open, closed] }
+                linkedChangeId:
+                  type: [string, "null"]
+                  description: Set to null or "" to unlink
+      responses:
+        "200":
+          description: Updated issue
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  issue: { $ref: "#/components/schemas/Issue" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/issues/{number}/close:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: number
+        in: path
+        required: true
+        schema: { type: integer, minimum: 1 }
+    post:
+      operationId: toggleIssueClosed
+      tags: [issues]
+      summary: Toggle an issue open/closed (form-friendly)
+      description: Flips the issue's status and redirects to the issue page.
+      responses:
+        "302":
+          description: Redirect to the issue page
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/projects/{name}/changes:
+    parameters:
+      - $ref: "#/components/parameters/ProjectName"
+    post:
+      operationId: createChange
+      tags: [changes]
+      summary: Create a change from a workspace and evaluate it
+      description: |
+        Diffs the workspace against the project, runs the project's evaluator
+        policy (secret scan always; diff/webhook/llm/sandbox per policy), records
+        eval runs, and sets the change status to `accepted` or `needs_changes`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [workspace]
+              properties:
+                workspace: { type: string }
+      responses:
+        "201":
+          description: Change created and evaluated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  change: { $ref: "#/components/schemas/Change" }
+                  eval: { $ref: "#/components/schemas/EvalResult" }
+                  evalRuns:
+                    type: array
+                    items: { $ref: "#/components/schemas/EvalRun" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/TargetDeleting"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listChanges
+      tags: [changes]
+      summary: List changes for a project
+      security: [{ bearerAuth: [] }, {}]
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [open, needs_changes, accepted, approved, promoted, merged, rejected]
+        - name: limit
+          in: query
+          schema: { type: integer, default: 100, maximum: 500 }
+      responses:
+        "200":
+          description: Changes
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  project: { type: string }
+                  changes:
+                    type: array
+                    items: { $ref: "#/components/schemas/Change" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/projects/{name}/changes/merge-batch:
+    parameters:
+      - $ref: "#/components/parameters/ProjectName"
+    post:
+      operationId: mergeBatch
+      tags: [changes]
+      summary: Merge many changes into the project in one request
+      description: |
+        Batched server-side merge (ADR 004): resolves and policy-gates every
+        change, then merges the eligible ones onto the project head with a
+        single push. At most 80 changes per request. Requires the RepoDO
+        backend to be enabled. `force` is deny-by-default and must be allowed
+        by the project policy (`merge.allowForce: true`).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [changeIds]
+              properties:
+                changeIds:
+                  type: array
+                  maxItems: 80
+                  items: { type: string }
+                force: { type: boolean, default: false }
+      responses:
+        "200":
+          description: Batch outcome
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  merged:
+                    type: array
+                    items: { type: string }
+                  conflicted:
+                    type: array
+                    items: { type: string }
+                  skipped:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        changeId: { type: string }
+                        reason: { type: string }
+                  timings:
+                    type: object
+                    properties:
+                      resolveMs: { type: number }
+                      batchMs: { type: number }
+                      persistMs: { type: number }
+                      serverMs: { type: number }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/changes/{id}:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    get:
+      operationId: getChange
+      tags: [changes]
+      summary: Get a change with its eval runs and cost summary
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Change detail
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  change: { $ref: "#/components/schemas/Change" }
+                  evalRuns:
+                    type: array
+                    items: { $ref: "#/components/schemas/EvalRun" }
+                  costs:
+                    type: array
+                    items:
+                      type: object
+                      description: Per-kind cost summary for this change
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/changes/{id}/merge:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    post:
+      operationId: mergeChange
+      tags: [changes]
+      summary: Merge a change into its project
+      description: |
+        Users only. The change must be approved, accepted, or promoted (unless
+        forcing, which the project policy must allow). Branch protection,
+        stale-base (`requireFreshBase`), and stale-workspace (SEC-2) gates run
+        before the merge.
+      parameters:
+        - name: force
+          in: query
+          schema: { type: boolean, default: false }
+          description: Bypass evaluation/approval gates. Only allowed when the project policy sets `merge.allowForce`.
+        - name: strategy
+          in: query
+          schema: { type: string, enum: [merge, squash], default: merge }
+      responses:
+        "200":
+          description: Merged
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  merged: { type: boolean }
+                  changeId: { type: string }
+                  project: { type: string }
+                  workspace: { type: string }
+                  commit: { type: string }
+                  postMerge:
+                    type: object
+                    description: Post-merge policy check outcome
+                    properties:
+                      status: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Project access denied, or merge blocked by branch protection (code PROTECTION_BLOCKED with `reasons`)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Error"
+                  - type: object
+                    properties:
+                      reasons:
+                        type: array
+                        items: { type: string }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: |
+            Structured conflict responses; `code` is one of STALE_BASE,
+            STALE_WORKSPACE, WORKSPACE_UNVERIFIABLE, or MERGE_CONFLICT (which
+            includes `conflictId` and `conflictingFiles` for
+            `POST /api/projects/conflicts/{id}/resolve`).
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Error"
+                  - type: object
+                    properties:
+                      baseSha: { type: string }
+                      currentHead: { type: string }
+                      evaluatedSha: { type: string }
+                      currentTip: { type: string }
+                      conflictId: { type: string }
+                      conflictingFiles:
+                        type: array
+                        items: { type: string }
+                      message: { type: string }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/changes/{id}/reject:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    post:
+      operationId: rejectChange
+      tags: [changes]
+      summary: Reject a change
+      description: Users only. Merged changes cannot be rejected.
+      responses:
+        "200":
+          description: Rejected
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  rejected: { type: boolean }
+                  changeId: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/changes/{id}/evaluate:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    post:
+      operationId: evaluateChange
+      tags: [changes]
+      summary: Re-run evaluation for a change
+      description: Users only. Merged, rejected, or promoted changes cannot be re-evaluated.
+      responses:
+        "200":
+          description: Evaluation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  changeId: { type: string }
+                  eval: { $ref: "#/components/schemas/EvalResult" }
+                  evalRuns:
+                    type: array
+                    items: { $ref: "#/components/schemas/EvalRun" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/changes/{id}/github-pr:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    post:
+      operationId: promoteChangeToGitHubPr
+      tags: [changes]
+      summary: Promote an accepted change to a GitHub pull request
+      description: |
+        Users only. The change must be accepted (or already promoted) and the
+        project connected to GitHub with a configured GitHub token. Creates a
+        (draft by default) PR from branch `stratum/{changeId}` and marks the
+        change `promoted`.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title: { type: string }
+                body: { type: string }
+                base: { type: string, description: "Defaults to the project's default branch" }
+                draft: { type: boolean, default: true }
+      responses:
+        "200":
+          description: PR created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  changeId: { type: string }
+                  github:
+                    type: object
+                    properties:
+                      owner: { type: string }
+                      repo: { type: string }
+                      branch: { type: string }
+                      pullRequestNumber: { type: integer }
+                      pullRequestUrl: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/changes/{id}/comments:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    post:
+      operationId: addChangeComment
+      tags: [reviews]
+      summary: Add a comment to a change
+      description: Users and agents with read access to the project may comment.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [body]
+              properties:
+                body: { type: string, maxLength: 20000 }
+      responses:
+        "201":
+          description: Comment created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  comment: { $ref: "#/components/schemas/ChangeComment" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listChangeComments
+      tags: [reviews]
+      summary: List comments on a change
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Comments
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  comments:
+                    type: array
+                    items: { $ref: "#/components/schemas/ChangeComment" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/changes/{id}/reviews:
+    parameters:
+      - $ref: "#/components/parameters/ChangeId"
+    post:
+      operationId: submitReview
+      tags: [reviews]
+      summary: Submit a human review verdict
+      description: |
+        Users only — agent tokens cannot approve work. An `approve` verdict
+        moves the change to `approved`; `request_changes` moves it to
+        `needs_changes`. Only open, needs_changes, accepted, or approved
+        changes can be reviewed.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [verdict]
+              properties:
+                verdict:
+                  type: string
+                  enum: [approve, request_changes]
+                comment: { type: string, maxLength: 20000 }
+      responses:
+        "201":
+          description: Review recorded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  review: { $ref: "#/components/schemas/Review" }
+                  changeStatus:
+                    type: string
+                    enum: [approved, needs_changes]
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/TargetDeleting"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listReviews
+      tags: [reviews]
+      summary: List reviews on a change
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Reviews
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reviews:
+                    type: array
+                    items: { $ref: "#/components/schemas/Review" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/workspaces/{namespace}/{slug}/workspaces:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    post:
+      operationId: createWorkspace
+      tags: [workspaces]
+      summary: Create a workspace (fork) for a project
+      description: Requires project write access. Omitting `name` generates one (`ws-<timestamp>`).
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: 1-64 char alphanumeric slug
+      responses:
+        "201":
+          description: Workspace created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  workspace: { type: string }
+                  remote: { type: string }
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/TargetDeleting"
+    get:
+      operationId: listWorkspaces
+      tags: [workspaces]
+      summary: List workspaces for a project
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Workspaces
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  workspaces:
+                    type: array
+                    items: { $ref: "#/components/schemas/Workspace" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/workspaces/{name}/commit:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema: { type: string }
+        description: Workspace name (scoped by projectId in the body)
+    post:
+      operationId: commitToWorkspace
+      tags: [workspaces]
+      summary: Commit files to a workspace
+      description: |
+        Writes the given file map onto the workspace fork as one commit. Bounded
+        to 2000 files / 25 MiB per commit. Requires project write access AND
+        workspace write access (creator or admin); failures return 404 to avoid
+        leaking existence.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [files, message, projectId]
+              properties:
+                files:
+                  type: object
+                  additionalProperties: { type: string }
+                  description: Path -> contents map
+                message: { type: string }
+                projectId: { type: string, format: uuid }
+      responses:
+        "200":
+          description: Commit pushed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  workspace: { type: string }
+                  commit: { type: string, description: Commit SHA }
+                  filesChanged:
+                    type: array
+                    items: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/workspaces/{name}/merge:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      operationId: mergeWorkspaceDeprecated
+      tags: [workspaces]
+      summary: Deprecated workspace merge endpoint
+      deprecated: true
+      responses:
+        "410":
+          description: 'Gone — use POST /api/projects/{name}/changes instead'
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/workspaces/{name}:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema: { type: string }
+    delete:
+      operationId: deleteWorkspace
+      tags: [workspaces]
+      summary: Delete a workspace
+      description: Requires project write access AND workspace write access (creator or admin). Also deletes the backing Artifacts fork.
+      parameters:
+        - name: projectId
+          in: query
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+                  workspace: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/orgs:
+    post:
+      operationId: createOrg
+      tags: [orgs]
+      summary: Create an organization
+      description: The creator becomes an org admin. The slug must not collide with an existing username.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, slug]
+              properties:
+                name: { type: string }
+                slug: { type: string, description: 1-64 char alphanumeric slug }
+      responses:
+        "201":
+          description: Organization created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  org: { $ref: "#/components/schemas/Org" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listOrgs
+      tags: [orgs]
+      summary: List organizations the caller belongs to
+      responses:
+        "200":
+          description: Organizations
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  orgs:
+                    type: array
+                    items: { $ref: "#/components/schemas/Org" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/orgs/{slug}:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+    get:
+      operationId: getOrg
+      tags: [orgs]
+      summary: Get an organization (members only)
+      description: Non-members receive the same 404 as a missing org.
+      responses:
+        "200":
+          description: Organization
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  org: { $ref: "#/components/schemas/Org" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/orgs/{slug}/members:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+    post:
+      operationId: addOrgMember
+      tags: [orgs]
+      summary: Add an organization member (admins only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId]
+              properties:
+                userId: { type: string }
+                role:
+                  type: string
+                  enum: [member, admin]
+                  default: member
+      responses:
+        "200":
+          description: Member added
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  added: { type: boolean }
+                  orgId: { type: string }
+                  userId: { type: string }
+                  role: { type: string, enum: [member, admin] }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/orgs/{slug}/members/{uid}:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+      - name: uid
+        in: path
+        required: true
+        schema: { type: string }
+        description: User id of the member to remove
+    delete:
+      operationId: removeOrgMember
+      tags: [orgs]
+      summary: Remove an organization member (admins only)
+      responses:
+        "200":
+          description: Member removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  removed: { type: boolean }
+                  orgId: { type: string }
+                  userId: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/orgs/{slug}/teams:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+    post:
+      operationId: createTeam
+      tags: [orgs]
+      summary: Create a team (admins only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, slug]
+              properties:
+                name: { type: string }
+                slug: { type: string }
+                permissions:
+                  type: string
+                  enum: [read, write, admin]
+                  default: read
+      responses:
+        "201":
+          description: Team created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  team: { $ref: "#/components/schemas/Team" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listTeams
+      tags: [orgs]
+      summary: List teams (members only)
+      responses:
+        "200":
+          description: Teams
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  teams:
+                    type: array
+                    items: { $ref: "#/components/schemas/Team" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/orgs/{slug}/teams/{id}:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    delete:
+      operationId: deleteTeam
+      tags: [orgs]
+      summary: Delete a team (admins only)
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+                  id: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/orgs/{slug}/teams/{id}/members:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      operationId: addTeamMember
+      tags: [orgs]
+      summary: Add a team member (admins only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId]
+              properties:
+                userId: { type: string }
+      responses:
+        "200":
+          description: Member added
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  added: { type: boolean }
+                  teamId: { type: string }
+                  userId: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/orgs/{slug}/teams/{id}/members/{uid}:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+      - name: uid
+        in: path
+        required: true
+        schema: { type: string }
+    delete:
+      operationId: removeTeamMember
+      tags: [orgs]
+      summary: Remove a team member (admins only)
+      responses:
+        "200":
+          description: Member removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  removed: { type: boolean }
+                  teamId: { type: string }
+                  userId: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
 
   /api/users/me:
+    get:
+      operationId: getMe
+      tags: [users]
+      summary: Get the authenticated user
+      responses:
+        "200":
+          description: Current user
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  email: { type: string, format: email }
+                  createdAt: { type: string, format: date-time }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
     delete:
+      operationId: deleteAccount
+      tags: [users]
       summary: Delete account (GDPR erasure, self-only, async)
+      description: |
+        Requires a confirm token equal to the caller's username. Marks the
+        account as deleting (credentials are invalidated immediately) and
+        enqueues the erasure cascade job.
       requestBody:
         required: true
         content:
@@ -97,21 +2204,1284 @@ paths:
                   type: string
                   description: Must exactly equal the caller's username.
       responses:
-        '202':
+        "202":
           description: Erasure enqueued (jobId returned); credentials invalidated immediately
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/DeletionAccepted" }
+        "400":
+          description: Confirmation mismatch
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated, or the user no longer exists
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/users/me/rotate-token:
+    post:
+      operationId: rotateToken
+      tags: [users]
+      summary: Rotate the caller's API token
+      description: The old token is invalid as of this response; the new one is shown once.
+      responses:
+        "200":
+          description: New API token
           content:
             application/json:
               schema:
                 type: object
-                required: [status, jobId]
+                required: [token]
                 properties:
-                  status:
+                  token: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/users/me/delete:
+    post:
+      operationId: deleteAccountForm
+      tags: [users]
+      summary: Delete account (form-friendly alias of DELETE /api/users/me)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [confirm]
+              properties:
+                confirm: { type: string }
+      responses:
+        "202":
+          description: Erasure enqueued (JSON callers)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/DeletionAccepted" }
+        "302":
+          description: Redirect to home (form callers)
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/users/check-username:
+    get:
+      operationId: checkUsername
+      tags: [users]
+      summary: Check whether a username is available
+      security: []
+      parameters:
+        - name: username
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Availability result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available: { type: boolean }
+                  message: { type: string }
+        "400":
+          description: Missing or invalid username (same body shape, available=false)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available: { type: boolean }
+                  message: { type: string }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/agents:
+    post:
+      operationId: createAgent
+      tags: [agents]
+      summary: Register an agent and mint its token
+      description: The agent token is returned once, on creation.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+                model: { type: string }
+                description: { type: string }
+                promptHash: { type: string }
+      responses:
+        "201":
+          description: Agent created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent: { $ref: "#/components/schemas/Agent" }
+                  token:
                     type: string
-                    example: deleting
-                  jobId:
-                    type: string
-                    example: del_abc123
-        '400':
-          description: Confirmation mismatch
-        '401':
-          description: Not authenticated, or the user no longer exists
+                    description: Plaintext agent token, shown once
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listAgents
+      tags: [agents]
+      summary: List the caller's agents
+      responses:
+        "200":
+          description: Agents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agents:
+                    type: array
+                    items: { $ref: "#/components/schemas/Agent" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/agents/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      operationId: getAgent
+      tags: [agents]
+      summary: Get an agent (owner only)
+      description: Non-owners receive a 404 (existence is not disclosed).
+      responses:
+        "200":
+          description: Agent
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Agent" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    delete:
+      operationId: deleteAgent
+      tags: [agents]
+      summary: Delete (revoke) an agent
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+                  id: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/bulk-import:
+    post:
+      operationId: startBulkImport
+      tags: [bulk-import]
+      summary: Start a bulk import job (up to 50 repositories)
+      description: Imports run in the background; poll `GET /api/bulk-import/{id}` for status. Only the caller's own namespace is allowed.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [repos]
+              properties:
+                repos:
+                  type: array
+                  minItems: 1
+                  maxItems: 50
+                  items:
+                    type: object
+                    required: [url]
+                    properties:
+                      url: { type: string }
+                      namespace: { type: string }
+                      slug: { type: string }
+                      branch: { type: string }
+                      visibility:
+                        type: string
+                        enum: [private, public]
+      responses:
+        "201":
+          description: Job started
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId: { type: string }
+                  status: { type: string, example: queued }
+                  totalRepos: { type: integer }
+                  message: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    get:
+      operationId: listBulkImportJobs
+      tags: [bulk-import]
+      summary: List the caller's bulk import jobs
+      responses:
+        "200":
+          description: Jobs, newest first
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobs:
+                    type: array
+                    items: { $ref: "#/components/schemas/BulkImportJobSummary" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/bulk-import/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      operationId: getBulkImportJob
+      tags: [bulk-import]
+      summary: Get bulk import job status
+      responses:
+        "200":
+          description: Job status with progress
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/BulkImportJobStatus" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/webhooks/github:
+    post:
+      operationId: receiveGitHubWebhook
+      tags: [github]
+      summary: GitHub webhook receiver
+      description: |
+        Inbound receiver for GitHub `push`, `pull_request`,
+        `pull_request_review`, and `ping` events. Authenticated by HMAC
+        signature (`X-Hub-Signature-256`) against the configured webhook
+        secret, not by bearer token. Requires `X-GitHub-Event` and
+        `X-GitHub-Delivery` headers; duplicate delivery ids are skipped.
+        Processing errors still return 200 to prevent GitHub retries.
+      security: []
+      parameters:
+        - name: X-Hub-Signature-256
+          in: header
+          required: true
+          schema: { type: string }
+        - name: X-GitHub-Event
+          in: header
+          required: true
+          schema: { type: string }
+        - name: X-GitHub-Delivery
+          in: header
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Raw GitHub webhook payload for the event type
+      responses:
+        "200":
+          description: Received (possibly a duplicate, or with a logged processing error)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  received: { type: boolean }
+                  duplicate: { type: boolean }
+                  error: { type: string }
+        "400":
+          description: Missing headers or invalid JSON
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Invalid signature
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "501":
+          description: Webhook secret not configured
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/admin/metrics:
+    get:
+      operationId: adminMetrics
+      tags: [admin]
+      summary: Import and commit/merge metrics dashboard
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Metrics summary (totals, rates, performance, time windows, queue status, error breakdown)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  timestamp: { type: string, format: date-time }
+                  commits: { type: object }
+                  totals: { type: object }
+                  rates: { type: object }
+                  performance: { type: object }
+                  timeWindows: { type: object }
+                  queue: { type: object }
+                  errors: { type: object }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/metrics/health:
+    get:
+      operationId: adminMetricsHealth
+      tags: [admin]
+      summary: Quick admin health check with key metrics
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Key metrics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+                  timestamp: { type: string, format: date-time }
+                  recentFailures24h: { type: integer }
+                  activeImports: { type: integer }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/metrics/bench:
+    post:
+      operationId: adminBenchCommit
+      tags: [admin]
+      summary: Commit-throughput probe (ADR 004 Phase 2)
+      description: Writes one R2 git blob and drives a group-commit ref advance through the RepoDO. Intended for benchmark scripts.
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      parameters:
+        - name: repo
+          in: query
+          schema: { type: string, default: bench-repo }
+        - name: path
+          in: query
+          schema: { type: string, default: shared.txt }
+        - name: bytes
+          in: query
+          schema: { type: integer, default: 256, minimum: 1, maximum: 100000 }
+      responses:
+        "200":
+          description: Blob written and ref advanced
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  blob: { type: string, description: Blob oid }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/metrics/bench-stats:
+    get:
+      operationId: adminBenchStats
+      tags: [admin]
+      summary: Read the bench Durable Object's counters
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      parameters:
+        - name: repo
+          in: query
+          schema: { type: string, default: bench-repo }
+      responses:
+        "200":
+          description: Bench counters
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  head: { type: string }
+                  batches: { type: integer }
+                  landed: { type: integer }
+                  conflictsResolved: { type: integer }
+                  treeSize: { type: integer }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/metrics/artifacts-bench:
+    post:
+      operationId: adminArtifactsBench
+      tags: [admin]
+      summary: Measure Artifacts single-repo push throughput
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      parameters:
+        - name: iterations
+          in: query
+          schema: { type: integer, default: 20, minimum: 1, maximum: 200 }
+        - name: batch
+          in: query
+          schema: { type: integer, default: 1, minimum: 1, maximum: 256 }
+        - name: bytes
+          in: query
+          schema: { type: integer, default: 256, minimum: 1, maximum: 100000 }
+      responses:
+        "200":
+          description: Push latency percentiles and effective commits/sec
+          content:
+            application/json:
+              schema: { type: object }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/metrics/realflow-bench:
+    post:
+      operationId: adminRealflowBench
+      tags: [admin]
+      summary: Batched-merge real-flow benchmark (ADR 004 Task 1)
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      parameters:
+        - name: n
+          in: query
+          schema: { type: integer, default: 25, minimum: 1, maximum: 50 }
+      responses:
+        "200":
+          description: Fetch/merge/push timing breakdown
+          content:
+            application/json:
+              schema: { type: object }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/metrics/r2flow-bench:
+    post:
+      operationId: adminR2flowBench
+      tags: [admin]
+      summary: R2-fed merge-flow benchmark (ADR 004 Task 1c)
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      parameters:
+        - name: n
+          in: query
+          schema: { type: integer, default: 25, minimum: 1, maximum: 50 }
+      responses:
+        "200":
+          description: Clone/load/merge/push timing breakdown
+          content:
+            application/json:
+              schema: { type: object }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/audit:
+    get:
+      operationId: adminAudit
+      tags: [admin]
+      summary: Query the audit trail
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      parameters:
+        - name: action
+          in: query
+          schema: { type: string }
+          description: Filter by audit action (e.g. merge.forced, token.rotated)
+        - name: actor
+          in: query
+          schema: { type: string }
+          description: Filter by actor id
+        - name: limit
+          in: query
+          schema: { type: integer }
+      responses:
+        "200":
+          description: Audit entries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  entries:
+                    type: array
+                    items: { $ref: "#/components/schemas/AuditEntry" }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/backup:
+    get:
+      operationId: adminListBackups
+      tags: [admin]
+      summary: List backup runs (newest first)
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Backup runs, each flagged complete/incomplete
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runs:
+                    type: array
+                    items: { type: object }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      operationId: adminRunBackup
+      tags: [admin]
+      summary: Trigger a backup run now (single-flight)
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Backup summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary: { type: object }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A backup run is already in progress
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/restore/{runTs}/plan:
+    parameters:
+      - name: runTs
+        in: path
+        required: true
+        schema: { type: string }
+        description: Backup run timestamp identifier
+    get:
+      operationId: adminRestorePlan
+      tags: [admin]
+      summary: Dry-run restorability check for a backup run
+      description: Reads and decrypts every blob in the run and verifies it against the manifest. Read-only.
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Restore plan
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  plan: { type: object }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/deletion-jobs/{id}/redrive:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      operationId: adminRedriveDeletionJob
+      tags: [admin]
+      summary: Re-drive an incomplete deletion job
+      description: Resets the attempt budget and drives the job once; idempotent.
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Job re-driven
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  job: { $ref: "#/components/schemas/DeletionJob" }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Deletion job is not in the incomplete state (code NOT_REDRIVABLE)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/admin/backfill-project-id/plan:
+    get:
+      operationId: adminBackfillPlan
+      tags: [admin]
+      summary: Dry-run plan for backfilling legacy project_id columns
+      description: Reports how much legacy (NULL project_id) data exists per table and which project names are safe to backfill. Read-only.
+      security:
+        - bearerAuth: []
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Backfill plan
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  plan: { type: object }
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: Stratum API token (user token or agent token)
+    adminApiKey:
+      type: apiKey
+      in: header
+      name: X-Admin-API-Key
+      description: Admin API key for administrator endpoints
+
+  parameters:
+    Namespace:
+      name: namespace
+      in: path
+      required: true
+      schema: { type: string }
+      description: Project namespace, including the @ prefix (e.g. "@alice")
+    Slug:
+      name: slug
+      in: path
+      required: true
+      schema: { type: string }
+      description: Project slug
+    ProjectName:
+      name: name
+      in: path
+      required: true
+      schema: { type: string }
+      description: Project name (single segment, not namespace/slug)
+    OrgSlug:
+      name: slug
+      in: path
+      required: true
+      schema: { type: string }
+      description: Organization slug
+    ChangeId:
+      name: id
+      in: path
+      required: true
+      schema: { type: string }
+      description: Change id
+
+  responses:
+    BadRequest:
+      description: Invalid request
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    Unauthorized:
+      description: Authentication required
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    Forbidden:
+      description: Access denied
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    NotFound:
+      description: Resource not found (also returned for access denied, to avoid disclosing existence)
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    TargetDeleting:
+      description: The project (or its owner) is being deleted (code TARGET_DELETING)
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    InternalError:
+      description: Internal server error
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+
+  schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+          description: Human-readable error message
+        code:
+          type: string
+          description: >
+            Machine-readable code present on some errors (e.g. TARGET_DELETING,
+            STALE_BASE, STALE_WORKSPACE, WORKSPACE_UNVERIFIABLE, MERGE_CONFLICT,
+            PROTECTION_BLOCKED, NOT_REDRIVABLE, GONE, INVALID_PATH)
+
+    Project:
+      type: object
+      required: [id, name, namespace, slug]
+      properties:
+        id: { type: string, format: uuid }
+        name: { type: string }
+        namespace:
+          type: string
+          description: '"@username" or "@org-slug"'
+        slug: { type: string }
+        path:
+          type: string
+          description: "/{namespace}/{slug}"
+        remote:
+          type: string
+          description: Backing Artifacts git remote URL
+        createdAt: { type: string, format: date-time }
+        visibility:
+          type: string
+          enum: [private, public]
+        githubUrl: { type: string }
+        githubOwner: { type: string }
+        githubRepo: { type: string }
+        githubDefaultBranch: { type: string }
+        githubConnectionStatus:
+          type: string
+          enum: [connected, disconnected]
+
+    Workspace:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        createdAt: { type: string, format: date-time }
+        path:
+          type: string
+          description: "/{namespace}/{slug}/workspaces/{name}"
+        remote:
+          type: string
+          description: Workspace fork remote (returned on creation)
+
+    Change:
+      type: object
+      required: [id, project, workspace, status, createdAt]
+      properties:
+        id: { type: string }
+        project:
+          type: string
+          description: Project name (or project id for changes created via the GitHub bridge)
+        projectId:
+          type: string
+          format: uuid
+          description: Globally-unique project id; absent on legacy rows
+        workspace: { type: string }
+        status:
+          type: string
+          enum: [open, needs_changes, accepted, approved, promoted, merged, rejected, reverted]
+        agentId: { type: string }
+        evalScore: { type: number }
+        evalPassed: { type: boolean }
+        evalReason: { type: string }
+        baseSha:
+          type: string
+          description: Project HEAD at change creation — the base the evaluation ran against
+        evaluatedSha:
+          type: string
+          description: Workspace tip the evaluation ran against; merges reject if it moved
+        evaluatedTreeOid: { type: string }
+        agentModel:
+          type: string
+          description: Authoring agent's model, snapshotted at change creation
+        agentPromptHash: { type: string }
+        workspaceHeadSha: { type: string }
+        createdAt: { type: string, format: date-time }
+        mergedAt: { type: string, format: date-time }
+        githubOwner: { type: string }
+        githubRepo: { type: string }
+        githubBranch: { type: string }
+        githubPrNumber: { type: integer }
+        githubPrUrl: { type: string }
+        githubPrState: { type: string }
+        githubHeadSha: { type: string }
+        promotedAt: { type: string, format: date-time }
+        promotedBy: { type: string }
+
+    EvalResult:
+      type: object
+      required: [score, passed, reason]
+      properties:
+        score: { type: number }
+        passed: { type: boolean }
+        reason: { type: string }
+        issues:
+          type: array
+          items: { type: string }
+
+    EvalRun:
+      type: object
+      required: [id, changeId, evaluatorType, score, passed, reason, ranAt]
+      properties:
+        id: { type: string }
+        changeId: { type: string }
+        evaluatorType:
+          type: string
+          description: e.g. secret_scan, diff, webhook, llm, sandbox
+        score: { type: number }
+        passed: { type: boolean }
+        reason: { type: string }
+        issues:
+          type: array
+          items: { type: string }
+        ranAt: { type: string, format: date-time }
+
+    Issue:
+      type: object
+      required: [id, project, number, title, status, authorType, authorId, createdAt, updatedAt]
+      properties:
+        id: { type: string }
+        project: { type: string }
+        projectId: { type: string, format: uuid }
+        number: { type: integer }
+        title: { type: string }
+        body: { type: string }
+        status:
+          type: string
+          enum: [open, closed]
+        authorType:
+          type: string
+          enum: [user, agent]
+        authorId: { type: string }
+        linkedChangeId: { type: string }
+        closedAt: { type: string, format: date-time }
+        closedBy: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    Review:
+      type: object
+      required: [id, changeId, reviewerId, verdict, createdAt]
+      properties:
+        id: { type: string }
+        changeId: { type: string }
+        reviewerId: { type: string }
+        verdict:
+          type: string
+          enum: [approve, request_changes]
+        comment: { type: string }
+        createdAt: { type: string, format: date-time }
+
+    ChangeComment:
+      type: object
+      required: [id, changeId, authorType, authorId, body, createdAt]
+      properties:
+        id: { type: string }
+        changeId: { type: string }
+        authorType:
+          type: string
+          enum: [user, agent]
+        authorId: { type: string }
+        body: { type: string }
+        createdAt: { type: string, format: date-time }
+
+    ActivityEvent:
+      type: object
+      required: [id, type, actorType, payload, createdAt]
+      properties:
+        id: { type: string }
+        type:
+          type: string
+          description: Domain event type (e.g. change.created, change.merged, issue.opened)
+        actorType:
+          type: string
+          enum: [user, agent, system]
+        actorId: { type: string }
+        payload:
+          type: object
+          additionalProperties: true
+        createdAt: { type: string, format: date-time }
+
+    Webhook:
+      type: object
+      required: [id, project, url, events, active, createdBy, createdAt]
+      properties:
+        id: { type: string }
+        project: { type: string }
+        projectId: { type: string, format: uuid }
+        url: { type: string, format: uri }
+        secret:
+          type: string
+          description: Returned only on creation; omitted from list responses
+        events:
+          type: string
+          description: Comma-separated event types, or "*" for all
+        active: { type: boolean }
+        createdBy: { type: string }
+        createdAt: { type: string, format: date-time }
+
+    WebhookDelivery:
+      type: object
+      required: [id, webhookId, eventId, eventType, status, createdAt]
+      properties:
+        id: { type: string }
+        webhookId: { type: string }
+        eventId: { type: string }
+        eventType: { type: string }
+        status:
+          type: string
+          enum: [success, failed]
+        statusCode: { type: integer }
+        error: { type: string }
+        durationMs: { type: number }
+        createdAt: { type: string, format: date-time }
+
+    CommitLogEntry:
+      type: object
+      required: [sha, message, author, timestamp]
+      properties:
+        sha: { type: string }
+        message: { type: string }
+        author: { type: string }
+        timestamp:
+          type: number
+          description: Unix timestamp
+
+    ProvenanceRecord:
+      type: object
+      required: [id, commitSha, project, workspace, changeId, mergedAt]
+      properties:
+        id: { type: string }
+        commitSha: { type: string }
+        project: { type: string }
+        projectId: { type: string, format: uuid }
+        workspace: { type: string }
+        changeId: { type: string }
+        agentId: { type: string }
+        evalScore: { type: number }
+        model:
+          type: string
+          description: Model that authored the change, snapshotted at change creation
+        promptHash: { type: string }
+        mergedAt: { type: string, format: date-time }
+
+    ImportProgress:
+      type: object
+      required: [id, projectId, namespace, slug, status, sourceUrl, branch, startedAt, updatedAt, version, progress, errors, logs]
+      properties:
+        id: { type: string }
+        projectId: { type: string, format: uuid }
+        namespace: { type: string }
+        slug: { type: string }
+        status:
+          type: string
+          enum: [queued, cloning, processing, completed, failed, cancelled, cancelling, syncing, checking]
+        sourceUrl: { type: string }
+        branch: { type: string }
+        startedAt: { type: string, format: date-time }
+        completedAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+        version:
+          type: integer
+          description: Optimistic-locking version, incremented on each update
+        progress:
+          type: object
+          properties:
+            totalFiles: { type: integer }
+            processedFiles: { type: integer }
+            currentFile: { type: string }
+            bytesTransferred: { type: integer }
+            totalBytes: { type: integer }
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              file: { type: string }
+              error: { type: string }
+              timestamp: { type: string }
+        logs:
+          type: array
+          items:
+            type: object
+            properties:
+              message: { type: string }
+              level:
+                type: string
+                enum: [info, warn, error]
+              timestamp: { type: string }
+
+    SyncStatus:
+      type: object
+      properties:
+        namespace: { type: string }
+        slug: { type: string }
+        sourceUrl: { type: string }
+        provider:
+          type: string
+          enum: [github, gitlab, bitbucket]
+        lastSyncedAt: { type: string, format: date-time }
+        lastSyncedCommit: { type: string }
+        lastSyncStatus:
+          type: string
+          enum: [success, failed, in_progress, idle]
+        lastSyncError: { type: string }
+        autoSyncEnabled: { type: boolean }
+        hasUpdates: { type: boolean }
+        commitsBehind: { type: integer }
+        latestCommit: { type: string }
+        lastCheckedAt: { type: string, format: date-time }
+        importProgress:
+          type: object
+          description: Present when a sync/import is active
+          properties:
+            status: { type: string }
+            progress: { type: object }
+            logs:
+              type: array
+              items: { type: object }
+            errors:
+              type: array
+              items: { type: object }
+
+    Org:
+      type: object
+      required: [id, name, slug, ownerId, createdAt]
+      properties:
+        id: { type: string }
+        name: { type: string }
+        slug: { type: string }
+        ownerId: { type: string }
+        createdAt: { type: string, format: date-time }
+
+    Team:
+      type: object
+      required: [id, orgId, name, slug, permissions, createdAt]
+      properties:
+        id: { type: string }
+        orgId: { type: string }
+        name: { type: string }
+        slug: { type: string }
+        permissions:
+          type: string
+          enum: [read, write, admin]
+        createdAt: { type: string, format: date-time }
+
+    Agent:
+      type: object
+      required: [id, name, ownerId, createdAt]
+      properties:
+        id: { type: string }
+        name: { type: string }
+        ownerId: { type: string }
+        model: { type: string }
+        description: { type: string }
+        promptHash: { type: string }
+        createdAt: { type: string, format: date-time }
+
+    AuditEntry:
+      type: object
+      required: [id, action, actorType, detail, createdAt]
+      properties:
+        id: { type: string }
+        action:
+          type: string
+          description: e.g. token.rotated, agent.created, merge.forced, deletion.requested
+        actorType:
+          type: string
+          enum: [user, agent, system]
+        actorId: { type: string }
+        subject: { type: string }
+        detail:
+          type: object
+          additionalProperties: true
+        createdAt: { type: string, format: date-time }
+
+    DeletionAccepted:
+      type: object
+      required: [status, jobId]
+      properties:
+        status:
+          type: string
+          example: deleting
+        jobId:
+          type: string
+          example: del_abc123
+
+    DeletionJob:
+      type: object
+      required: [id, kind, state, attempts, createdAt]
+      properties:
+        id: { type: string }
+        kind:
+          type: string
+          enum: [project, account]
+        target:
+          type: string
+          description: Raw JSON of the captured deletion target
+        state:
+          type: string
+          enum: [pending, running, verifying, completed, incomplete]
+        checkpoint: { type: [string, "null"] }
+        heartbeatAt: { type: [string, "null"] }
+        leaseOwner: { type: [string, "null"] }
+        leaseExpiresAt: { type: [string, "null"] }
+        residuals:
+          type: array
+          items: { type: string }
+        attempts: { type: integer }
+        createdAt: { type: string, format: date-time }
+        startedAt: { type: [string, "null"] }
+        finishedAt: { type: [string, "null"] }
+
+    BulkImportJobSummary:
+      type: object
+      properties:
+        jobId: { type: string }
+        status:
+          type: string
+          enum: [queued, processing, completed, failed, partial]
+        totalRepos: { type: integer }
+        processedRepos: { type: integer }
+        successfulRepos: { type: integer }
+        failedRepos: { type: integer }
+        createdAt: { type: string, format: date-time }
+        completedAt: { type: string, format: date-time }
+        hasErrors: { type: boolean }
+
+    BulkImportJobStatus:
+      type: object
+      properties:
+        jobId: { type: string }
+        status:
+          type: string
+          enum: [queued, processing, completed, failed, partial]
+        totalRepos: { type: integer }
+        processedRepos: { type: integer }
+        successfulRepos: { type: integer }
+        failedRepos: { type: integer }
+        createdAt: { type: string, format: date-time }
+        completedAt: { type: string, format: date-time }
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              repo: { type: string }
+              error: { type: string }
+        progress:
+          type: object
+          properties:
+            percentage: { type: integer }
+            current: { type: integer }
+            total: { type: integer }
+
+    HealthCheckResult:
+      type: object
+      required: [status, latency]
+      properties:
+        status:
+          type: string
+          enum: [ok, error, degraded]
+        latency:
+          type: string
+          example: 12ms
+        message: { type: string }
+
+    HealthCheckResponse:
+      type: object
+      required: [status, timestamp, checks]
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy]
+        timestamp: { type: string, format: date-time }
+        checks:
+          type: object
+          required: [database, kv, queue, artifacts]
+          properties:
+            database: { $ref: "#/components/schemas/HealthCheckResult" }
+            kv: { $ref: "#/components/schemas/HealthCheckResult" }
+            queue: { $ref: "#/components/schemas/HealthCheckResult" }
+            artifacts: { $ref: "#/components/schemas/HealthCheckResult" }

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -93,15 +93,15 @@ planned but not built.
 
 Honestly, several:
 
-- **Diff accuracy**: diffs are currently shown as full-file rewrites rather than
-  precise hunks. This affects both the diff viewer and what evaluators see; real
-  unified diffs are pending.
+- **Diff limits**: diffs are hunk-level with unified and side-by-side views,
+  but binary files are not diffed and very large files are rendered whole.
 - **Scale**: git operations run in-memory inside a Worker, so very large
   repositories will hit Worker limits. Moving git ops off the Worker is on the
   roadmap.
 - **Squash-only merges**: true merge commits are not yet supported.
-- **Push to project remotes is not supported yet** (`403`) — push to workspace
-  remotes and open a change. Gated project-push is designed but deferred.
+- **Push to project remotes doesn't move `main` directly** — the push is
+  rejected in-protocol with the reason (and, where gated push is enabled, opens
+  an eval-gated change instead). Push to workspace remotes for direct writes.
 - **Authorization** is still minimal in places; project-level access control is
   not enforced on every route.
 - **Evaluation runs synchronously** at change creation — there's no async
@@ -111,10 +111,12 @@ See `docs/CURRENT_CAPABILITIES.md` for the authoritative, current state.
 
 ## Can I use plain `git` with Stratum?
 
-Yes, over smart HTTP with your API key as the HTTP Basic password:
-`git clone https://x:<key>@<host>/@ns/slug.git` for projects (read), and
+Yes, over smart HTTP with your API key as the HTTP Basic password (enter it at
+the prompt or store it with a git credential helper — don't embed it in the
+URL): `git clone https://<host>/@ns/slug.git` for projects (read), and
 `.../@ns/slug/workspaces/<name>.git` for workspaces (read **and** `git push`).
-Pushing to the project URL is refused so the evaluation gate can't be bypassed.
+A push to the project URL is rejected in-protocol so the evaluation gate can't
+be bypassed.
 SSH transport is not supported (Workers have no raw TCP listener).
 
 ## What do I need to self-host?

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -2,16 +2,155 @@
 
 ## What is Stratum?
 
-A code collaboration platform for AI engineering.
+A code collaboration platform where humans and AI agents are both first-class
+citizens. It hosts git repositories (on Cloudflare Artifacts), and every
+proposed change — whether a human or an agent wrote it — passes through
+policy-defined evaluation gates before it can merge. Merged changes carry
+provenance (which agent, which model, which prompt) and cost records.
 
-## Do I need GitHub?
+## How is this different from GitHub branch protection and required checks?
 
-No, Stratum works independently with email authentication.
+GitHub branch protection gates on external check *statuses*; Stratum runs the
+evaluation itself, treats agents as first-class identities, and enforces
+invariants GitHub doesn't have:
 
-## Is it free?
+- **A secret scan is always on and always blocking** — not a configurable check
+  someone can remove.
+- **Approvals are human-only by construction.** An agent token cannot approve
+  any change on any surface (API, CLI, MCP). On GitHub, a bot with the right
+  permissions can approve and merge.
+- **Staleness is enforced against what was evaluated**: a merge is rejected if
+  the workspace advanced after evaluation (`409 STALE_WORKSPACE`), so you can
+  never merge commits the evaluators didn't see. `requireFreshBase` additionally
+  rejects merges when the base moved (`409 STALE_BASE`).
+- **Force-merge is deny-by-default** — the override only exists if the policy
+  explicitly sets `merge.allowForce: true`.
+- **Post-merge smoke with auto-revert**: a configured command runs against the
+  merged HEAD, and a failure automatically lands a forward revert commit.
+- **Provenance and cost are recorded per merged change** — model, prompt hash,
+  eval score, LLM tokens, sandbox time.
+- A malformed `.stratum/policy.yaml` **fails closed** (blocks merges) instead of
+  silently falling back to defaults.
 
-Yes, you pay only for Cloudflare resources used.
+## Do I have to leave GitHub to use it?
+
+No. Stratum supports two modes with the same codebase. In **layer mode**,
+Stratum sits between your agents and GitHub: import the repo, enable
+bidirectional sync (inbound webhooks, outbound PR promotion), and agent work
+goes through Stratum's gates while your team keeps reviewing GitHub PRs —
+evaluation results are posted to the PR as comments and commit statuses. In
+**alternative mode**, Stratum is the source of truth and GitHub isn't involved
+at all. You choose the level of buy-in, and you can start with layer mode.
+
+## Do I need a GitHub account at all?
+
+No. Email magic-link authentication is the recommended sign-in and has no
+external dependencies. GitHub OAuth (needed for GitHub sync) and Google OAuth
+are alternatives; all resolve to the same email-based identity.
+
+## What happens when an evaluation fails?
+
+The change is created anyway, with each evaluator's verdict, findings, and score
+recorded as evidence you can inspect (`stratum change show <id>` or the UI). What
+a failure blocks is the **merge**: any evaluator type listed in
+`merge.requiredEvaluators` must have a passing latest run. To recover, push new
+commits to the workspace — re-evaluation runs against the new state — or, if
+your policy allows it (`allowForce: true`, off by default), force-merge past it.
+The reference agent exits with code `2` in this case so CI wrappers can
+distinguish "agent produced rejected work" from operational errors.
+
+## Can agents approve or merge their own code?
+
+Agents can never **approve** — reviews are human-only, everywhere, with no
+configuration that relaxes it. Whether an agent can trigger a *merge* is up to
+your policy: with `merge.requiredApprovals: 1` or more, at least one human must
+approve first, so an agent can never land work no human has seen. If you set no
+required approvals and its required evaluators pass, a merge call with an agent
+token will go through — so set `requiredApprovals` on anything you care about.
+
+## What does provenance actually record?
+
+Per merged change: the author identity (human or agent), the model and a hash of
+the prompt snapshotted at change creation, and the evaluation score, per merged
+commit. Full per-evaluator evidence (scores, findings, durations) is linked by
+change. The schema also has room for model config, reasoning traces, and tool
+calls where the client supplies them. Agents authenticate with their own
+short-lived tokens (scoped to an owning user), so work is attributed to the
+agent, not laundered through a human account.
+
+## What does it cost, and what is metered?
+
+The software is MIT-licensed and free; self-hosted, you pay only for the
+Cloudflare resources you use (Workers, Artifacts, D1, KV, Queues, plus AI
+Gateway and Sandboxes if you enable those evaluators). Stratum meters estimated
+resource usage per change — LLM tokens, sandbox execution milliseconds, and git
+operations — and shows it alongside the evaluation evidence, so you can see what
+each (agent) change cost you. The hosted instance has open signup and is free
+while billing and multi-tenancy for a managed offering ("Stratum Cloud") are
+planned but not built.
+
+## What are the current limitations?
+
+Honestly, several:
+
+- **Diff accuracy**: diffs are currently shown as full-file rewrites rather than
+  precise hunks. This affects both the diff viewer and what evaluators see; real
+  unified diffs are pending.
+- **Scale**: git operations run in-memory inside a Worker, so very large
+  repositories will hit Worker limits. Moving git ops off the Worker is on the
+  roadmap.
+- **Squash-only merges**: true merge commits are not yet supported.
+- **Push to project remotes is not supported yet** (`403`) — push to workspace
+  remotes and open a change. Gated project-push is designed but deferred.
+- **Authorization** is still minimal in places; project-level access control is
+  not enforced on every route.
+- **Evaluation runs synchronously** at change creation — there's no async
+  evaluation queue yet, so very slow evaluators stretch the request.
+
+See `docs/CURRENT_CAPABILITIES.md` for the authoritative, current state.
+
+## Can I use plain `git` with Stratum?
+
+Yes, over smart HTTP with your API key as the HTTP Basic password:
+`git clone https://x:<key>@<host>/@ns/slug.git` for projects (read), and
+`.../@ns/slug/workspaces/<name>.git` for workspaces (read **and** `git push`).
+Pushing to the project URL is refused so the evaluation gate can't be bypassed.
+SSH transport is not supported (Workers have no raw TCP listener).
+
+## What do I need to self-host?
+
+Node.js 20+ and your own Cloudflare account with Workers, **Artifacts (which is
+in beta — you need access to it)**, D1, KV, and Queues. Optional: AI Gateway for
+the LLM evaluator, Sandboxes for the sandbox evaluator (without the binding that
+evaluator fails closed), R2 for backups, and Cloudflare Email for magic links.
+The README Quick Start covers secrets, migrations, and deployment; keep
+production and staging in separate Artifacts namespaces.
+
+## How do backups work?
+
+D1 (changes, issues, events, costs, audit) and KV identity data back up to R2
+daily and on demand, along with the reachable history of a rotating slice of
+repositories — coverage rotates across runs under a per-run cap, so every repo
+is covered over time rather than every run. There is a tested restore path,
+documented in `docs/runbooks/backup-restore.md`.
+
+## Can I turn off telemetry?
+
+Yes. Analytics (PostHog) is optional — it only runs if you set a
+`POSTHOG_API_KEY`, and self-hosted instances can set
+`STRATUM_TELEMETRY_DISABLED = "true"` in `wrangler.toml` to switch it off
+entirely.
+
+## What if my policy file has a mistake in it?
+
+A present-but-malformed `.stratum/policy.yaml` fails closed: the merge gate
+blocks until the file parses, rather than silently running on defaults. This is
+deliberate — a typo in a stricter policy can't quietly downgrade governance.
+Fix the YAML and re-evaluate.
 
 ## How do I get help?
 
-Open an issue on GitHub or check the documentation.
+Open an issue on the GitHub repository, or start with the
+[getting started guide](getting-started.md),
+[troubleshooting](troubleshooting.md), and the API reference in
+`docs/api/openapi.yml`.

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -103,7 +103,10 @@ Honestly, several:
   rejected in-protocol with the reason (and, where gated push is enabled, opens
   an eval-gated change instead). Push to workspace remotes for direct writes.
 - **Authorization** is still minimal in places; project-level access control is
-  not enforced on every route.
+  not enforced on every route. One deliberate GitHub-parity choice worth
+  knowing: any authenticated user can **open** an issue on a public project
+  (rate-limited), while editing or closing issues requires project write
+  access.
 - **Evaluation runs synchronously** at change creation — there's no async
   evaluation queue yet, so very slow evaluators stretch the request.
 
@@ -130,11 +133,13 @@ production and staging in separate Artifacts namespaces.
 
 ## How do backups work?
 
-D1 (changes, issues, events, costs, audit) and KV identity data back up to R2
-daily and on demand, along with the reachable history of a rotating slice of
-repositories — coverage rotates across runs under a per-run cap, so every repo
-is covered over time rather than every run. There is a tested restore path,
-documented in `docs/runbooks/backup-restore.md`.
+Backups require the **optional R2 bucket binding** — without it the scheduled
+backup logs a warning and skips the run, so configure R2 if you want backups.
+With R2 configured, D1 (changes, issues, events, costs, audit) and KV identity
+data back up daily and on demand, along with the reachable history of a
+rotating slice of repositories — coverage rotates across runs under a per-run
+cap, so every repo is covered over time rather than every run. There is a
+tested restore path, documented in `docs/runbooks/backup-restore.md`.
 
 ## Can I turn off telemetry?
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -46,6 +46,7 @@ the API:
 ```bash
 curl -X POST https://app.usestratum.dev/api/projects \
   -H "Authorization: Bearer stratum_user_xxxxx" \
+  -H "Content-Type: application/json" \
   -d '{"name": "my-project", "visibility": "private"}'
 ```
 
@@ -61,6 +62,7 @@ jobs, so large repositories don't block the request:
 ```bash
 curl -X POST https://app.usestratum.dev/api/projects/@you/my-project/import \
   -H "Authorization: Bearer stratum_user_xxxxx" \
+  -H "Content-Type: application/json" \
   -d '{"url": "https://github.com/your-org/your-repo", "branch": "main"}'
 ```
 
@@ -282,6 +284,7 @@ npm — install it from the `cli/` directory of the repo:
 ```bash
 git clone https://github.com/stratum-eng/stratum.git
 cd stratum/cli && npm install && npm run build
+npm link   # puts the `stratum` binary on your PATH
 
 stratum login --host https://app.usestratum.dev --key stratum_user_xxxxx
 # or: export STRATUM_HOST=... STRATUM_API_KEY=...   (env overrides the config file)
@@ -304,7 +307,7 @@ Claude Code:
 
 ```bash
 export STRATUM_API_KEY=stratum_user_xxxxx
-claude mcp add stratum -e STRATUM_API_KEY=$STRATUM_API_KEY -- stratum-mcp
+claude mcp add stratum -e STRATUM_API_KEY=$STRATUM_API_KEY -- node /path/to/stratum/mcp/dist/index.js
 ```
 
 Any MCP client (stdio):
@@ -313,7 +316,8 @@ Any MCP client (stdio):
 {
   "mcpServers": {
     "stratum": {
-      "command": "stratum-mcp",
+      "command": "node",
+      "args": ["/path/to/stratum/mcp/dist/index.js"],
       "env": { "STRATUM_API_KEY": "stratum_user_..." }
     }
   }
@@ -328,23 +332,28 @@ provenance is recorded.
 ### Plain git over smart HTTP
 
 Stratum projects and workspaces are real git remotes. Authenticate with your API
-key as the HTTP Basic password (username is ignored):
+key as the HTTP Basic password (username is ignored) — when prompted, or via a
+[git credential helper](https://git-scm.com/docs/gitcredentials). Don't embed
+the key in the URL: it ends up in shell history and `.git/config`.
 
 ```bash
-# Clone a project (read)
-git clone https://x:stratum_user_xxxxx@app.usestratum.dev/@you/my-project.git
+# Clone a project (read) — enter your API key at the password prompt
+git clone https://app.usestratum.dev/@you/my-project.git
 
 # Clone AND push to a workspace (read + write)
-git clone https://x:stratum_user_xxxxx@app.usestratum.dev/@you/my-project/workspaces/fix-n-plus-one.git
+git clone https://app.usestratum.dev/@you/my-project/workspaces/fix-n-plus-one.git
 cd fix-n-plus-one
 # ...edit, commit...
 git push
 ```
 
-Note the asymmetry: **pushing to the project URL is not yet supported** — it
-returns `403`, because a direct push to a protected ref would bypass the
-evaluation gate. Push to a **workspace** remote instead, then open a change as
-usual. Gated project-push (push-opens-a-change semantics) is planned.
+Note the asymmetry: a push to the **project** URL does not update `main`
+directly — a direct push to a protected ref would bypass the evaluation gate.
+The push is answered in-protocol: each ref reports `remote rejected` with the
+reason, and on instances with gated push enabled, a single-ref push to `main`
+lands your commits on a server-managed workspace and opens an eval-gated
+change whose id is streamed back in the push output. Otherwise, push to a
+**workspace** remote and open a change as usual.
 
 ## Where to go next
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,25 +1,354 @@
-# Getting Started
+# Getting started
 
-## Sign In
+This guide walks a new team from zero to a merged, evaluation-gated change. By the
+end you will have a project, a merge policy, a registered agent identity, and the
+CLI and MCP server connected to your tools.
 
-Visit https://your-instance.workers.dev/auth/email
+Stratum is a code collaboration platform where humans and AI agents are both
+first-class citizens. Every proposed change — human or agent — passes through the
+same evaluation gates before it can merge, and every merged change carries a
+provenance record of who (or what model) produced it.
 
-## Create Project
+## 1. Sign up or self-host
 
-Click "New Project" and enter a name.
+### Hosted
 
-## Fork Workspace
+The hosted instance runs at `https://app.usestratum.dev` with **open signup** —
+no invite code or waitlist. (If you hit an invite prompt, you're on an instance
+whose operator has enabled the optional closed-beta gate.)
 
-Workspaces are isolated development environments.
+Sign in with any of:
 
-## Make Changes
+- **Email magic link** (recommended — no external accounts needed): enter your
+  email at `/auth/email` and click the link you receive.
+- **GitHub OAuth** at `/auth/github` — required later if you want bidirectional
+  GitHub sync.
+- **Google OAuth** at `/auth/google`.
 
-Commit file changes to your workspace.
+All three resolve to the same email-identity account, so you can mix methods.
 
-## Create Change
+### Self-hosting
 
-Propose your workspace for merge.
+Stratum is MIT-licensed and self-hostable on your own Cloudflare account. You
+need Node.js 20+ and a Cloudflare account with Workers, **Artifacts (beta)**, D1,
+KV, and Queues; AI Gateway is optional and only needed for the LLM evaluator,
+and Sandboxes only for the sandbox evaluator. Follow the
+[Quick Start in the README](../../README.md#quick-start) — everywhere this guide
+says `app.usestratum.dev`, substitute your own `https://your-instance.workers.dev`.
 
-## Merge
+## 2. Create or import a project
 
-After evaluation passes, merge to main.
+### Create a fresh project
+
+From the dashboard, click **New Project** and pick a name and visibility, or use
+the API:
+
+```bash
+curl -X POST https://app.usestratum.dev/api/projects \
+  -H "Authorization: Bearer stratum_user_xxxxx" \
+  -d '{"name": "my-project", "visibility": "private"}'
+```
+
+Projects live under a namespace — `@your-username` for personal projects, or an
+org slug for org-owned projects. Org membership grants read access; the org
+owner/admin role or membership in a write/admin team grants write access.
+
+### Import an existing repository
+
+Stratum imports from **GitHub, GitLab, and Bitbucket**. Imports run as background
+jobs, so large repositories don't block the request:
+
+```bash
+curl -X POST https://app.usestratum.dev/api/projects/@you/my-project/import \
+  -H "Authorization: Bearer stratum_user_xxxxx" \
+  -d '{"url": "https://github.com/your-org/your-repo", "branch": "main"}'
+```
+
+### Choose your level of buy-in: layer mode vs. alternative mode
+
+You do not have to leave your current forge to use Stratum. The same codebase
+supports two modes:
+
+- **Layer mode (minimal buy-in).** Stratum sits between your agents and GitHub.
+  Import a GitHub repo and enable **bidirectional GitHub sync**: inbound webhooks
+  keep the Stratum project current with pushes and PRs, and outbound sync
+  promotes a Stratum change to a GitHub PR with evaluation results posted as a PR
+  comment and commit status. Agents work through Stratum's gates; your team keeps
+  reviewing in GitHub PRs.
+- **Alternative mode (full buy-in).** Stratum is the source of truth for repos,
+  workspaces, and changes. No GitHub required — email magic links mean no
+  external accounts at all.
+
+Start in layer mode if you're evaluating; nothing about the change flow below
+differs between the modes.
+
+## 3. Write your evaluation policy
+
+Merge gates are configured in a `.stratum/policy.yaml` file at the root of your
+repository. Commit it like any other file. Here is a realistic policy for a
+TypeScript service:
+
+```yaml
+evaluation:
+  evaluators:
+    # Bound the blast radius of any single change.
+    - type: diff
+      maxFiles: 30
+      maxLines: 1000
+      forbiddenPatterns:
+        - "console.log("
+        - "TODO: remove"
+
+    # Call your existing CI system.
+    - type: webhook
+      url: "https://ci.example.com/evaluate"
+      secret: "${CI_WEBHOOK_SECRET}"
+      timeoutMs: 300000
+
+    # Run the test suite in a Cloudflare Sandbox.
+    - type: sandbox
+      command: "npm test"
+      timeoutMs: 120000
+
+    # AI review of the diff, scored 0.0-1.0.
+    - type: llm
+      model: "claude-sonnet-4-20250514"
+      threshold: 0.7
+      maxDiffChars: 100000
+
+merge:
+  requiredApprovals: 1
+  requiredEvaluators: ["secret_scan", "diff", "sandbox"]
+  allowForce: false
+  requireFreshBase: true
+  postMergeCommand: "npm test"
+  postMergeTimeoutMs: 120000
+  autoRevert: true
+```
+
+A malformed policy file **fails closed**: the merge gate blocks rather than
+silently falling back to defaults, so a typo in a stricter policy can't quietly
+downgrade your governance.
+
+### The evaluators
+
+- **Secret scan — always on, always blocking.** You don't configure it and you
+  can't turn it off. Every change is scanned for API keys, tokens, and other
+  credentials; a hit blocks the merge.
+- **`diff`** — pure analysis of the change, no code execution. Caps the number
+  of files (`maxFiles`) and lines (`maxLines`) changed, and can reject diffs
+  containing `forbiddenPatterns` or missing `requiredPatterns`. Cheap, fast, and
+  the first line of defense against runaway agent edits.
+- **`webhook`** — POSTs the change to an external URL (your existing CI) and
+  waits up to `timeoutMs` for a verdict. `secret` signs the delivery so your CI
+  can verify it came from Stratum.
+- **`sandbox`** — clones the workspace into a Cloudflare Sandbox and runs
+  `command` (default: the project's test command), passing or failing on exit
+  code. Requires the Sandboxes binding on self-hosted instances; when the
+  binding is absent this evaluator **fails closed** rather than silently
+  passing.
+- **`llm`** — sends the diff to an LLM (via AI Gateway) for review against your
+  criteria. `model` picks the reviewer, `threshold` is the minimum passing score
+  (0.0–1.0), and `maxDiffChars` bounds how much diff is sent. Token usage is
+  recorded on the change as a cost record.
+
+### The merge protections
+
+Everything under `merge:` is branch protection, enforced at the merge step:
+
+- **`requiredApprovals`** — how many **human** approvals a change needs before
+  it can merge. Agent approvals never count (see the invariant below).
+- **`requiredEvaluators`** — evaluator types whose *latest run* must have
+  passed. A change with a failing required evaluator cannot merge.
+- **`allowForce`** — force-merge is **deny-by-default**. The `?force=true`
+  override is rejected unless the policy explicitly sets `allowForce: true`.
+  Leave it off (or set it to `false`, as above) unless you have a specific
+  break-glass need.
+- **`requireFreshBase`** — when true, a change whose recorded base is behind
+  the project HEAD is rejected with `409 STALE_BASE`; re-evaluate on the new
+  base first. Independently of this flag, a merge is always rejected if the
+  workspace advanced after it was evaluated (`409 STALE_WORKSPACE`) — you can
+  never merge commits the evaluators didn't see.
+- **`postMergeCommand`** + **`postMergeTimeoutMs`** — a smoke command run in a
+  sandbox against the merged HEAD (e.g. `npm test`), with a default timeout of
+  60 seconds.
+- **`autoRevert`** — if the post-merge command fails, Stratum lands a forward
+  revert commit, marks the change `reverted`, and emits a `change.reverted`
+  event. On by default when a `postMergeCommand` is set.
+
+## 4. Register an agent identity
+
+Agents are not shared service accounts — each one is a first-class identity:
+
+```bash
+curl -X POST https://app.usestratum.dev/api/agents \
+  -H "Authorization: Bearer stratum_user_xxxxx" \
+  -d '{"name": "refactor-bot"}'
+```
+
+This returns a **short-lived agent token** (`stratum_agent_...`). Two things to
+know about its scope:
+
+- The token is **scoped to the owning user**: the agent inherits your project
+  access (including org access) and nothing more. Tokens are short-lived and
+  managed from the settings UI alongside your API keys.
+- All writes made with an agent token are attributed to the agent in
+  **provenance** — merged changes record which agent and which model produced
+  them, not just which human owned the token.
+
+### The human-approval invariant
+
+Reviews (approve / request changes) are **human-only**. An agent token cannot
+approve any change — not its own, not another agent's. This holds across every
+surface (REST API, CLI, MCP): if your policy sets `requiredApprovals: 1`, a
+human must look at the change before it merges. There is no configuration that
+relaxes this.
+
+The reference agent in [`agent/`](../../agent/README.md) shows the intended
+shape: it creates its own identity, forks a workspace, asks Claude for edits,
+commits, and opens a change — then stops. Review and merge stay on the platform.
+
+## 5. The change flow
+
+Every contribution — human or agent — follows the same path:
+
+```text
+workspace  →  commit  →  change (evaluation runs)  →  review  →  merge
+```
+
+1. **Fork a workspace.** A workspace is an isolated fork of the project — the
+   equivalent of a branch, with its own git remote.
+
+   ```bash
+   stratum workspace create @you/my-project --name fix-n-plus-one
+   ```
+
+2. **Commit.** Commit files to the workspace via the CLI (`stratum commit` sends
+   your staged files), the API, or `git push` to the workspace remote (see
+   section 6).
+
+   ```bash
+   stratum commit --project @you/my-project --workspace fix-n-plus-one -m "Fix N+1 query"
+   ```
+
+3. **Create a change.** A change is Stratum's merge proposal (a PR, roughly).
+   Creating it runs your full evaluation policy **synchronously** — you get each
+   gate's verdict in the response.
+
+   ```bash
+   stratum change create --project @you/my-project --workspace fix-n-plus-one
+   stratum change show chg_xxxxx   # eval evidence + costs
+   ```
+
+4. **Review.** A human approves or requests changes; this moves the change's
+   state machine. Agents cannot perform this step.
+
+   ```bash
+   stratum change review chg_xxxxx --verdict approve --comment "LGTM"
+   ```
+
+5. **Merge.** Merges are **squash merges**, serialized per-project through a
+   Durable Object merge queue so there are no races. The merge is rejected if a
+   required evaluator is failing, approvals are short, the base is stale
+   (`requireFreshBase`), or the workspace moved since evaluation. If a
+   `postMergeCommand` is configured it runs against the merged HEAD, and a
+   failure auto-reverts.
+
+   ```bash
+   stratum change merge chg_xxxxx
+   ```
+
+### What a merged change carries
+
+Every merged change keeps:
+
+- **Provenance** — the author (human or agent), the model and prompt hash
+  snapshotted at change creation, and the evaluation score, per merged commit.
+- **Evaluator evidence** — the full per-evaluator results (score, findings,
+  duration), linked by change and browsable in the UI.
+- **Cost records** — estimated resource usage per change: LLM tokens, sandbox
+  execution time, and git operations.
+
+If a change was linked to an issue, the issue auto-closes on merge.
+
+## 6. Connect your tools
+
+### CLI — `@stratum/cli`
+
+The CLI wraps the full REST API: projects, workspaces, commits, changes
+(including review and merge), issues, and activity. It is not yet published to
+npm — install it from the `cli/` directory of the repo:
+
+```bash
+git clone https://github.com/stratum-eng/stratum.git
+cd stratum/cli && npm install && npm run build
+
+stratum login --host https://app.usestratum.dev --key stratum_user_xxxxx
+# or: export STRATUM_HOST=... STRATUM_API_KEY=...   (env overrides the config file)
+
+stratum status        # who am I
+stratum projects      # list your projects
+```
+
+See [`cli/README.md`](../../cli/README.md) for the full command reference.
+
+### MCP server — `@stratum/mcp`
+
+The MCP server gives **any** MCP-capable agent or editor (Claude Code, Cursor,
+Zed, Copilot, custom agents) the full eval-gated change flow: read files, fork
+workspaces, commit, create changes (with each gate's verdict returned), review,
+merge, and track issues. Like the CLI, it is not yet on npm — install from the
+`mcp/` directory.
+
+Claude Code:
+
+```bash
+export STRATUM_API_KEY=stratum_user_xxxxx
+claude mcp add stratum -e STRATUM_API_KEY=$STRATUM_API_KEY -- stratum-mcp
+```
+
+Any MCP client (stdio):
+
+```json
+{
+  "mcpServers": {
+    "stratum": {
+      "command": "stratum-mcp",
+      "env": { "STRATUM_API_KEY": "stratum_user_..." }
+    }
+  }
+}
+```
+
+`STRATUM_HOST` defaults to `https://app.usestratum.dev`; set it for self-hosted
+instances. All governance invariants hold over MCP exactly as over REST: agent
+tokens can't approve their own work, failing evaluators block merges, and
+provenance is recorded.
+
+### Plain git over smart HTTP
+
+Stratum projects and workspaces are real git remotes. Authenticate with your API
+key as the HTTP Basic password (username is ignored):
+
+```bash
+# Clone a project (read)
+git clone https://x:stratum_user_xxxxx@app.usestratum.dev/@you/my-project.git
+
+# Clone AND push to a workspace (read + write)
+git clone https://x:stratum_user_xxxxx@app.usestratum.dev/@you/my-project/workspaces/fix-n-plus-one.git
+cd fix-n-plus-one
+# ...edit, commit...
+git push
+```
+
+Note the asymmetry: **pushing to the project URL is not yet supported** — it
+returns `403`, because a direct push to a protected ref would bypass the
+evaluation gate. Push to a **workspace** remote instead, then open a change as
+usual. Gated project-push (push-opens-a-change semantics) is planned.
+
+## Where to go next
+
+- [FAQ](faq.md) — common questions, including honest current limitations
+- [Importing from GitHub](importing.md) — import and sync details
+- [Troubleshooting](troubleshooting.md) — common issues
+- [API reference](../api/openapi.yml) — the complete REST surface

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -239,16 +239,15 @@ REPO_DO_ENABLED = "false"
 # in the GitHub and Google OAuth app settings.
 OAUTH_REDIRECT_URI = "https://app.usestratum.dev/auth/github/callback"
 GOOGLE_REDIRECT_URI = "https://app.usestratum.dev/auth/google/callback"
-# Closed beta — invite code required at signup. The gate fails closed, so
-# REFERRAL_SERVICE_URL must point at a LIVE referral service over a real public
-# hostname: Worker->Worker subrequests over *.workers.dev are intermittently
-# 404'd by the edge, so the referral service has its own custom domain
-# (referral.usestratum.dev -> stratum-landing Worker). The apex usestratum.dev
-# is still on the legacy Pages project; fold this into usestratum.dev after that
-# cutover if desired.
-# REFERRAL_SERVICE_SECRET is set out-of-band via `wrangler secret put` and must
-# match the value on the stratum-landing Worker.
-BETA_GATE = "1"
+# Open signup — the closed-beta invite gate is OFF in production ("available
+# today" is the positioning; Origin launched to every paid Cursor plan).
+# To re-enable the invite wall set BETA_GATE = "1"; the gate fails closed and
+# needs REFERRAL_SERVICE_URL live (referral.usestratum.dev -> stratum-landing
+# Worker; *.workers.dev subrequests are intermittently 404'd by the edge, hence
+# the custom domain). REFERRAL_SERVICE_SECRET is set out-of-band via
+# `wrangler secret put` and must match the stratum-landing Worker. Staging keeps
+# the gate ON so the invite path stays exercised end-to-end.
+BETA_GATE = "0"
 REFERRAL_SERVICE_URL = "https://referral.usestratum.dev"
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Carved out of #173 (6/6). **Merge this one last** — the docs reference features from the sibling PRs (#174–#178).

- ⚠️ **Open production signup**: `BETA_GATE = "0"` in the production config — no invite wall (deliberate go-to-market change; takes effect on the next approved production deploy; staging keeps the gate on so the invite path stays exercised). Flag if you want the wall kept.
- **Complete OpenAPI 3.1 spec**: 72 paths / 91 operations generated from the route code, replacing the 4-path stub. Redocly-validated (0 errors).
- **Real user docs**: full getting-started walkthrough (signup/self-host, import + layer vs alternative mode, a complete `policy.yaml` with every gate and merge protection explained, agent identities, the change flow, CLI/MCP/git hookup) and a 15-question FAQ — honest about current limitations.
- **README repositioned** around the control plane: Stratum is the governance layer for AI-written code on top of wherever code lives, reachable from any agent or editor. Also corrects the stale "full file rewrites" diff limitation (diffs have been hunk-level; split view lands in #176).
- **CHANGELOG**: the full Unreleased entry for the campaign lives here so sibling PRs don't fight over adjacent lines.

## Related issues

None filed; part of the Origin-response campaign (see #173).

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Other: go-to-market config change (open signup)

## How was this verified?

- [x] `npm run typecheck` (no code changes)
- [x] `npm test` (no code changes; suite unaffected)
- [x] `npm run lint`
- OpenAPI validated with Redocly (0 errors); wrangler.toml edit is scoped to the production `BETA_GATE` block only

## Checklist

- [x] Tests added or updated for the change (n/a — docs/config)
- [x] Docs updated where the change makes them inaccurate (this is the docs PR)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (no UI changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiAwmc2tXjt6tHrGEpmnJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiAwmc2tXjt6tHrGEpmnJj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Production signup is now open without beta invitations.
  - Added evaluation-gated pushes, repository policies, configurable diff views, in-protocol push errors, expanded secret scanning, and MCP integration.
  - Added configurable evaluation windows and safer handling for evaluator failures and large diffs.
- **Documentation**
  - Expanded guidance on governance, provenance, cost tracking, approvals, deployment, and integrations.
  - Added comprehensive getting-started and FAQ content covering setup, workflows, permissions, troubleshooting, limitations, self-hosting, and Git access.
  - Documented hunk-level diff views and current binary-file limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->