### PR TITLE
Isolate staging onto its own Cloudflare queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,24 @@ jobs:
           npx wrangler d1 migrations apply stratum-staging --remote --env=staging
           echo "✓ Migrations applied successfully"
 
+      # Staging binds its own -staging queues (see wrangler.toml); a deploy
+      # fails if a bound queue doesn't exist, so create them idempotently.
+      - name: Ensure Staging Queues Exist
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          for queue in stratum-events-staging stratum-imports-staging; do
+            if out=$(npx wrangler queues create "$queue" 2>&1); then
+              echo "✓ Created queue $queue"
+            elif echo "$out" | grep -qi "already exists"; then
+              echo "✓ Queue $queue already exists"
+            else
+              echo "$out"
+              exit 1
+            fi
+          done
+
       - name: Deploy to Cloudflare Staging
         id: deploy
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           for queue in stratum-events-staging stratum-imports-staging; do
             if out=$(npx wrangler queues create "$queue" 2>&1); then
               echo "✓ Created queue $queue"
-            elif echo "$out" | grep -qi "already exists"; then
+            elif echo "$out" | grep -qiE "already (exists|taken)|11009"; then
               echo "✓ Queue $queue already exists"
             else
               echo "$out"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -194,7 +194,7 @@ jobs:
           for queue in stratum-events-staging stratum-imports-staging; do
             if out=$(npx wrangler queues create "$queue" 2>&1); then
               echo "✓ Created queue $queue"
-            elif echo "$out" | grep -qi "already exists"; then
+            elif echo "$out" | grep -qiE "already (exists|taken)|11009"; then
               echo "✓ Queue $queue already exists"
             else
               echo "$out"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -184,6 +184,24 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Staging binds its own -staging queues (see wrangler.toml); a deploy
+      # fails if a bound queue doesn't exist, so create them idempotently.
+      - name: Ensure Staging Queues Exist
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          for queue in stratum-events-staging stratum-imports-staging; do
+            if out=$(npx wrangler queues create "$queue" 2>&1); then
+              echo "✓ Created queue $queue"
+            elif echo "$out" | grep -qi "already exists"; then
+              echo "✓ Queue $queue already exists"
+            else
+              echo "$out"
+              exit 1
+            fi
+          done
+
       - name: Deploy to Cloudflare Staging
         id: deploy
         env:

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,7 +207,6 @@ export default {
     const queueName = batch.queue;
 
     if (queueName.startsWith("stratum-imports")) {
-      // Handle import queue messages
       logger.info("Processing import queue batch", {
         queue: queueName,
         messageCount: batch.messages.length,

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,17 +201,19 @@ export default {
   async queue(batch: MessageBatch<unknown>, env: Env): Promise<void> {
     const logger = createLogger({ component: "queue" });
 
-    // Determine which queue this is based on the queue name
+    // Route by queue-name prefix: Cloudflare queues are account-level, so each
+    // environment gets its own instance ("stratum-events", "stratum-events-staging")
+    // while this one codebase consumes them all.
     const queueName = batch.queue;
 
-    if (queueName === "stratum-imports") {
+    if (queueName.startsWith("stratum-imports")) {
       // Handle import queue messages
       logger.info("Processing import queue batch", {
         queue: queueName,
         messageCount: batch.messages.length,
       });
       await handleImportQueue(batch as MessageBatch<ImportJobMessage | SyncJobMessage>, env);
-    } else if (queueName === "stratum-events") {
+    } else if (queueName.startsWith("stratum-events")) {
       await handleEventQueue(batch as MessageBatch<EventQueueMessage>, env);
     } else {
       // Unknown queue - ack all messages to prevent retries

--- a/tests/queue-dispatch.test.ts
+++ b/tests/queue-dispatch.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import worker from "../src/index";
+import type { Env, MessageBatch } from "../src/types";
+
+vi.mock("../src/queue/event-consumer", () => ({
+  handleEventQueue: vi.fn(async () => {}),
+  sweepStaleEvents: vi.fn(async () => {}),
+}));
+vi.mock("../src/queue/import-queue", () => ({
+  handleImportQueue: vi.fn(async () => {}),
+}));
+
+import { handleEventQueue } from "../src/queue/event-consumer";
+import { handleImportQueue } from "../src/queue/import-queue";
+
+function makeBatch(queue: string): MessageBatch<unknown> {
+  return {
+    queue,
+    messages: [],
+    ackAll: vi.fn(),
+    retryAll: vi.fn(),
+  } as unknown as MessageBatch<unknown>;
+}
+
+const env = {} as Env;
+
+/**
+ * Queue names are per-environment ("stratum-events" in production,
+ * "stratum-events-staging" on staging) but one codebase consumes them all, so
+ * the dispatcher must route by prefix. An exact-name match here silently
+ * ack-drops every staging batch as "Unknown queue".
+ */
+describe("worker queue dispatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(["stratum-events", "stratum-events-staging"])(
+    "routes %s to the event consumer",
+    async (name) => {
+      const batch = makeBatch(name);
+      await worker.queue(batch, env);
+      expect(handleEventQueue).toHaveBeenCalledWith(batch, env);
+      expect(handleImportQueue).not.toHaveBeenCalled();
+      expect(batch.ackAll).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["stratum-imports", "stratum-imports-staging"])(
+    "routes %s to the import consumer",
+    async (name) => {
+      const batch = makeBatch(name);
+      await worker.queue(batch, env);
+      expect(handleImportQueue).toHaveBeenCalledWith(batch, env);
+      expect(handleEventQueue).not.toHaveBeenCalled();
+      expect(batch.ackAll).not.toHaveBeenCalled();
+    },
+  );
+
+  it("acks batches from unknown queues without invoking a consumer", async () => {
+    const batch = makeBatch("some-other-queue");
+    await worker.queue(batch, env);
+    expect(handleEventQueue).not.toHaveBeenCalled();
+    expect(handleImportQueue).not.toHaveBeenCalled();
+    expect(batch.ackAll).toHaveBeenCalled();
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -315,25 +315,29 @@ script_name = "stratum-staging"
 binding = "REPO_OBJECTS"
 bucket_name = "stratum-repo-objects-staging"
 
+# Staging gets its own queues: queue names are account-level, so sharing
+# "stratum-events"/"stratum-imports" with production delivered every staging
+# message to the PRODUCTION consumer, whose D1 has no matching outbox row —
+# each one was dropped ("Event row missing for queue message") and staging's
+# 5-minute sweep cron re-enqueued it until its attempt budget ran out. The
+# -staging suffix keeps each environment's producer/consumer pair on its own
+# database. The CI staging deploy creates these queues idempotently.
 [[env.staging.queues.producers]]
 binding = "EVENTS_QUEUE"
-queue = "stratum-events"
+queue = "stratum-events-staging"
 
 [[env.staging.queues.producers]]
 binding = "IMPORT_QUEUE"
-queue = "stratum-imports"
+queue = "stratum-imports-staging"
 
-# Staging queue consumers for testing
-# These are disabled by default to prevent staging from competing with production
-# Enable when running integration tests: wrangler deploy --env=staging
-# [[env.staging.queues.consumers]]
-# queue = "stratum-events-staging"
-#
-# [[env.staging.queues.consumers]]
-# queue = "stratum-imports-staging"
-# max_batch_size = 1
-# max_retries = 3
-# retry_delay = 30
+[[env.staging.queues.consumers]]
+queue = "stratum-events-staging"
+
+[[env.staging.queues.consumers]]
+queue = "stratum-imports-staging"
+max_batch_size = 1
+max_retries = 3
+retry_delay = 30
 
 [[env.staging.send_email]]
 name = "EMAIL"


### PR DESCRIPTION
## Summary

Fixes the "Event row missing for queue message; dropping" warn spam observed in the production worker's logs — and the silent breakage behind it.

**Root cause:** Cloudflare queue names are account-level, and `env.staging` produced to the same `stratum-events` / `stratum-imports` queues the **production** worker consumes. Every staging event landed in production's consumer, which looked up the eventId in production's D1, found nothing, and (correctly, defensively) dropped it. Staging's 5-minute sweep cron re-enqueued each stale pending event until its attempt budget ran out, so each staging event was dropped up to 5 times. Consequences:

- Warn spam and wasted consumer invocations in production (no production data affected).
- Staging's event pipeline (webhooks, issue auto-close, activity fan-out) and import pipeline never actually ran — its consumers were commented out precisely because they'd have competed with production on the shared queue, which was the same root cause.

**The fix:**

- `wrangler.toml`: staging now produces to and consumes `stratum-events-staging` / `stratum-imports-staging`, with consumer settings mirroring production. The previously commented-out staging consumers are enabled on the new names.
- `src/index.ts`: the queue dispatcher routes by name prefix (`stratum-events*`, `stratum-imports*`) so one codebase serves every environment's queue instance — an exact-name match would silently ack-drop every staging batch as "Unknown queue".
- `ci.yml` / `pr-checks.yml`: an idempotent "Ensure Staging Queues Exist" step runs before each staging deploy (`wrangler deploy` fails if a bound queue doesn't exist; "already exists" is tolerated, any other create error fails the step).

Preview (pr-NNN) environments are unaffected — their generated `wrangler.preview.toml` binds no queues.

## Related issues

None filed; root-caused from production Observability logs (2026-08-18, `stratum` worker, queue `stratum-events`).

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` (1237 passed; new `tests/queue-dispatch.test.ts` covers prefix routing for both `-staging` names and unknown-queue ack)
- [x] `npm run lint` (exit code checked directly)
- `wrangler.toml` re-validated as parseable TOML; both workflow files re-validated as parseable YAML

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (config comments explain the isolation invariant)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (no UI changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiAwmc2tXjt6tHrGEpmnJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiAwmc2tXjt6tHrGEpmnJj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated staging queues for event and import processing.
  * Staging deployments now create required queues automatically.
  * Enabled staging consumers with controlled batch sizes, retries, and retry delays.
  * Staging queues route to the appropriate event and import handlers.

* **Bug Fixes**
  * Improved queue handling across production and staging environments.
  * Unknown queues are acknowledged safely without triggering unintended processing.

* **Testing**
  * Added coverage for production and staging queue dispatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->