### PR TITLE
Fix daily project-sync cron: correct Artifacts repo name, honor autoSyncEnabled, gate on update check

### DIFF
--- a/src/routes/sync.ts
+++ b/src/routes/sync.ts
@@ -2,7 +2,8 @@ import { Hono } from "hono";
 import { importFromGitHub } from "../storage/git-ops";
 import { writeSnapshotFromRepo } from "../storage/repo-snapshot";
 import { listProjects } from "../storage/state";
-import type { Env } from "../types";
+import { checkForSyncUpdates, getProjectSourceUrl, updateProjectAfterSync } from "../storage/sync";
+import { type Env, artifactsRepoName } from "../types";
 import { createLogger } from "../utils/logger";
 
 // The former unauthenticated `POST /projects/:name/sync` handler was removed: it
@@ -14,31 +15,51 @@ const app = new Hono<{ Bindings: Env }>();
 
 export { app as syncRouter };
 
-export async function syncAllProjects(env: Env): Promise<{ synced: number; failed: number }> {
+export async function syncAllProjects(
+  env: Env,
+): Promise<{ synced: number; failed: number; skipped: number }> {
   const logger = createLogger({ operation: "syncAllProjects" });
 
   const projectsResult = await listProjects(env.STATE, logger);
   if (!projectsResult.success) {
     logger.error("Failed to list projects for sync", projectsResult.error);
-    return { synced: 0, failed: 0 };
+    return { synced: 0, failed: 0, skipped: 0 };
   }
 
   const projects = projectsResult.data;
   let synced = 0;
   let failed = 0;
+  let skipped = 0;
 
   for (const project of projects) {
-    if (!project.githubUrl) continue;
+    if (!project.autoSyncEnabled) continue;
 
-    const projectLogger = logger.child({ projectName: project.name, githubUrl: project.githubUrl });
+    const sourceUrl = getProjectSourceUrl(project);
+    if (!sourceUrl) continue;
+
+    const projectLogger = logger.child({ projectName: project.name, sourceUrl });
 
     try {
-      projectLogger.info("Syncing project");
+      const checkResult = await checkForSyncUpdates(env.STATE, project, undefined, projectLogger);
+      if (!checkResult.success) {
+        failed++;
+        projectLogger.error("Sync update check failed", checkResult.error);
+        continue;
+      }
+      if (!checkResult.data.hasUpdates) {
+        skipped++;
+        projectLogger.debug("Project up to date, skipping sync");
+        continue;
+      }
+
+      projectLogger.info("Syncing project", { commitsBehind: checkResult.data.commitsBehind });
+      const branch = project.sourceDefaultBranch || project.githubDefaultBranch || "main";
       const result = await importFromGitHub(
         env.ARTIFACTS,
-        project.name,
-        project.githubUrl,
+        artifactsRepoName(project),
+        sourceUrl,
         projectLogger,
+        branch,
       );
       if (result.success) {
         synced++;
@@ -54,6 +75,14 @@ export async function syncAllProjects(env: Env): Promise<{ synced: number; faile
           },
           projectLogger,
         );
+        if (checkResult.data.latestCommit) {
+          await updateProjectAfterSync(
+            env.STATE,
+            project,
+            checkResult.data.latestCommit,
+            projectLogger,
+          );
+        }
       } else {
         failed++;
         projectLogger.error("Project sync failed", result.error);
@@ -67,6 +96,6 @@ export async function syncAllProjects(env: Env): Promise<{ synced: number; faile
     }
   }
 
-  logger.info("Batch sync completed", { synced, failed, total: projects.length });
-  return { synced, failed };
+  logger.info("Batch sync completed", { synced, failed, skipped, total: projects.length });
+  return { synced, failed, skipped };
 }

--- a/src/routes/sync.ts
+++ b/src/routes/sync.ts
@@ -62,7 +62,6 @@ export async function syncAllProjects(
         branch,
       );
       if (result.success) {
-        synced++;
         projectLogger.info("Project synced successfully");
         // NOTE: writeSnapshotFromRepo must be called after any new sync trigger added here
         await writeSnapshotFromRepo(
@@ -76,13 +75,22 @@ export async function syncAllProjects(
           projectLogger,
         );
         if (checkResult.data.latestCommit) {
-          await updateProjectAfterSync(
+          const updateResult = await updateProjectAfterSync(
             env.STATE,
             project,
             checkResult.data.latestCommit,
             projectLogger,
           );
+          // Count the project as synced only once the metadata write lands:
+          // a stale lastSyncedCommit would make the next cron run re-import
+          // a repo that is already up to date.
+          if (!updateResult.success) {
+            failed++;
+            projectLogger.error("Failed to record sync metadata", updateResult.error);
+            continue;
+          }
         }
+        synced++;
       } else {
         failed++;
         projectLogger.error("Project sync failed", result.error);

--- a/tests/sync-cron.test.ts
+++ b/tests/sync-cron.test.ts
@@ -128,6 +128,41 @@ describe("syncAllProjects (project-sync cron)", () => {
     );
   });
 
+  it("prefers sourceDefaultBranch over githubDefaultBranch when both are set", async () => {
+    mockListProjects.mockResolvedValue({
+      success: true,
+      data: [makeProject({ sourceDefaultBranch: "trunk", githubDefaultBranch: "master" })],
+    });
+
+    await syncAllProjects(makeEnv());
+
+    expect(mockImport).toHaveBeenCalledWith(
+      expect.anything(),
+      "alice__my-repo",
+      "https://github.com/alice/my-repo",
+      expect.anything(),
+      "trunk",
+    );
+  });
+
+  it("counts the project as failed when recording sync metadata fails", async () => {
+    mockUpdateAfterSync.mockResolvedValueOnce({
+      success: false,
+      error: Object.assign(new Error("KV write failed"), {
+        code: "STORAGE_ERROR",
+        statusCode: 500,
+      }),
+    } as Awaited<ReturnType<typeof updateProjectAfterSync>>);
+    mockListProjects.mockResolvedValue({ success: true, data: [makeProject()] });
+
+    const result = await syncAllProjects(makeEnv());
+
+    // The import itself succeeded, but a stale lastSyncedCommit would trigger
+    // a pointless re-import next run — report it as failed, not synced.
+    expect(result).toEqual({ synced: 0, failed: 1, skipped: 0 });
+    expect(mockSnapshot).toHaveBeenCalledTimes(1);
+  });
+
   it("skips projects that have not enabled auto-sync", async () => {
     mockListProjects.mockResolvedValue({
       success: true,

--- a/tests/sync-cron.test.ts
+++ b/tests/sync-cron.test.ts
@@ -26,11 +26,16 @@ vi.mock("../src/storage/repo-snapshot", () => ({
   writeSnapshotFromRepo: vi.fn(async () => undefined),
 }));
 
-vi.mock("../src/storage/sync", () => ({
-  checkForSyncUpdates: vi.fn(),
-  getProjectSourceUrl: (p: ProjectEntry) => p.sourceUrl || p.githubUrl,
-  updateProjectAfterSync: vi.fn(async () => ({ success: true, data: {} })),
-}));
+// Keep the real getProjectSourceUrl so the sourceUrl/githubUrl preference is
+// exercised; only the network/KV-touching functions are mocked.
+vi.mock("../src/storage/sync", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/storage/sync")>();
+  return {
+    ...actual,
+    checkForSyncUpdates: vi.fn(),
+    updateProjectAfterSync: vi.fn(async () => ({ success: true, data: {} })),
+  };
+});
 
 import { importFromGitHub } from "../src/storage/git-ops";
 import { writeSnapshotFromRepo } from "../src/storage/repo-snapshot";
@@ -184,6 +189,97 @@ describe("syncAllProjects (project-sync cron)", () => {
 
     expect(result).toEqual({ synced: 0, failed: 1, skipped: 0 });
     expect(mockImport).not.toHaveBeenCalled();
+  });
+
+  it("returns zeros and imports nothing when listing projects fails", async () => {
+    mockListProjects.mockResolvedValue({
+      success: false,
+      error: Object.assign(new Error("KV down"), { code: "STORAGE_ERROR", statusCode: 500 }),
+    } as Awaited<ReturnType<typeof listProjects>>);
+
+    const result = await syncAllProjects(makeEnv());
+
+    expect(result).toEqual({ synced: 0, failed: 0, skipped: 0 });
+    expect(mockCheck).not.toHaveBeenCalled();
+    expect(mockImport).not.toHaveBeenCalled();
+  });
+
+  it("prefers sourceUrl over the legacy githubUrl", async () => {
+    mockListProjects.mockResolvedValue({
+      success: true,
+      data: [makeProject({ sourceUrl: "https://gitlab.com/alice/my-repo" })],
+    });
+
+    await syncAllProjects(makeEnv());
+
+    expect(mockImport).toHaveBeenCalledWith(
+      expect.anything(),
+      "alice__my-repo",
+      "https://gitlab.com/alice/my-repo",
+      expect.anything(),
+      "main",
+    );
+  });
+
+  it("falls back to githubDefaultBranch when sourceDefaultBranch is unset", async () => {
+    mockListProjects.mockResolvedValue({
+      success: true,
+      data: [makeProject({ githubDefaultBranch: "master" })],
+    });
+
+    await syncAllProjects(makeEnv());
+
+    expect(mockImport).toHaveBeenCalledWith(
+      expect.anything(),
+      "alice__my-repo",
+      "https://github.com/alice/my-repo",
+      expect.anything(),
+      "master",
+    );
+  });
+
+  it("counts a synced project without recording a commit when the check has no latestCommit", async () => {
+    mockCheck.mockResolvedValue({
+      success: true,
+      data: { hasUpdates: true, commitsBehind: 1 },
+    });
+    mockListProjects.mockResolvedValue({ success: true, data: [makeProject()] });
+
+    const result = await syncAllProjects(makeEnv());
+
+    expect(result).toEqual({ synced: 1, failed: 0, skipped: 0 });
+    expect(mockSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockUpdateAfterSync).not.toHaveBeenCalled();
+  });
+
+  it("counts a thrown exception as failed and continues with the remaining projects", async () => {
+    mockListProjects.mockResolvedValue({
+      success: true,
+      data: [
+        makeProject({ slug: "boom", remote: "https://acct.artifacts.cloudflare.net/alice__boom" }),
+        makeProject(),
+      ],
+    });
+    mockImport.mockRejectedValueOnce(new Error("network exploded")).mockResolvedValueOnce({
+      success: true,
+      data: { remote: "https://acct.artifacts.cloudflare.net/alice__my-repo" },
+    } as Awaited<ReturnType<typeof importFromGitHub>>);
+
+    const result = await syncAllProjects(makeEnv());
+
+    expect(result).toEqual({ synced: 1, failed: 1, skipped: 0 });
+    expect(mockImport).toHaveBeenCalledTimes(2);
+    expect(mockSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("counts a thrown non-Error value as failed", async () => {
+    mockListProjects.mockResolvedValue({ success: true, data: [makeProject()] });
+    mockImport.mockRejectedValueOnce("string rejection");
+
+    const result = await syncAllProjects(makeEnv());
+
+    expect(result).toEqual({ synced: 0, failed: 1, skipped: 0 });
+    expect(mockSnapshot).not.toHaveBeenCalled();
   });
 
   it("counts a failed import as failed and writes no snapshot", async () => {

--- a/tests/sync-cron.test.ts
+++ b/tests/sync-cron.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Regression tests for the daily `project-sync` cron helper (issue #191):
+ *
+ * 1. It must import into the project's Artifacts repo name
+ *    (`getArtifactsRepoName(namespace, slug)` = `ns__slug`), not the display
+ *    `project.name` — the old behavior imported into a differently-named repo
+ *    and then wrote the KV snapshot for `namespace/slug` from that wrong
+ *    repo's remote.
+ * 2. It must only sync projects that opted in via `autoSyncEnabled`.
+ * 3. It must gate the (destructive) re-import on an actual update check and
+ *    record the synced commit so the next run's check has a baseline.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { syncAllProjects } from "../src/routes/sync";
+import type { Env, ProjectEntry } from "../src/types";
+
+vi.mock("../src/storage/state", () => ({
+  listProjects: vi.fn(),
+}));
+
+vi.mock("../src/storage/git-ops", () => ({
+  importFromGitHub: vi.fn(),
+}));
+
+vi.mock("../src/storage/repo-snapshot", () => ({
+  writeSnapshotFromRepo: vi.fn(async () => undefined),
+}));
+
+vi.mock("../src/storage/sync", () => ({
+  checkForSyncUpdates: vi.fn(),
+  getProjectSourceUrl: (p: ProjectEntry) => p.sourceUrl || p.githubUrl,
+  updateProjectAfterSync: vi.fn(async () => ({ success: true, data: {} })),
+}));
+
+import { importFromGitHub } from "../src/storage/git-ops";
+import { writeSnapshotFromRepo } from "../src/storage/repo-snapshot";
+import { listProjects } from "../src/storage/state";
+import { checkForSyncUpdates, updateProjectAfterSync } from "../src/storage/sync";
+
+const mockListProjects = vi.mocked(listProjects);
+const mockImport = vi.mocked(importFromGitHub);
+const mockCheck = vi.mocked(checkForSyncUpdates);
+const mockSnapshot = vi.mocked(writeSnapshotFromRepo);
+const mockUpdateAfterSync = vi.mocked(updateProjectAfterSync);
+
+function makeProject(overrides: Partial<ProjectEntry> = {}): ProjectEntry {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    name: "My Display Name",
+    slug: "my-repo",
+    namespace: "@alice",
+    ownerId: "user-1",
+    ownerType: "user",
+    remote: "https://acct.artifacts.cloudflare.net/alice__my-repo",
+    createdAt: "2026-01-01T00:00:00Z",
+    githubUrl: "https://github.com/alice/my-repo",
+    autoSyncEnabled: true,
+    ...overrides,
+  } as ProjectEntry;
+}
+
+function makeEnv(): Env {
+  return {
+    ARTIFACTS: {} as Env["ARTIFACTS"],
+    STATE: {} as KVNamespace,
+  } as unknown as Env;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCheck.mockResolvedValue({
+    success: true,
+    data: { hasUpdates: true, latestCommit: "abc1234def", commitsBehind: 2 },
+  });
+  mockImport.mockResolvedValue({
+    success: true,
+    data: { remote: "https://acct.artifacts.cloudflare.net/alice__my-repo" },
+  } as Awaited<ReturnType<typeof importFromGitHub>>);
+});
+
+describe("syncAllProjects (project-sync cron)", () => {
+  it("imports into the Artifacts repo name (ns__slug), not the display name", async () => {
+    mockListProjects.mockResolvedValue({ success: true, data: [makeProject()] });
+
+    const result = await syncAllProjects(makeEnv());
+
+    expect(result).toEqual({ synced: 1, failed: 0, skipped: 0 });
+    expect(mockImport).toHaveBeenCalledTimes(1);
+    expect(mockImport).toHaveBeenCalledWith(
+      expect.anything(),
+      "alice__my-repo",
+      "https://github.com/alice/my-repo",
+      expect.anything(),
+      "main",
+    );
+    // Snapshot is written from the imported repo's remote for namespace/slug.
+    expect(mockSnapshot).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        remote: "https://acct.artifacts.cloudflare.net/alice__my-repo",
+        namespace: "@alice",
+        slug: "my-repo",
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("passes the project's resolved default branch to the import", async () => {
+    mockListProjects.mockResolvedValue({
+      success: true,
+      data: [makeProject({ sourceDefaultBranch: "trunk" })],
+    });
+
+    await syncAllProjects(makeEnv());
+
+    expect(mockImport).toHaveBeenCalledWith(
+      expect.anything(),
+      "alice__my-repo",
+      "https://github.com/alice/my-repo",
+      expect.anything(),
+      "trunk",
+    );
+  });
+
+  it("skips projects that have not enabled auto-sync", async () => {
+    mockListProjects.mockResolvedValue({
+      success: true,
+      data: [makeProject({ autoSyncEnabled: false }), makeProject({ autoSyncEnabled: undefined })],
+    });
+
+    const result = await syncAllProjects(makeEnv());
+
+    expect(result).toEqual({ synced: 0, failed: 0, skipped: 0 });
+    expect(mockCheck).not.toHaveBeenCalled();
+    expect(mockImport).not.toHaveBeenCalled();
+  });
+
+  it("skips projects with no source URL", async () => {
+    mockListProjects.mockResolvedValue({
+      success: true,
+      data: [makeProject({ githubUrl: undefined, sourceUrl: undefined })],
+    });
+
+    const result = await syncAllProjects(makeEnv());
+
+    expect(result).toEqual({ synced: 0, failed: 0, skipped: 0 });
+    expect(mockImport).not.toHaveBeenCalled();
+  });
+
+  it("does not re-import when the remote has no updates", async () => {
+    mockCheck.mockResolvedValue({ success: true, data: { hasUpdates: false } });
+    mockListProjects.mockResolvedValue({ success: true, data: [makeProject()] });
+
+    const result = await syncAllProjects(makeEnv());
+
+    expect(result).toEqual({ synced: 0, failed: 0, skipped: 1 });
+    expect(mockImport).not.toHaveBeenCalled();
+    expect(mockSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("records the synced commit after a successful sync", async () => {
+    const project = makeProject();
+    mockListProjects.mockResolvedValue({ success: true, data: [project] });
+
+    await syncAllProjects(makeEnv());
+
+    expect(mockUpdateAfterSync).toHaveBeenCalledWith(
+      expect.anything(),
+      project,
+      "abc1234def",
+      expect.anything(),
+    );
+  });
+
+  it("counts a failed update check as failed and does not import", async () => {
+    mockCheck.mockResolvedValue({
+      success: false,
+      error: Object.assign(new Error("provider down"), { code: "SYNC_ERROR", statusCode: 500 }),
+    } as Awaited<ReturnType<typeof checkForSyncUpdates>>);
+    mockListProjects.mockResolvedValue({ success: true, data: [makeProject()] });
+
+    const result = await syncAllProjects(makeEnv());
+
+    expect(result).toEqual({ synced: 0, failed: 1, skipped: 0 });
+    expect(mockImport).not.toHaveBeenCalled();
+  });
+
+  it("counts a failed import as failed and writes no snapshot", async () => {
+    mockImport.mockResolvedValue({
+      success: false,
+      error: Object.assign(new Error("import blew up"), { code: "IMPORT_ERROR", statusCode: 502 }),
+    } as Awaited<ReturnType<typeof importFromGitHub>>);
+    mockListProjects.mockResolvedValue({ success: true, data: [makeProject()] });
+
+    const result = await syncAllProjects(makeEnv());
+
+    expect(result).toEqual({ synced: 0, failed: 1, skipped: 0 });
+    expect(mockSnapshot).not.toHaveBeenCalled();
+    expect(mockUpdateAfterSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

The 06:00 `project-sync` cron (`syncAllProjects` in `src/routes/sync.ts`) had three defects:

- It imported into an Artifacts repo named after the project's **display name** (`project.name`) instead of `getArtifactsRepoName(namespace, slug)` (`ns__slug`) used by every other call site, then wrote the `namespace/slug` KV snapshot from that wrong repo's remote — corrupting snapshot state on every run.
- It ran against **every** project with a `githubUrl`, ignoring the `autoSyncEnabled` opt-in.
- It re-imported **unconditionally** with no update check, and never recorded the synced commit.

Now the cron skips projects without `autoSyncEnabled` or a source URL, checks the remote for updates first (skipping up-to-date projects — which also stops the destructive delete+re-import cycle from running daily on unchanged repos), imports into the correct Artifacts repo name on the project's resolved default branch (`sourceDefaultBranch || githubDefaultBranch || "main"`), and records the synced commit via `updateProjectAfterSync` so subsequent runs have a baseline. It also prefers `sourceUrl` over the legacy `githubUrl` and reports a `skipped` count.

## Related issues

Closes #191

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

New regression suite `tests/sync-cron.test.ts` (14 tests) covers every code path in the cron helper: correct repo name + snapshot remote, branch resolution and fallbacks, `autoSyncEnabled` gating, missing source URL, no-updates skip, synced-commit recording (and the no-`latestCommit` guard), failed update check, failed import, `listProjects` failure, a thrown exception mid-loop continuing with remaining projects, and non-Error rejections. `src/routes/sync.ts` is at 100% statement/branch/function/line coverage (`vitest --coverage`). Full suite: 1251 passed.

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript

---
_Generated by [Claude Code](https://claude.ai/code/session_015dp67PBbFT666GnMLuxvm1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project synchronization now respects auto-sync settings and configured source branches.
  * Successful syncs record the latest available commit and update project metadata.
  * Sync results now distinguish between completed, failed, and skipped projects.

* **Bug Fixes**
  * Projects without a valid source or with no available updates are skipped safely.
  * Synchronization continues processing remaining projects after an individual failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->