### PR TITLE
Webhook evaluator: validate the verdict fail-closed and stop shipping webhook.secret in the payload

### DIFF
--- a/src/evaluation/llm-evaluator.ts
+++ b/src/evaluation/llm-evaluator.ts
@@ -4,7 +4,8 @@ import { ExternalServiceError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
 import type { Result } from "../utils/result";
 import { err, ok } from "../utils/result";
-import type { EvalPolicy, EvalResult, Evaluator, EvaluatorConfig } from "./types";
+import { sanitizePolicy } from "./sanitize-policy";
+import type { EvalPolicy, EvalResult, Evaluator } from "./types";
 
 const DEFAULT_MODEL = "@cf/meta/llama-3.1-8b-instruct";
 const DEFAULT_THRESHOLD = 0.7;
@@ -27,19 +28,6 @@ const SYSTEM_PROMPT = [
   "Respond with ONLY a JSON object and no other text:",
   '{"score": <0.0-1.0>, "passed": <bool>, "reason": "<one sentence>", "issues": ["<finding>"]}',
 ].join(" ");
-
-function sanitizePolicy(policy: EvalPolicy): EvalPolicy {
-  return {
-    ...policy,
-    evaluators: policy.evaluators.map((cfg: EvaluatorConfig) => {
-      if (cfg.type === "webhook") {
-        const { secret: _secret, ...rest } = cfg;
-        return rest;
-      }
-      return cfg;
-    }),
-  };
-}
 
 export class LLMEvaluator implements Evaluator {
   constructor(private ai: AiBinding) {}

--- a/src/evaluation/sanitize-policy.ts
+++ b/src/evaluation/sanitize-policy.ts
@@ -1,0 +1,19 @@
+import type { EvalPolicy, EvaluatorConfig } from "./types";
+
+/**
+ * Strip credentials from a policy before it leaves the Worker (serialized into
+ * an LLM prompt or a webhook request body). The webhook secret is used to sign
+ * outgoing requests; it must never appear in a payload itself.
+ */
+export function sanitizePolicy(policy: EvalPolicy): EvalPolicy {
+  return {
+    ...policy,
+    evaluators: policy.evaluators.map((cfg: EvaluatorConfig) => {
+      if (cfg.type === "webhook") {
+        const { secret: _secret, ...rest } = cfg;
+        return rest;
+      }
+      return cfg;
+    }),
+  };
+}

--- a/src/evaluation/webhook-evaluator.ts
+++ b/src/evaluation/webhook-evaluator.ts
@@ -4,6 +4,7 @@ import type { Logger } from "../utils/logger";
 import type { Result } from "../utils/result";
 import { err, ok } from "../utils/result";
 import { validateWebhookUrl } from "../utils/validation";
+import { sanitizePolicy } from "./sanitize-policy";
 import type { EvalPolicy, EvalResult, Evaluator } from "./types";
 
 async function computeHmacSha256(secret: string, body: string): Promise<string> {
@@ -49,7 +50,9 @@ export class WebhookEvaluator implements Evaluator {
     }
 
     const timeoutMs = config.timeoutMs ?? 10000;
-    const body = JSON.stringify({ diff, policy });
+    // The payload leaves the Worker, so strip credentials (webhook secrets)
+    // from the policy first — the secret signs the request, it is not content.
+    const body = JSON.stringify({ diff, policy: sanitizePolicy(policy) });
     const headers: Record<string, string> = { "Content-Type": "application/json" };
 
     if (config.secret) {
@@ -78,9 +81,41 @@ export class WebhookEvaluator implements Evaluator {
         return ok({ score: 0, passed: false, reason: `Webhook failed: HTTP ${response.status}` });
       }
 
-      const json = (await response.json()) as { score: number; passed: boolean; reason: string };
-      logger.info("Webhook evaluation complete", { score: json.score, passed: json.passed });
-      return ok({ score: json.score, passed: json.passed, reason: json.reason });
+      // A gate whose verdict can't be read has not passed. The endpoint is
+      // external, so never trust its shape: require a real boolean `passed`
+      // and a finite numeric `score`, and fail closed otherwise — a truthy
+      // string like {"passed":"no"} must not open the gate.
+      const failClosed = (why: string): Result<EvalResult, AppError> => {
+        logger.warn("Webhook response unusable, failing closed", { why });
+        return ok({ score: 0, passed: false, reason: `Webhook evaluator failed closed: ${why}` });
+      };
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        return failClosed("response was not valid JSON");
+      }
+
+      if (parsed === null || typeof parsed !== "object") {
+        return failClosed("response JSON was not an object");
+      }
+
+      const verdict = parsed as { score?: unknown; passed?: unknown; reason?: unknown };
+      if (
+        typeof verdict.score !== "number" ||
+        !Number.isFinite(verdict.score) ||
+        typeof verdict.passed !== "boolean"
+      ) {
+        return failClosed("response JSON missing a finite numeric `score` or boolean `passed`");
+      }
+
+      const score = Math.min(1, Math.max(0, verdict.score));
+      const reason =
+        typeof verdict.reason === "string" ? verdict.reason : "Webhook returned no reason.";
+
+      logger.info("Webhook evaluation complete", { score, passed: verdict.passed });
+      return ok({ score, passed: verdict.passed, reason });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger.error(

--- a/tests/evaluation.test.ts
+++ b/tests/evaluation.test.ts
@@ -21,8 +21,17 @@ vi.mock("../src/storage/git-ops", () => ({
   readFileFromRepo: vi.fn(),
 }));
 
+// Wrap (not replace) the URL validator so individual tests can force edge-case
+// return shapes; by default it calls through to the real implementation.
+vi.mock("../src/utils/validation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/utils/validation")>();
+  return { ...actual, validateWebhookUrl: vi.fn(actual.validateWebhookUrl) };
+});
+
 import { readFileFromRepo } from "../src/storage/git-ops";
+import { validateWebhookUrl } from "../src/utils/validation";
 const mockReadFileFromRepo = vi.mocked(readFileFromRepo);
+const mockValidateWebhookUrl = vi.mocked(validateWebhookUrl);
 
 function makeDiff(
   opts: {
@@ -288,6 +297,181 @@ describe("WebhookEvaluator", () => {
 
     expect(capturedHeaders["X-Stratum-Signature"]).toBeDefined();
     expect(capturedHeaders["X-Stratum-Signature"]).toMatch(/^sha256=[0-9a-f]{64}$/);
+  });
+
+  it("fails closed with a generic reason when URL validation reports no detail", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    mockValidateWebhookUrl.mockReturnValueOnce({ success: false, error: [] });
+
+    const policy = makePolicy({
+      evaluators: [{ type: "webhook", url: "https://example.com/eval" }],
+    });
+    const result = await evaluator.evaluate("diff content", policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.passed).toBe(false);
+      expect(result.data.score).toBe(0);
+      expect(result.data.reason).toContain("invalid URL");
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when no webhook configuration is present", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const policy = makePolicy({ evaluators: [{ type: "diff" }] });
+    const result = await evaluator.evaluate("diff content", policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.passed).toBe(false);
+      expect(result.data.score).toBe(0);
+      expect(result.data.reason).toContain("no configuration");
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  function stubFetchJson(payload: unknown): void {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => payload,
+      }),
+    );
+  }
+
+  async function evaluateWithStub(payload: unknown) {
+    stubFetchJson(payload);
+    const policy = makePolicy({
+      evaluators: [{ type: "webhook", url: "https://example.com/eval" }],
+    });
+    const result = await evaluator.evaluate("diff content", policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("unreachable");
+    return result.data;
+  }
+
+  it("SEC: fails closed when `passed` is a truthy string instead of a boolean", async () => {
+    const data = await evaluateWithStub({ score: 0.9, passed: "no", reason: "nope" });
+    expect(data.passed).toBe(false);
+    expect(data.score).toBe(0);
+    expect(data.reason).toMatch(/failed closed/i);
+  });
+
+  it("fails closed when `score` is not a number", async () => {
+    const data = await evaluateWithStub({ score: "0.9", passed: true, reason: "ok" });
+    expect(data.passed).toBe(false);
+    expect(data.score).toBe(0);
+    expect(data.reason).toMatch(/failed closed/i);
+  });
+
+  it("fails closed when `score` is not finite", async () => {
+    const data = await evaluateWithStub({
+      score: Number.POSITIVE_INFINITY,
+      passed: true,
+      reason: "ok",
+    });
+    expect(data.passed).toBe(false);
+    expect(data.score).toBe(0);
+  });
+
+  it("fails closed when verdict fields are missing entirely", async () => {
+    const data = await evaluateWithStub({});
+    expect(data.passed).toBe(false);
+    expect(data.score).toBe(0);
+    expect(data.reason).toMatch(/failed closed/i);
+  });
+
+  it("fails closed when the response JSON is not an object", async () => {
+    const data = await evaluateWithStub(null);
+    expect(data.passed).toBe(false);
+    expect(data.score).toBe(0);
+    expect(data.reason).toMatch(/not an object/i);
+  });
+
+  it("fails closed when the response body is not valid JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError("Unexpected token < in JSON");
+        },
+      }),
+    );
+
+    const policy = makePolicy({
+      evaluators: [{ type: "webhook", url: "https://example.com/eval" }],
+    });
+    const result = await evaluator.evaluate("diff content", policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.passed).toBe(false);
+      expect(result.data.score).toBe(0);
+      expect(result.data.reason).toMatch(/not valid JSON/i);
+    }
+  });
+
+  it("clamps an out-of-range score into [0, 1]", async () => {
+    const high = await evaluateWithStub({ score: 999, passed: true, reason: "ok" });
+    expect(high.score).toBe(1);
+    expect(high.passed).toBe(true);
+
+    const low = await evaluateWithStub({ score: -5, passed: false, reason: "bad" });
+    expect(low.score).toBe(0);
+    expect(low.passed).toBe(false);
+  });
+
+  it("defaults `reason` to a string when the response omits it", async () => {
+    const data = await evaluateWithStub({ score: 1, passed: true });
+    expect(data.passed).toBe(true);
+    expect(data.score).toBe(1);
+    expect(data.reason).toBe("Webhook returned no reason.");
+  });
+
+  it("wraps a non-Error fetch rejection in an ExternalServiceError", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue("socket hangup"));
+
+    const policy = makePolicy({
+      evaluators: [{ type: "webhook", url: "https://example.com/eval" }],
+    });
+    const result = await evaluator.evaluate("diff content", policy, mockLogger);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("socket hangup");
+    }
+  });
+
+  it("SEC: strips webhook.secret from the outgoing request body", async () => {
+    let capturedBody = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+        capturedBody = init.body as string;
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ score: 1, passed: true, reason: "ok" }),
+        });
+      }),
+    );
+
+    const policy = makePolicy({
+      evaluators: [{ type: "webhook", url: "https://example.com/eval", secret: "super-secret" }],
+    });
+    await evaluator.evaluate("diff content", policy, mockLogger);
+
+    expect(capturedBody).not.toContain("super-secret");
+    expect(capturedBody).not.toContain("secret");
+    const payload = JSON.parse(capturedBody) as { diff: string; policy: EvalPolicy };
+    expect(payload.diff).toBe("diff content");
+    expect(payload.policy.evaluators).toEqual([
+      { type: "webhook", url: "https://example.com/eval" },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

The webhook evaluator trusted the external CI endpoint's response verbatim (`await response.json() as {score, passed, reason}`), so `{"passed":"no"}` (a truthy string), `{"score":999}`, missing fields, or a non-JSON body could open the merge gate. It also serialized the full policy — including `webhook.secret` — into the outgoing request body.

Fix, mirroring the LLM evaluator's conventions:

- **Fail-closed validation:** the response must be a JSON object with a real `boolean` `passed` and a finite `number` `score` (clamped to [0,1]); `reason` defaults when not a string. Non-JSON bodies, non-object JSON, and missing/mistyped fields all return `{score: 0, passed: false}` with a warn log — the gate never passes on an unreadable verdict. Network/timeout errors still surface as `ExternalServiceError` as before.
- **Secret stripping:** the outgoing body is now `JSON.stringify({diff, policy: sanitizePolicy(policy)})`, reusing the same `sanitizePolicy` the LLM path uses — extracted from `llm-evaluator.ts` into a shared `src/evaluation/sanitize-policy.ts` (moved verbatim; LLM behavior unchanged) to avoid a webhook→llm import. The secret still signs the request via `X-Stratum-Signature`, computed over the sanitized body.

Notes for review:
- No threshold is applied to the webhook verdict (webhook config has none); `passed` is taken as reported once validated.
- A body-read timeout during `response.json()` now fails closed as "not valid JSON" instead of surfacing as an `ExternalServiceError` — consistent with fail-closed intent, but a slight behavior shift for that narrow race.
- The async status-callback path for long CI runs mentioned in the issue is out of scope here.

## Related issues

Closes #195

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

12 new WebhookEvaluator tests in `tests/evaluation.test.ts`: valid verdict passthrough with clamping, truthy-string `passed` fails closed, non-finite/missing score, missing fields, non-JSON and non-object responses, and an assertion that the outgoing fetch body does not contain the secret. Coverage on `src/evaluation/webhook-evaluator.ts`: 100% statements/lines/functions, 97.43% branches (the one missed branch is v8's synthetic exceptional-finally entry, unreachable because the preceding catch is exhaustive); `sanitize-policy.ts` at 100%. Full suite: 1249 passed.

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript

---
_Generated by [Claude Code](https://claude.ai/code/session_015dp67PBbFT666GnMLuxvm1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Webhook requests no longer transmit evaluator secrets, while signing continues to work securely.

* **Bug Fixes**
  * Improved handling of malformed, invalid, or unexpected webhook responses.
  * Invalid scores are safely constrained to the 0–1 range.
  * Missing or invalid result details now receive safe default values.
  * Webhook evaluation failures now fail closed with a score of zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->