### PR TITLE
Telemetry: send matched route patterns to PostHog instead of concrete request paths

### DIFF
--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -287,7 +287,9 @@ npx wrangler secret put GITHUB_CLIENT_SECRET
 # Email
 npx wrangler secret put EMAIL_FROM_ADDRESS
 
-# Analytics
+# Analytics — request events carry only the matched route pattern
+# (e.g. /:namespace/:slug/files), method, status, and latency; concrete
+# paths (namespaces, repo slugs, change ids, file paths) are never sent.
 npx wrangler secret put POSTHOG_API_KEY
 
 # Backups — encrypts backup blobs at rest (D1 dumps contain secrets).

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -290,11 +290,14 @@ npx wrangler secret put EMAIL_FROM_ADDRESS
 # Analytics — each request event carries the request properties: the matched
 # route pattern (e.g. /:namespace/:slug/files), method, status, and latency;
 # concrete paths (namespaces, repo slugs, change ids, file paths) are never
-# sent. Events also carry identity attribution: distinctId is the acting
-# user/agent id, or "server" for unattributed requests (those are marked
-# $process_person_profile: false so no person profile is created). Note: the
-# event property was renamed `path` -> `route`; dashboards and queries keyed
-# on `path` must switch to `route` — old `path` references receive no new data.
+# sent. A request that never reached a registered route (e.g. rejected by
+# global middleware before routing) is captured with route: "*"; a 404 is
+# excluded entirely, not captured with route: "*". Events also carry identity
+# attribution: distinctId is the acting user/agent id, or "server" for
+# unattributed requests (those are marked $process_person_profile: false so
+# no person profile is created). Note: the event property was renamed
+# `path` -> `route`; dashboards and queries keyed on `path` must switch to
+# `route` — old `path` references receive no new data.
 npx wrangler secret put POSTHOG_API_KEY
 
 # Backups — encrypts backup blobs at rest (D1 dumps contain secrets).

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -287,9 +287,14 @@ npx wrangler secret put GITHUB_CLIENT_SECRET
 # Email
 npx wrangler secret put EMAIL_FROM_ADDRESS
 
-# Analytics — request events carry only the matched route pattern
-# (e.g. /:namespace/:slug/files), method, status, and latency; concrete
-# paths (namespaces, repo slugs, change ids, file paths) are never sent.
+# Analytics — each request event carries the request properties: the matched
+# route pattern (e.g. /:namespace/:slug/files), method, status, and latency;
+# concrete paths (namespaces, repo slugs, change ids, file paths) are never
+# sent. Events also carry identity attribution: distinctId is the acting
+# user/agent id, or "server" for unattributed requests (those are marked
+# $process_person_profile: false so no person profile is created). Note: the
+# event property was renamed `path` -> `route`; dashboards and queries keyed
+# on `path` must switch to `route` — old `path` references receive no new data.
 npx wrangler secret put POSTHOG_API_KEY
 
 # Backups — encrypts backup blobs at rest (D1 dumps contain secrets).

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -149,10 +149,11 @@ Yes. Analytics (PostHog) is optional — it only runs if you set a
 entirely. When enabled, each event's request properties are limited to the
 matched route pattern (e.g. `/:namespace/:slug/files`), method, status, and
 latency — never the concrete URL, so namespaces, repo slugs, change ids, and
-file paths are not sent to PostHog. Events also carry identity attribution:
-the `distinctId` is the acting user or agent id (or `server` for
-unattributed requests, which are marked personless) so usage can be counted
-per account.
+file paths are not sent to PostHog. A request that never reached a
+registered route is captured with `route: "*"`; a 404 is excluded entirely
+rather than captured as `"*"`. Events also carry identity attribution: the
+`distinctId` is the acting user or agent id (or `server` for unattributed
+requests, which are marked personless) so usage can be counted per account.
 
 ## What if my policy file has a mistake in it?
 

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -146,10 +146,13 @@ tested restore path, documented in `docs/runbooks/backup-restore.md`.
 Yes. Analytics (PostHog) is optional — it only runs if you set a
 `POSTHOG_API_KEY`, and self-hosted instances can set
 `STRATUM_TELEMETRY_DISABLED = "true"` in `wrangler.toml` to switch it off
-entirely. When enabled, request events carry only the matched route pattern
-(e.g. `/:namespace/:slug/files`), method, status, and latency — never the
-concrete URL, so namespaces, repo slugs, change ids, and file paths are not
-sent to PostHog.
+entirely. When enabled, each event's request properties are limited to the
+matched route pattern (e.g. `/:namespace/:slug/files`), method, status, and
+latency — never the concrete URL, so namespaces, repo slugs, change ids, and
+file paths are not sent to PostHog. Events also carry identity attribution:
+the `distinctId` is the acting user or agent id (or `server` for
+unattributed requests, which are marked personless) so usage can be counted
+per account.
 
 ## What if my policy file has a mistake in it?
 

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -146,7 +146,10 @@ tested restore path, documented in `docs/runbooks/backup-restore.md`.
 Yes. Analytics (PostHog) is optional — it only runs if you set a
 `POSTHOG_API_KEY`, and self-hosted instances can set
 `STRATUM_TELEMETRY_DISABLED = "true"` in `wrangler.toml` to switch it off
-entirely.
+entirely. When enabled, request events carry only the matched route pattern
+(e.g. `/:namespace/:slug/files`), method, status, and latency — never the
+concrete URL, so namespaces, repo slugs, change ids, and file paths are not
+sent to PostHog.
 
 ## What if my policy file has a mistake in it?
 

--- a/src/middleware/analytics.ts
+++ b/src/middleware/analytics.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from "hono";
+import { routePath } from "hono/route";
 import { createPostHogClient } from "../analytics/posthog";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
@@ -17,10 +18,15 @@ export const analyticsMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (
   const latency = Date.now() - start;
   const userId = c.get("userId");
   const agentId = c.get("agentId");
+  // Report the matched route pattern (e.g. /:namespace/:slug/blob/*), never
+  // the concrete path — namespaces, repo slugs, change ids, and file paths
+  // must not leave the process. Route patterns are source-code literals, so
+  // they carry no request data by construction.
+  const route = routePath(c, -1);
 
   logger.debug("Recording analytics", {
     method: c.req.method,
-    path,
+    route,
     status: c.res.status,
     latency_ms: latency,
     userId,
@@ -34,7 +40,7 @@ export const analyticsMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (
     distinctId,
     properties: {
       method: c.req.method,
-      path,
+      route,
       status: c.res.status,
       latency_ms: latency,
       // Unattributed events would otherwise accrete on a shared "server"

--- a/tests/analytics-middleware.test.ts
+++ b/tests/analytics-middleware.test.ts
@@ -18,6 +18,9 @@ function makeApp(vars: { userId?: string; agentId?: string } = {}) {
   });
   app.use("*", analyticsMiddleware);
   app.get("/api/changes", (c) => c.json({ ok: true }));
+  app.get("/api/changes/:changeId", (c) => c.json({ ok: true }));
+  app.get("/login", (c) => c.json({ ok: true }));
+  app.get("/:ns/:slug/blob/*", (c) => c.json({ ok: true }));
   app.get("/health", (c) => c.json({ ok: true }));
   return app;
 }
@@ -47,7 +50,7 @@ describe("analyticsMiddleware", () => {
     vi.unstubAllGlobals();
   });
 
-  it("captures matched requests with method, path, status, and latency", async () => {
+  it("captures matched requests with method, route, status, and latency", async () => {
     const captured = stubCapture();
     const res = await makeApp().fetch(new Request("https://api.example.com/api/changes"), env);
     await flushCapture();
@@ -56,8 +59,71 @@ describe("analyticsMiddleware", () => {
     expect(captured).toHaveLength(1);
     expect(captured[0]?.event).toBe("api_request");
     expect(captured[0]?.properties.method).toBe("GET");
-    expect(captured[0]?.properties.path).toBe("/api/changes");
+    expect(captured[0]?.properties.route).toBe("/api/changes");
     expect(captured[0]?.properties.status).toBe(200);
+    expect(typeof captured[0]?.properties.latency_ms).toBe("number");
+  });
+
+  it("sends the route pattern for blob paths, never the namespace, slug, or file path", async () => {
+    const captured = stubCapture();
+    const res = await makeApp().fetch(
+      new Request("https://api.example.com/@acme/secret-repo/blob/src/deep/private.ts"),
+      env,
+    );
+    await flushCapture();
+
+    expect(res.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.properties.route).toBe("/:ns/:slug/blob/*");
+    expect(captured[0]?.properties.path).toBeUndefined();
+    const body = JSON.stringify(captured[0]);
+    expect(body).not.toContain("acme");
+    expect(body).not.toContain("secret-repo");
+    expect(body).not.toContain("private.ts");
+  });
+
+  it("sends the route pattern for change-id paths, never the concrete id", async () => {
+    const captured = stubCapture();
+    await makeApp().fetch(new Request("https://api.example.com/api/changes/ch_8f3a2b1c"), env);
+    await flushCapture();
+
+    expect(captured[0]?.properties.route).toBe("/api/changes/:changeId");
+    expect(JSON.stringify(captured[0])).not.toContain("ch_8f3a2b1c");
+  });
+
+  it("sends static routes as-is", async () => {
+    const captured = stubCapture();
+    await makeApp().fetch(new Request("https://api.example.com/login"), env);
+    await flushCapture();
+
+    expect(captured[0]?.properties.route).toBe("/login");
+  });
+
+  it("defers the capture through waitUntil when an execution context is present", async () => {
+    const captured = stubCapture();
+    const waitUntil = vi.fn();
+    const executionCtx = { waitUntil, passThroughOnException: () => undefined, props: {} };
+    await makeApp().fetch(
+      new Request("https://api.example.com/api/changes"),
+      env,
+      executionCtx as ExecutionContext,
+    );
+    await flushCapture();
+
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    expect(captured).toHaveLength(1);
+  });
+
+  it("captures nothing when telemetry is disabled", async () => {
+    const captured = stubCapture();
+    const res = await makeApp().fetch(
+      new Request("https://api.example.com/@acme/secret-repo/blob/src/deep/private.ts"),
+      { ...env, STRATUM_TELEMETRY_DISABLED: "true" } as Env,
+    );
+    await flushCapture();
+
+    expect(res.status).toBe(200);
+    expect(captured).toHaveLength(0);
   });
 
   it("does not capture 404s (scanner probes on unmatched routes)", async () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -130,7 +130,7 @@ OAUTH_REDIRECT_URI = "http://localhost:8787/auth/github/callback"
 # REFERRAL_SERVICE_URL = "https://your-referral-service.example.com"
 
 # Secrets — set via: wrangler secret put <NAME>
-# POSTHOG_API_KEY =
+# POSTHOG_API_KEY =  # telemetry sends route patterns only, never concrete paths
 # STRATUM_TELEMETRY_DISABLED = "true"  # uncomment to disable telemetry for self-hosted
 # GITHUB_CLIENT_ID =
 # GITHUB_CLIENT_SECRET =


### PR DESCRIPTION
## Summary

The analytics middleware sent `c.req.path` — the concrete request path — to PostHog on every non-404 request, leaking private namespaces, repo slugs, change ids, and file paths (e.g. `/@acme/secret-repo/blob/src/private.ts`) to a third-party provider by default.

It now sends the matched Hono route pattern instead, via `routePath(c, -1)` from `hono/route`: the same request is reported as `/:ns/:slug/blob/*`. Route patterns are source-code literals, so no request-derived path data can leave the process by construction; requests short-circuited before a route match report the middleware pattern `*`. The event property is renamed `path` → `route` to make the semantic change explicit. `method`, `status`, `latency_ms`, distinct-id attribution, and the `/health`/404 exclusions are unchanged.

Docs for `POSTHOG_API_KEY` / `STRATUM_TELEMETRY_DISABLED` (FAQ, deployment guide, `wrangler.toml` comments) now state that telemetry sends route patterns only.

Note for operators: PostHog dashboards keyed on the old `path` property need to switch to `route`.

## Related issues

Closes #199

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

`tests/analytics-middleware.test.ts` extended to 12 tests: a deep `/blob/` path event contains no namespace/slug/filename string anywhere in the serialized event body; change-id paths generalize to `/api/changes/:changeId`; static `/login` reports its own pattern; disabled telemetry sends nothing; the `waitUntil` deferral path is covered (a pre-existing gap). Coverage on `src/middleware/analytics.ts`: 100% statements/branches/functions/lines. Full suite: 0 failures.

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript

---
_Generated by [Claude Code](https://claude.ai/code/session_015dp67PBbFT666GnMLuxvm1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Privacy**
  - Request analytics record route patterns, methods, status codes, latency, and identity attribution—excluding concrete URLs and sensitive identifiers.
  - Unattributed requests use a personless server identity and do not create person profiles.

- **Bug Fixes**
  - Prevented dynamic route details, namespaces, repository slugs, change IDs, and file paths from appearing in analytics.

- **Documentation**
  - Updated deployment, FAQ, and configuration guidance, including the `path` to `route` property rename and required dashboard or query updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->