### PR TITLE
Report conflicting file names on merge conflicts and stop misclassifying operational failures as 409s

### DIFF
--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -1,5 +1,5 @@
 import { createPatch } from "diff";
-import git from "isomorphic-git";
+import git, { Errors as GitErrors } from "isomorphic-git";
 import type { ArtifactsCreateResult, ArtifactsNamespace, Author, CommitLogEntry } from "../types";
 import { AppError, ExternalServiceError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
@@ -128,6 +128,22 @@ export interface MergeWorkspaceOptions {
    * workspace history, else the merge fails closed.
    */
   workspaceSha?: string;
+}
+
+/**
+ * isomorphic-git reports a genuine content conflict as its own
+ * `MergeConflictError`, carrying the conflicting paths in `data.filepaths`.
+ * Matched by `code` as well as `instanceof` so a duplicated module instance
+ * (dual ESM/CJS load) still classifies correctly.
+ */
+function isGitMergeConflict(
+  error: unknown,
+): error is InstanceType<typeof GitErrors.MergeConflictError> {
+  return (
+    error instanceof GitErrors.MergeConflictError ||
+    (error instanceof Error &&
+      (error as { code?: unknown }).code === GitErrors.MergeConflictError.code)
+  );
 }
 
 export class MergeConflictError extends AppError {
@@ -547,8 +563,33 @@ export async function mergeWorkspaceIntoProject(
     const message =
       mergeResult.error instanceof Error ? mergeResult.error.message : String(mergeResult.error);
     logger.error("Merge failed", mergeResult.error, { projectRemote, workspaceRemote, message });
+    if (isGitMergeConflict(mergeResult.error)) {
+      const filepaths = Array.isArray(mergeResult.error.data?.filepaths)
+        ? mergeResult.error.data.filepaths
+        : [];
+      return err(
+        new MergeConflictError(
+          `Merge failed; workspace may be stale or conflicting: ${message}`,
+          filepaths,
+        ),
+      );
+    }
+    // isomorphic-git throws MergeNotSupportedError for conflict shapes it can't
+    // auto-resolve (e.g. add/add) and for histories with no single merge base —
+    // still content conflicts the caller must resolve, just with no file list.
+    if (mergeResult.error instanceof GitErrors.MergeNotSupportedError) {
+      return err(
+        new MergeConflictError(`Merge failed; workspace may be stale or conflicting: ${message}`),
+      );
+    }
+    // Anything else (network, auth, corrupt objects) is an operational failure —
+    // surface it as such rather than telling the client to resolve conflicts.
     return err(
-      new MergeConflictError(`Merge failed; workspace may be stale or conflicting: ${message}`),
+      new ExternalServiceError(
+        "Git",
+        `Merge failed: ${message}`,
+        mergeResult.error instanceof Error ? mergeResult.error : undefined,
+      ),
     );
   }
 

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -564,6 +564,12 @@ export async function mergeWorkspaceIntoProject(
         theirs: workspaceSha,
         author,
         message: "Merge workspace into project",
+        // isomorphic-git defaults to true, which throws the file-list-less
+        // MergeNotSupportedError for any conflict its diff3 algorithm can't
+        // auto-resolve. false lets it write conflict markers instead and throw
+        // MergeConflictError with the real filepaths — safe here since `dir` is
+        // a fresh, throwaway MemoryFS clone discarded after this call returns.
+        abortOnConflict: false,
       }),
     ),
   );

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -131,19 +131,28 @@ export interface MergeWorkspaceOptions {
 }
 
 /**
+ * Matches an isomorphic-git error class by `instanceof` as well as by its
+ * static `code`, so a duplicated module instance (dual ESM/CJS load) still
+ * classifies correctly.
+ */
+function matchesGitError(
+  error: unknown,
+  errorClass: { code: string } & (new (...args: never[]) => unknown),
+): boolean {
+  return (
+    error instanceof errorClass ||
+    (error instanceof Error && (error as { code?: unknown }).code === errorClass.code)
+  );
+}
+
+/**
  * isomorphic-git reports a genuine content conflict as its own
  * `MergeConflictError`, carrying the conflicting paths in `data.filepaths`.
- * Matched by `code` as well as `instanceof` so a duplicated module instance
- * (dual ESM/CJS load) still classifies correctly.
  */
 function isGitMergeConflict(
   error: unknown,
 ): error is InstanceType<typeof GitErrors.MergeConflictError> {
-  return (
-    error instanceof GitErrors.MergeConflictError ||
-    (error instanceof Error &&
-      (error as { code?: unknown }).code === GitErrors.MergeConflictError.code)
-  );
+  return matchesGitError(error, GitErrors.MergeConflictError);
 }
 
 export class MergeConflictError extends AppError {
@@ -577,7 +586,7 @@ export async function mergeWorkspaceIntoProject(
     // isomorphic-git throws MergeNotSupportedError for conflict shapes it can't
     // auto-resolve (e.g. add/add) and for histories with no single merge base —
     // still content conflicts the caller must resolve, just with no file list.
-    if (mergeResult.error instanceof GitErrors.MergeNotSupportedError) {
+    if (matchesGitError(mergeResult.error, GitErrors.MergeNotSupportedError)) {
       return err(
         new MergeConflictError(`Merge failed; workspace may be stale or conflicting: ${message}`),
       );

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -157,6 +157,7 @@ import {
 import { isTargetDeleting } from "../src/storage/deletion";
 import { listEvalRuns, recordEvalRuns } from "../src/storage/eval-runs";
 import {
+  MergeConflictError,
   batchMergeStagedTrees,
   freshRepoToken,
   getCommitLog,
@@ -1223,6 +1224,53 @@ describe("POST /api/changes/:id/merge", () => {
       expect.any(Object),
       { strategy: "squash" },
     );
+  });
+
+  it("returns 409 with the conflicting file list and persists conflict context (#185)", async () => {
+    const approvedChange: Change = { ...mockChange, status: "accepted" };
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: approvedChange,
+    });
+    vi.mocked(mergeWorkspaceIntoProject).mockResolvedValue({
+      success: false,
+      error: new MergeConflictError("Merge failed; workspace may be stale or conflicting", [
+        "src/a.ts",
+        "docs/readme.md",
+      ]),
+    });
+    const put = vi.fn(async (_key: string, _value: string, _opts?: unknown) => undefined);
+    env.STATE = { put } as unknown as KVNamespace;
+
+    const res = await app.fetch(
+      request("POST", "/api/changes/chg_abc123/merge", undefined, USER_AUTH),
+      env,
+    );
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as {
+      code: string;
+      conflictId: string;
+      conflictingFiles: string[];
+    };
+    expect(body.code).toBe("MERGE_CONFLICT");
+    expect(body.conflictingFiles).toEqual(["src/a.ts", "docs/readme.md"]);
+    expect(body.conflictId).toBeTruthy();
+
+    // The persisted conflict context carries the same file list for the
+    // resolution flow.
+    expect(put).toHaveBeenCalledWith(
+      `conflict:${body.conflictId}`,
+      expect.any(String),
+      expect.objectContaining({ expirationTtl: expect.any(Number) }),
+    );
+    const persisted = JSON.parse(put.mock.calls[0]?.[1] ?? "{}") as {
+      conflictingFiles: string[];
+      workspaceName: string;
+    };
+    expect(persisted.conflictingFiles).toEqual(["src/a.ts", "docs/readme.md"]);
+    expect(persisted.workspaceName).toBe("fix-bug");
+    expect(markChangeMerged).not.toHaveBeenCalled();
   });
 
   it("returns 400 when merge implementation reports a conflict", async () => {

--- a/tests/git-ops.test.ts
+++ b/tests/git-ops.test.ts
@@ -292,6 +292,16 @@ describe("mergeWorkspaceIntoProject merge-failure classification (#185)", () => 
     expect(git.push).not.toHaveBeenCalled();
   });
 
+  it("merges with abortOnConflict: false so real conflicts carry their file list", async () => {
+    vi.mocked(git.merge).mockResolvedValue({
+      oid: "merged-sha",
+    } as Awaited<ReturnType<typeof git.merge>>);
+
+    await doMerge();
+
+    expect(git.merge).toHaveBeenCalledWith(expect.objectContaining({ abortOnConflict: false }));
+  });
+
   it("classifies a conflict by code when instanceof fails (duplicate module instance)", async () => {
     const foreign = Object.assign(new Error("Automatic merge failed: README.md"), {
       code: "MergeConflictError",

--- a/tests/git-ops.test.ts
+++ b/tests/git-ops.test.ts
@@ -1,13 +1,34 @@
-import { describe, expect, it, vi } from "vitest";
+import git, { Errors as GitErrors } from "isomorphic-git";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  MergeConflictError,
   artifactsRepoNameFromRemote,
   buildUnifiedDiff,
   extractTokenSecret,
   freshRepoToken,
+  mergeWorkspaceIntoProject,
 } from "../src/storage/git-ops";
 import { MemoryFS } from "../src/storage/memory-fs";
 import type { ArtifactsNamespace } from "../src/types";
 import type { Logger } from "../src/utils/logger";
+
+// Mock only the git functions the merge path drives over the network; keep the
+// real Errors classes so classification is exercised against the genuine shapes.
+vi.mock("isomorphic-git", async (importActual) => {
+  const actual = await importActual<typeof import("isomorphic-git")>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      clone: vi.fn(),
+      addRemote: vi.fn(),
+      fetch: vi.fn(),
+      resolveRef: vi.fn(),
+      merge: vi.fn(),
+      push: vi.fn(),
+    },
+  };
+});
 
 const noopLogger: Logger = {
   debug: () => {},
@@ -223,5 +244,158 @@ describe("buildUnifiedDiff", () => {
     expect(diff).toContain("diff --git a/src/old.ts b/src/old.ts");
     expect(diff).toContain("deleted file mode 100644");
     expect(diff).toContain("-export const old = true;");
+  });
+});
+
+describe("mergeWorkspaceIntoProject merge-failure classification (#185)", () => {
+  const projectRemote = "https://acct.artifacts.cloudflare.net/git/ns/owner__project.git";
+  const workspaceRemote = "https://acct.artifacts.cloudflare.net/git/ns/owner__ws.git";
+
+  const doMerge = () =>
+    mergeWorkspaceIntoProject(projectRemote, "pt", workspaceRemote, "wt", noopLogger);
+
+  beforeEach(() => {
+    vi.mocked(git.clone).mockReset().mockResolvedValue(undefined);
+    vi.mocked(git.addRemote).mockReset().mockResolvedValue(undefined);
+    vi.mocked(git.fetch)
+      .mockReset()
+      .mockResolvedValue({} as Awaited<ReturnType<typeof git.fetch>>);
+    vi.mocked(git.resolveRef).mockReset().mockResolvedValue("ws-sha");
+    vi.mocked(git.merge).mockReset();
+    vi.mocked(git.push)
+      .mockReset()
+      .mockResolvedValue({ ok: true } as unknown as Awaited<ReturnType<typeof git.push>>);
+  });
+
+  it("propagates the exact conflicting file list on a real merge conflict", async () => {
+    vi.mocked(git.merge).mockRejectedValue(
+      new GitErrors.MergeConflictError(
+        ["src/a.ts", "docs/readme.md"],
+        ["src/a.ts", "docs/readme.md"],
+        [],
+        [],
+      ),
+    );
+
+    const result = await doMerge();
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(MergeConflictError);
+      expect(result.error.code).toBe("MERGE_CONFLICT");
+      expect(result.error.statusCode).toBe(409);
+      expect((result.error as MergeConflictError).conflictingFiles).toEqual([
+        "src/a.ts",
+        "docs/readme.md",
+      ]);
+    }
+    expect(git.push).not.toHaveBeenCalled();
+  });
+
+  it("classifies a conflict by code when instanceof fails (duplicate module instance)", async () => {
+    const foreign = Object.assign(new Error("Automatic merge failed: README.md"), {
+      code: "MergeConflictError",
+      data: { filepaths: ["README.md"], bothModified: ["README.md"] },
+    });
+    vi.mocked(git.merge).mockRejectedValue(foreign);
+
+    const result = await doMerge();
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(MergeConflictError);
+      expect((result.error as MergeConflictError).conflictingFiles).toEqual(["README.md"]);
+    }
+  });
+
+  it("falls back to an empty file list when a code-matched conflict carries no data", async () => {
+    const foreign = Object.assign(new Error("merge conflict"), { code: "MergeConflictError" });
+    vi.mocked(git.merge).mockRejectedValue(foreign);
+
+    const result = await doMerge();
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(MergeConflictError);
+      expect((result.error as MergeConflictError).conflictingFiles).toEqual([]);
+    }
+  });
+
+  it("maps MergeNotSupportedError to a conflict with no file list", async () => {
+    vi.mocked(git.merge).mockRejectedValue(new GitErrors.MergeNotSupportedError());
+
+    const result = await doMerge();
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(MergeConflictError);
+      expect(result.error.statusCode).toBe(409);
+      expect((result.error as MergeConflictError).conflictingFiles).toEqual([]);
+    }
+  });
+
+  it("does NOT report an operational failure (network) as a merge conflict", async () => {
+    vi.mocked(git.merge).mockRejectedValue(new Error("connect ETIMEDOUT 203.0.113.9:443"));
+
+    const result = await doMerge();
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).not.toBeInstanceOf(MergeConflictError);
+      expect(result.error.code).toBe("EXTERNAL_SERVICE_ERROR");
+      expect(result.error.statusCode).toBe(502);
+      expect(result.error.message).toContain("ETIMEDOUT");
+    }
+  });
+
+  it("does NOT report an HTTP-layer git error as a merge conflict", async () => {
+    vi.mocked(git.merge).mockRejectedValue(
+      new GitErrors.HttpError(502, "Bad Gateway", "upstream unavailable"),
+    );
+
+    const result = await doMerge();
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).not.toBeInstanceOf(MergeConflictError);
+      expect(result.error.code).toBe("EXTERNAL_SERVICE_ERROR");
+      expect(result.error.statusCode).toBe(502);
+    }
+  });
+
+  it("surfaces a push failure after a clean merge as an external service error", async () => {
+    vi.mocked(git.merge).mockResolvedValue({
+      oid: "merged-sha",
+    } as Awaited<ReturnType<typeof git.merge>>);
+    vi.mocked(git.push).mockRejectedValue(new Error("503 Service Unavailable"));
+
+    const result = await doMerge();
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).not.toBeInstanceOf(MergeConflictError);
+      expect(result.error.code).toBe("EXTERNAL_SERVICE_ERROR");
+    }
+  });
+
+  it("errors when the merge succeeds without producing a commit oid", async () => {
+    vi.mocked(git.merge).mockResolvedValue({} as Awaited<ReturnType<typeof git.merge>>);
+
+    const result = await doMerge();
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("EXTERNAL_SERVICE_ERROR");
+  });
+
+  it("returns the merge commit oid and pushes when the merge succeeds", async () => {
+    vi.mocked(git.merge).mockResolvedValue({
+      oid: "merged-sha",
+    } as Awaited<ReturnType<typeof git.merge>>);
+
+    const result = await doMerge();
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe("merged-sha");
+    expect(git.push).toHaveBeenCalled();
   });
 });

--- a/tests/git-ops.test.ts
+++ b/tests/git-ops.test.ts
@@ -334,6 +334,23 @@ describe("mergeWorkspaceIntoProject merge-failure classification (#185)", () => 
     }
   });
 
+  it("classifies MergeNotSupportedError by code when instanceof fails (duplicate module instance)", async () => {
+    const foreign = Object.assign(new Error("merge not supported"), {
+      code: "MergeNotSupportedError",
+    });
+    vi.mocked(git.merge).mockRejectedValue(foreign);
+
+    const result = await doMerge();
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(MergeConflictError);
+      expect(result.error.code).toBe("MERGE_CONFLICT");
+      expect(result.error.statusCode).toBe(409);
+      expect((result.error as MergeConflictError).conflictingFiles).toEqual([]);
+    }
+  });
+
   it("does NOT report an operational failure (network) as a merge conflict", async () => {
     vi.mocked(git.merge).mockRejectedValue(new Error("connect ETIMEDOUT 203.0.113.9:443"));
 


### PR DESCRIPTION
## Summary

`mergeWorkspaceIntoProject` caught every `git.merge` failure and returned the app's `MergeConflictError` with a defaulted empty file list — so `conflictingFiles` was always `[]` in the 409 response and the persisted KV conflict context, and operational failures (network, auth, corrupt objects) were mis-reported to clients as merge conflicts.

The fix classifies the underlying error at the single site in `src/storage/git-ops.ts` that constructs the app `MergeConflictError`:

- isomorphic-git's `MergeConflictError` (shape confirmed: `error.data.filepaths`) → app `MergeConflictError` carrying the real file list. Matched by both `instanceof` and `error.code` so a duplicated ESM/CJS module instance still classifies; missing/malformed `data` falls back to `[]`.
- `MergeNotSupportedError` (add/add conflicts, no-single-merge-base histories) → still 409 `MERGE_CONFLICT` (it's a content conflict the user resolves via the resolution flow), no file list.
- Anything else → `ExternalServiceError` (502), so clients are no longer told to "resolve conflicts" for a network error.

Downstream needed no changes: `src/routes/changes.ts` already forwards `error.conflictingFiles` into the 409 body and the `conflict:` KV record, and the conflict-resolution strategies already consume the list — the `conflictingFiles` field advertised in `docs/api/openapi.yml` is now genuinely populated.

Reviewer notes: the conflict message keeps its existing prefix to avoid breaking client string-matching; the batch/benchmark merge paths don't construct `MergeConflictError` and were left out of scope per the issue.

## Related issues

Closes #185

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

New `mergeWorkspaceIntoProject merge-failure classification` suite in `tests/git-ops.test.ts` (8 tests, mocking only isomorphic-git's network functions while keeping the real `Errors` classes): exact filepath propagation, code-matched foreign conflict instance, missing-data fallback, `MergeNotSupportedError` → 409 with empty list, network `Error` and `Errors.HttpError` → 502 non-conflict, push-failure and no-oid tails, and the success path. Plus a route-level test in `tests/changes.test.ts` asserting the 409 body and the KV `conflict:<id>` record carry the real file list. Every statement in the touched region is covered (verified via the JSON coverage report). Full suite: 1247 passed, 0 failed.

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript

---
_Generated by [Claude Code](https://claude.ai/code/session_015dp67PBbFT666GnMLuxvm1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved merge conflict detection, including conflicts from different library instances.
  - Merge failures now provide clearer error classifications and preserve affected file paths.
  - Structured merge conflicts return an appropriate conflict response with affected files and details.
  - Changes are no longer marked as merged when conflicts occur.
  - Improved handling of unsupported merges, network failures, push failures, and incomplete merge results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->