### PR TITLE
Fix GitHub PR promotion: push the change branch before opening the PR, validate base, support sourceUrl projects

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/user/stratum/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/user/stratum/node_modules

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -120,10 +120,13 @@ export function buildSnapshot(
 }
 
 /**
- * Creates a backup snapshot of a project's repository.
+ * Creates a backup snapshot of a project's repository: clone (the sole
+ * Artifacts-coupled call here), walk the full reachable object set, and pack it
+ * with a manifest carrying the tip sha and full identity.
  *
- * Empty or oversized repositories produce a skipped result; repository access,
- * cloning, and traversal failures are returned as errors.
+ * Empty or oversized repositories produce a skip rather than an error — neither
+ * is a backup failure, and reporting them as one would make a healthy cron run
+ * look broken. Repository access, cloning, and traversal failures are errors.
  *
  * @param capturedAt - Timestamp recorded in the snapshot manifest
  * @returns A successful snapshot or a reason the repository was skipped

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -102,6 +102,10 @@ export async function walkRepoObjects(
 /**
  * Builds a repository snapshot from walked objects and capture metadata.
  *
+ * The manifest carries `tipSha` and the whole project record, not just an id,
+ * because restore has to work without consulting live state — a snapshot must
+ * stay restorable after the project entry has changed or been deleted.
+ *
  * @param project - The project associated with the snapshot
  * @param walk - The walked objects and repository tip commit
  * @param capturedAt - The snapshot capture timestamp
@@ -129,8 +133,10 @@ export function buildSnapshot(
 /**
  * Creates a repository backup snapshot with its manifest.
  *
- * Empty or oversized repositories produce a skipped result. Repository access,
- * cloning, and traversal failures produce an application error.
+ * Empty and oversized repositories are a skip rather than an error: neither is
+ * a backup failure, and reporting them as one would make a healthy cron run
+ * look broken and bury the failures that matter. Repository access, cloning
+ * and traversal failures are real errors and surface as such.
  *
  * @param capturedAt - Timestamp recorded in the snapshot manifest
  * @returns A successful snapshot, a skipped result, or an application error

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -99,7 +99,14 @@ export async function walkRepoObjects(
   }
 }
 
-/** Assemble a snapshot from a walked object set. Pure — the unit under test. */
+/**
+ * Builds a repository snapshot from walked objects and capture metadata.
+ *
+ * @param project - The project associated with the snapshot
+ * @param walk - The walked objects and repository tip commit
+ * @param capturedAt - The snapshot capture timestamp
+ * @returns The packed repository objects and their manifest
+ */
 export function buildSnapshot(
   project: ProjectEntry,
   walk: WalkResult,
@@ -120,16 +127,13 @@ export function buildSnapshot(
 }
 
 /**
- * Creates a backup snapshot of a project's repository: clone (the sole
- * Artifacts-coupled call here), walk the full reachable object set, and pack it
- * with a manifest carrying the tip sha and full identity.
+ * Creates a repository backup snapshot with its manifest.
  *
- * Empty or oversized repositories produce a skip rather than an error — neither
- * is a backup failure, and reporting them as one would make a healthy cron run
- * look broken. Repository access, cloning, and traversal failures are errors.
+ * Empty or oversized repositories produce a skipped result. Repository access,
+ * cloning, and traversal failures produce an application error.
  *
  * @param capturedAt - Timestamp recorded in the snapshot manifest
- * @returns A successful snapshot or a reason the repository was skipped
+ * @returns A successful snapshot, a skipped result, or an application error
  */
 export async function snapshotRepo(
   env: Env,

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -120,9 +120,13 @@ export function buildSnapshot(
 }
 
 /**
- * Snapshot one project's repo: clone (the sole Artifacts-coupled call), walk the
- * full reachable object set, and pack it with a manifest carrying the tip sha and
- * full identity. Returns a skip (not an error) for empty or over-cap repos.
+ * Creates a backup snapshot of a project's repository.
+ *
+ * Empty or oversized repositories produce a skipped result; repository access,
+ * cloning, and traversal failures are returned as errors.
+ *
+ * @param capturedAt - Timestamp recorded in the snapshot manifest
+ * @returns A successful snapshot or a reason the repository was skipped
  */
 export async function snapshotRepo(
   env: Env,

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1389,6 +1389,9 @@ app.post("/changes/:id/evaluate", async (c) => {
  */
 const GITHUB_API_TIMEOUT_MS = 15_000;
 
+/** The repository a promotion is targeting, as resolved from the project source. */
+type GithubRepoTarget = { owner: string; repo: string };
+
 interface GithubPr {
   number: number;
   html_url: string;
@@ -1421,13 +1424,18 @@ function isGithubErrorDetail(value: unknown): value is GithubErrorDetail {
  * PR that isn't there — so both the create response and the duplicate-head
  * lookup are validated through this before anything is written.
  *
- * `html_url` is parsed rather than prefix-matched: `"https://"` passes a
- * `startsWith` check but is not a reachable PR link.
+ * `html_url` is checked against the repository and number it is supposed to
+ * describe, not merely parsed. A shape-only check passes values that are real
+ * GitHub URLs but not this PR's page — `https://api.github.com/repos/o/r/pulls/1`
+ * (an API endpoint, not a web link) and `https://github.com/login` both look
+ * fine to a host-and-non-empty-path test. Persisting either strands the change
+ * exactly as a malformed record would.
  *
  * @param value - The value to validate
- * @returns `true` if the value contains a positive safe integer number, a usable GitHub HTTPS URL, and an open state; `false` otherwise.
+ * @param target - The repository this promotion is pushing to
+ * @returns `true` if the value contains a positive safe integer number, an `html_url` that is this PR's page in `target`, and an open state; `false` otherwise.
  */
-function isUsableGithubPr(value: unknown): value is GithubPr {
+function isUsableGithubPr(value: unknown, target: GithubRepoTarget): value is GithubPr {
   if (typeof value !== "object" || value === null) return false;
   const pr = value as Partial<GithubPr>;
   return (
@@ -1435,27 +1443,32 @@ function isUsableGithubPr(value: unknown): value is GithubPr {
     Number.isSafeInteger(pr.number) &&
     pr.number > 0 &&
     typeof pr.html_url === "string" &&
-    isUsableGithubUrl(pr.html_url) &&
+    isUsableGithubUrl(pr.html_url, target, pr.number) &&
     pr.state === "open"
   );
 }
 
-/** A PR link this app would be willing to store and hand back to a caller. */
-function isUsableGithubUrl(raw: string): boolean {
+/**
+ * A PR link this app would be willing to store and hand back to a caller.
+ *
+ * The host must be exactly `github.com`: the promotion path is hard-coded to
+ * github.com, and a suffix test would also accept `api.github.com` and
+ * `gist.github.com`. The path must be the canonical PR page for this exact
+ * repository and number, so a well-formed URL pointing somewhere else on
+ * GitHub is rejected too. Owner and repo compare case-insensitively because
+ * GitHub echoes its own canonical casing, which need not match the casing
+ * parsed out of the project's source URL.
+ */
+function isUsableGithubUrl(raw: string, target: GithubRepoTarget, prNumber: number): boolean {
   let url: URL;
   try {
     url = new URL(raw);
   } catch {
     return false;
   }
-  // The whole promotion path is hard-coded to github.com (api.github.com, the
-  // github.com clone URL), so anything else here is a malformed or spoofed
-  // response rather than a legitimate enterprise host.
-  return (
-    url.protocol === "https:" &&
-    (url.hostname === "github.com" || url.hostname.endsWith(".github.com")) &&
-    url.pathname.length > 1
-  );
+  if (url.protocol !== "https:" || url.hostname !== "github.com") return false;
+  const path = url.pathname.replace(/\/$/, "");
+  return path.toLowerCase() === `/${target.owner}/${target.repo}/pull/${prNumber}`.toLowerCase();
 }
 
 /**
@@ -1471,7 +1484,7 @@ function isUsableGithubUrl(raw: string): boolean {
  * @returns The matching pull request, or `undefined` if none is found or the lookup fails.
  */
 async function findOpenPrForHead(
-  repo: { owner: string; repo: string },
+  repo: GithubRepoTarget,
   branch: string,
   headers: Record<string, string>,
   logger: Logger,
@@ -1494,7 +1507,7 @@ async function findOpenPrForHead(
   const body: unknown = await res.json().catch(() => undefined);
   if (!Array.isArray(body)) return undefined;
   const pr = body[0];
-  return isUsableGithubPr(pr) ? pr : undefined;
+  return isUsableGithubPr(pr, repo) ? pr : undefined;
 }
 
 app.post("/changes/:id/github-pr", async (c) => {
@@ -1638,7 +1651,7 @@ app.post("/changes/:id/github-pr", async (c) => {
     change.githubOwner === repo.owner &&
     change.githubRepo === repo.repo &&
     change.githubBranch === branch;
-  if (isUsableGithubPr(storedPr) && storedPrMatchesTarget) {
+  if (isUsableGithubPr(storedPr, repo) && storedPrMatchesTarget) {
     logger.info("Change branch re-pushed to existing GitHub PR", {
       changeId: id,
       prNumber: storedPr.number,
@@ -1766,7 +1779,7 @@ app.post("/changes/:id/github-pr", async (c) => {
     // must not escape as an unhandled rejection (a bare 500): map it to the
     // same structured 502 every other GitHub failure uses.
     const parsed: unknown = await ghRes.json().catch(() => undefined);
-    if (!isUsableGithubPr(parsed)) {
+    if (!isUsableGithubPr(parsed, repo)) {
       logger.error("GitHub PR creation returned an unusable response body", undefined, {
         status: ghRes.status,
         changeId: id,

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -34,7 +34,9 @@ import {
   getDiffBetweenRepos,
   mergeWorkspaceIntoProject,
   parseStagedTree,
+  pushBranchToRemote,
 } from "../storage/git-ops";
+import { parseRepoUrl } from "../storage/git-providers";
 import { recordProvenance } from "../storage/provenance";
 import { getProject, getWorkspace } from "../storage/state";
 import type { Change, Env, ProjectEntry } from "../types";
@@ -43,6 +45,7 @@ import { newId } from "../utils/ids";
 import { createLogger } from "../utils/logger";
 import type { Logger } from "../utils/logger";
 import {
+  appError,
   badRequest,
   created,
   forbidden,
@@ -113,10 +116,22 @@ async function loadMergePolicyCached(
   return inflight;
 }
 
-function parseGitHubRepo(url: string): { owner: string; repo: string } | null {
-  const match = url.match(/^https?:\/\/github\.com\/([^/]+)\/([^/\s]+?)(?:\.git|\/)?$/i);
-  if (!match || !match[1] || !match[2]) return null;
-  return { owner: match[1], repo: match[2] };
+/** Hard cap for a caller-supplied PR base branch name. */
+const MAX_BASE_REF_LENGTH = 200;
+
+/**
+ * Loose git branch-name validation for the PR `base` taken from the request
+ * body: printable, no whitespace/control chars, none of git's forbidden
+ * sequences. Rejecting here keeps garbage out of the GitHub API call.
+ */
+function isValidBaseRef(ref: string): boolean {
+  if (ref.length === 0 || ref.length > MAX_BASE_REF_LENGTH) return false;
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: control chars are exactly what's rejected
+  if (/[\s~^:?*[\\\x00-\x1f\x7f]/.test(ref)) return false;
+  if (ref.startsWith("-") || ref.startsWith("/") || ref.startsWith(".")) return false;
+  if (ref.endsWith("/") || ref.endsWith(".") || ref.endsWith(".lock")) return false;
+  if (ref.includes("..") || ref.includes("//") || ref.includes("@{")) return false;
+  return true;
 }
 
 const MERGEABLE_STATUSES: Change["status"][] = ["approved", "accepted", "promoted"];
@@ -1333,21 +1348,91 @@ app.post("/changes/:id/github-pr", async (c) => {
 
   if (!(await canWriteProject(c.env.DB, project, userId)))
     return forbidden("Project access denied");
-  if (!project?.githubUrl) return badRequest("Project is not connected to GitHub");
 
-  const repo = parseGitHubRepo(project.githubUrl);
-  if (!repo) return badRequest("Project githubUrl is invalid");
+  // Accept the legacy githubUrl or the generic sourceUrl — bulk-imported
+  // projects only set sourceUrl (#189) — as long as it points at github.com.
+  const repoUrl = project.githubUrl ?? project.sourceUrl;
+  if (!repoUrl) return badRequest("Project is not connected to GitHub");
+  const parsedRepo = parseRepoUrl(repoUrl);
+  if (!parsedRepo || parsedRepo.provider !== "github") {
+    return badRequest("Project source is not a GitHub repository");
+  }
+  const repo = { owner: parsedRepo.info.owner, repo: parsedRepo.info.repo };
 
   const body = await c.req
     .json<{ title?: string; body?: string; base?: string; draft?: boolean }>()
     .catch(() => ({}) as { title?: string; body?: string; base?: string; draft?: boolean });
+
+  // `base` comes straight from the request body — only a sane branch name may
+  // reach the GitHub API. Absent, fall back to the project's known default.
+  if (body.base !== undefined && (typeof body.base !== "string" || !isValidBaseRef(body.base))) {
+    return badRequest("Invalid base branch name");
+  }
+  const base = body.base ?? project.sourceDefaultBranch ?? project.githubDefaultBranch ?? "main";
 
   // GitHub PR creation needs a GitHub credential — the Artifacts repo token (now
   // never persisted) was never valid here. Use the app's configured GitHub token.
   const githubToken = c.env.GITHUB_TOKEN;
   if (!githubToken) return badRequest("GitHub integration is not configured");
 
+  // The PR's head ref must exist on GitHub before the PR is opened — a missing
+  // head is a guaranteed 422 (#189). Clone the change's workspace fork and
+  // (force-)push its tip to the Stratum-owned `stratum/<changeId>` ref first.
+  const workspaceResult = await getWorkspace(c.env.STATE, project.id, change.workspace, logger);
+  if (!workspaceResult.success) {
+    if (workspaceResult.error.code === "NOT_FOUND") {
+      return notFound("Workspace", change.workspace);
+    }
+    logger.error("Failed to get workspace", workspaceResult.error);
+    return badRequest(workspaceResult.error.message);
+  }
+  const workspaceRemote = workspaceResult.data.remote;
+
   const branch = `stratum/${change.id}`;
+
+  const repoTokenResult = await freshRepoToken(c.env.ARTIFACTS, workspaceRemote, "read", logger);
+  if (!repoTokenResult.success) return internalError(repoTokenResult.error.message);
+  const cloneResult = await cloneRepo(workspaceRemote, repoTokenResult.data, logger);
+  if (!cloneResult.success) return internalError(cloneResult.error.message);
+
+  const pushResult = await pushBranchToRemote(
+    cloneResult.data.fs,
+    cloneResult.data.dir,
+    {
+      url: `https://github.com/${repo.owner}/${repo.repo}.git`,
+      remoteRef: `refs/heads/${branch}`,
+      token: githubToken,
+    },
+    logger,
+  );
+  if (!pushResult.success) {
+    logger.error("Failed to push change branch to GitHub", pushResult.error, {
+      changeId: id,
+      branch,
+    });
+    return appError(pushResult.error);
+  }
+
+  // Re-promotion: the PR already exists and the force-push above refreshed its
+  // head, so skip the create call (GitHub 422s on a duplicate head ref).
+  if (change.githubPrNumber !== undefined && change.githubPrUrl !== undefined) {
+    logger.info("Change branch re-pushed to existing GitHub PR", {
+      changeId: id,
+      prNumber: change.githubPrNumber,
+      repo: `${repo.owner}/${repo.repo}`,
+    });
+    return okOrFormRedirect(c, id, {
+      changeId: id,
+      github: {
+        owner: repo.owner,
+        repo: repo.repo,
+        branch,
+        pullRequestNumber: change.githubPrNumber,
+        pullRequestUrl: change.githubPrUrl,
+      },
+    });
+  }
+
   const prBody =
     `## Stratum review\n\n- Change: \`${change.id}\`\n- Workspace: \`${change.workspace}\`\n- Evaluation: ${change.evalPassed ? "passed" : "failed"}, score ${change.evalScore ?? "n/a"}\n\n${body.body ?? ""}`.trim();
 
@@ -1362,14 +1447,46 @@ app.post("/changes/:id/github-pr", async (c) => {
       title: body.title ?? `Stratum: ${change.id}`,
       body: prBody,
       head: branch,
-      base: body.base ?? project.githubDefaultBranch ?? "main",
+      base,
       draft: body.draft ?? true,
     }),
   });
 
   if (!ghRes.ok) {
-    logger.error("GitHub PR creation failed", undefined, { status: ghRes.status, changeId: id });
-    return badRequest(`GitHub PR creation failed (${ghRes.status})`);
+    // Surface GitHub's own status + message (never the token) instead of a
+    // generic 400 — a 422 "head invalid" vs. a 404 repo tells the caller
+    // exactly what to fix.
+    const detail = await ghRes.text().catch(() => "");
+    let githubMessage: string | undefined;
+    try {
+      const parsed = JSON.parse(detail) as {
+        message?: string;
+        errors?: Array<{ message?: string; code?: string; field?: string }>;
+      };
+      githubMessage = [
+        parsed.message,
+        ...(parsed.errors ?? []).map(
+          (e) => e.message ?? (e.field ? `${e.field} ${e.code}` : e.code),
+        ),
+      ]
+        .filter(Boolean)
+        .join("; ");
+    } catch {
+      githubMessage = undefined;
+    }
+    logger.error("GitHub PR creation failed", undefined, {
+      status: ghRes.status,
+      changeId: id,
+      githubMessage,
+    });
+    return c.json(
+      {
+        error: `GitHub PR creation failed (${ghRes.status})${githubMessage ? `: ${githubMessage}` : ""}`,
+        code: "GITHUB_ERROR",
+        githubStatus: ghRes.status,
+      },
+      502,
+    );
   }
 
   const pr = (await ghRes.json()) as { number: number; html_url: string; state: string };

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1354,6 +1354,46 @@ app.post("/changes/:id/evaluate", async (c) => {
   return okOrFormRedirect(c, id, { changeId: id, eval: evalResult, evalRuns: recordResult.data });
 });
 
+/** Bound on every direct GitHub API call in the promotion flow below. */
+const GITHUB_API_TIMEOUT_MS = 15_000;
+
+interface GithubPr {
+  number: number;
+  html_url: string;
+  state: string;
+}
+
+/**
+ * GitHub 422s PR creation with a "pull request already exists" error when the
+ * head ref already has an open PR — a race between a concurrent promotion (or
+ * a retry after `updateChangeStatus` failed post-creation) and the create
+ * call above. Look up and reuse that PR instead of failing the request.
+ */
+async function findOpenPrForHead(
+  repo: { owner: string; repo: string },
+  branch: string,
+  headers: Record<string, string>,
+  logger: Logger,
+): Promise<GithubPr | undefined> {
+  const url = `https://api.github.com/repos/${repo.owner}/${repo.repo}/pulls?head=${repo.owner}:${branch}&state=open`;
+  let res: Response;
+  try {
+    res = await fetch(url, { headers, signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) });
+  } catch (error) {
+    logger.error(
+      "Lookup of existing PR for duplicate head failed",
+      error instanceof Error ? error : undefined,
+      {
+        branch,
+      },
+    );
+    return undefined;
+  }
+  if (!res.ok) return undefined;
+  const prs = (await res.json().catch(() => [])) as GithubPr[];
+  return prs[0];
+}
+
 app.post("/changes/:id/github-pr", async (c) => {
   const logger = createLogger({
     requestId: crypto.randomUUID(),
@@ -1487,21 +1527,42 @@ app.post("/changes/:id/github-pr", async (c) => {
   const prBody =
     `## Stratum review\n\n- Change: \`${change.id}\`\n- Workspace: \`${change.workspace}\`\n- Evaluation: ${change.evalPassed ? "passed" : "failed"}, score ${change.evalScore ?? "n/a"}\n\n${body.body ?? ""}`.trim();
 
-  const ghRes = await fetch(`https://api.github.com/repos/${repo.owner}/${repo.repo}/pulls`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${githubToken}`,
-      "User-Agent": "stratum",
-    },
-    body: JSON.stringify({
-      title: body.title ?? `Stratum: ${change.id}`,
-      body: prBody,
-      head: branch,
-      base,
-      draft: body.draft ?? true,
-    }),
-  });
+  const githubHeaders = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${githubToken}`,
+    "User-Agent": "stratum",
+  };
+
+  let ghRes: Response;
+  try {
+    ghRes = await fetch(`https://api.github.com/repos/${repo.owner}/${repo.repo}/pulls`, {
+      method: "POST",
+      headers: githubHeaders,
+      body: JSON.stringify({
+        title: body.title ?? `Stratum: ${change.id}`,
+        body: prBody,
+        head: branch,
+        base,
+        draft: body.draft ?? true,
+      }),
+      // A slow GitHub response must not hold the request open until the
+      // platform's own subrequest limit kills it.
+      signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+    });
+  } catch (error) {
+    logger.error("GitHub PR creation request failed", error instanceof Error ? error : undefined, {
+      changeId: id,
+    });
+    return c.json(
+      {
+        error: "GitHub PR creation failed: request timed out or network error",
+        code: "GITHUB_ERROR",
+      },
+      502,
+    );
+  }
+
+  let pr: GithubPr;
 
   if (!ghRes.ok) {
     // Surface GitHub's own status + message (never the token) instead of a
@@ -1509,38 +1570,53 @@ app.post("/changes/:id/github-pr", async (c) => {
     // exactly what to fix.
     const detail = await ghRes.text().catch(() => "");
     let githubMessage: string | undefined;
+    let errors: Array<{ message?: string; code?: string; field?: string }> = [];
     try {
       const parsed = JSON.parse(detail) as {
         message?: string;
         errors?: Array<{ message?: string; code?: string; field?: string }>;
       };
+      errors = parsed.errors ?? [];
       githubMessage = [
         parsed.message,
-        ...(parsed.errors ?? []).map(
-          (e) => e.message ?? (e.field ? `${e.field} ${e.code}` : e.code),
-        ),
+        ...errors.map((e) => e.message ?? (e.field ? `${e.field} ${e.code}` : e.code)),
       ]
         .filter(Boolean)
         .join("; ");
     } catch {
       githubMessage = undefined;
     }
-    logger.error("GitHub PR creation failed", undefined, {
-      status: ghRes.status,
-      changeId: id,
-      githubMessage,
-    });
-    return c.json(
-      {
-        error: `GitHub PR creation failed (${ghRes.status})${githubMessage ? `: ${githubMessage}` : ""}`,
-        code: "GITHUB_ERROR",
-        githubStatus: ghRes.status,
-      },
-      502,
-    );
+
+    // GitHub's duplicate-head 422 ("A pull request already exists for
+    // owner:branch") means the PR the caller wanted already exists — reuse it
+    // rather than failing (see findOpenPrForHead above).
+    const duplicateHead =
+      ghRes.status === 422 &&
+      errors.some((e) => e.message?.toLowerCase().includes("pull request already exists"));
+    const existingPr = duplicateHead
+      ? await findOpenPrForHead(repo, branch, githubHeaders, logger)
+      : undefined;
+
+    if (!existingPr) {
+      logger.error("GitHub PR creation failed", undefined, {
+        status: ghRes.status,
+        changeId: id,
+        githubMessage,
+      });
+      return c.json(
+        {
+          error: `GitHub PR creation failed (${ghRes.status})${githubMessage ? `: ${githubMessage}` : ""}`,
+          code: "GITHUB_ERROR",
+          githubStatus: ghRes.status,
+        },
+        502,
+      );
+    }
+    pr = existingPr;
+  } else {
+    pr = (await ghRes.json()) as GithubPr;
   }
 
-  const pr = (await ghRes.json()) as { number: number; html_url: string; state: string };
   const promotedAt = new Date().toISOString();
 
   const updateResult = await updateChangeStatus(c.env.DB, logger, id, "promoted", {

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -71,12 +71,14 @@ const policyInflight = new Map<string, Promise<EvalPolicy>>();
 const policyKvKey = (projectId: string) => `policy:${projectId}`;
 
 /**
- * Load a project's merge policy through a two-level cache so the hot merge paths
- * don't clone the repo just to read `.stratum/policy.yaml`:
- *   in-isolate Map  ->  KV (shared across isolates)  ->  clone (loadPolicy).
- * Request-coalesced per project. Gated on REPO_DO_ENABLED so tests always load
- * fresh (no KV access). The cache TTL bounds how long a branch-protection change
- * takes to apply on these paths. Throws if the read token can't be minted.
+ * Loads a project's merge policy using cached values when caching is enabled.
+ *
+ * Concurrent requests for the same project share one policy load. Cached policies
+ * expire after the configured cache TTL; uncached loads read the policy from the
+ * project's repository and propagate token or policy-loading failures.
+ *
+ * @param project - The project whose merge policy to load
+ * @returns The project's merge policy
  */
 async function loadMergePolicyCached(
   env: Env,
@@ -1389,12 +1391,10 @@ interface GithubPr {
 }
 
 /**
- * A PR record is only usable if it can be persisted: `githubPrNumber` and
- * `githubPrUrl` are what a later re-promotion checks to decide the PR already
- * exists and skip creation entirely. Persisting a malformed record therefore
- * strands the change permanently — every retry short-circuits to a PR that
- * isn't there — so both the create response and the duplicate-head lookup are
- * validated through here before anything is stored.
+ * Validates whether a value represents an open GitHub pull request.
+ *
+ * @param value - The value to validate
+ * @returns `true` if the value has a positive safe integer number, an HTTPS URL, and an open state, `false` otherwise.
  */
 function isUsableGithubPr(value: unknown): value is GithubPr {
   if (typeof value !== "object" || value === null) return false;
@@ -1410,10 +1410,11 @@ function isUsableGithubPr(value: unknown): value is GithubPr {
 }
 
 /**
- * GitHub 422s PR creation with a "pull request already exists" error when the
- * head ref already has an open PR — a race between a concurrent promotion (or
- * a retry after `updateChangeStatus` failed post-creation) and the create
- * call above. Look up and reuse that PR instead of failing the request.
+ * Finds an open GitHub pull request associated with a branch.
+ *
+ * @param repo - The GitHub repository to search
+ * @param branch - The head branch associated with the pull request
+ * @returns The matching pull request, or `undefined` if none is found or the lookup fails.
  */
 async function findOpenPrForHead(
   repo: { owner: string; repo: string },

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -117,22 +117,33 @@ async function loadMergePolicyCached(
   return inflight;
 }
 
-/** Hard cap for a caller-supplied PR base branch name. */
+/**
+ * `base` arrives in the request body, so it is untrusted input on its way to
+ * the GitHub API — this bounds it before it gets there.
+ */
 const MAX_BASE_REF_LENGTH = 200;
 
 /**
  * Loose git branch-name validation for the PR `base` taken from the request
  * body: printable, no whitespace/control chars, none of git's forbidden
  * sequences. Rejecting here keeps garbage out of the GitHub API call.
+ *
+ * git applies its per-component rules to every slash-separated component, not
+ * just to the ref as a whole, so `release/.hidden` and `release/v1.lock` are
+ * invalid even though the full string neither starts with `.` nor ends with
+ * `.lock`. A bare `@` is a legal branch name — only the `@{` reflog syntax is
+ * rejected.
  */
 function isValidBaseRef(ref: string): boolean {
   if (ref.length === 0 || ref.length > MAX_BASE_REF_LENGTH) return false;
   // biome-ignore lint/suspicious/noControlCharactersInRegex: control chars are exactly what's rejected
   if (/[\s~^:?*[\\\x00-\x1f\x7f]/.test(ref)) return false;
-  if (ref.startsWith("-") || ref.startsWith("/") || ref.startsWith(".")) return false;
-  if (ref.endsWith("/") || ref.endsWith(".") || ref.endsWith(".lock")) return false;
+  if (ref.startsWith("-") || ref.startsWith("/")) return false;
+  if (ref.endsWith("/")) return false;
   if (ref.includes("..") || ref.includes("//") || ref.includes("@{")) return false;
-  return true;
+  return ref
+    .split("/")
+    .every((c) => c.length > 0 && !c.startsWith(".") && !c.endsWith(".") && !c.endsWith(".lock"));
 }
 
 const MERGEABLE_STATUSES: Change["status"][] = ["approved", "accepted", "promoted"];
@@ -1354,13 +1365,38 @@ app.post("/changes/:id/evaluate", async (c) => {
   return okOrFormRedirect(c, id, { changeId: id, eval: evalResult, evalRuns: recordResult.data });
 });
 
-/** Bound on every direct GitHub API call in the promotion flow below. */
+/**
+ * Bound on every direct GitHub API call in the promotion flow below, so one
+ * slow GitHub subrequest cannot consume the whole request lifetime and get the
+ * worker killed by the platform's own limit instead of failing cleanly.
+ */
 const GITHUB_API_TIMEOUT_MS = 15_000;
 
 interface GithubPr {
   number: number;
   html_url: string;
   state: string;
+}
+
+/**
+ * A PR record is only usable if it can be persisted: `githubPrNumber` and
+ * `githubPrUrl` are what a later re-promotion checks to decide the PR already
+ * exists and skip creation entirely. Persisting a malformed record therefore
+ * strands the change permanently — every retry short-circuits to a PR that
+ * isn't there — so both the create response and the duplicate-head lookup are
+ * validated through here before anything is stored.
+ */
+function isUsableGithubPr(value: unknown): value is GithubPr {
+  if (typeof value !== "object" || value === null) return false;
+  const pr = value as Partial<GithubPr>;
+  return (
+    typeof pr.number === "number" &&
+    Number.isSafeInteger(pr.number) &&
+    pr.number > 0 &&
+    typeof pr.html_url === "string" &&
+    pr.html_url.startsWith("https://") &&
+    pr.state === "open"
+  );
 }
 
 /**
@@ -1390,8 +1426,10 @@ async function findOpenPrForHead(
     return undefined;
   }
   if (!res.ok) return undefined;
-  const prs = (await res.json().catch(() => [])) as GithubPr[];
-  return prs[0];
+  const body: unknown = await res.json().catch(() => undefined);
+  if (!Array.isArray(body)) return undefined;
+  const pr = body[0];
+  return isUsableGithubPr(pr) ? pr : undefined;
 }
 
 app.post("/changes/:id/github-pr", async (c) => {
@@ -1617,17 +1655,9 @@ app.post("/changes/:id/github-pr", async (c) => {
     // The branch is already pushed by this point, so a malformed success body
     // must not escape as an unhandled rejection (a bare 500): map it to the
     // same structured 502 every other GitHub failure uses.
-    const parsed = await ghRes
-      .json()
-      .then((value) => value as Partial<GithubPr>)
-      .catch(() => undefined);
-    if (
-      !parsed ||
-      typeof parsed.number !== "number" ||
-      typeof parsed.html_url !== "string" ||
-      typeof parsed.state !== "string"
-    ) {
-      logger.error("GitHub PR creation returned an unreadable response body", undefined, {
+    const parsed: unknown = await ghRes.json().catch(() => undefined);
+    if (!isUsableGithubPr(parsed)) {
+      logger.error("GitHub PR creation returned an unusable response body", undefined, {
         status: ghRes.status,
         changeId: id,
       });
@@ -1640,7 +1670,7 @@ app.post("/changes/:id/github-pr", async (c) => {
         502,
       );
     }
-    pr = parsed as GithubPr;
+    pr = parsed;
   }
 
   const promotedAt = new Date().toISOString();

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -71,18 +71,11 @@ const policyInflight = new Map<string, Promise<EvalPolicy>>();
 const policyKvKey = (projectId: string) => `policy:${projectId}`;
 
 /**
- * Loads a project's merge policy through a two-level cache, so the hot merge
- * paths don't clone the repo just to read `.stratum/policy.yaml`:
- *   in-isolate Map  ->  KV (shared across isolates)  ->  clone (loadPolicy).
- *
- * Concurrent requests for the same project share one policy load. Caching is
- * gated on REPO_DO_ENABLED so tests always load fresh with no KV access. The
- * cache TTL is the bound on how long a branch-protection change takes to take
- * effect on these paths — shortening it costs clones, lengthening it widens
- * that window. Throws if the read token can't be minted.
+ * Loads a project's merge policy, using the shared and isolate-local caches when enabled.
  *
  * @param project - The project whose merge policy to load
  * @returns The project's merge policy
+ * @throws If a read token cannot be minted or the policy cannot be loaded
  */
 async function loadMergePolicyCached(
   env: Env,
@@ -131,23 +124,10 @@ async function loadMergePolicyCached(
 const MAX_BASE_REF_LENGTH = 200;
 
 /**
- * Loose git branch-name validation for the PR `base` taken from the request
- * body: printable, no whitespace/control chars, none of git's forbidden
- * sequences. Rejecting here keeps garbage out of the GitHub API call.
+ * Validates a Git branch reference for use as a GitHub pull request base branch.
  *
- * git applies its per-component rules to every slash-separated component, not
- * just to the ref as a whole, so `release/.hidden` and `release/v1.lock` are
- * invalid even though the full string neither starts with `.` nor ends with
- * `.lock`.
- *
- * A bare `@` is rejected deliberately. git itself will happily create
- * `refs/heads/@` (verified against git 2.43), but `@` is its shorthand for
- * HEAD, so `git checkout @` resolves to HEAD rather than to the branch — the
- * name is ambiguous wherever it is used, and GitHub blocks ambiguous branch
- * names of its own accord. `@` inside a longer name (`feature/@/thing`) is
- * unambiguous and stays legal; only the `@{` reflog syntax is a hard error.
- * This is an allowlist for untrusted input, not a reimplementation of git's
- * parser, so erring toward rejection here is deliberate.
+ * @param ref - The branch reference to validate
+ * @returns `true` if the reference satisfies the allowed branch-name rules, `false` otherwise
  */
 function isValidBaseRef(ref: string): boolean {
   if (ref.length === 0 || ref.length > MAX_BASE_REF_LENGTH) return false;
@@ -1395,17 +1375,10 @@ interface GithubPr {
 }
 
 /**
- * Validates whether a value represents an open GitHub pull request.
- *
- * A PR record is only usable if it is safe to persist: `githubPrNumber` and
- * `githubPrUrl` are what a later re-promotion checks to decide the PR already
- * exists and skip creation entirely. Persisting a malformed record therefore
- * strands the change permanently — every retry short-circuits to a PR that
- * isn't there — so both the create response and the duplicate-head lookup are
- * validated through here before anything is stored.
+ * Determines whether a value represents an open GitHub pull request.
  *
  * @param value - The value to validate
- * @returns `true` if the value has a positive safe integer number, an HTTPS URL, and an open state, `false` otherwise.
+ * @returns `true` if the value contains a positive safe integer number, an HTTPS URL, and an open state; `false` otherwise.
  */
 function isUsableGithubPr(value: unknown): value is GithubPr {
   if (typeof value !== "object" || value === null) return false;

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -40,6 +40,7 @@ import {
 import { parseRepoUrl } from "../storage/git-providers";
 import { recordProvenance } from "../storage/provenance";
 import { getProject, getWorkspace } from "../storage/state";
+import { getProjectSourceUrl } from "../storage/sync";
 import type { Change, Env, ProjectEntry } from "../types";
 import { canReadProject, canWriteProject } from "../utils/authz";
 import { newId } from "../utils/ids";
@@ -1481,9 +1482,13 @@ app.post("/changes/:id/github-pr", async (c) => {
   if (!(await canWriteProject(c.env.DB, project, userId)))
     return forbidden("Project access denied");
 
-  // Accept the legacy githubUrl or the generic sourceUrl — bulk-imported
+  // Accept the generic sourceUrl or the legacy githubUrl — bulk-imported
   // projects only set sourceUrl (#189) — as long as it points at github.com.
-  const repoUrl = project.githubUrl ?? project.sourceUrl;
+  // Via the shared accessor, so this can't drift from the precedence the rest
+  // of the codebase uses: sourceUrl wins. A project migrated off githubUrl
+  // keeps the stale value, and this URL is what the branch is force-pushed to,
+  // so preferring the legacy field would publish to the wrong repository.
+  const repoUrl = getProjectSourceUrl(project);
   if (!repoUrl) return badRequest("Project is not connected to GitHub");
   const parsedRepo = parseRepoUrl(repoUrl);
   if (!parsedRepo || parsedRepo.provider !== "github") {

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1473,11 +1473,19 @@ function isUsableGithubUrl(raw: string, target: GithubRepoTarget, prNumber: numb
   } catch {
     return false;
   }
-  if (url.protocol !== "https:" || url.hostname !== "github.com") return false;
+  // `host`, not `hostname`: hostname discards the port entirely, so
+  // `https://github.com:8443/o/r/pull/1` would pass a hostname check. `host`
+  // keeps a non-default port and still normalises the default `:443` away, so
+  // the canonical form is unaffected.
+  if (url.protocol !== "https:" || url.host !== "github.com") return false;
   if (url.username !== "" || url.password !== "") return false;
   if (url.search !== "" || url.hash !== "") return false;
-  const path = url.pathname.replace(/\/$/, "");
-  return path.toLowerCase() === `/${target.owner}/${target.repo}/pull/${prNumber}`.toLowerCase();
+  // Compared as-is rather than after trimming a trailing slash: a canonical
+  // html_url has none, and this value is persisted and handed back, so the
+  // stored string should be the canonical one rather than a variant of it.
+  return (
+    url.pathname.toLowerCase() === `/${target.owner}/${target.repo}/pull/${prNumber}`.toLowerCase()
+  );
 }
 
 /**

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1458,6 +1458,13 @@ function isUsableGithubPr(value: unknown, target: GithubRepoTarget): value is Gi
  * GitHub is rejected too. Owner and repo compare case-insensitively because
  * GitHub echoes its own canonical casing, which need not match the casing
  * parsed out of the project's source URL.
+ *
+ * Userinfo, query, and fragment are all rejected rather than ignored. A
+ * canonical `html_url` carries none of them, and this string is persisted and
+ * handed back to callers verbatim — so `https://user:pw@github.com/o/r/pull/1`
+ * would store credentials, and `...?token=x` would store a secret in a
+ * user-visible link. Checking the host and path alone accepts both, because
+ * `hostname` and `pathname` exclude those components.
  */
 function isUsableGithubUrl(raw: string, target: GithubRepoTarget, prNumber: number): boolean {
   let url: URL;
@@ -1467,6 +1474,8 @@ function isUsableGithubUrl(raw: string, target: GithubRepoTarget, prNumber: numb
     return false;
   }
   if (url.protocol !== "https:" || url.hostname !== "github.com") return false;
+  if (url.username !== "" || url.password !== "") return false;
+  if (url.search !== "" || url.hash !== "") return false;
   const path = url.pathname.replace(/\/$/, "");
   return path.toLowerCase() === `/${target.owner}/${target.repo}/pull/${prNumber}`.toLowerCase();
 }

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -71,11 +71,15 @@ const policyInflight = new Map<string, Promise<EvalPolicy>>();
 const policyKvKey = (projectId: string) => `policy:${projectId}`;
 
 /**
- * Loads a project's merge policy using cached values when caching is enabled.
+ * Loads a project's merge policy through a two-level cache, so the hot merge
+ * paths don't clone the repo just to read `.stratum/policy.yaml`:
+ *   in-isolate Map  ->  KV (shared across isolates)  ->  clone (loadPolicy).
  *
- * Concurrent requests for the same project share one policy load. Cached policies
- * expire after the configured cache TTL; uncached loads read the policy from the
- * project's repository and propagate token or policy-loading failures.
+ * Concurrent requests for the same project share one policy load. Caching is
+ * gated on REPO_DO_ENABLED so tests always load fresh with no KV access. The
+ * cache TTL is the bound on how long a branch-protection change takes to take
+ * effect on these paths — shortening it costs clones, lengthening it widens
+ * that window. Throws if the read token can't be minted.
  *
  * @param project - The project whose merge policy to load
  * @returns The project's merge policy
@@ -1393,6 +1397,13 @@ interface GithubPr {
 /**
  * Validates whether a value represents an open GitHub pull request.
  *
+ * A PR record is only usable if it is safe to persist: `githubPrNumber` and
+ * `githubPrUrl` are what a later re-promotion checks to decide the PR already
+ * exists and skip creation entirely. Persisting a malformed record therefore
+ * strands the change permanently — every retry short-circuits to a PR that
+ * isn't there — so both the create response and the duplicate-head lookup are
+ * validated through here before anything is stored.
+ *
  * @param value - The value to validate
  * @returns `true` if the value has a positive safe integer number, an HTTPS URL, and an open state, `false` otherwise.
  */
@@ -1411,6 +1422,11 @@ function isUsableGithubPr(value: unknown): value is GithubPr {
 
 /**
  * Finds an open GitHub pull request associated with a branch.
+ *
+ * GitHub 422s PR creation with "a pull request already exists" when the head
+ * ref already has one open — either a concurrent promotion, or a retry after
+ * `updateChangeStatus` failed post-creation. Looking the PR up and reusing it
+ * turns that dead end into a successful, idempotent promotion.
  *
  * @param repo - The GitHub repository to search
  * @param branch - The head branch associated with the pull request

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1625,7 +1625,20 @@ app.post("/changes/:id/github-pr", async (c) => {
     html_url: change.githubPrUrl,
     state: change.githubPrState,
   };
-  if (isUsableGithubPr(storedPr)) {
+  // The stored PR is only reusable if it belongs to the repository this
+  // promotion is actually pushing to. `repo` is derived from the project's
+  // source URL, which can change (a project migrated between GitHub repos, or
+  // `sourceUrl` superseding a legacy `githubUrl`) — and when it does, the push
+  // above lands in the new repository while these stored values still describe
+  // a PR in the old one. Reusing them would answer with the new owner/repo
+  // beside an unrelated PR URL. Legacy rows predating this persistence have the
+  // fields undefined and so fall through, which is correct: creation plus
+  // duplicate-head reconciliation rewrites them from GitHub's own answer.
+  const storedPrMatchesTarget =
+    change.githubOwner === repo.owner &&
+    change.githubRepo === repo.repo &&
+    change.githubBranch === branch;
+  if (isUsableGithubPr(storedPr) && storedPrMatchesTarget) {
     logger.info("Change branch re-pushed to existing GitHub PR", {
       changeId: id,
       prNumber: storedPr.number,
@@ -1643,10 +1656,12 @@ app.post("/changes/:id/github-pr", async (c) => {
     });
   }
   if (change.githubPrNumber !== undefined || change.githubPrUrl !== undefined) {
-    logger.warn("Stored GitHub PR record is unusable; re-creating", {
+    logger.warn("Stored GitHub PR record is unusable or targets another repo; re-creating", {
       changeId: id,
       prNumber: change.githubPrNumber,
       prState: change.githubPrState,
+      storedTarget: `${change.githubOwner ?? "?"}/${change.githubRepo ?? "?"}#${change.githubBranch ?? "?"}`,
+      currentTarget: `${repo.owner}/${repo.repo}#${branch}`,
     });
   }
 

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -131,11 +131,20 @@ const MAX_BASE_REF_LENGTH = 200;
  * git applies its per-component rules to every slash-separated component, not
  * just to the ref as a whole, so `release/.hidden` and `release/v1.lock` are
  * invalid even though the full string neither starts with `.` nor ends with
- * `.lock`. A bare `@` is a legal branch name — only the `@{` reflog syntax is
- * rejected.
+ * `.lock`.
+ *
+ * A bare `@` is rejected deliberately. git itself will happily create
+ * `refs/heads/@` (verified against git 2.43), but `@` is its shorthand for
+ * HEAD, so `git checkout @` resolves to HEAD rather than to the branch — the
+ * name is ambiguous wherever it is used, and GitHub blocks ambiguous branch
+ * names of its own accord. `@` inside a longer name (`feature/@/thing`) is
+ * unambiguous and stays legal; only the `@{` reflog syntax is a hard error.
+ * This is an allowlist for untrusted input, not a reimplementation of git's
+ * parser, so erring toward rejection here is deliberate.
  */
 function isValidBaseRef(ref: string): boolean {
   if (ref.length === 0 || ref.length > MAX_BASE_REF_LENGTH) return false;
+  if (ref === "@") return false;
   // biome-ignore lint/suspicious/noControlCharactersInRegex: control chars are exactly what's rejected
   if (/[\s~^:?*[\\\x00-\x1f\x7f]/.test(ref)) return false;
   if (ref.startsWith("-") || ref.startsWith("/")) return false;

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1613,10 +1613,22 @@ app.post("/changes/:id/github-pr", async (c) => {
 
   // Re-promotion: the PR already exists and the force-push above refreshed its
   // head, so skip the create call (GitHub 422s on a duplicate head ref).
-  if (change.githubPrNumber !== undefined && change.githubPrUrl !== undefined) {
+  //
+  // The stored record is validated rather than trusted: rows written before
+  // this route validated GitHub's responses can hold anything, and a closed PR
+  // must not be handed back as a successful promotion. Falling through on a bad
+  // record is the recovery path, not a failure — creation runs, and the
+  // duplicate-head branch below repairs the stored values from GitHub's own
+  // answer when an open PR does exist for this head.
+  const storedPr = {
+    number: change.githubPrNumber,
+    html_url: change.githubPrUrl,
+    state: change.githubPrState,
+  };
+  if (isUsableGithubPr(storedPr)) {
     logger.info("Change branch re-pushed to existing GitHub PR", {
       changeId: id,
-      prNumber: change.githubPrNumber,
+      prNumber: storedPr.number,
       repo: `${repo.owner}/${repo.repo}`,
     });
     return okOrFormRedirect(c, id, {
@@ -1625,9 +1637,16 @@ app.post("/changes/:id/github-pr", async (c) => {
         owner: repo.owner,
         repo: repo.repo,
         branch,
-        pullRequestNumber: change.githubPrNumber,
-        pullRequestUrl: change.githubPrUrl,
+        pullRequestNumber: storedPr.number,
+        pullRequestUrl: storedPr.html_url,
       },
+    });
+  }
+  if (change.githubPrNumber !== undefined || change.githubPrUrl !== undefined) {
+    logger.warn("Stored GitHub PR record is unusable; re-creating", {
+      changeId: id,
+      prNumber: change.githubPrNumber,
+      prState: change.githubPrState,
     });
   }
 

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -71,7 +71,15 @@ const policyInflight = new Map<string, Promise<EvalPolicy>>();
 const policyKvKey = (projectId: string) => `policy:${projectId}`;
 
 /**
- * Loads a project's merge policy, using the shared and isolate-local caches when enabled.
+ * Loads a project's merge policy through a two-level cache — in-isolate Map,
+ * then KV (shared across isolates), then a clone via `loadPolicy`.
+ *
+ * The cache exists because the hot merge paths would otherwise clone the repo
+ * just to read `.stratum/policy.yaml`. Caching is gated on REPO_DO_ENABLED so
+ * tests always load fresh with no KV access, and the TTL is the bound on how
+ * long a branch-protection change takes to take effect here: shortening it
+ * costs clones, lengthening it widens the window where a revoked rule still
+ * applies.
  *
  * @param project - The project whose merge policy to load
  * @returns The project's merge policy
@@ -125,6 +133,19 @@ const MAX_BASE_REF_LENGTH = 200;
 
 /**
  * Validates a Git branch reference for use as a GitHub pull request base branch.
+ *
+ * `base` arrives in the request body, so this is the boundary where untrusted
+ * input is bounded before it reaches the GitHub API — an allowlist, not a
+ * faithful reimplementation of git's parser.
+ *
+ * Two rules are easy to get wrong. git applies its per-component rules to
+ * every slash-separated component, not just the whole ref, so `release/.hidden`
+ * and `release/v1.lock` are invalid even though the full string neither starts
+ * with `.` nor ends with `.lock`. And a bare `@` is rejected deliberately even
+ * though git will happily create `refs/heads/@` (verified against git 2.43):
+ * `@` is git's shorthand for HEAD, so `git checkout @` resolves to HEAD rather
+ * than the branch. `@` inside a longer name is unambiguous and stays legal;
+ * only the `@{` reflog syntax is a hard error.
  *
  * @param ref - The branch reference to validate
  * @returns `true` if the reference satisfies the allowed branch-name rules, `false` otherwise
@@ -1374,11 +1395,37 @@ interface GithubPr {
   state: string;
 }
 
+/** One entry of GitHub's `errors` array, as far as this route relies on it. */
+interface GithubErrorDetail {
+  message?: string;
+  code?: string;
+  field?: string;
+}
+
+/** Narrows one element of an untrusted `errors` array before it is read. */
+function isGithubErrorDetail(value: unknown): value is GithubErrorDetail {
+  if (typeof value !== "object" || value === null) return false;
+  const detail = value as Record<string, unknown>;
+  return (["message", "code", "field"] as const).every(
+    (key) => detail[key] === undefined || typeof detail[key] === "string",
+  );
+}
+
 /**
  * Determines whether a value represents an open GitHub pull request.
  *
+ * Validation is strict because these fields get persisted: `githubPrNumber`
+ * and `githubPrUrl` are what a later re-promotion checks to decide the PR
+ * already exists and skip creation entirely. A malformed record stored here
+ * therefore strands the change permanently — every retry short-circuits to a
+ * PR that isn't there — so both the create response and the duplicate-head
+ * lookup are validated through this before anything is written.
+ *
+ * `html_url` is parsed rather than prefix-matched: `"https://"` passes a
+ * `startsWith` check but is not a reachable PR link.
+ *
  * @param value - The value to validate
- * @returns `true` if the value contains a positive safe integer number, an HTTPS URL, and an open state; `false` otherwise.
+ * @returns `true` if the value contains a positive safe integer number, a usable GitHub HTTPS URL, and an open state; `false` otherwise.
  */
 function isUsableGithubPr(value: unknown): value is GithubPr {
   if (typeof value !== "object" || value === null) return false;
@@ -1388,8 +1435,26 @@ function isUsableGithubPr(value: unknown): value is GithubPr {
     Number.isSafeInteger(pr.number) &&
     pr.number > 0 &&
     typeof pr.html_url === "string" &&
-    pr.html_url.startsWith("https://") &&
+    isUsableGithubUrl(pr.html_url) &&
     pr.state === "open"
+  );
+}
+
+/** A PR link this app would be willing to store and hand back to a caller. */
+function isUsableGithubUrl(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  // The whole promotion path is hard-coded to github.com (api.github.com, the
+  // github.com clone URL), so anything else here is a malformed or spoofed
+  // response rather than a legitimate enterprise host.
+  return (
+    url.protocol === "https:" &&
+    (url.hostname === "github.com" || url.hostname.endsWith(".github.com")) &&
+    url.pathname.length > 1
   );
 }
 
@@ -1612,15 +1677,22 @@ app.post("/changes/:id/github-pr", async (c) => {
     // exactly what to fix.
     const detail = await ghRes.text().catch(() => "");
     let githubMessage: string | undefined;
-    let errors: Array<{ message?: string; code?: string; field?: string }> = [];
+    let errors: GithubErrorDetail[] = [];
     try {
-      const parsed = JSON.parse(detail) as {
-        message?: string;
-        errors?: Array<{ message?: string; code?: string; field?: string }>;
+      // The branch is already pushed by this point, so anything thrown while
+      // parsing an error body escapes as a bare 500 and loses the structured
+      // GITHUB_ERROR/502 the caller needs. GitHub is not guaranteed to send the
+      // documented shape on every failure, so validate rather than cast:
+      // `{"errors":{}}`, `{"errors":"invalid"}` and `{"errors":[null]}` all
+      // reach `.map()` otherwise.
+      const parsed: unknown = JSON.parse(detail);
+      const body = (typeof parsed === "object" && parsed !== null ? parsed : {}) as {
+        message?: unknown;
+        errors?: unknown;
       };
-      errors = parsed.errors ?? [];
+      errors = Array.isArray(body.errors) ? body.errors.filter(isGithubErrorDetail) : [];
       githubMessage = [
-        parsed.message,
+        typeof body.message === "string" ? body.message : undefined,
         ...errors.map((e) => e.message ?? (e.field ? `${e.field} ${e.code}` : e.code)),
       ]
         .filter(Boolean)

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1614,7 +1614,33 @@ app.post("/changes/:id/github-pr", async (c) => {
     }
     pr = existingPr;
   } else {
-    pr = (await ghRes.json()) as GithubPr;
+    // The branch is already pushed by this point, so a malformed success body
+    // must not escape as an unhandled rejection (a bare 500): map it to the
+    // same structured 502 every other GitHub failure uses.
+    const parsed = await ghRes
+      .json()
+      .then((value) => value as Partial<GithubPr>)
+      .catch(() => undefined);
+    if (
+      !parsed ||
+      typeof parsed.number !== "number" ||
+      typeof parsed.html_url !== "string" ||
+      typeof parsed.state !== "string"
+    ) {
+      logger.error("GitHub PR creation returned an unreadable response body", undefined, {
+        status: ghRes.status,
+        changeId: id,
+      });
+      return c.json(
+        {
+          error: "GitHub PR creation failed: unreadable response from GitHub",
+          code: "GITHUB_ERROR",
+          githubStatus: ghRes.status,
+        },
+        502,
+      );
+    }
+    pr = parsed as GithubPr;
   }
 
   const promotedAt = new Date().toISOString();

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -276,7 +276,14 @@ export async function pushMain(
 }
 
 /**
- * Pushes the local `main` branch to a branch on an external remote.
+ * Pushes the local `main` branch to a branch on an external remote — e.g.
+ * GitHub's `stratum/<changeId>` ref before a PR is opened (#189).
+ *
+ * Auth is HTTP basic with the token as the password; GitHub accepts any
+ * username alongside a token. `force` defaults to false because `remoteRef` is
+ * caller-supplied and could name a branch this app does not own — a defaulted
+ * force-push there would destroy someone else's work. Pass `force: true`
+ * explicitly, and only when overwriting a ref Stratum owns (re-promotion).
  *
  * @param opts - Remote URL, target branch, authentication token, and optional force-push setting.
  * @returns A successful result when the push completes, or an application error when it fails.

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -246,6 +246,10 @@ export async function freshRepoToken(
 /**
  * Publishes the local `main` branch to a remote repository.
  *
+ * `force` is opt-in because it overwrites the remote's `main` outright — the
+ * project's canonical branch — so defaulting it on would discard any commits
+ * pushed by someone else since this clone was taken.
+ *
  * @param opts - Controls whether an existing remote `main` branch may be overwritten.
  * @returns No value on success, or an application error if the push fails.
  */
@@ -321,6 +325,9 @@ export async function pushBranchToRemote(
 /**
  * Initializes a repository with the supplied files, commits them, and pushes the commit to `main`.
  *
+ * Only valid against a remote with no history: this builds the root commit, so
+ * running it on a populated repository would orphan whatever is already there.
+ *
  * @param remote - The remote repository URL
  * @param token - The authentication token for the remote repository
  * @param files - Files to add to the initial commit, keyed by path
@@ -393,6 +400,10 @@ export async function initAndPush(
 
 /**
  * Clones the `main` branch of a repository into an in-memory filesystem.
+ *
+ * The whole tree lands in worker memory, which is what makes the depth choice
+ * a real tradeoff rather than a preference — see the `fullHistory` branch at
+ * the `depth` option for why backup needs full history and merges do not.
  *
  * @param remote - The repository URL to clone
  * @param token - The authentication token for the repository

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -250,6 +250,42 @@ export async function pushMain(
   return ok(undefined);
 }
 
+/**
+ * Push the cloned repo's local `main` to an arbitrary branch on an external
+ * remote (e.g. GitHub's `stratum/<changeId>` ref before a PR is opened, #189).
+ * Auth is HTTP basic with the token as the password — GitHub accepts any
+ * username alongside a token. Forces by default: the target ref is
+ * Stratum-owned, so re-promotion must move it to the current tip.
+ */
+export async function pushBranchToRemote(
+  fs: NodeFS,
+  dir: string,
+  opts: { url: string; remoteRef: string; token: string; force?: boolean },
+  logger: Logger,
+): Promise<Result<void, AppError>> {
+  const res = await fromPromise(
+    git.push({
+      fs,
+      dir,
+      http,
+      url: opts.url,
+      ref: "main",
+      remoteRef: opts.remoteRef,
+      onAuth: () => ({ username: "x-access-token", password: opts.token }),
+      force: opts.force ?? true,
+    }),
+  );
+  if (!res.success) {
+    const cause = res.error instanceof Error ? res.error.message : String(res.error);
+    logger.error("Failed to push branch to remote", res.error, {
+      url: opts.url,
+      remoteRef: opts.remoteRef,
+    });
+    return err(new ExternalServiceError("Git", `Failed to push branch: ${cause}`, res.error));
+  }
+  return ok(undefined);
+}
+
 export async function initAndPush(
   remote: string,
   token: string,

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -276,12 +276,10 @@ export async function pushMain(
 }
 
 /**
- * Push the cloned repo's local `main` to an arbitrary branch on an external
- * remote (e.g. GitHub's `stratum/<changeId>` ref before a PR is opened, #189).
- * Auth is HTTP basic with the token as the password — GitHub accepts any
- * username alongside a token. `force` defaults to false since `remoteRef` is
- * caller-supplied and could name a non-Stratum-owned branch; pass `force: true`
- * explicitly when overwriting a ref this app owns (e.g. re-promotion).
+ * Pushes the local `main` branch to a branch on an external remote.
+ *
+ * @param opts - Remote URL, target branch, authentication token, and optional force-push setting.
+ * @returns A successful result when the push completes, or an application error when it fails.
  */
 export async function pushBranchToRemote(
   fs: NodeFS,
@@ -312,6 +310,15 @@ export async function pushBranchToRemote(
   return ok(undefined);
 }
 
+/**
+ * Initializes a repository with the supplied files, commits them, and pushes the commit to `main`.
+ *
+ * @param remote - The remote repository URL
+ * @param files - Files to add to the initial commit, keyed by path
+ * @param message - The commit message
+ * @param author - The commit author
+ * @returns The SHA of the pushed commit
+ */
 export async function initAndPush(
   remote: string,
   token: string,
@@ -375,6 +382,15 @@ export async function initAndPush(
   return ok(commitResult.data);
 }
 
+/**
+ * Clones the `main` branch of a repository into an in-memory filesystem.
+ *
+ * @param remote - The repository URL to clone
+ * @param token - The authentication token for the repository
+ * @param opts - Clone options
+ * @param opts.fullHistory - Whether to clone the complete reachable history; otherwise, clone the most recent 50 commits
+ * @returns The cloned filesystem and its working directory, or an application error
+ */
 export async function cloneRepo(
   remote: string,
   token: string,

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -244,9 +244,10 @@ export async function freshRepoToken(
 }
 
 /**
- * Push the local `main` ref (its objects + the ref) to an Artifacts remote.
- * Used by backup restore to publish a reconstructed repo. `force` overwrites a
- * non-empty remote (restore-over-existing behind an explicit opt-in).
+ * Publishes the local `main` branch to a remote repository.
+ *
+ * @param opts - Controls whether an existing remote `main` branch may be overwritten.
+ * @returns No value on success, or an application error if the push fails.
  */
 export async function pushMain(
   remote: string,
@@ -321,6 +322,7 @@ export async function pushBranchToRemote(
  * Initializes a repository with the supplied files, commits them, and pushes the commit to `main`.
  *
  * @param remote - The remote repository URL
+ * @param token - The authentication token for the remote repository
  * @param files - Files to add to the initial commit, keyed by path
  * @param message - The commit message
  * @param author - The commit author

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -2550,6 +2550,9 @@ describe("POST /api/changes/:id/github-pr", () => {
       data: {
         ...acceptedChange,
         status: "promoted",
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubBranch: "stratum/chg_abc123",
         githubPrNumber: 7,
         githubPrUrl: "https://github.com/acme/widgets/pull/7",
         githubPrState: "open",
@@ -2576,15 +2579,98 @@ describe("POST /api/changes/:id/github-pr", () => {
   it.each([
     [
       "a closed PR",
-      { githubPrNumber: 7, githubPrUrl: "https://github.com/a/b/pull/7", githubPrState: "closed" },
+      {
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubBranch: "stratum/chg_abc123",
+        githubPrNumber: 7,
+        githubPrUrl: "https://github.com/a/b/pull/7",
+        githubPrState: "closed",
+      },
     ],
-    ["no stored state", { githubPrNumber: 7, githubPrUrl: "https://github.com/a/b/pull/7" }],
+    // A project can be re-pointed at a different GitHub repo (migration, or
+    // sourceUrl superseding a legacy githubUrl). The push then lands in the new
+    // repo while these stored values still name a PR in the old one, so the
+    // record is well-formed but belongs to the wrong target.
+    [
+      "a PR from a different owner",
+      {
+        githubOwner: "other",
+        githubRepo: "widgets",
+        githubBranch: "stratum/chg_abc123",
+        githubPrNumber: 7,
+        githubPrUrl: "https://github.com/a/b/pull/7",
+        githubPrState: "open",
+      },
+    ],
+    [
+      "a PR from a different repo",
+      {
+        githubOwner: "acme",
+        githubRepo: "gadgets",
+        githubBranch: "stratum/chg_abc123",
+        githubPrNumber: 7,
+        githubPrUrl: "https://github.com/a/b/pull/7",
+        githubPrState: "open",
+      },
+    ],
+    [
+      "a PR for a different branch",
+      {
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubBranch: "stratum/chg_old",
+        githubPrNumber: 7,
+        githubPrUrl: "https://github.com/a/b/pull/7",
+        githubPrState: "open",
+      },
+    ],
+    [
+      "no stored target (legacy row)",
+      { githubPrNumber: 7, githubPrUrl: "https://github.com/a/b/pull/7", githubPrState: "open" },
+    ],
+    [
+      "no stored state",
+      {
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubBranch: "stratum/chg_abc123",
+        githubPrNumber: 7,
+        githubPrUrl: "https://github.com/a/b/pull/7",
+      },
+    ],
     [
       "a zero PR number",
-      { githubPrNumber: 0, githubPrUrl: "https://github.com/a/b/pull/7", githubPrState: "open" },
+      {
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubBranch: "stratum/chg_abc123",
+        githubPrNumber: 0,
+        githubPrUrl: "https://github.com/a/b/pull/7",
+        githubPrState: "open",
+      },
     ],
-    ["an unusable url", { githubPrNumber: 7, githubPrUrl: "https://", githubPrState: "open" }],
-    ["a number but no url", { githubPrNumber: 7, githubPrState: "open" }],
+    [
+      "an unusable url",
+      {
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubBranch: "stratum/chg_abc123",
+        githubPrNumber: 7,
+        githubPrUrl: "https://",
+        githubPrState: "open",
+      },
+    ],
+    [
+      "a number but no url",
+      {
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubBranch: "stratum/chg_abc123",
+        githubPrNumber: 7,
+        githubPrState: "open",
+      },
+    ],
   ])("re-creates the PR when the stored record has %s", async (_label, stored) => {
     vi.mocked(getChange).mockResolvedValue({
       success: true,
@@ -2611,7 +2697,11 @@ describe("POST /api/changes/:id/github-pr", () => {
       expect.anything(),
       "chg_abc123",
       "promoted",
-      expect.objectContaining({ githubPrNumber: 42 }),
+      expect.objectContaining({
+        githubPrNumber: 42,
+        githubPrUrl: "https://github.com/acme/widgets/pull/42",
+        githubPrState: "open",
+      }),
     );
   });
 

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -2180,8 +2180,8 @@ describe("POST /api/changes/:id/github-pr", () => {
     expect(prPayload.base).toBe("release/1.2");
   });
 
-  it.each(["@", "feature/@/thing", "v1.0.0", "a.b.c/d.e"])(
-    "accepts the legal base %j (only the @{ reflog syntax is rejected)",
+  it.each(["feature/@/thing", "feature/@-fix", "v1.0.0", "a.b.c/d.e"])(
+    "accepts the legal base %j (@ inside a longer name is unambiguous)",
     async (base) => {
       const res = await promote({ base });
       expect(res.status).toBe(200);
@@ -2215,6 +2215,9 @@ describe("POST /api/changes/:id/github-pr", () => {
     "release/v1.",
     "release/v1.lock",
     "release/v1.lock/next",
+    // git will create refs/heads/@, but "@" is git's shorthand for HEAD, so the
+    // name is ambiguous everywhere it is used. Rejected deliberately.
+    "@",
   ])("rejects garbage base %j without touching GitHub", async (base) => {
     const res = await promote({ base });
     expect(res.status).toBe(400);

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -2022,11 +2022,16 @@ describe("POST /api/changes/:id/github-pr", () => {
     githubDefaultBranch: "develop",
   };
 
-  function githubPrCreated(): Response {
+  // GitHub always answers with an html_url inside the repository the request was
+  // addressed to, so derive it from the API URL rather than hard-coding one repo.
+  // A fixed acme/widgets link would be wrong for the sourceUrl tests, which
+  // promote to a different repository.
+  function githubPrCreated(apiUrl = "https://api.github.com/repos/acme/widgets/pulls"): Response {
+    const slug = new URL(apiUrl).pathname.replace(/^\/repos\//, "").replace(/\/pulls.*$/, "");
     return new Response(
       JSON.stringify({
         number: 42,
-        html_url: "https://github.com/acme/widgets/pull/42",
+        html_url: `https://github.com/${slug}/pull/42`,
         state: "open",
       }),
       { status: 201, headers: { "Content-Type": "application/json" } },
@@ -2067,7 +2072,7 @@ describe("POST /api/changes/:id/github-pr", () => {
       data: { fs: {} as NodeFS, dir: "/" },
     });
     vi.mocked(pushBranchToRemote).mockResolvedValue({ success: true, data: undefined });
-    fetchMock = vi.fn(async () => githubPrCreated());
+    fetchMock = vi.fn(async (url: string) => githubPrCreated(url));
     vi.stubGlobal("fetch", fetchMock);
   });
 
@@ -2171,6 +2176,46 @@ describe("POST /api/changes/:id/github-pr", () => {
     );
     const prPayload = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
     expect(prPayload.base).toBe("trunk"); // sourceDefaultBranch wins
+  });
+
+  // A shape-only URL check (github.com suffix + non-empty path) accepts real
+  // GitHub URLs that are not this PR's page. Persisting one strands the change
+  // exactly as a malformed record would, so the create response is rejected.
+  it.each([
+    ["an api.github.com endpoint", "https://api.github.com/repos/acme/widgets/pulls/42"],
+    ["a gist.github.com subdomain", "https://gist.github.com/acme/widgets/pull/42"],
+    ["an unrelated github.com page", "https://github.com/login"],
+    ["a PR in another repository", "https://github.com/other/repo/pull/42"],
+    ["a different PR number", "https://github.com/acme/widgets/pull/99"],
+    ["a non-https scheme", "http://github.com/acme/widgets/pull/42"],
+  ])("502s when GitHub returns %s as html_url", async (_label, htmlUrl) => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ number: 42, html_url: htmlUrl, state: "open" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const res = await promote();
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("GITHUB_ERROR");
+    // Nothing unusable may be persisted.
+    expect(updateChangeStatus).not.toHaveBeenCalled();
+  });
+
+  it("accepts the canonical PR url regardless of owner/repo casing", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          number: 42,
+          html_url: "https://github.com/Acme/Widgets/pull/42",
+          state: "open",
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const res = await promote();
+    expect(res.status).toBe(200);
   });
 
   it("prefers sourceUrl over a stale legacy githubUrl", async () => {

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { authMiddleware } from "../src/middleware/auth";
 import { changesRouter } from "../src/routes/changes";
 import type { Change, Env } from "../src/types";
@@ -33,6 +33,7 @@ vi.mock("../src/storage/git-ops", async (importActual) => {
     freshRepoToken: vi.fn(async () => ({ success: true, data: "test-token" })),
     cloneRepo: vi.fn(async () => ({ success: true, data: { fs: {}, dir: "/" } })),
     batchMergeStagedTrees: vi.fn(),
+    pushBranchToRemote: vi.fn(async () => ({ success: true, data: undefined })),
   };
 });
 
@@ -158,10 +159,12 @@ import { isTargetDeleting } from "../src/storage/deletion";
 import { listEvalRuns, recordEvalRuns } from "../src/storage/eval-runs";
 import {
   batchMergeStagedTrees,
+  cloneRepo,
   freshRepoToken,
   getCommitLog,
   getDiffBetweenRepos,
   mergeWorkspaceIntoProject,
+  pushBranchToRemote,
 } from "../src/storage/git-ops";
 import { packObjects } from "../src/storage/object-loader";
 import { recordProvenance } from "../src/storage/provenance";
@@ -1893,5 +1896,403 @@ describe("POST /api/projects/:name/changes/merge-batch", () => {
       exec() as any,
     );
     expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/changes/:id/github-pr", () => {
+  let app: ReturnType<typeof makeApp>;
+  let env: Env;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  const acceptedChange: Change = {
+    ...mockChange,
+    status: "accepted",
+    evalScore: 0.9,
+    evalPassed: true,
+  };
+
+  const githubProject = {
+    ...mockProject,
+    githubUrl: "https://github.com/acme/widgets",
+    githubDefaultBranch: "develop",
+  };
+
+  function githubPrCreated(): Response {
+    return new Response(
+      JSON.stringify({
+        number: 42,
+        html_url: "https://github.com/acme/widgets/pull/42",
+        state: "open",
+      }),
+      { status: 201, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  beforeEach(() => {
+    app = makeApp();
+    env = makeEnv();
+    env.GITHUB_TOKEN = "ghp_secret_token";
+    vi.clearAllMocks();
+    vi.mocked(getUserByToken).mockImplementation(async (_db, token) => {
+      if (token === "stratum_user_testtoken00000000000000000") {
+        return {
+          success: true,
+          data: {
+            id: "user_test",
+            email: "test@example.com",
+            username: "test",
+            tokenHash: "hash",
+            createdAt: "2026-01-01T00:00:00.000Z",
+          },
+        };
+      }
+      return { success: false, error: new NotFoundError("User", token) };
+    });
+    vi.mocked(getAgentByToken).mockResolvedValue({
+      success: false,
+      error: new NotFoundError("Agent", "none"),
+    });
+    vi.mocked(getChange).mockResolvedValue({ success: true, data: acceptedChange });
+    vi.mocked(getProject).mockResolvedValue({ success: true, data: githubProject });
+    vi.mocked(getWorkspace).mockResolvedValue({ success: true, data: mockWorkspace });
+    vi.mocked(updateChangeStatus).mockResolvedValue({ success: true, data: undefined });
+    vi.mocked(freshRepoToken).mockResolvedValue({ success: true, data: "artifacts-token" });
+    vi.mocked(cloneRepo).mockResolvedValue({
+      success: true,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal NodeFS stub
+      data: { fs: {} as any, dir: "/" },
+    });
+    vi.mocked(pushBranchToRemote).mockResolvedValue({ success: true, data: undefined });
+    fetchMock = vi.fn(async () => githubPrCreated());
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const promote = (body?: unknown) =>
+    app.fetch(request("POST", "/api/changes/chg_abc123/github-pr", body ?? {}, USER_AUTH), env);
+
+  it("pushes the change branch to GitHub, then opens the PR from it", async () => {
+    const res = await promote();
+    expect(res.status).toBe(200);
+
+    // The workspace fork is cloned with a fresh read token…
+    expect(freshRepoToken).toHaveBeenCalledWith(
+      env.ARTIFACTS,
+      mockWorkspace.remote,
+      "read",
+      expect.anything(),
+    );
+    expect(cloneRepo).toHaveBeenCalledWith(
+      mockWorkspace.remote,
+      "artifacts-token",
+      expect.anything(),
+    );
+    // …and its tip is pushed to the Stratum-owned head ref on GitHub.
+    expect(pushBranchToRemote).toHaveBeenCalledWith(
+      {},
+      "/",
+      {
+        url: "https://github.com/acme/widgets.git",
+        remoteRef: "refs/heads/stratum/chg_abc123",
+        token: "ghp_secret_token",
+      },
+      expect.anything(),
+    );
+
+    // The push strictly precedes PR creation (a missing head ref is a 422).
+    const pushOrder = vi.mocked(pushBranchToRemote).mock.invocationCallOrder[0] ?? -1;
+    const prOrder = fetchMock.mock.invocationCallOrder[0] ?? -1;
+    expect(pushOrder).toBeGreaterThan(0);
+    expect(pushOrder).toBeLessThan(prOrder);
+
+    // The PR is opened from the branch that was just pushed.
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/widgets/pulls",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const prPayload = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(prPayload.head).toBe("stratum/chg_abc123");
+    expect(prPayload.base).toBe("develop"); // project's known default branch
+    expect(prPayload.draft).toBe(true);
+
+    const body = (await res.json()) as { github: Record<string, unknown> };
+    expect(body.github).toEqual({
+      owner: "acme",
+      repo: "widgets",
+      branch: "stratum/chg_abc123",
+      pullRequestNumber: 42,
+      pullRequestUrl: "https://github.com/acme/widgets/pull/42",
+    });
+    expect(updateChangeStatus).toHaveBeenCalledWith(
+      env.DB,
+      expect.anything(),
+      "chg_abc123",
+      "promoted",
+      expect.objectContaining({
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubBranch: "stratum/chg_abc123",
+        githubPrNumber: 42,
+        promotedBy: "user_test",
+      }),
+    );
+  });
+
+  it("promotes a bulk-imported project that only has sourceUrl", async () => {
+    vi.mocked(getProject).mockResolvedValue({
+      success: true,
+      data: {
+        ...mockProject,
+        sourceUrl: "https://github.com/imported/repo.git",
+        sourceDefaultBranch: "trunk",
+      },
+    });
+
+    const res = await promote();
+    expect(res.status).toBe(200);
+    expect(pushBranchToRemote).toHaveBeenCalledWith(
+      {},
+      "/",
+      expect.objectContaining({ url: "https://github.com/imported/repo.git" }),
+      expect.anything(),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/imported/repo/pulls",
+      expect.anything(),
+    );
+    const prPayload = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(prPayload.base).toBe("trunk"); // sourceDefaultBranch wins
+  });
+
+  it("passes a valid caller-supplied base through to GitHub", async () => {
+    const res = await promote({ base: "release/1.2" });
+    expect(res.status).toBe(200);
+    const prPayload = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(prPayload.base).toBe("release/1.2");
+  });
+
+  it.each([
+    "two words",
+    "bad..dots",
+    "-leading-dash",
+    "@{upstream}",
+    "branch.lock",
+    "/leading-slash",
+    "trailing-slash/",
+    "trailing-dot.",
+    "double//slash",
+    "back\\slash",
+    "colon:ref",
+    "star*glob",
+    "quest?ion",
+    "ctrl\u0007bell",
+    "a".repeat(201),
+    "",
+  ])("rejects garbage base %j without touching GitHub", async (base) => {
+    const res = await promote({ base });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("Invalid base branch name");
+    expect(pushBranchToRemote).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-string base", async () => {
+    const res = await promote({ base: 42 });
+    expect(res.status).toBe(400);
+    expect(pushBranchToRemote).not.toHaveBeenCalled();
+  });
+
+  it("400s when the project has neither githubUrl nor sourceUrl", async () => {
+    vi.mocked(getProject).mockResolvedValue({ success: true, data: mockProject });
+    const res = await promote();
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "Project is not connected to GitHub",
+    );
+  });
+
+  it("400s when the source is not a GitHub repository", async () => {
+    vi.mocked(getProject).mockResolvedValue({
+      success: true,
+      data: { ...mockProject, sourceUrl: "https://gitlab.com/acme/widgets" },
+    });
+    const res = await promote();
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "Project source is not a GitHub repository",
+    );
+    expect(pushBranchToRemote).not.toHaveBeenCalled();
+  });
+
+  it("surfaces GitHub's status and message on PR-creation failure, without the token", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          message: "Validation Failed",
+          errors: [{ resource: "PullRequest", field: "base", code: "invalid" }],
+        }),
+        { status: 422 },
+      ),
+    );
+    const res = await promote();
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string; code: string; githubStatus: number };
+    expect(body.code).toBe("GITHUB_ERROR");
+    expect(body.githubStatus).toBe(422);
+    expect(body.error).toContain("422");
+    expect(body.error).toContain("Validation Failed");
+    expect(body.error).toContain("base invalid");
+    expect(JSON.stringify(body)).not.toContain("ghp_secret_token");
+    expect(updateChangeStatus).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a non-JSON GitHub failure as status-only", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("<html>bad gateway</html>", { status: 502 }));
+    const res = await promote();
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string; githubStatus: number };
+    expect(body.error).toBe("GitHub PR creation failed (502)");
+    expect(body.githubStatus).toBe(502);
+  });
+
+  it("502s when the branch push fails, without calling the PR API", async () => {
+    vi.mocked(pushBranchToRemote).mockResolvedValue({
+      success: false,
+      error: new AppError(
+        "Git error: Failed to push branch: remote hung up",
+        "EXTERNAL_SERVICE_ERROR",
+        502,
+      ),
+    });
+    const res = await promote();
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string; code: string };
+    expect(body.code).toBe("EXTERNAL_SERVICE_ERROR");
+    expect(body.error).toContain("Failed to push branch");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(updateChangeStatus).not.toHaveBeenCalled();
+  });
+
+  it("re-promotion re-pushes the branch and reuses the existing PR", async () => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: {
+        ...acceptedChange,
+        status: "promoted",
+        githubPrNumber: 7,
+        githubPrUrl: "https://github.com/acme/widgets/pull/7",
+      },
+    });
+    const res = await promote();
+    expect(res.status).toBe(200);
+    expect(pushBranchToRemote).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled(); // no duplicate-head 422
+    const body = (await res.json()) as { github: Record<string, unknown> };
+    expect(body.github).toEqual(
+      expect.objectContaining({
+        pullRequestNumber: 7,
+        pullRequestUrl: "https://github.com/acme/widgets/pull/7",
+      }),
+    );
+    expect(updateChangeStatus).not.toHaveBeenCalled();
+  });
+
+  it("400s when the change is not accepted", async () => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: { ...mockChange, status: "open" },
+    });
+    const res = await promote();
+    expect(res.status).toBe(400);
+    expect(pushBranchToRemote).not.toHaveBeenCalled();
+  });
+
+  it("400s when GITHUB_TOKEN is not configured", async () => {
+    env.GITHUB_TOKEN = undefined;
+    const res = await promote();
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "GitHub integration is not configured",
+    );
+    expect(pushBranchToRemote).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("404s when the change's workspace no longer exists", async () => {
+    vi.mocked(getWorkspace).mockResolvedValue({
+      success: false,
+      error: new NotFoundError("Workspace", "fix-bug"),
+    });
+    const res = await promote();
+    expect(res.status).toBe(404);
+    expect(pushBranchToRemote).not.toHaveBeenCalled();
+  });
+
+  it("400s when the workspace lookup fails for another reason", async () => {
+    vi.mocked(getWorkspace).mockResolvedValue({
+      success: false,
+      error: new AppError("KV unavailable", "KV_ERROR", 500),
+    });
+    const res = await promote();
+    expect(res.status).toBe(400);
+    expect(pushBranchToRemote).not.toHaveBeenCalled();
+  });
+
+  it("404s when the change does not exist", async () => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: false,
+      error: new NotFoundError("Change", "chg_abc123"),
+    });
+    const res = await promote();
+    expect(res.status).toBe(404);
+  });
+
+  it("400s when the change lookup fails for another reason", async () => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: false,
+      error: new AppError("D1 unavailable", "DATABASE_ERROR", 500),
+    });
+    const res = await promote();
+    expect(res.status).toBe(400);
+  });
+
+  it("404s when the project does not exist", async () => {
+    vi.mocked(getProject).mockResolvedValue({
+      success: false,
+      error: new NotFoundError("Project", "my-project"),
+    });
+    const res = await promote();
+    expect(res.status).toBe(404);
+  });
+
+  it("400s when the project lookup fails for another reason", async () => {
+    vi.mocked(getProject).mockResolvedValue({
+      success: false,
+      error: new AppError("KV unavailable", "KV_ERROR", 500),
+    });
+    const res = await promote();
+    expect(res.status).toBe(400);
+  });
+
+  it("400s when recording the promoted status fails after PR creation", async () => {
+    vi.mocked(updateChangeStatus).mockResolvedValue({
+      success: false,
+      error: new AppError("write failed", "DATABASE_ERROR", 500),
+    });
+    const res = await promote();
+    expect(res.status).toBe(400);
+  });
+
+  it("500s when the workspace clone fails", async () => {
+    vi.mocked(cloneRepo).mockResolvedValue({
+      success: false,
+      error: new AppError("Git error: Failed to clone repository", "EXTERNAL_SERVICE_ERROR", 502),
+    });
+    const res = await promote();
+    expect(res.status).toBe(500);
+    expect(pushBranchToRemote).not.toHaveBeenCalled();
   });
 });

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -2274,6 +2274,28 @@ describe("POST /api/changes/:id/github-pr", () => {
     expect(updateChangeStatus).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["invalid JSON", () => new Response("not json at all", { status: 201 })],
+    [
+      "a body missing the PR fields",
+      () => new Response(JSON.stringify({ ok: true }), { status: 201 }),
+    ],
+  ])(
+    "502s rather than throwing when GitHub returns a 2xx with %s",
+    async (_label, makeResponse) => {
+      fetchMock.mockResolvedValueOnce(makeResponse());
+      const res = await promote();
+      expect(res.status).toBe(502);
+      const body = (await res.json()) as { error: string; code: string };
+      expect(body.code).toBe("GITHUB_ERROR");
+      expect(body.error).toContain("unreadable response");
+      // The branch was already pushed by this point; the change must not be
+      // recorded as promoted against a PR number we never actually read.
+      expect(pushBranchToRemote).toHaveBeenCalledTimes(1);
+      expect(updateChangeStatus).not.toHaveBeenCalled();
+    },
+  );
+
   it("reconciles a duplicate-head 422 by reusing the PR GitHub already has open", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -2194,6 +2194,9 @@ describe("POST /api/changes/:id/github-pr", () => {
     ["an embedded username only", "https://user@github.com/acme/widgets/pull/42"],
     ["a query string", "https://github.com/acme/widgets/pull/42?token=secret"],
     ["a fragment", "https://github.com/acme/widgets/pull/42#diff-abc"],
+    // hostname drops the port, so a non-default port needs `host` to be caught.
+    ["a non-default port", "https://github.com:8443/acme/widgets/pull/42"],
+    ["a trailing slash", "https://github.com/acme/widgets/pull/42/"],
   ])("502s when GitHub returns %s as html_url", async (_label, htmlUrl) => {
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ number: 42, html_url: htmlUrl, state: "open" }), {

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -2180,6 +2180,16 @@ describe("POST /api/changes/:id/github-pr", () => {
     expect(prPayload.base).toBe("release/1.2");
   });
 
+  it.each(["@", "feature/@/thing", "v1.0.0", "a.b.c/d.e"])(
+    "accepts the legal base %j (only the @{ reflog syntax is rejected)",
+    async (base) => {
+      const res = await promote({ base });
+      expect(res.status).toBe(200);
+      const prPayload = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+      expect(prPayload.base).toBe(base);
+    },
+  );
+
   it.each([
     "two words",
     "bad..dots",
@@ -2197,6 +2207,14 @@ describe("POST /api/changes/:id/github-pr", () => {
     "ctrl\u0007bell",
     "a".repeat(201),
     "",
+    // git applies its per-component rules to every slash-separated component,
+    // not just the whole ref, so these are invalid despite the full string
+    // neither starting with "." nor ending with "." / ".lock".
+    ".hidden",
+    "release/.hidden",
+    "release/v1.",
+    "release/v1.lock",
+    "release/v1.lock/next",
   ])("rejects garbage base %j without touching GitHub", async (base) => {
     const res = await promote({ base });
     expect(res.status).toBe(400);
@@ -2344,6 +2362,67 @@ describe("POST /api/changes/:id/github-pr", () => {
       expect.objectContaining({ githubPrNumber: 99 }),
     );
   });
+
+  // A persisted PR record is what a later re-promotion checks to decide the PR
+  // already exists and skip creation, so storing a malformed one strands the
+  // change forever. Every one of these must 502 rather than persist.
+  it.each([
+    ["a zero PR number", { number: 0, html_url: "https://github.com/a/b/pull/1", state: "open" }],
+    [
+      "a non-integer PR number",
+      { number: 1.5, html_url: "https://github.com/a/b/pull/1", state: "open" },
+    ],
+    [
+      "a string PR number",
+      { number: "7", html_url: "https://github.com/a/b/pull/7", state: "open" },
+    ],
+    ["an empty url", { number: 7, html_url: "", state: "open" }],
+    ["a non-https url", { number: 7, html_url: "javascript:alert(1)", state: "open" }],
+    ["a closed state", { number: 7, html_url: "https://github.com/a/b/pull/7", state: "closed" }],
+    ["a missing state", { number: 7, html_url: "https://github.com/a/b/pull/7" }],
+    ["a null body", null],
+  ])("502s instead of persisting a create response with %s", async (_label, payload) => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(payload), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const res = await promote();
+    expect(res.status).toBe(502);
+    expect(((await res.json()) as { code: string }).code).toBe("GITHUB_ERROR");
+    expect(updateChangeStatus).not.toHaveBeenCalled();
+  });
+
+  // Same guard on the other path in: the duplicate-head lookup must not hand
+  // back an unusable record either, and must survive a non-array body.
+  it.each([
+    ["a non-array body", { message: "not a list" }],
+    ["an empty array", []],
+    ["a closed PR", [{ number: 5, html_url: "https://github.com/a/b/pull/5", state: "closed" }]],
+    ["a malformed entry", [{ number: -1, html_url: "" }]],
+  ])(
+    "falls back to the original 502 when the duplicate-head lookup returns %s",
+    async (_l, body) => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            message: "Validation Failed",
+            errors: [{ message: "A pull request already exists for acme:stratum/chg_abc123." }],
+          }),
+          { status: 422 },
+        ),
+      );
+      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(body), { status: 200 }));
+
+      const res = await promote();
+      expect(res.status).toBe(502);
+      const parsed = (await res.json()) as { code: string; githubStatus: number };
+      expect(parsed.code).toBe("GITHUB_ERROR");
+      expect(parsed.githubStatus).toBe(422);
+      expect(updateChangeStatus).not.toHaveBeenCalled();
+    },
+  );
 
   it("falls back to the original 502 when the duplicate-head lookup itself finds nothing open", async () => {
     fetchMock.mockResolvedValueOnce(

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -2264,6 +2264,91 @@ describe("POST /api/changes/:id/github-pr", () => {
     expect(body.githubStatus).toBe(502);
   });
 
+  it("502s without leaking details when the PR-creation request itself fails (timeout/network)", async () => {
+    fetchMock.mockRejectedValueOnce(new DOMException("The operation was aborted", "TimeoutError"));
+    const res = await promote();
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string; code: string };
+    expect(body.code).toBe("GITHUB_ERROR");
+    expect(body.error).toContain("timed out or network error");
+    expect(updateChangeStatus).not.toHaveBeenCalled();
+  });
+
+  it("reconciles a duplicate-head 422 by reusing the PR GitHub already has open", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          message: "Validation Failed",
+          errors: [
+            {
+              resource: "PullRequest",
+              code: "custom",
+              message: "A pull request already exists for acme:stratum/chg_abc123.",
+            },
+          ],
+        }),
+        { status: 422 },
+      ),
+    );
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([
+          { number: 99, html_url: "https://github.com/acme/widgets/pull/99", state: "open" },
+        ]),
+        { status: 200 },
+      ),
+    );
+
+    const res = await promote();
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/repos/acme/widgets/pulls?head=acme:stratum/chg_abc123&state=open",
+      expect.anything(),
+    );
+    const body = (await res.json()) as { github: Record<string, unknown> };
+    expect(body.github).toEqual(
+      expect.objectContaining({
+        pullRequestNumber: 99,
+        pullRequestUrl: "https://github.com/acme/widgets/pull/99",
+      }),
+    );
+    expect(updateChangeStatus).toHaveBeenCalledWith(
+      env.DB,
+      expect.anything(),
+      "chg_abc123",
+      "promoted",
+      expect.objectContaining({ githubPrNumber: 99 }),
+    );
+  });
+
+  it("falls back to the original 502 when the duplicate-head lookup itself finds nothing open", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          message: "Validation Failed",
+          errors: [
+            {
+              resource: "PullRequest",
+              code: "custom",
+              message: "A pull request already exists for acme:stratum/chg_abc123.",
+            },
+          ],
+        }),
+        { status: 422 },
+      ),
+    );
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }));
+
+    const res = await promote();
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { code: string; githubStatus: number };
+    expect(body.code).toBe("GITHUB_ERROR");
+    expect(body.githubStatus).toBe(422);
+    expect(updateChangeStatus).not.toHaveBeenCalled();
+  });
+
   it("502s when the branch push fails, without calling the PR API", async () => {
     vi.mocked(pushBranchToRemote).mockResolvedValue({
       success: false,

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -2317,6 +2317,47 @@ describe("POST /api/changes/:id/github-pr", () => {
     expect(body.githubStatus).toBe(502);
   });
 
+  // The branch is already pushed when the error body is parsed, so anything
+  // thrown here escapes as a bare 500 and loses the structured GITHUB_ERROR
+  // the caller needs. GitHub is not guaranteed to send the documented shape.
+  it.each([
+    ["an object instead of an array", { message: "Validation Failed", errors: {} }],
+    ["a string instead of an array", { message: "Validation Failed", errors: "invalid" }],
+    ["null entries", { message: "Validation Failed", errors: [null] }],
+    ["non-string members", { message: "Validation Failed", errors: [{ message: 42 }] }],
+    ["a non-object body", "just a string"],
+    ["a null body", null],
+  ])("still returns a structured 502 when GitHub sends %s", async (_label, payload) => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(payload), { status: 422 }));
+    const res = await promote();
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { code: string; githubStatus: number };
+    expect(body.code).toBe("GITHUB_ERROR");
+    expect(body.githubStatus).toBe(422);
+    expect(updateChangeStatus).not.toHaveBeenCalled();
+  });
+
+  // startsWith("https://") accepts values that are not reachable PR links.
+  it.each([
+    ["a bare scheme", "https://"],
+    ["no path", "https://github.com"],
+    ["a non-GitHub host", "https://evil.example.com/acme/widgets/pull/1"],
+    ["a lookalike host", "https://github.com.evil.example/acme/widgets/pull/1"],
+    ["a non-https scheme", "http://github.com/acme/widgets/pull/1"],
+    ["not a URL at all", "https:/ /nonsense"],
+  ])("502s instead of persisting a PR whose html_url is %s", async (_label, url) => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ number: 7, html_url: url, state: "open" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const res = await promote();
+    expect(res.status).toBe(502);
+    expect(((await res.json()) as { code: string }).code).toBe("GITHUB_ERROR");
+    expect(updateChangeStatus).not.toHaveBeenCalled();
+  });
+
   it("502s without leaking details when the PR-creation request itself fails (timeout/network)", async () => {
     fetchMock.mockRejectedValueOnce(new DOMException("The operation was aborted", "TimeoutError"));
     const res = await promote();

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -2552,6 +2552,7 @@ describe("POST /api/changes/:id/github-pr", () => {
         status: "promoted",
         githubPrNumber: 7,
         githubPrUrl: "https://github.com/acme/widgets/pull/7",
+        githubPrState: "open",
       },
     });
     const res = await promote();
@@ -2566,6 +2567,52 @@ describe("POST /api/changes/:id/github-pr", () => {
       }),
     );
     expect(updateChangeStatus).not.toHaveBeenCalled();
+  });
+
+  // Rows written before this route validated GitHub responses can hold
+  // anything, and a closed PR must not be returned as a live promotion.
+  // Falling through to creation is the recovery path: the record gets rebuilt
+  // from GitHub's own answer rather than left broken.
+  it.each([
+    [
+      "a closed PR",
+      { githubPrNumber: 7, githubPrUrl: "https://github.com/a/b/pull/7", githubPrState: "closed" },
+    ],
+    ["no stored state", { githubPrNumber: 7, githubPrUrl: "https://github.com/a/b/pull/7" }],
+    [
+      "a zero PR number",
+      { githubPrNumber: 0, githubPrUrl: "https://github.com/a/b/pull/7", githubPrState: "open" },
+    ],
+    ["an unusable url", { githubPrNumber: 7, githubPrUrl: "https://", githubPrState: "open" }],
+    ["a number but no url", { githubPrNumber: 7, githubPrState: "open" }],
+  ])("re-creates the PR when the stored record has %s", async (_label, stored) => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: { ...acceptedChange, status: "promoted", ...stored },
+    });
+
+    const res = await promote();
+    expect(res.status).toBe(200);
+    // It must not short-circuit on the bad record — creation has to run.
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/widgets/pulls",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = (await res.json()) as { github: Record<string, unknown> };
+    expect(body.github).toEqual(
+      expect.objectContaining({
+        pullRequestNumber: 42,
+        pullRequestUrl: "https://github.com/acme/widgets/pull/42",
+      }),
+    );
+    // …and the repaired record is what gets persisted.
+    expect(updateChangeStatus).toHaveBeenCalledWith(
+      env.DB,
+      expect.anything(),
+      "chg_abc123",
+      "promoted",
+      expect.objectContaining({ githubPrNumber: 42 }),
+    );
   });
 
   it("400s when the change is not accepted", async () => {

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -2188,6 +2188,12 @@ describe("POST /api/changes/:id/github-pr", () => {
     ["a PR in another repository", "https://github.com/other/repo/pull/42"],
     ["a different PR number", "https://github.com/acme/widgets/pull/99"],
     ["a non-https scheme", "http://github.com/acme/widgets/pull/42"],
+    // Userinfo/query/fragment survive into the persisted, user-visible link, so
+    // a host+path check that ignores them would store credentials or a token.
+    ["embedded credentials", "https://user:password@github.com/acme/widgets/pull/42"],
+    ["an embedded username only", "https://user@github.com/acme/widgets/pull/42"],
+    ["a query string", "https://github.com/acme/widgets/pull/42?token=secret"],
+    ["a fragment", "https://github.com/acme/widgets/pull/42#diff-abc"],
   ])("502s when GitHub returns %s as html_url", async (_label, htmlUrl) => {
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ number: 42, html_url: htmlUrl, state: "open" }), {

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -2173,6 +2173,38 @@ describe("POST /api/changes/:id/github-pr", () => {
     expect(prPayload.base).toBe("trunk"); // sourceDefaultBranch wins
   });
 
+  it("prefers sourceUrl over a stale legacy githubUrl", async () => {
+    // A project migrated onto sourceUrl keeps its old githubUrl value. This URL
+    // is what the change branch gets FORCE-PUSHED to, so preferring the legacy
+    // field would publish to — and open a PR against — the wrong repository.
+    vi.mocked(getProject).mockResolvedValue({
+      success: true,
+      data: {
+        ...mockProject,
+        githubUrl: "https://github.com/stale/old-repo",
+        sourceUrl: "https://github.com/current/new-repo.git",
+      },
+    });
+
+    const res = await promote();
+    expect(res.status).toBe(200);
+    expect(pushBranchToRemote).toHaveBeenCalledWith(
+      {},
+      "/",
+      expect.objectContaining({ url: "https://github.com/current/new-repo.git" }),
+      expect.anything(),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/current/new-repo/pulls",
+      expect.anything(),
+    );
+    // Nothing may reach the stale repo.
+    expect(JSON.stringify(vi.mocked(pushBranchToRemote).mock.calls)).not.toContain(
+      "stale/old-repo",
+    );
+    expect(JSON.stringify(fetchMock.mock.calls)).not.toContain("stale/old-repo");
+  });
+
   it("passes a valid caller-supplied base through to GitHub", async () => {
     const res = await promote({ base: "release/1.2" });
     expect(res.status).toBe(200);

--- a/tests/push-branch-to-remote.test.ts
+++ b/tests/push-branch-to-remote.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("isomorphic-git", () => ({
+  default: { push: vi.fn() },
+}));
+
+import git from "isomorphic-git";
+import { type NodeFS, pushBranchToRemote } from "../src/storage/git-ops";
+import { createLogger } from "../src/utils/logger";
+
+const logger = createLogger({ component: "test" });
+const fs = {} as NodeFS;
+
+describe("pushBranchToRemote", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("pushes local main to the given remote ref with token auth, forced by default", async () => {
+    vi.mocked(git.push).mockResolvedValueOnce({ ok: true } as never);
+
+    const result = await pushBranchToRemote(
+      fs,
+      "/",
+      {
+        url: "https://github.com/acme/widgets.git",
+        remoteRef: "refs/heads/stratum/chg_1",
+        token: "gh-token",
+      },
+      logger,
+    );
+
+    expect(result.success).toBe(true);
+    expect(git.push).toHaveBeenCalledTimes(1);
+    const opts = vi.mocked(git.push).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+    expect(opts.url).toBe("https://github.com/acme/widgets.git");
+    expect(opts.ref).toBe("main");
+    expect(opts.remoteRef).toBe("refs/heads/stratum/chg_1");
+    expect(opts.force).toBe(true);
+    const onAuth = opts.onAuth as () => { username: string; password: string };
+    expect(onAuth()).toEqual({ username: "x-access-token", password: "gh-token" });
+  });
+
+  it("passes an explicit force: false through", async () => {
+    vi.mocked(git.push).mockResolvedValueOnce({ ok: true } as never);
+
+    const result = await pushBranchToRemote(
+      fs,
+      "/",
+      {
+        url: "https://github.com/acme/widgets.git",
+        remoteRef: "refs/heads/feature",
+        token: "gh-token",
+        force: false,
+      },
+      logger,
+    );
+
+    expect(result.success).toBe(true);
+    const opts = vi.mocked(git.push).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+    expect(opts.force).toBe(false);
+  });
+
+  it("wraps push failures in a 502 external-service error without leaking the token", async () => {
+    vi.mocked(git.push).mockRejectedValueOnce(new Error("HTTP Error: 403 Forbidden"));
+
+    const result = await pushBranchToRemote(
+      fs,
+      "/",
+      {
+        url: "https://github.com/acme/widgets.git",
+        remoteRef: "refs/heads/stratum/chg_1",
+        token: "gh-token",
+      },
+      logger,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("EXTERNAL_SERVICE_ERROR");
+      expect(result.error.statusCode).toBe(502);
+      expect(result.error.message).toContain("Failed to push branch");
+      expect(result.error.message).toContain("HTTP Error: 403 Forbidden");
+      expect(result.error.message).not.toContain("gh-token");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`POST /changes/:id/github-pr` created a PR with head `stratum/${change.id}` — a ref nothing ever pushed to GitHub — so every call was a guaranteed 422, mapped to a generic `badRequest`. It also required the legacy `project.githubUrl` (never set by bulk import) and took `base` from the body unvalidated.

Promotion now works end-to-end:

1. Resolves the GitHub repo from `githubUrl` **or** `sourceUrl` via the shared `parseRepoUrl` provider parser — bulk-imported projects can now be promoted; non-github.com sources are rejected cleanly.
2. Validates a caller-supplied `base` as a sane git branch name (length cap, no whitespace/control chars, `..`, `@{`, `//`, glob/`:`/`~`/`^` chars, leading `-`/`/`/`.`, trailing `/`/`.`/`.lock`), defaulting to `sourceDefaultBranch || githubDefaultBranch || "main"`.
3. Clones the change's workspace fork with a fresh Artifacts read token and **pushes its tip to `refs/heads/stratum/<changeId>` on GitHub** (new `pushBranchToRemote` helper in `git-ops.ts`, following the existing `pushMain` plumbing) — before touching the PR API.
4. Opens the draft PR from that ref; re-promotion of a change that already has a PR refreshes the branch and returns the existing PR instead of 422ing on a duplicate head.
5. GitHub API failures surface as 502 with `code: "GITHUB_ERROR"`, `githubStatus`, and GitHub's own message (token never included), instead of a generic 400.

Reviewer notes:
- `pushChangeToGitHub` in `src/github/sync.ts` was deliberately **not** reused: despite its name it never pushes a branch (PR API only), uses a different auth model (per-user OAuth from the users table), and contradicts the documented `stratum/{changeId}` head. That file is left untouched for the #188 cleanup.
- Instance-wide `env.GITHUB_TOKEN` is kept, as sanctioned by the issue; per-user credentials are a follow-up.
- The branch push is a force-push of a Stratum-owned ref, making promotion idempotent. It pushes the live workspace tip (same trust model as before; the PR is a draft for human review) — pinning to `evaluatedSha` would be a separate change.
- `docs/api/openapi.yml` doesn't yet reflect the 400→502 error-shape change; happy to update it here if preferred.

## Related issues

Closes #189

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

27 new tests: a 24-test suite for the endpoint in `tests/changes.test.ts` (push-before-PR ordering asserted via mock invocation order and the head-ref payload, base validation matrix, sourceUrl-only promotion, existing-PR idempotency, GitHub error propagation without token leakage) plus 3 unit tests for `pushBranchToRemote`. All code written for this issue is 100% line-covered per lcov (`isValidBaseRef`, the full handler, and the helper each report 0 uncovered lines). Full suite: 1276 passed, 0 failed.

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [ ] Docs updated where the change makes them inaccurate — openapi.yml error-shape update deferred, see notes
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript

---
_Generated by [Claude Code](https://claude.ai/code/session_015dp67PBbFT666GnMLuxvm1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub pull request promotion accepts repository URLs that resolve to GitHub.
  * Changes are published to a dedicated branch before creating or refreshing a pull request.
  * Existing pull requests are refreshed and reused, including during concurrent requests.
  * Configured project defaults apply when repository or base branch details are omitted.

* **Bug Fixes**
  * Added repository, base branch, and GitHub response validation.
  * GitHub and publishing failures now provide clearer error details.
  * Requests time out appropriately, with sensitive authentication information protected.
  * Repository snapshots preserve complete Git history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->