### PR TITLE
Sandbox evaluator: materialize the full evaluated tree and install dependencies before running tests

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -328,12 +328,12 @@ const sandboxEvaluator: Evaluator = {
 **Configuration:**
 ```yaml
 evaluators:
-  - id: tests
-    type: sandbox
+  - type: sandbox
     command: "npm test"        # default
     timeoutMs: 60000           # command timeout (default 60s)
     installTimeoutMs: 120000   # dependency install timeout (default 120s)
-    required: true
+# Pass/fail is decided by the policy-level `minScore` and `requireAll` fields,
+# not by a per-evaluator `required` flag.
 ```
 
 **Fail-closed when unavailable:** the `[[sandboxes]]` binding is commented out

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -315,7 +315,10 @@ const sandboxEvaluator: Evaluator = {
   id: 'tests',
   type: 'sandbox',
   async evaluate(ctx) {
-    // Clone workspace to Sandbox
+    // Materialize the FULL workspace tree at the evaluated commit
+    // (readRepoFiles pinned to evaluated_sha), not just the diff
+    // Install dependencies (npm ci with a lockfile, npm install with
+    // only a package.json, nothing otherwise)
     // Run configured command
     // Capture output and exit code
   }
@@ -327,9 +330,19 @@ const sandboxEvaluator: Evaluator = {
 evaluators:
   - id: tests
     type: sandbox
-    command: "npm test"
+    command: "npm test"        # default
+    timeoutMs: 60000           # command timeout (default 60s)
+    installTimeoutMs: 120000   # dependency install timeout (default 120s)
     required: true
 ```
+
+**Fail-closed when unavailable:** the `[[sandboxes]]` binding is commented out
+in `wrangler.toml` (beta feature; enabling it is an ops decision). While it is
+absent, any policy naming a `sandbox` evaluator fails closed — every evaluation
+records `sandbox unavailable: SANDBOX binding is not configured — enable
+[[sandboxes]] in wrangler.toml or remove the sandbox evaluator from the policy`
+with score 0, which blocks the merge. Remove the evaluator from the policy or
+enable the binding.
 
 ### Composite Scoring
 

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -149,9 +149,7 @@ export async function snapshotRepo(
   // bounded/streaming fetch that aborts mid-clone would be the real fix (tracked
   // as a follow-up); for now MAX_BACKUP_BYTES should be set well under the
   // Worker's memory budget so a normal repo never approaches it.
-  const clone = await cloneRepo(project.remote, token.data, logger, undefined, {
-    fullHistory: true,
-  });
+  const clone = await cloneRepo(project.remote, token.data, logger, { fullHistory: true });
   if (!clone.success) return err(clone.error);
 
   const walk = await walkRepoObjects(clone.data.fs, clone.data.dir, maxBytes, logger);

--- a/src/evaluation/sandbox-evaluator.ts
+++ b/src/evaluation/sandbox-evaluator.ts
@@ -34,6 +34,20 @@ export type RepoFilesReader = (
   ref?: string,
 ) => Promise<Result<Map<string, string>, AppError>>;
 
+/**
+ * Derives a pass ratio from a test runner's own summary line.
+ *
+ * Scored from the summary rather than the exit code because the exit code is
+ * binary: a suite where 99 of 100 tests pass is indistinguishable from one
+ * where none do. Both patterns are tried because runners disagree on whether
+ * a clean run prints a "failed" count at all — vitest and jest omit it, so
+ * "N passed" alone has to be accepted, with `failed` re-matched separately
+ * rather than assumed zero from the first pattern.
+ *
+ * Returns `null`, never 0, when nothing parses: an unrecognised format means
+ * the score is *unknown*, and reporting that as a zero would fail a change on
+ * the runner's output format instead of on its tests.
+ */
 function parseTestOutput(stdout: string, stderr: string): number | null {
   const combined = `${stdout}\n${stderr}`;
 
@@ -76,6 +90,20 @@ export class SandboxEvaluator implements Evaluator {
     private readFiles: RepoFilesReader = readRepoFiles,
   ) {}
 
+  /**
+   * Runs the configured command against the full evaluated tree in a sandbox.
+   *
+   * The `_diff` argument is ignored on purpose. The evaluator that this
+   * replaced reconstructed a pseudo-tree from the diff's `+` lines, which
+   * could not run any real suite — no base tree, no untouched sources, no
+   * `package.json` unless it happened to change. The tree is read from the
+   * pinned commit instead, so the sandbox holds exactly what the merge would
+   * land. The parameter stays because it is part of the `Evaluator` contract
+   * shared with the diff-based evaluators.
+   *
+   * Every failure path scores 0 and `passed: false` rather than returning an
+   * error: an evaluation that could not run must not read as one that passed.
+   */
   async evaluate(
     _diff: string,
     policy: EvalPolicy,

--- a/src/evaluation/sandbox-evaluator.ts
+++ b/src/evaluation/sandbox-evaluator.ts
@@ -1,3 +1,4 @@
+import { readRepoFiles } from "../storage/git-ops";
 import type { SandboxBinding } from "../types";
 import type { AppError } from "../utils/errors";
 import { ExternalServiceError } from "../utils/errors";
@@ -6,39 +7,32 @@ import type { Result } from "../utils/result";
 import { err, ok } from "../utils/result";
 import type { EvalPolicy, EvalResult, Evaluator } from "./types";
 
-function parseDiffFiles(diff: string): Map<string, string> {
-  const files = new Map<string, string>();
-  const lines = diff.split("\n");
-  let currentPath: string | null = null;
-  const contentLines: string[] = [];
+const DEFAULT_COMMAND = "npm test";
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_INSTALL_TIMEOUT_MS = 120_000;
+const MAX_OUTPUT_IN_REASON = 500;
 
-  const flush = () => {
-    if (currentPath !== null) {
-      files.set(currentPath, contentLines.join("\n"));
-    }
-  };
-
-  for (const line of lines) {
-    if (line.startsWith("+++ b/")) {
-      flush();
-      currentPath = line.slice(6);
-      contentLines.length = 0;
-    } else if (
-      currentPath !== null &&
-      !line.startsWith("--- ") &&
-      !line.startsWith("diff ") &&
-      !line.startsWith("index ") &&
-      !line.startsWith("@@ ")
-    ) {
-      if (line.startsWith("+") && !line.startsWith("+++")) {
-        contentLines.push(line.slice(1));
-      }
-    }
-  }
-
-  flush();
-  return files;
+/**
+ * Read access to the workspace repo whose tree is being evaluated. Threaded in
+ * by `buildEvaluators` so the sandbox runs against the FULL workspace tree
+ * (the evaluated commit), not a reconstruction from diff hunks.
+ */
+export interface SandboxRepoAccess {
+  /** The workspace repo remote. */
+  remote: string;
+  /** A read-scoped token for that remote. */
+  token: string;
+  /** The evaluated commit sha (pinned as evaluated_sha). HEAD when absent. */
+  ref?: string;
 }
+
+/** Reads a repo tree into path → contents; injectable for tests. */
+export type RepoFilesReader = (
+  remote: string,
+  token: string,
+  logger: Logger,
+  ref?: string,
+) => Promise<Result<Map<string, string>, AppError>>;
 
 function parseTestOutput(stdout: string, stderr: string): number | null {
   const combined = `${stdout}\n${stderr}`;
@@ -58,18 +52,28 @@ function parseTestOutput(stdout: string, stderr: string): number | null {
   return null;
 }
 
+/** `npm ci` with a lockfile, `npm install` without one, nothing without a package.json. */
+export function installCommandFor(files: ReadonlyMap<string, string>): string | null {
+  if (!files.has("package.json")) return null;
+  return files.has("package-lock.json") ? "npm ci" : "npm install";
+}
+
 export class SandboxEvaluator implements Evaluator {
-  constructor(private sandbox: SandboxBinding) {}
+  constructor(
+    private sandbox: SandboxBinding,
+    private repo: SandboxRepoAccess,
+    private readFiles: RepoFilesReader = readRepoFiles,
+  ) {}
 
   async evaluate(
-    diff: string,
+    _diff: string,
     policy: EvalPolicy,
     logger: Logger,
   ): Promise<Result<EvalResult, AppError>> {
     logger.debug("Starting sandbox evaluation");
 
     const config = policy.evaluators.find((e) => e.type === "sandbox") as
-      | { type: "sandbox"; command?: string; timeoutMs?: number }
+      | { type: "sandbox"; command?: string; timeoutMs?: number; installTimeoutMs?: number }
       | undefined;
 
     if (!config) {
@@ -77,16 +81,36 @@ export class SandboxEvaluator implements Evaluator {
       return ok({ score: 1.0, passed: true, reason: "No sandbox evaluator configured" });
     }
 
-    const command = config.command ?? "npm test";
-    const timeoutMs = config.timeoutMs ?? 60_000;
+    const command = config.command ?? DEFAULT_COMMAND;
+    const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const installTimeoutMs = config.installTimeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS;
     const minScore = policy.minScore ?? 0.7;
 
-    logger.debug("Sandbox config", { command, timeoutMs });
+    logger.debug("Sandbox config", { command, timeoutMs, installTimeoutMs });
 
-    const files = parseDiffFiles(diff);
     let sb: Awaited<ReturnType<SandboxBinding["create"]>> | null = null;
 
     try {
+      // Materialize the full workspace tree at the evaluated commit — the same
+      // tree the merge would land — so the command runs against real sources,
+      // not just the added lines of the diff.
+      const filesResult = await this.readFiles(
+        this.repo.remote,
+        this.repo.token,
+        logger,
+        this.repo.ref,
+      );
+      if (!filesResult.success) {
+        logger.error("Could not read workspace tree for sandbox", filesResult.error);
+        return err(
+          new ExternalServiceError(
+            "Sandbox",
+            `Could not read workspace tree: ${filesResult.error.message}`,
+          ) as AppError,
+        );
+      }
+      const files = filesResult.data;
+
       sb = await this.sandbox.create();
       logger.debug("Sandbox created");
 
@@ -95,9 +119,32 @@ export class SandboxEvaluator implements Evaluator {
       }
       logger.debug("Files written to sandbox", { fileCount: files.size });
 
+      let sandboxMs = 0;
+
+      const installCommand = installCommandFor(files);
+      if (installCommand !== null) {
+        const installStartedAt = Date.now();
+        const install = await sb.run(installCommand, { timeout: installTimeoutMs });
+        sandboxMs += Date.now() - installStartedAt;
+        logger.debug("Sandbox install completed", {
+          installCommand,
+          exitCode: install.exitCode,
+        });
+        if (install.exitCode !== 0) {
+          const output = (install.stdout + install.stderr).slice(0, MAX_OUTPUT_IN_REASON).trim();
+          logger.info("Sandbox evaluation failed at dependency install", { installCommand });
+          return ok({
+            score: 0,
+            passed: false,
+            reason: `Dependency install (${installCommand}) failed: ${output}`,
+            costs: [{ kind: "sandbox_ms", quantity: sandboxMs }],
+          });
+        }
+      }
+
       const runStartedAt = Date.now();
       const result = await sb.run(command, { timeout: timeoutMs });
-      const sandboxMs = Date.now() - runStartedAt;
+      sandboxMs += Date.now() - runStartedAt;
       logger.debug("Sandbox command completed", { exitCode: result.exitCode, sandboxMs });
 
       let score: number;
@@ -109,7 +156,7 @@ export class SandboxEvaluator implements Evaluator {
       }
 
       const passed = score >= minScore;
-      const reason = (result.stdout + result.stderr).slice(0, 500).trim();
+      const reason = (result.stdout + result.stderr).slice(0, MAX_OUTPUT_IN_REASON).trim();
 
       logger.info("Sandbox evaluation complete", { score, passed });
       return ok({ score, passed, reason, costs: [{ kind: "sandbox_ms", quantity: sandboxMs }] });

--- a/src/evaluation/sandbox-evaluator.ts
+++ b/src/evaluation/sandbox-evaluator.ts
@@ -52,14 +52,20 @@ function parseTestOutput(stdout: string, stderr: string): number | null {
   return null;
 }
 
+/** The lockfile names `npm ci` accepts. */
+const NPM_LOCKFILES = ["package-lock.json", "npm-shrinkwrap.json"] as const;
+
 /**
- * `npm ci` with a lockfile, `npm install` without one, nothing without a
- * package.json. `--no-audit --no-fund` skip registry calls the sandbox
- * evaluation has no use for.
+ * A lockfile means the dependency tree is already pinned, so `npm ci` installs
+ * it verbatim — an evaluation score only means something if every run resolves
+ * the same versions. Without one, `npm install` is the best available
+ * (unpinned) approximation; without a package.json there is nothing to install,
+ * because the repo is not an npm project. `--no-audit --no-fund` skip registry
+ * round trips the evaluation has no use for.
  */
 export function installCommandFor(files: ReadonlyMap<string, string>): string | null {
   if (!files.has("package.json")) return null;
-  const base = files.has("package-lock.json") ? "npm ci" : "npm install";
+  const base = NPM_LOCKFILES.some((lockfile) => files.has(lockfile)) ? "npm ci" : "npm install";
   return `${base} --no-audit --no-fund`;
 }
 

--- a/src/evaluation/sandbox-evaluator.ts
+++ b/src/evaluation/sandbox-evaluator.ts
@@ -52,10 +52,15 @@ function parseTestOutput(stdout: string, stderr: string): number | null {
   return null;
 }
 
-/** `npm ci` with a lockfile, `npm install` without one, nothing without a package.json. */
+/**
+ * `npm ci` with a lockfile, `npm install` without one, nothing without a
+ * package.json. `--no-audit --no-fund` skip registry calls the sandbox
+ * evaluation has no use for.
+ */
 export function installCommandFor(files: ReadonlyMap<string, string>): string | null {
   if (!files.has("package.json")) return null;
-  return files.has("package-lock.json") ? "npm ci" : "npm install";
+  const base = files.has("package-lock.json") ? "npm ci" : "npm install";
+  return `${base} --no-audit --no-fund`;
 }
 
 export class SandboxEvaluator implements Evaluator {
@@ -112,10 +117,19 @@ export class SandboxEvaluator implements Evaluator {
       const files = filesResult.data;
 
       sb = await this.sandbox.create();
+      const instance = sb;
       logger.debug("Sandbox created");
 
-      for (const [path, content] of files) {
-        await sb.writeFile(path, content);
+      // The full tree can hold thousands of files; one round trip per file
+      // dominates evaluation latency, so write in bounded concurrent batches.
+      const WRITE_CONCURRENCY = 16;
+      const entries = [...files];
+      for (let i = 0; i < entries.length; i += WRITE_CONCURRENCY) {
+        await Promise.all(
+          entries
+            .slice(i, i + WRITE_CONCURRENCY)
+            .map(([path, content]) => instance.writeFile(path, content)),
+        );
       }
       logger.debug("Files written to sandbox", { fileCount: files.size });
 

--- a/src/evaluation/sandbox-evaluator.ts
+++ b/src/evaluation/sandbox-evaluator.ts
@@ -101,8 +101,16 @@ export class SandboxEvaluator implements Evaluator {
    * land. The parameter stays because it is part of the `Evaluator` contract
    * shared with the diff-based evaluators.
    *
-   * Every failure path scores 0 and `passed: false` rather than returning an
-   * error: an evaluation that could not run must not read as one that passed.
+   * Two kinds of failure, deliberately distinguished:
+   *
+   * - The suite ran and did not pass, or could not run *inside* the sandbox
+   *   (install failed, no binding, no repo access): score 0 with
+   *   `passed: false`. An evaluation that could not run must never read as
+   *   one that passed, so these are verdicts, not errors.
+   * - The evaluated tree could not be reached or read at all, or the sandbox
+   *   itself threw: `err(ExternalServiceError)`. There is no verdict to give
+   *   here — the caller decides whether to retry or surface the failure, and
+   *   scoring 0 would fabricate a judgement about code we never saw.
    */
   async evaluate(
     _diff: string,

--- a/src/evaluation/sandbox-evaluator.ts
+++ b/src/evaluation/sandbox-evaluator.ts
@@ -103,14 +103,17 @@ export class SandboxEvaluator implements Evaluator {
    *
    * Two kinds of failure, deliberately distinguished:
    *
-   * - The suite ran and did not pass, or could not run *inside* the sandbox
-   *   (install failed, no binding, no repo access): score 0 with
-   *   `passed: false`. An evaluation that could not run must never read as
-   *   one that passed, so these are verdicts, not errors.
-   * - The evaluated tree could not be reached or read at all, or the sandbox
-   *   itself threw: `err(ExternalServiceError)`. There is no verdict to give
-   *   here — the caller decides whether to retry or surface the failure, and
-   *   scoring 0 would fabricate a judgement about code we never saw.
+   * - The suite ran and did not pass, or a dependency install failed: score 0
+   *   with `passed: false`. An evaluation that could not run must never read
+   *   as one that passed, so these are verdicts, not errors.
+   * - The evaluated tree could not be reached or read, or the sandbox itself
+   *   threw: `err(ExternalServiceError)`. There is no verdict to give here —
+   *   the caller decides whether to retry or surface the failure, and scoring
+   *   0 would fabricate a judgement about code we never saw.
+   *
+   * A missing SANDBOX binding or missing repo access never reaches this method
+   * at all: `buildEvaluators` substitutes an `UnavailableEvaluator` at
+   * construction, which is what fails those closed.
    */
   async evaluate(
     _diff: string,
@@ -167,11 +170,17 @@ export class SandboxEvaluator implements Evaluator {
       const WRITE_CONCURRENCY = 16;
       const entries = [...files];
       for (let i = 0; i < entries.length; i += WRITE_CONCURRENCY) {
-        await Promise.all(
+        // allSettled, not all: `all` rejects on the first failure while its
+        // siblings are still in flight, and the `finally` below would then
+        // destroy the sandbox out from under them. Wait for the whole batch to
+        // settle, then surface the first failure.
+        const settled = await Promise.allSettled(
           entries
             .slice(i, i + WRITE_CONCURRENCY)
             .map(([path, content]) => instance.writeFile(path, content)),
         );
+        const failed = settled.find((r) => r.status === "rejected");
+        if (failed?.status === "rejected") throw failed.reason;
       }
       logger.debug("Files written to sandbox", { fileCount: files.size });
 

--- a/src/evaluation/types.ts
+++ b/src/evaluation/types.ts
@@ -56,5 +56,5 @@ export type EvaluatorConfig =
       requiredPatterns?: string[];
     }
   | { type: "webhook"; url: string; secret?: string; timeoutMs?: number }
-  | { type: "sandbox"; command?: string; timeoutMs?: number }
+  | { type: "sandbox"; command?: string; timeoutMs?: number; installTimeoutMs?: number }
   | { type: "llm"; model?: string; threshold?: number; maxDiffChars?: number };

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1241,7 +1241,11 @@ app.post("/changes/:id/evaluate", async (c) => {
     workspaceSha: workspaceHeadSha,
   } = diffResult.data;
 
-  const evaluators = buildEvaluators(c.env, policy, change.project, logger);
+  const evaluators = buildEvaluators(c.env, policy, change.project, logger, {
+    remote: workspace.remote,
+    token: workspaceReadToken.data,
+    ref: evaluatedSha,
+  });
   const { evalRuns, evalResult } = await runEvaluation(evaluators, diff, policy, logger);
 
   const recordResult = await recordEvalRuns(c.env.DB, logger, id, evalRuns);

--- a/src/services/change-flow.ts
+++ b/src/services/change-flow.ts
@@ -54,6 +54,15 @@ export async function resolveProjectHead(
   return logResult.success ? (logResult.data[0]?.sha ?? null) : null;
 }
 
+/**
+ * Stands in for an evaluator whose prerequisites are missing.
+ *
+ * Exists so a misconfigured policy fails closed. Dropping the evaluator from
+ * the list instead would let a change be scored — and merged — by whichever
+ * evaluators happened to be wired up, with nothing in the result showing that
+ * a required one never ran. Scoring 0 with the reason naming the missing
+ * prerequisite turns silent under-evaluation into a visible failure.
+ */
 export class UnavailableEvaluator implements Evaluator {
   constructor(
     private evaluatorType: string,

--- a/src/services/change-flow.ts
+++ b/src/services/change-flow.ts
@@ -7,6 +7,7 @@ import {
   WebhookEvaluator,
   loadPolicy,
 } from "../evaluation";
+import type { SandboxRepoAccess } from "../evaluation/sandbox-evaluator";
 import type { EvalPolicy, EvalResult, Evaluator } from "../evaluation/types";
 import { type EventActor, emitEvent } from "../queue/events";
 import { getAgent } from "../storage/agents";
@@ -76,12 +77,20 @@ export class UnavailableEvaluator implements Evaluator {
  * Build the evaluator set for a policy: the always-on blocking secret scan plus
  * whatever the policy configures. Evaluators whose binding is missing become
  * UnavailableEvaluator (score 0, fail) rather than silently vanishing.
+ *
+ * `workspaceRepo` is read access to the workspace being evaluated (remote +
+ * read token + the pinned evaluated commit); the sandbox evaluator needs it to
+ * materialize the full tree it runs the test command against. Without it — or
+ * without the SANDBOX binding (`[[sandboxes]]` in wrangler.toml, currently an
+ * ops decision) — a policy naming `sandbox` fails closed with a reason that
+ * says exactly which prerequisite is missing.
  */
 export function buildEvaluators(
   env: Env,
   policy: EvalPolicy,
   projectName: string,
   logger: Logger,
+  workspaceRepo?: SandboxRepoAccess,
 ): Array<{ type: string; evaluator: Evaluator }> {
   const evaluators: Array<{ type: string; evaluator: Evaluator }> = [
     { type: "secret_scan", evaluator: new SecretScanEvaluator() },
@@ -103,15 +112,33 @@ export function buildEvaluators(
             },
           ];
         case "sandbox":
-          if (env.SANDBOX) {
-            return [{ type: "sandbox", evaluator: new SandboxEvaluator(env.SANDBOX) }];
+          if (!env.SANDBOX) {
+            // Fail closed with an actionable reason: the [[sandboxes]] binding
+            // is commented out in wrangler.toml until the beta is enabled, and
+            // any policy naming `sandbox` blocks merges until it is (or the
+            // evaluator is removed from the policy).
+            return [
+              {
+                type: "sandbox",
+                evaluator: new UnavailableEvaluator(
+                  "sandbox",
+                  "SANDBOX binding is not configured — enable [[sandboxes]] in wrangler.toml or remove the sandbox evaluator from the policy",
+                ),
+              },
+            ];
           }
-          return [
-            {
-              type: "sandbox",
-              evaluator: new UnavailableEvaluator("sandbox", "SANDBOX binding is not configured"),
-            },
-          ];
+          if (!workspaceRepo) {
+            return [
+              {
+                type: "sandbox",
+                evaluator: new UnavailableEvaluator(
+                  "sandbox",
+                  "workspace repository access was not provided to the evaluation pipeline",
+                ),
+              },
+            ];
+          }
+          return [{ type: "sandbox", evaluator: new SandboxEvaluator(env.SANDBOX, workspaceRepo) }];
         default:
           logger.warn(
             `Unknown evaluator type "${(cfg as { type: string }).type}" in policy for project ${projectName}`,
@@ -326,7 +353,11 @@ export async function createChangeWithEvaluation(
     workspaceSha: workspaceHeadSha,
   } = diffResult.data;
 
-  const evaluators = buildEvaluators(env, policy, projectName, logger);
+  const evaluators = buildEvaluators(env, policy, projectName, logger, {
+    remote: workspaceRemote,
+    token: workspaceReadToken.data,
+    ref: evaluatedSha,
+  });
   const { evalRuns, evalResult } = await runEvaluation(evaluators, diff, policy, logger);
 
   const newStatus: Change["status"] = evalResult.passed ? "accepted" : "needs_changes";

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -1679,12 +1679,17 @@ export async function readTreeAtCommit(
   for (const path of listResult.data) {
     const blobResult = await fromPromise(git.readBlob({ fs, dir, oid: commitSha, filepath: path }));
     if (!blobResult.success) {
-      logger.warn("Skipping unreadable file in commit tree", {
-        path,
-        commitSha,
-        error: blobResult.error.message,
-      });
-      continue;
+      // A pinned commit's tree is expected to be complete; an unreadable blob
+      // means object corruption, not a benign gap. Fail closed rather than
+      // handing a caller (e.g. the sandbox evaluator) a silently partial tree.
+      logger.error("Unreadable file in commit tree", blobResult.error, { path, commitSha });
+      return err(
+        new ExternalServiceError(
+          "Git",
+          `Failed to read tree at commit ${commitSha}: unreadable object at ${path}`,
+          blobResult.error,
+        ),
+      );
     }
     contents.set(path, new TextDecoder().decode(blobResult.data.blob));
   }

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -342,8 +342,8 @@ export async function cloneRepo(
   remote: string,
   token: string,
   logger: Logger,
-  httpClient: HttpClient = http,
   opts: { fullHistory?: boolean } = {},
+  httpClient: HttpClient = http,
 ): Promise<Result<{ fs: NodeFS; dir: string }, AppError>> {
   logger.debug("Cloning repository", { remote, fullHistory: opts.fullHistory ?? false });
 
@@ -1618,9 +1618,10 @@ export async function listFilesInRepo(
  * Read the full working tree (paths → text contents) in a single clone.
  * Used by the post-merge smoke check and the sandbox evaluator to populate a
  * sandbox. When `ref` (a commit sha) is given, the tree of that commit is read
- * instead of the clone's HEAD, so callers can pin the exact evaluated commit;
- * a ref that is not reachable in the (shallow) clone is an error — the pinned
- * tree no longer exists, so callers must not silently evaluate something else.
+ * instead of the clone's HEAD, so callers can pin the exact evaluated commit —
+ * cloned in full, since a pinned sha can fall outside a shallow clone's depth
+ * window; a ref still not reachable after that is an error, never a silent
+ * fall-through to evaluating something else.
  */
 export async function readRepoFiles(
   remote: string,
@@ -1630,7 +1631,7 @@ export async function readRepoFiles(
 ): Promise<Result<Map<string, string>, AppError>> {
   logger.debug("Reading repo files", { remote, ref });
 
-  const cloneResult = await cloneRepo(remote, token, logger);
+  const cloneResult = await cloneRepo(remote, token, logger, { fullHistory: ref !== undefined });
   if (!cloneResult.success) return err(cloneResult.error);
   const { fs, dir } = cloneResult.data;
 

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -1560,18 +1560,27 @@ export async function listFilesInRepo(
 
 /**
  * Read the full working tree (paths → text contents) in a single clone.
- * Used by the post-merge smoke check to populate a sandbox.
+ * Used by the post-merge smoke check and the sandbox evaluator to populate a
+ * sandbox. When `ref` (a commit sha) is given, the tree of that commit is read
+ * instead of the clone's HEAD, so callers can pin the exact evaluated commit;
+ * a ref that is not reachable in the (shallow) clone is an error — the pinned
+ * tree no longer exists, so callers must not silently evaluate something else.
  */
 export async function readRepoFiles(
   remote: string,
   token: string,
   logger: Logger,
+  ref?: string,
 ): Promise<Result<Map<string, string>, AppError>> {
-  logger.debug("Reading repo files", { remote });
+  logger.debug("Reading repo files", { remote, ref });
 
   const cloneResult = await cloneRepo(remote, token, logger);
   if (!cloneResult.success) return err(cloneResult.error);
   const { fs, dir } = cloneResult.data;
+
+  if (ref !== undefined) {
+    return readTreeAtCommit(fs, dir, ref, logger);
+  }
 
   const filesResult = await walkDir(fs, dir, "", logger);
   if (!filesResult.success) return err(filesResult.error);
@@ -1587,6 +1596,41 @@ export async function readRepoFiles(
         error: error instanceof Error ? error.message : String(error),
       });
     }
+  }
+  return ok(contents);
+}
+
+/** Every file (path → text contents) in the tree of one commit. Exported for tests. */
+export async function readTreeAtCommit(
+  fs: NodeFS,
+  dir: string,
+  commitSha: string,
+  logger: Logger,
+): Promise<Result<Map<string, string>, AppError>> {
+  const listResult = await fromPromise(git.listFiles({ fs, dir, ref: commitSha }));
+  if (!listResult.success) {
+    logger.error("Failed to list files at commit", listResult.error, { commitSha });
+    return err(
+      new ExternalServiceError(
+        "Git",
+        `Failed to read tree at commit ${commitSha}`,
+        listResult.error,
+      ),
+    );
+  }
+
+  const contents = new Map<string, string>();
+  for (const path of listResult.data) {
+    const blobResult = await fromPromise(git.readBlob({ fs, dir, oid: commitSha, filepath: path }));
+    if (!blobResult.success) {
+      logger.warn("Skipping unreadable file in commit tree", {
+        path,
+        commitSha,
+        error: blobResult.error.message,
+      });
+      continue;
+    }
+    contents.set(path, new TextDecoder().decode(blobResult.data.blob));
   }
   return ok(contents);
 }

--- a/tests/costs.test.ts
+++ b/tests/costs.test.ts
@@ -5,6 +5,7 @@ import type { EvalPolicy } from "../src/evaluation/types";
 import { getChangeCostSummary, recordCosts } from "../src/storage/costs";
 import type { AiBinding, SandboxBinding } from "../src/types";
 import type { Logger } from "../src/utils/logger";
+import { ok } from "../src/utils/result";
 
 const mockLogger: Logger = {
   trace: vi.fn(),
@@ -162,7 +163,15 @@ describe("evaluator cost reporting", () => {
     };
     const policy: EvalPolicy = { evaluators: [{ type: "sandbox", command: "npm test" }] };
 
-    const result = await new SandboxEvaluator(sandbox).evaluate("diff", policy, mockLogger);
+    const repo = { remote: "https://artifacts.example/ws.git", token: "t", ref: "a".repeat(40) };
+    const readFiles = vi
+      .fn()
+      .mockResolvedValue(ok(new Map([["src/index.ts", "export const x = 1;"]])));
+    const result = await new SandboxEvaluator(sandbox, repo, readFiles).evaluate(
+      "diff",
+      policy,
+      mockLogger,
+    );
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.data.costs?.[0]?.kind).toBe("sandbox_ms");

--- a/tests/git-ops.test.ts
+++ b/tests/git-ops.test.ts
@@ -1,9 +1,12 @@
+import git from "isomorphic-git";
 import { describe, expect, it, vi } from "vitest";
 import {
+  type NodeFS,
   artifactsRepoNameFromRemote,
   buildUnifiedDiff,
   extractTokenSecret,
   freshRepoToken,
+  readTreeAtCommit,
 } from "../src/storage/git-ops";
 import { MemoryFS } from "../src/storage/memory-fs";
 import type { ArtifactsNamespace } from "../src/types";
@@ -223,5 +226,90 @@ describe("buildUnifiedDiff", () => {
     expect(diff).toContain("diff --git a/src/old.ts b/src/old.ts");
     expect(diff).toContain("deleted file mode 100644");
     expect(diff).toContain("-export const old = true;");
+  });
+});
+
+describe("readTreeAtCommit", () => {
+  async function makeRepo() {
+    const fs = new MemoryFS().toNodeFS() as unknown as NodeFS;
+    const dir = "/";
+    await git.init({ fs, dir, defaultBranch: "main" });
+
+    const author = { name: "Test", email: "test@example.com" };
+    await fs.promises.writeFile("/package.json", '{"name":"app"}');
+    await fs.promises.mkdir("/src");
+    await fs.promises.writeFile("/src/math.ts", "export const add = 1;");
+    await git.add({ fs, dir, filepath: ["package.json", "src/math.ts"] });
+    const first = await git.commit({ fs, dir, message: "first", author });
+
+    await fs.promises.writeFile("/src/math.ts", "export const add = 2;");
+    await fs.promises.writeFile("/src/new.ts", "export const fresh = true;");
+    await git.add({ fs, dir, filepath: ["src/math.ts", "src/new.ts"] });
+    const second = await git.commit({ fs, dir, message: "second", author });
+
+    return { fs, first, second };
+  }
+
+  it("reads the full file set of the pinned commit, not the current HEAD", async () => {
+    const { fs, first } = await makeRepo();
+    const result = await readTreeAtCommit(fs, "/", first, noopLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect([...result.data.keys()].sort()).toEqual(["package.json", "src/math.ts"]);
+    expect(result.data.get("src/math.ts")).toBe("export const add = 1;");
+  });
+
+  it("reads the later commit's tree including files it added", async () => {
+    const { fs, second } = await makeRepo();
+    const result = await readTreeAtCommit(fs, "/", second, noopLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect([...result.data.keys()].sort()).toEqual(["package.json", "src/math.ts", "src/new.ts"]);
+    expect(result.data.get("src/math.ts")).toBe("export const add = 2;");
+  });
+
+  it("skips files whose blobs cannot be read, keeping the rest of the tree", async () => {
+    const { fs } = await makeRepo();
+    const dir = "/";
+    const goodBlob = await git.writeBlob({
+      fs,
+      dir,
+      blob: new TextEncoder().encode("still readable"),
+    });
+    const treeOid = await git.writeTree({
+      fs,
+      dir,
+      tree: [
+        { mode: "100644", path: "good.txt", oid: goodBlob, type: "blob" },
+        // A dangling oid: listed in the tree but the object does not exist.
+        {
+          mode: "100644",
+          path: "missing.txt",
+          oid: "0123456789abcdef0123456789abcdef01234567",
+          type: "blob",
+        },
+      ],
+    });
+    const author = { name: "Test", email: "test@example.com", timestamp: 0, timezoneOffset: 0 };
+    const commit = await git.writeCommit({
+      fs,
+      dir,
+      commit: { tree: treeOid, parent: [], author, committer: author, message: "broken tree" },
+    });
+
+    const result = await readTreeAtCommit(fs, dir, commit, noopLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect([...result.data.keys()]).toEqual(["good.txt"]);
+    expect(result.data.get("good.txt")).toBe("still readable");
+  });
+
+  it("errors when the pinned commit is not present in the clone", async () => {
+    const { fs } = await makeRepo();
+    const missing = "0123456789abcdef0123456789abcdef01234567";
+    const result = await readTreeAtCommit(fs, "/", missing, noopLogger);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.message).toContain(`Failed to read tree at commit ${missing}`);
   });
 });

--- a/tests/git-ops.test.ts
+++ b/tests/git-ops.test.ts
@@ -288,7 +288,7 @@ describe("readTreeAtCommit", () => {
     expect(result.data.get("src/math.ts")).toBe("export const add = 2;");
   });
 
-  it("skips files whose blobs cannot be read, keeping the rest of the tree", async () => {
+  it("fails closed when a blob in the pinned tree cannot be read", async () => {
     const { fs } = await makeRepo();
     const dir = "/";
     const goodBlob = await git.writeBlob({
@@ -318,10 +318,10 @@ describe("readTreeAtCommit", () => {
     });
 
     const result = await readTreeAtCommit(fs, dir, commit, noopLogger);
-    expect(result.success).toBe(true);
-    if (!result.success) return;
-    expect([...result.data.keys()]).toEqual(["good.txt"]);
-    expect(result.data.get("good.txt")).toBe("still readable");
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.message).toContain(`Failed to read tree at commit ${commit}`);
+    expect(result.error.message).toContain("missing.txt");
   });
 
   it("errors when the pinned commit is not present in the clone", async () => {

--- a/tests/git-ops.test.ts
+++ b/tests/git-ops.test.ts
@@ -8,6 +8,7 @@ import {
   extractTokenSecret,
   freshRepoToken,
   mergeWorkspaceIntoProject,
+  readRepoFiles,
   readTreeAtCommit,
 } from "../src/storage/git-ops";
 import { MemoryFS } from "../src/storage/memory-fs";
@@ -331,6 +332,26 @@ describe("readTreeAtCommit", () => {
     expect(result.success).toBe(false);
     if (result.success) return;
     expect(result.error.message).toContain(`Failed to read tree at commit ${missing}`);
+  });
+});
+
+describe("readRepoFiles clone depth", () => {
+  beforeEach(() => {
+    vi.mocked(git.clone).mockReset().mockResolvedValue(undefined);
+  });
+
+  it("clones with full history when pinning a commit sha", async () => {
+    await readRepoFiles("https://example.com/repo.git", "token", noopLogger, "some-sha");
+
+    const cloneOpts = vi.mocked(git.clone).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+    expect(cloneOpts.depth).toBeUndefined();
+  });
+
+  it("clones shallow (depth 50) when reading the live HEAD", async () => {
+    await readRepoFiles("https://example.com/repo.git", "token", noopLogger);
+
+    const cloneOpts = vi.mocked(git.clone).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+    expect(cloneOpts.depth).toBe(50);
   });
 });
 

--- a/tests/sandbox-evaluator.test.ts
+++ b/tests/sandbox-evaluator.test.ts
@@ -149,7 +149,7 @@ describe("SandboxEvaluator — dependency install", () => {
 
     await evaluator.evaluate("", makePolicy(), mockLogger);
 
-    expect(runCalls.map((c) => c.command)).toEqual(["npm ci", "npm test"]);
+    expect(runCalls.map((c) => c.command)).toEqual(["npm ci --no-audit --no-fund", "npm test"]);
   });
 
   it("runs `npm install` when package.json exists without a lockfile", async () => {
@@ -160,7 +160,10 @@ describe("SandboxEvaluator — dependency install", () => {
 
     await evaluator.evaluate("", makePolicy(), mockLogger);
 
-    expect(runCalls.map((c) => c.command)).toEqual(["npm install", "npm test"]);
+    expect(runCalls.map((c) => c.command)).toEqual([
+      "npm install --no-audit --no-fund",
+      "npm test",
+    ]);
   });
 
   it("skips the install step entirely when there is no package.json", async () => {
@@ -182,7 +185,10 @@ describe("SandboxEvaluator — dependency install", () => {
 
     await evaluator.evaluate("", policy, mockLogger);
 
-    expect(runCalls[0]).toEqual({ command: "npm ci", opts: { timeout: 120_000 } });
+    expect(runCalls[0]).toEqual({
+      command: "npm ci --no-audit --no-fund",
+      opts: { timeout: 120_000 },
+    });
     expect(runCalls[1]).toEqual({ command: "npm test", opts: { timeout: 30_000 } });
   });
 
@@ -202,7 +208,10 @@ describe("SandboxEvaluator — dependency install", () => {
     const { binding, runCalls } = makeMockSandbox({
       exitCode: 0,
       runResults: {
-        "npm ci": { exitCode: 1, stderr: "ERESOLVE unable to resolve dependency tree" },
+        "npm ci --no-audit --no-fund": {
+          exitCode: 1,
+          stderr: "ERESOLVE unable to resolve dependency tree",
+        },
       },
     });
     const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
@@ -213,18 +222,22 @@ describe("SandboxEvaluator — dependency install", () => {
     if (result.success) {
       expect(result.data.score).toBe(0);
       expect(result.data.passed).toBe(false);
-      expect(result.data.reason).toContain("Dependency install (npm ci) failed");
+      expect(result.data.reason).toContain(
+        "Dependency install (npm ci --no-audit --no-fund) failed",
+      );
       expect(result.data.reason).toContain("ERESOLVE");
       expect(result.data.costs?.[0]?.kind).toBe("sandbox_ms");
     }
-    expect(runCalls.map((c) => c.command)).toEqual(["npm ci"]);
+    expect(runCalls.map((c) => c.command)).toEqual(["npm ci --no-audit --no-fund"]);
   });
 });
 
 describe("installCommandFor", () => {
   it("maps manifest/lockfile presence to the right command", () => {
     expect(installCommandFor(new Map())).toBeNull();
-    expect(installCommandFor(new Map([["package.json", "{}"]]))).toBe("npm install");
+    expect(installCommandFor(new Map([["package.json", "{}"]]))).toBe(
+      "npm install --no-audit --no-fund",
+    );
     expect(
       installCommandFor(
         new Map([
@@ -232,7 +245,7 @@ describe("installCommandFor", () => {
           ["package-lock.json", "{}"],
         ]),
       ),
-    ).toBe("npm ci");
+    ).toBe("npm ci --no-audit --no-fund");
     expect(installCommandFor(new Map([["package-lock.json", "{}"]]))).toBeNull();
   });
 });
@@ -417,7 +430,7 @@ describe("SandboxEvaluator — destroy lifecycle", () => {
   it("destroy() is called when the install step fails", async () => {
     const { binding, instance } = makeMockSandbox({
       exitCode: 0,
-      runResults: { "npm ci": { exitCode: 1, stderr: "boom" } },
+      runResults: { "npm ci --no-audit --no-fund": { exitCode: 1, stderr: "boom" } },
     });
     const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
 
@@ -460,14 +473,30 @@ describe("SandboxEvaluator — reason field", () => {
   });
 
   it("reports sandbox_ms cost covering install + test run", async () => {
-    const { binding } = makeMockSandbox({ exitCode: 0 });
-    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
-    const result = await evaluator.evaluate("", makePolicy(), mockLogger);
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.costs).toHaveLength(1);
-      expect(result.data.costs?.[0]?.kind).toBe("sandbox_ms");
-      expect(result.data.costs?.[0]?.quantity).toBeGreaterThanOrEqual(0);
+    vi.useFakeTimers();
+    try {
+      const instance: SandboxInstance = {
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        run: vi.fn().mockImplementation(async () => {
+          // Each step (install, then the test command) takes 1000ms.
+          vi.advanceTimersByTime(1000);
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }),
+        destroy: vi.fn().mockResolvedValue(undefined),
+      };
+      const binding: SandboxBinding = { create: vi.fn().mockResolvedValue(instance) };
+      const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
+
+      const result = await evaluator.evaluate("", makePolicy(), mockLogger);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.costs).toHaveLength(1);
+        expect(result.data.costs?.[0]?.kind).toBe("sandbox_ms");
+        expect(result.data.costs?.[0]?.quantity).toBe(2000);
+      }
+    } finally {
+      vi.useRealTimers();
     }
   });
 });

--- a/tests/sandbox-evaluator.test.ts
+++ b/tests/sandbox-evaluator.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
-import { SandboxEvaluator } from "../src/evaluation/sandbox-evaluator";
+import {
+  SandboxEvaluator,
+  type SandboxRepoAccess,
+  installCommandFor,
+} from "../src/evaluation/sandbox-evaluator";
 import type { EvalPolicy } from "../src/evaluation/types";
-import type { SandboxBinding, SandboxInstance } from "../src/types";
+import { buildEvaluators } from "../src/services/change-flow";
+import type { Env, SandboxBinding, SandboxInstance } from "../src/types";
+import { AppError } from "../src/utils/errors";
 import type { Logger } from "../src/utils/logger";
+import { err, ok } from "../src/utils/result";
 
 const mockLogger: Logger = {
   trace: vi.fn(),
@@ -14,30 +21,65 @@ const mockLogger: Logger = {
   child: vi.fn(() => mockLogger),
 };
 
+const repo: SandboxRepoAccess = {
+  remote: "https://artifacts.example/ws.git",
+  token: "read-token",
+  ref: "a".repeat(40),
+};
+
+/** A realistic workspace tree: sources the diff never touched, manifest, lockfile. */
+const FULL_TREE = new Map<string, string>([
+  ["package.json", JSON.stringify({ name: "app", scripts: { test: "vitest run" } })],
+  ["package-lock.json", JSON.stringify({ lockfileVersion: 3 })],
+  ["src/index.ts", "export { add } from './math';"],
+  ["src/math.ts", "export const add = (a: number, b: number) => a + b;"],
+  ["tests/math.test.ts", "import { add } from '../src/math';"],
+]);
+
+function makeReadFiles(files: Map<string, string> = FULL_TREE) {
+  return vi.fn().mockResolvedValue(ok(files));
+}
+
+interface RunCall {
+  command: string;
+  opts?: { timeout?: number };
+}
+
 function makeMockSandbox(opts: {
   exitCode?: number;
   stdout?: string;
   stderr?: string;
   createThrows?: boolean;
   runThrows?: boolean;
-}): SandboxBinding {
+  /** Per-command results; falls back to the flat exitCode/stdout/stderr. */
+  runResults?: Record<string, { exitCode: number; stdout?: string; stderr?: string }>;
+}): { binding: SandboxBinding; instance: SandboxInstance; runCalls: RunCall[] } {
+  const runCalls: RunCall[] = [];
   const instance: SandboxInstance = {
     writeFile: vi.fn().mockResolvedValue(undefined),
-    run: opts.runThrows
-      ? vi.fn().mockRejectedValue(new Error("Timeout"))
-      : vi.fn().mockResolvedValue({
-          exitCode: opts.exitCode ?? 0,
-          stdout: opts.stdout ?? "",
-          stderr: opts.stderr ?? "",
-        }),
+    run: vi.fn().mockImplementation(async (command: string, runOpts?: { timeout?: number }) => {
+      runCalls.push({ command, opts: runOpts });
+      if (opts.runThrows) throw new Error("Timeout");
+      const specific = opts.runResults?.[command];
+      if (specific) {
+        return {
+          exitCode: specific.exitCode,
+          stdout: specific.stdout ?? "",
+          stderr: specific.stderr ?? "",
+        };
+      }
+      return { exitCode: opts.exitCode ?? 0, stdout: opts.stdout ?? "", stderr: opts.stderr ?? "" };
+    }),
     destroy: vi.fn().mockResolvedValue(undefined),
   };
 
-  return {
+  const binding: SandboxBinding = {
     create: opts.createThrows
       ? vi.fn().mockRejectedValue(new Error("Sandbox unavailable"))
       : vi.fn().mockResolvedValue(instance),
   };
+
+  return { binding, instance, runCalls };
 }
 
 function makePolicy(overrides: Partial<EvalPolicy> = {}): EvalPolicy {
@@ -48,28 +90,157 @@ function makePolicy(overrides: Partial<EvalPolicy> = {}): EvalPolicy {
   };
 }
 
-function makeDiff(files: Array<{ path: string; content: string }> = []): string {
-  return files
-    .map(({ path, content }) => {
-      const addedLines = content
-        .split("\n")
-        .map((l) => `+${l}`)
-        .join("\n");
-      return [
-        `diff --git a/${path} b/${path}`,
-        `--- a/${path}`,
-        `+++ b/${path}`,
-        "@@ -0,0 +1 @@",
-        addedLines,
-      ].join("\n");
-    })
-    .join("\n");
-}
+describe("SandboxEvaluator — workspace tree materialization", () => {
+  it("reads the workspace tree at the pinned evaluated commit", async () => {
+    const { binding } = makeMockSandbox({ exitCode: 0 });
+    const readFiles = makeReadFiles();
+    const evaluator = new SandboxEvaluator(binding, repo, readFiles);
+
+    await evaluator.evaluate("ignored diff", makePolicy(), mockLogger);
+
+    expect(readFiles).toHaveBeenCalledWith(repo.remote, repo.token, mockLogger, repo.ref);
+  });
+
+  it("writes EVERY file of the tree into the sandbox, not just changed ones", async () => {
+    const { binding, instance } = makeMockSandbox({ exitCode: 0 });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
+
+    await evaluator.evaluate("diff --git a/src/math.ts b/src/math.ts", makePolicy(), mockLogger);
+
+    expect(instance.writeFile).toHaveBeenCalledTimes(FULL_TREE.size);
+    for (const [path, content] of FULL_TREE) {
+      expect(instance.writeFile).toHaveBeenCalledWith(path, content);
+    }
+  });
+
+  it("passes ref: undefined through when no commit is pinned", async () => {
+    const { binding } = makeMockSandbox({ exitCode: 0 });
+    const readFiles = makeReadFiles();
+    const unpinned: SandboxRepoAccess = { remote: repo.remote, token: repo.token };
+    const evaluator = new SandboxEvaluator(binding, unpinned, readFiles);
+
+    await evaluator.evaluate("", makePolicy(), mockLogger);
+
+    expect(readFiles).toHaveBeenCalledWith(repo.remote, repo.token, mockLogger, undefined);
+  });
+
+  it("fails (err) with a clear reason when the tree cannot be read, without creating a sandbox", async () => {
+    const { binding } = makeMockSandbox({ exitCode: 0 });
+    const readFiles = vi
+      .fn()
+      .mockResolvedValue(err(new AppError("clone exploded", "GIT_ERROR", 502)));
+    const evaluator = new SandboxEvaluator(binding, repo, readFiles);
+
+    const result = await evaluator.evaluate("", makePolicy(), mockLogger);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("Could not read workspace tree");
+      expect(result.error.message).toContain("clone exploded");
+    }
+    expect(binding.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("SandboxEvaluator — dependency install", () => {
+  it("runs `npm ci` before the test command when package.json + lockfile exist", async () => {
+    const { binding, runCalls } = makeMockSandbox({ exitCode: 0 });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
+
+    await evaluator.evaluate("", makePolicy(), mockLogger);
+
+    expect(runCalls.map((c) => c.command)).toEqual(["npm ci", "npm test"]);
+  });
+
+  it("runs `npm install` when package.json exists without a lockfile", async () => {
+    const tree = new Map(FULL_TREE);
+    tree.delete("package-lock.json");
+    const { binding, runCalls } = makeMockSandbox({ exitCode: 0 });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles(tree));
+
+    await evaluator.evaluate("", makePolicy(), mockLogger);
+
+    expect(runCalls.map((c) => c.command)).toEqual(["npm install", "npm test"]);
+  });
+
+  it("skips the install step entirely when there is no package.json", async () => {
+    const tree = new Map([["main.py", "print('hi')"]]);
+    const { binding, runCalls } = makeMockSandbox({ exitCode: 0 });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles(tree));
+
+    await evaluator.evaluate("", makePolicy(), mockLogger);
+
+    expect(runCalls.map((c) => c.command)).toEqual(["npm test"]);
+  });
+
+  it("uses the install timeout (default 120s) for install and timeoutMs for the command", async () => {
+    const { binding, runCalls } = makeMockSandbox({ exitCode: 0 });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
+    const policy = makePolicy({
+      evaluators: [{ type: "sandbox", command: "npm test", timeoutMs: 30_000 }],
+    });
+
+    await evaluator.evaluate("", policy, mockLogger);
+
+    expect(runCalls[0]).toEqual({ command: "npm ci", opts: { timeout: 120_000 } });
+    expect(runCalls[1]).toEqual({ command: "npm test", opts: { timeout: 30_000 } });
+  });
+
+  it("honors a configured installTimeoutMs", async () => {
+    const { binding, runCalls } = makeMockSandbox({ exitCode: 0 });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
+    const policy = makePolicy({
+      evaluators: [{ type: "sandbox", installTimeoutMs: 300_000 }],
+    });
+
+    await evaluator.evaluate("", policy, mockLogger);
+
+    expect(runCalls[0]?.opts).toEqual({ timeout: 300_000 });
+  });
+
+  it("install failure → score 0, failed, reason names the install command, test never runs", async () => {
+    const { binding, runCalls } = makeMockSandbox({
+      exitCode: 0,
+      runResults: {
+        "npm ci": { exitCode: 1, stderr: "ERESOLVE unable to resolve dependency tree" },
+      },
+    });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
+
+    const result = await evaluator.evaluate("", makePolicy(), mockLogger);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.score).toBe(0);
+      expect(result.data.passed).toBe(false);
+      expect(result.data.reason).toContain("Dependency install (npm ci) failed");
+      expect(result.data.reason).toContain("ERESOLVE");
+      expect(result.data.costs?.[0]?.kind).toBe("sandbox_ms");
+    }
+    expect(runCalls.map((c) => c.command)).toEqual(["npm ci"]);
+  });
+});
+
+describe("installCommandFor", () => {
+  it("maps manifest/lockfile presence to the right command", () => {
+    expect(installCommandFor(new Map())).toBeNull();
+    expect(installCommandFor(new Map([["package.json", "{}"]]))).toBe("npm install");
+    expect(
+      installCommandFor(
+        new Map([
+          ["package.json", "{}"],
+          ["package-lock.json", "{}"],
+        ]),
+      ),
+    ).toBe("npm ci");
+    expect(installCommandFor(new Map([["package-lock.json", "{}"]]))).toBeNull();
+  });
+});
 
 describe("SandboxEvaluator — exit code behaviour", () => {
   it("exit code 0 → score 1.0, passed: true", async () => {
-    const binding = makeMockSandbox({ exitCode: 0, stdout: "ok" });
-    const evaluator = new SandboxEvaluator(binding);
+    const { binding } = makeMockSandbox({ exitCode: 0, stdout: "ok" });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
     const result = await evaluator.evaluate("", makePolicy(), mockLogger);
     expect(result.success).toBe(true);
     if (result.success) {
@@ -79,8 +250,11 @@ describe("SandboxEvaluator — exit code behaviour", () => {
   });
 
   it("exit code 1 with no parseable output → score 0.0, passed: false", async () => {
-    const binding = makeMockSandbox({ exitCode: 1, stdout: "something broke" });
-    const evaluator = new SandboxEvaluator(binding);
+    const { binding } = makeMockSandbox({
+      exitCode: 0,
+      runResults: { "npm test": { exitCode: 1, stdout: "something broke" } },
+    });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
     const result = await evaluator.evaluate("", makePolicy(), mockLogger);
     expect(result.success).toBe(true);
     if (result.success) {
@@ -91,10 +265,19 @@ describe("SandboxEvaluator — exit code behaviour", () => {
 });
 
 describe("SandboxEvaluator — test output parsing", () => {
+  const treeWithoutManifest = new Map([["src/app.ts", "export {};"]]);
+
+  function evaluatorWithTestOutput(exitCode: number, stdout: string) {
+    const { binding } = makeMockSandbox({ exitCode, stdout });
+    return new SandboxEvaluator(binding, repo, makeReadFiles(treeWithoutManifest));
+  }
+
   it('"5 passed, 0 failed" → score 1.0', async () => {
-    const binding = makeMockSandbox({ exitCode: 0, stdout: "5 passed, 0 failed" });
-    const evaluator = new SandboxEvaluator(binding);
-    const result = await evaluator.evaluate("", makePolicy(), mockLogger);
+    const result = await evaluatorWithTestOutput(0, "5 passed, 0 failed").evaluate(
+      "",
+      makePolicy(),
+      mockLogger,
+    );
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.score).toBe(1.0);
@@ -102,9 +285,11 @@ describe("SandboxEvaluator — test output parsing", () => {
   });
 
   it('"3 passed, 2 failed" → score 0.6, passed: false (minScore 0.7)', async () => {
-    const binding = makeMockSandbox({ exitCode: 1, stdout: "3 passed, 2 failed" });
-    const evaluator = new SandboxEvaluator(binding);
-    const result = await evaluator.evaluate("", makePolicy({ minScore: 0.7 }), mockLogger);
+    const result = await evaluatorWithTestOutput(1, "3 passed, 2 failed").evaluate(
+      "",
+      makePolicy({ minScore: 0.7 }),
+      mockLogger,
+    );
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.score).toBeCloseTo(0.6);
@@ -113,9 +298,11 @@ describe("SandboxEvaluator — test output parsing", () => {
   });
 
   it('"0 passed, 5 failed" → score 0.0', async () => {
-    const binding = makeMockSandbox({ exitCode: 1, stdout: "0 passed, 5 failed" });
-    const evaluator = new SandboxEvaluator(binding);
-    const result = await evaluator.evaluate("", makePolicy(), mockLogger);
+    const result = await evaluatorWithTestOutput(1, "0 passed, 5 failed").evaluate(
+      "",
+      makePolicy(),
+      mockLogger,
+    );
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.score).toBe(0.0);
@@ -124,9 +311,11 @@ describe("SandboxEvaluator — test output parsing", () => {
   });
 
   it('"5 passed, 1 failed" → score ~0.833, passed: true (minScore 0.7)', async () => {
-    const binding = makeMockSandbox({ exitCode: 1, stdout: "5 passed, 1 failed" });
-    const evaluator = new SandboxEvaluator(binding);
-    const result = await evaluator.evaluate("", makePolicy({ minScore: 0.7 }), mockLogger);
+    const result = await evaluatorWithTestOutput(1, "5 passed, 1 failed").evaluate(
+      "",
+      makePolicy({ minScore: 0.7 }),
+      mockLogger,
+    );
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.score).toBeCloseTo(5 / 6);
@@ -134,10 +323,37 @@ describe("SandboxEvaluator — test output parsing", () => {
     }
   });
 
+  it('"0 passed" alone (zero total) → unparseable, score 0.0', async () => {
+    const result = await evaluatorWithTestOutput(1, "0 passed").evaluate(
+      "",
+      makePolicy(),
+      mockLogger,
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.score).toBe(0.0);
+      expect(result.data.passed).toBe(false);
+    }
+  });
+
+  it('"5 passed" alone (no failed count) → score 1.0', async () => {
+    const result = await evaluatorWithTestOutput(1, "5 passed").evaluate(
+      "",
+      makePolicy(),
+      mockLogger,
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.score).toBe(1.0);
+    }
+  });
+
   it("exit code 0 with no parseable output → score 1.0", async () => {
-    const binding = makeMockSandbox({ exitCode: 0, stdout: "All done." });
-    const evaluator = new SandboxEvaluator(binding);
-    const result = await evaluator.evaluate("", makePolicy(), mockLogger);
+    const result = await evaluatorWithTestOutput(0, "All done.").evaluate(
+      "",
+      makePolicy(),
+      mockLogger,
+    );
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.score).toBe(1.0);
@@ -146,9 +362,9 @@ describe("SandboxEvaluator — test output parsing", () => {
 });
 
 describe("SandboxEvaluator — error handling", () => {
-  it("sandbox.create() throws → returns failed EvalResult without rethrowing", async () => {
-    const binding = makeMockSandbox({ createThrows: true });
-    const evaluator = new SandboxEvaluator(binding);
+  it("sandbox.create() throws → returns err without rethrowing", async () => {
+    const { binding } = makeMockSandbox({ createThrows: true });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
     const result = await evaluator.evaluate("", makePolicy(), mockLogger);
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -156,70 +372,66 @@ describe("SandboxEvaluator — error handling", () => {
     }
   });
 
-  it("run() throws (timeout) → returns failed EvalResult without rethrowing", async () => {
-    const binding = makeMockSandbox({ runThrows: true });
-    const evaluator = new SandboxEvaluator(binding);
+  it("run() throws (timeout) → returns err without rethrowing", async () => {
+    const { binding } = makeMockSandbox({ runThrows: true });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
     const result = await evaluator.evaluate("", makePolicy(), mockLogger);
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.message).toContain("Timeout");
     }
   });
-});
 
-describe("SandboxEvaluator — file writing", () => {
-  it("writes files parsed from diff to sandbox via writeFile", async () => {
-    const binding = makeMockSandbox({ exitCode: 0 });
-    const instance = await (binding.create as ReturnType<typeof vi.fn>)();
-    (binding.create as ReturnType<typeof vi.fn>).mockResolvedValue(instance);
-
-    const diff = makeDiff([
-      { path: "src/foo.ts", content: "export const x = 1;" },
-      { path: "src/bar.ts", content: "export const y = 2;" },
-    ]);
-
-    const evaluator = new SandboxEvaluator(binding);
-    await evaluator.evaluate(diff, makePolicy(), mockLogger);
-
-    expect(instance.writeFile).toHaveBeenCalledWith("src/foo.ts", expect.any(String));
-    expect(instance.writeFile).toHaveBeenCalledWith("src/bar.ts", expect.any(String));
+  it("readFiles rejecting (non-Error) is contained and surfaced as err", async () => {
+    const { binding } = makeMockSandbox({ exitCode: 0 });
+    const readFiles = vi.fn().mockRejectedValue("string failure");
+    const evaluator = new SandboxEvaluator(binding, repo, readFiles);
+    const result = await evaluator.evaluate("", makePolicy(), mockLogger);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("string failure");
+    }
+    expect(binding.create).not.toHaveBeenCalled();
   });
 });
 
 describe("SandboxEvaluator — destroy lifecycle", () => {
   it("destroy() is called after successful run", async () => {
-    const binding = makeMockSandbox({ exitCode: 0 });
-    const instance = await (binding.create as ReturnType<typeof vi.fn>)();
-    (binding.create as ReturnType<typeof vi.fn>).mockResolvedValue(instance);
+    const { binding, instance } = makeMockSandbox({ exitCode: 0 });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
 
-    const evaluator = new SandboxEvaluator(binding);
     await evaluator.evaluate("", makePolicy(), mockLogger);
 
     expect(instance.destroy).toHaveBeenCalledOnce();
   });
 
   it("destroy() is called even when run() throws", async () => {
-    const destroyFn = vi.fn().mockResolvedValue(undefined);
-    const instance: SandboxInstance = {
-      writeFile: vi.fn().mockResolvedValue(undefined),
-      run: vi.fn().mockRejectedValue(new Error("Timeout")),
-      destroy: destroyFn,
-    };
-    const binding: SandboxBinding = {
-      create: vi.fn().mockResolvedValue(instance),
-    };
+    const { binding, instance } = makeMockSandbox({ runThrows: true });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
 
-    const evaluator = new SandboxEvaluator(binding);
     await evaluator.evaluate("", makePolicy(), mockLogger);
 
-    expect(destroyFn).toHaveBeenCalledOnce();
+    expect(instance.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("destroy() is called when the install step fails", async () => {
+    const { binding, instance } = makeMockSandbox({
+      exitCode: 0,
+      runResults: { "npm ci": { exitCode: 1, stderr: "boom" } },
+    });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
+
+    await evaluator.evaluate("", makePolicy(), mockLogger);
+
+    expect(instance.destroy).toHaveBeenCalledOnce();
   });
 });
 
 describe("SandboxEvaluator — feature flag / no-op", () => {
-  it("returns passed: true, score: 1.0 when no sandbox evaluator in policy", async () => {
-    const binding = makeMockSandbox({ exitCode: 0 });
-    const evaluator = new SandboxEvaluator(binding);
+  it("returns passed: true, score: 1.0 when no sandbox evaluator in policy, without repo reads", async () => {
+    const { binding } = makeMockSandbox({ exitCode: 0 });
+    const readFiles = makeReadFiles();
+    const evaluator = new SandboxEvaluator(binding, repo, readFiles);
     const policy: EvalPolicy = {
       evaluators: [{ type: "diff" }],
       minScore: 0.7,
@@ -231,18 +443,81 @@ describe("SandboxEvaluator — feature flag / no-op", () => {
       expect(result.data.passed).toBe(true);
     }
     expect(binding.create).not.toHaveBeenCalled();
+    expect(readFiles).not.toHaveBeenCalled();
   });
 });
 
 describe("SandboxEvaluator — reason field", () => {
   it("reason is first 500 chars of stdout + stderr combined", async () => {
     const longOutput = "x".repeat(600);
-    const binding = makeMockSandbox({ exitCode: 0, stdout: longOutput });
-    const evaluator = new SandboxEvaluator(binding);
+    const { binding } = makeMockSandbox({ exitCode: 0, stdout: longOutput });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
     const result = await evaluator.evaluate("", makePolicy(), mockLogger);
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.reason.length).toBeLessThanOrEqual(500);
     }
+  });
+
+  it("reports sandbox_ms cost covering install + test run", async () => {
+    const { binding } = makeMockSandbox({ exitCode: 0 });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
+    const result = await evaluator.evaluate("", makePolicy(), mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.costs).toHaveLength(1);
+      expect(result.data.costs?.[0]?.kind).toBe("sandbox_ms");
+      expect(result.data.costs?.[0]?.quantity).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("buildEvaluators — sandbox wiring", () => {
+  const sandboxPolicy: EvalPolicy = { evaluators: [{ type: "sandbox" }] };
+
+  function findSandbox(evaluators: ReturnType<typeof buildEvaluators>) {
+    const entry = evaluators.find((e) => e.type === "sandbox");
+    expect(entry).toBeDefined();
+    // biome-ignore lint/style/noNonNullAssertion: asserted above
+    return entry!.evaluator;
+  }
+
+  it("no SANDBOX binding → fails closed with an actionable wrangler.toml reason", async () => {
+    const evaluators = buildEvaluators({} as Env, sandboxPolicy, "proj", mockLogger, repo);
+    const result = await findSandbox(evaluators).evaluate("", sandboxPolicy, mockLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.passed).toBe(false);
+    expect(result.data.score).toBe(0);
+    expect(result.data.reason).toContain("SANDBOX binding is not configured");
+    expect(result.data.reason).toContain("[[sandboxes]] in wrangler.toml");
+  });
+
+  it("SANDBOX binding without workspace repo access → fails closed", async () => {
+    const { binding } = makeMockSandbox({ exitCode: 0 });
+    const evaluators = buildEvaluators(
+      { SANDBOX: binding } as Env,
+      sandboxPolicy,
+      "proj",
+      mockLogger,
+    );
+    const result = await findSandbox(evaluators).evaluate("", sandboxPolicy, mockLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.passed).toBe(false);
+    expect(result.data.reason).toContain("workspace repository access was not provided");
+    expect(binding.create).not.toHaveBeenCalled();
+  });
+
+  it("SANDBOX binding + workspace repo access → a real SandboxEvaluator", () => {
+    const { binding } = makeMockSandbox({ exitCode: 0 });
+    const evaluators = buildEvaluators(
+      { SANDBOX: binding } as Env,
+      sandboxPolicy,
+      "proj",
+      mockLogger,
+      repo,
+    );
+    expect(findSandbox(evaluators)).toBeInstanceOf(SandboxEvaluator);
   });
 });

--- a/tests/sandbox-evaluator.test.ts
+++ b/tests/sandbox-evaluator.test.ts
@@ -113,6 +113,33 @@ describe("SandboxEvaluator — workspace tree materialization", () => {
     }
   });
 
+  it("waits for every file write to settle before destroying the sandbox", async () => {
+    // The failure this pins: Promise.all rejects on the first failure while its
+    // siblings are still in flight, so the `finally` could destroy the sandbox
+    // mid-write. Here one write rejects immediately and a sibling resolves
+    // slowly; destroy must not run until the slow one has finished.
+    const { binding, instance } = makeMockSandbox({ exitCode: 0 });
+    let slowWriteFinished = false;
+    let destroyedBeforeSlowWriteFinished = false;
+
+    (instance.writeFile as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
+      if (path === "src/math.ts") throw new Error("disk full");
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      slowWriteFinished = true;
+    });
+    (instance.destroy as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      if (!slowWriteFinished) destroyedBeforeSlowWriteFinished = true;
+    });
+
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
+    const result = await evaluator.evaluate("ignored diff", makePolicy(), mockLogger);
+
+    expect(destroyedBeforeSlowWriteFinished).toBe(false);
+    expect(slowWriteFinished).toBe(true);
+    // The write failure still surfaces — settling the batch must not swallow it.
+    expect(result.success).toBe(false);
+  });
+
   it("passes ref: undefined through when no commit is pinned", async () => {
     const { binding } = makeMockSandbox({ exitCode: 0 });
     const readFiles = makeReadFiles();

--- a/tests/sandbox-evaluator.test.ts
+++ b/tests/sandbox-evaluator.test.ts
@@ -248,6 +248,32 @@ describe("installCommandFor", () => {
     ).toBe("npm ci --no-audit --no-fund");
     expect(installCommandFor(new Map([["package-lock.json", "{}"]]))).toBeNull();
   });
+
+  it("treats npm-shrinkwrap.json as a lockfile", () => {
+    // `npm ci` accepts either lockfile name. A shrinkwrap-only project is just
+    // as pinned as a package-lock one, so it must not fall back to the
+    // unpinned `npm install`.
+    expect(
+      installCommandFor(
+        new Map([
+          ["package.json", "{}"],
+          ["npm-shrinkwrap.json", "{}"],
+        ]),
+      ),
+    ).toBe("npm ci --no-audit --no-fund");
+    // Both present is still a frozen install (npm prefers the shrinkwrap).
+    expect(
+      installCommandFor(
+        new Map([
+          ["package.json", "{}"],
+          ["npm-shrinkwrap.json", "{}"],
+          ["package-lock.json", "{}"],
+        ]),
+      ),
+    ).toBe("npm ci --no-audit --no-fund");
+    // A lockfile alone is still not an npm project.
+    expect(installCommandFor(new Map([["npm-shrinkwrap.json", "{}"]]))).toBeNull();
+  });
 });
 
 describe("SandboxEvaluator — exit code behaviour", () => {


### PR DESCRIPTION
## Summary

The sandbox evaluator populated the sandbox with only the reconstructed `+` lines of changed files and then ran `npm test` — no base tree, no untouched sources, no `package.json` unless it happened to change, no dependency install. It could not meaningfully run any real test suite (the defect flagged in `docs/archive/CODE_REVIEW.md`).

Now:

- **Full tree materialization:** `SandboxEvaluator.evaluate()` calls `readRepoFiles(remote, token, logger, ref)` — the same pattern `post-merge.ts` already uses correctly — with `ref` pinned to `evaluatedSha` (the `workspaceOid` the pipeline records). A new `readTreeAtCommit` in `git-ops.ts` reads every file of that commit's tree, so the sandbox gets the exact tree the merge would land. A pinned commit missing from the clone is an error (fail closed), never a silently different tree.
- **Repo access threading:** a new `SandboxRepoAccess {remote, token, ref?}` is passed via an optional trailing parameter on `buildEvaluators`. Both call sites (`createChangeWithEvaluation` and `POST /changes/:id/evaluate`) already had the workspace remote, a freshly minted read token, and `evaluatedSha` in scope — no new tokens or clones. The `Evaluator` interface is unchanged.
- **Dependency install:** when the tree has `package.json`, `npm ci` (lockfile) or `npm install` runs before the configured command, with a configurable `installTimeoutMs` (default 120s). Nonzero install exit fails the evaluation with a clear reason. `sandbox_ms` cost covers install + run.
- **Fail-closed messaging:** a missing `SANDBOX` binding now says exactly what's wrong ("enable `[[sandboxes]]` in wrangler.toml or remove the sandbox evaluator from the policy"). `wrangler.toml` itself is untouched — enabling the binding stays an ops decision; the behavior is documented in `architecture.md`.

Reviewer notes: binary files are decoded as UTF-8 (same pre-existing limitation as post-merge's sandbox population — `SandboxInstance.writeFile` only accepts strings); install runs for any tree with a `package.json` regardless of the configured command (custom commands need `node_modules` too); post-merge was left without an install step to keep the diff focused — unifying is a natural follow-up.

## Related issues

Closes #194

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

`tests/sandbox-evaluator.test.ts` was rewritten to exercise a realistic tree (the old tests pinned the broken all-`+`-lines model in): asserts the sandbox receives the full file set from the mocked repo read at the pinned ref, the install→test command sequence (`npm ci` vs `npm install` vs no manifest), install-failure fail-closed, no-binding and no-repo-access fail-closed reasons. `readTreeAtCommit` is covered including the unreadable-blob skip branch (via a dangling-oid tree). Coverage on `sandbox-evaluator.ts`: 100% statements/lines/functions, 94% branches (remaining branches are pre-existing unreachable TS-strictness fallbacks and a v8 finally-line artifact). Full suite: 1259 passed, 0 failures.

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript

---
_Generated by [Claude Code](https://claude.ai/code/session_015dp67PBbFT666GnMLuxvm1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sandbox evaluations now assess the complete repository at the selected commit.
  - Dependencies are installed automatically based on available lockfiles and package metadata.
  - Separate time limits are supported for dependency installation and evaluation commands.
  - Sandbox policies support minimum score requirements and requiring all evaluations to pass.

- **Bug Fixes**
  - Improved diagnostics for repository access and dependency installation failures.
  - Missing sandbox or repository access safely fails closed with a zero score, preventing merges.
  - Output handling and repository reads are more reliable for large or historical workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->