### PR TITLE
Harden CSP with per-request script-src nonces; convert all inline scripts and event handlers

### DIFF
--- a/src/middleware/security-headers.ts
+++ b/src/middleware/security-headers.ts
@@ -2,47 +2,89 @@ import type { Context, MiddlewareHandler } from "hono";
 import { isGitHttpPath } from "../routes/git-http";
 import type { Env } from "../types";
 
-/**
- * CSP for the server-rendered UI and API. Exported so the request middleware and
- * the error boundary (src/index.ts) share ONE source of truth — a 500 response
- * must carry the same policy as a 200, and duplicating the string let them drift.
- */
-export const CONTENT_SECURITY_POLICY =
-  "frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-src 'none'";
+declare module "hono" {
+  interface ContextVariableMap {
+    /**
+     * Per-request CSP nonce (base64). Set by `setHtmlSecurityHeaders` (i.e. the
+     * security-headers middleware) before route handlers run; pages thread it
+     * onto every `<script nonce={...}>` they render so the `script-src` policy
+     * admits exactly those scripts and nothing an injection could smuggle in.
+     */
+    cspNonce?: string;
+  }
+}
 
 /**
- * Apply the static HTML security headers (content-type sniffing, framing,
- * referrer, CSP). Used by both the middleware and the error boundary so the two
- * paths stay identical. HSTS is applied separately — it is conditional on HTTPS.
+ * Generate a fresh CSP nonce: 128 bits from the platform CSPRNG, base64-encoded
+ * (the encoding the CSP spec recommends for nonce values).
+ */
+export function generateCspNonce(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  let binary = "";
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary);
+}
+
+/**
+ * CSP for the server-rendered UI and API, parameterized by the per-request
+ * script nonce. Built in ONE place so the request middleware and the error
+ * boundary (src/index.ts) share a single source of truth — a 500 response must
+ * carry the same policy as a 200, and duplicating the string let them drift.
+ *
+ * `script-src 'nonce-…'` (issue #161): every inline `<script>` the UI renders
+ * carries this request's nonce; the old inline `onclick=`/`onsubmit=` handlers
+ * were refactored into nonce'd `addEventListener` blocks, so nothing else needs
+ * to execute. Deliberately NO:
+ * - `'unsafe-inline'` fallback — it only aids pre-2016 browsers that ignore
+ *   nonces (CSP1-only), at the cost of advertising an inline-script escape
+ *   hatch to every scanner; all supported browsers understand nonces.
+ * - `'strict-dynamic'` — it exists to let nonce'd loaders inject further
+ *   scripts; the UI loads no external scripts and injects none, so granting
+ *   transitive trust would only widen the policy.
+ */
+export function contentSecurityPolicy(nonce: string): string {
+  return `frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-src 'none'; script-src 'nonce-${nonce}'`;
+}
+
+/**
+ * Apply the HTML security headers (content-type sniffing, framing, referrer,
+ * CSP). Used by both the middleware and the error boundary so the two paths
+ * stay identical. The CSP nonce is generated once per request and cached on the
+ * context: the error boundary re-asserts headers on a context the middleware
+ * already stamped, and both calls must emit the SAME policy string. HSTS is
+ * applied separately — it is conditional on HTTPS.
  */
 export function setHtmlSecurityHeaders(c: Context<{ Bindings: Env }>): void {
+  let nonce = c.get("cspNonce");
+  if (nonce === undefined) {
+    nonce = generateCspNonce();
+    c.set("cspNonce", nonce);
+  }
   c.header("X-Content-Type-Options", "nosniff");
   c.header("X-Frame-Options", "DENY");
   c.header("Referrer-Policy", "strict-origin-when-cross-origin");
-  c.header("Content-Security-Policy", CONTENT_SECURITY_POLICY);
+  c.header("Content-Security-Policy", contentSecurityPolicy(nonce));
 }
 
 /**
  * Response security headers for the server-rendered UI and API.
  *
- * The CSP is deliberately limited to directives that do NOT restrict inline
- * scripts: the UI ships inline `onclick` handlers and inline `<script>` blocks
- * (file-tree, conflict-resolution, import-progress), and inline event-handler
- * attributes cannot be nonce'd — a `script-src` policy would break them. So we
- * ship the script-safe subset now and defer `script-src` behind an
- * inline-handler nonce refactor (tracked in issue #161).
- *
- * `form-action 'self'` and `frame-src 'none'` are safe to add without that
- * refactor (all forms post same-origin; the UI embeds no iframes) and add real
- * defense-in-depth: they stop a would-be injection from exfiltrating via a
- * cross-origin form target or a smuggled iframe.
+ * The CSP restricts script execution to `<script>` elements carrying this
+ * request's nonce (stored on the context as `cspNonce`, threaded through page
+ * props to every script tag the UI renders). `default-src` is still omitted on
+ * purpose: adding it would (via fallback) govern style/img/connect/font, and
+ * the UI relies on inline `style=` attributes, `<style>` blocks and `data:`
+ * favicons — locking those down is a separate refactor.
  *
  * Git smart-HTTP responses are left untouched — they are not HTML and must not
  * carry frame/CSP headers that could confuse git clients or proxies.
  */
 export const securityHeadersMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
   // Register headers BEFORE next() so they survive on the response even if a
-  // downstream handler throws and the error boundary produces the 500. Git
+  // downstream handler throws and the error boundary produces the 500 (and so
+  // route handlers can read the nonce off the context while rendering). Git
   // smart-HTTP responses are not HTML and must stay untouched, so they are
   // skipped — the single await next() below still runs for them.
   if (!isGitHttpPath(c.req.path)) {

--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -495,6 +495,7 @@ app.get("/", (c) => {
 
         {!success && (
           <script
+            nonce={c.get("cspNonce") ?? ""}
             dangerouslySetInnerHTML={{
               __html: SIGNUP_SCRIPT,
             }}

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -155,7 +155,7 @@ app.get("/new", async (c) => {
   }
 
   logger.debug("Rendering new project page");
-  return c.html(<NewProjectPage user={user} />);
+  return c.html(<NewProjectPage user={user} nonce={c.get("cspNonce") ?? ""} />);
 });
 
 async function loadAgentSummaries(
@@ -424,6 +424,7 @@ app.get("/p/:name", async (c) => {
       syncStatus={syncStatus}
       canSync={canSync}
       isOwner={isOwner}
+      nonce={c.get("cspNonce") ?? ""}
     />,
   );
 });
@@ -1152,6 +1153,7 @@ app.get("/:namespace/:slug/sync", async (c) => {
       syncStatus={syncStatus}
       syncHistory={[]}
       user={userResult}
+      nonce={c.get("cspNonce") ?? ""}
     />,
   );
 });
@@ -1412,6 +1414,7 @@ app.get("/:namespace/:slug", async (c) => {
       syncStatus={syncStatus}
       canSync={canSync}
       isOwner={isOwner}
+      nonce={c.get("cspNonce") ?? ""}
     />,
   );
 });

--- a/src/ui/components/conflict-resolution.tsx
+++ b/src/ui/components/conflict-resolution.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "hono/jsx";
+import { serializeForScript } from "../../utils/html";
 
 export interface ConflictFile {
   path: string;
@@ -274,8 +275,8 @@ const ConflictFileViewer: FC<ConflictFileViewerProps> = ({ file, conflictId, dis
             __html: `
             // Track resolutions for this file
             if (!window.fileResolutions) window.fileResolutions = {};
-            window.fileResolutions[${JSON.stringify(fileId)}] = {
-              path: ${JSON.stringify(file.path)},
+            window.fileResolutions[${serializeForScript(fileId)}] = {
+              path: ${serializeForScript(file.path)},
               strategy: null,
               content: null
             };
@@ -307,7 +308,7 @@ const ConflictFileViewer: FC<ConflictFileViewerProps> = ({ file, conflictId, dis
               window.fileResolutions[fileId].strategy = 'manual';
               window.fileResolutions[fileId].content = content;
 
-              const conflictId = ${JSON.stringify(conflictId)};
+              const conflictId = ${serializeForScript(conflictId)};
               const filePath = window.fileResolutions[fileId].path;
 
               try {
@@ -338,7 +339,7 @@ const ConflictFileViewer: FC<ConflictFileViewerProps> = ({ file, conflictId, dis
             // attributes). Scoped to this fileId and guarded so repeated
             // per-file scripts never double-bind.
             (function () {
-              var fileId = ${JSON.stringify(fileId)};
+              var fileId = ${serializeForScript(fileId)};
               document
                 .querySelectorAll('button[data-file-id="' + fileId + '"][data-resolution]')
                 .forEach(function (btn) {

--- a/src/ui/components/conflict-resolution.tsx
+++ b/src/ui/components/conflict-resolution.tsx
@@ -39,9 +39,11 @@ interface ConflictResolutionProps {
     strategy: "ours" | "theirs" | "manual";
     content?: string;
   }) => void;
+  /** Per-request CSP nonce — required so the card's scripts pass `script-src`. */
+  nonce: string;
 }
 
-export const ConflictResolution: FC<ConflictResolutionProps> = ({ conflict, onResolve }) => {
+export const ConflictResolution: FC<ConflictResolutionProps> = ({ conflict, onResolve, nonce }) => {
   const isResolved = !!conflict.resolvedAt;
 
   return (
@@ -79,6 +81,7 @@ export const ConflictResolution: FC<ConflictResolutionProps> = ({ conflict, onRe
             conflictId={conflict.id}
             onResolve={onResolve}
             disabled={isResolved}
+            nonce={nonce}
           />
         ))}
       </div>
@@ -88,14 +91,16 @@ export const ConflictResolution: FC<ConflictResolutionProps> = ({ conflict, onRe
           <button
             type="button"
             class="btn btn-primary"
-            onclick={`resolveAllConflicts('${conflict.id}', 'ours')`}
+            data-resolve-all="ours"
+            data-conflict-id={conflict.id}
           >
             Accept All Ours
           </button>
           <button
             type="button"
             class="btn btn-secondary"
-            onclick={`resolveAllConflicts('${conflict.id}', 'theirs')`}
+            data-resolve-all="theirs"
+            data-conflict-id={conflict.id}
           >
             Accept All Theirs
           </button>
@@ -107,6 +112,7 @@ export const ConflictResolution: FC<ConflictResolutionProps> = ({ conflict, onRe
 
       {!isResolved && (
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `
             async function resolveAllConflicts(conflictId, strategy) {
@@ -131,6 +137,19 @@ export const ConflictResolution: FC<ConflictResolutionProps> = ({ conflict, onRe
                 alert('Network error: ' + err.message);
               }
             }
+
+            // Wire the "Accept All" buttons (replaces the former inline onclick
+            // attributes). Guarded per-button so a page with several conflict
+            // cards never double-binds.
+            (function () {
+              document.querySelectorAll('button[data-resolve-all]').forEach(function (btn) {
+                if (btn.dataset.wired) return;
+                btn.dataset.wired = '1';
+                btn.addEventListener('click', function () {
+                  resolveAllConflicts(btn.dataset.conflictId, btn.dataset.resolveAll);
+                });
+              });
+            })();
           `,
           }}
         />
@@ -148,13 +167,15 @@ interface ConflictFileViewerProps {
     content?: string;
   }) => void;
   disabled?: boolean;
+  /** Per-request CSP nonce for the per-file script block. */
+  nonce: string;
 }
 
 /**
  * Server-rendered conflict file viewer with client-side JavaScript for interactivity.
- * Uses data attributes and inline scripts for state management instead of React hooks.
+ * Uses data attributes and nonce'd scripts for state management instead of React hooks.
  */
-const ConflictFileViewer: FC<ConflictFileViewerProps> = ({ file, conflictId, disabled }) => {
+const ConflictFileViewer: FC<ConflictFileViewerProps> = ({ file, conflictId, disabled, nonce }) => {
   const fileId = file.path.replace(/[^a-zA-Z0-9]/g, "_");
 
   return (
@@ -171,7 +192,6 @@ const ConflictFileViewer: FC<ConflictFileViewerProps> = ({ file, conflictId, dis
                 class="btn btn-sm btn-secondary"
                 data-resolution="ours"
                 data-file-id={fileId}
-                onclick={`handleFileResolve('${fileId}', 'ours')`}
               >
                 Accept Ours
               </button>
@@ -180,7 +200,6 @@ const ConflictFileViewer: FC<ConflictFileViewerProps> = ({ file, conflictId, dis
                 class="btn btn-sm btn-secondary"
                 data-resolution="theirs"
                 data-file-id={fileId}
-                onclick={`handleFileResolve('${fileId}', 'theirs')`}
               >
                 Accept Theirs
               </button>
@@ -189,7 +208,6 @@ const ConflictFileViewer: FC<ConflictFileViewerProps> = ({ file, conflictId, dis
                 class="btn btn-sm btn-secondary"
                 data-resolution="manual"
                 data-file-id={fileId}
-                onclick={`handleFileResolve('${fileId}', 'manual')`}
               >
                 Manual Edit
               </button>
@@ -243,11 +261,7 @@ const ConflictFileViewer: FC<ConflictFileViewerProps> = ({ file, conflictId, dis
             rows={10}
             placeholder="Enter the resolved file content here..."
           />
-          <button
-            type="button"
-            class="btn btn-sm btn-primary"
-            onclick={`submitManualResolution('${fileId}')`}
-          >
+          <button type="button" class="btn btn-sm btn-primary" id={`manual-save-${fileId}`}>
             Save Manual Resolution
           </button>
         </div>
@@ -255,6 +269,7 @@ const ConflictFileViewer: FC<ConflictFileViewerProps> = ({ file, conflictId, dis
 
       {!disabled && (
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `
             // Track resolutions for this file
@@ -318,6 +333,29 @@ const ConflictFileViewer: FC<ConflictFileViewerProps> = ({ file, conflictId, dis
                 alert('Network error: ' + err.message);
               }
             }
+
+            // Wire this file's buttons (replaces the former inline onclick
+            // attributes). Scoped to this fileId and guarded so repeated
+            // per-file scripts never double-bind.
+            (function () {
+              var fileId = ${JSON.stringify(fileId)};
+              document
+                .querySelectorAll('button[data-file-id="' + fileId + '"][data-resolution]')
+                .forEach(function (btn) {
+                  if (btn.dataset.wired) return;
+                  btn.dataset.wired = '1';
+                  btn.addEventListener('click', function () {
+                    handleFileResolve(fileId, btn.dataset.resolution);
+                  });
+                });
+              var saveBtn = document.getElementById('manual-save-' + fileId);
+              if (saveBtn && !saveBtn.dataset.wired) {
+                saveBtn.dataset.wired = '1';
+                saveBtn.addEventListener('click', function () {
+                  submitManualResolution(fileId);
+                });
+              }
+            })();
           `,
           }}
         />

--- a/src/ui/components/file-tree.tsx
+++ b/src/ui/components/file-tree.tsx
@@ -5,7 +5,33 @@ interface FileTreeProps {
   nodes: FileTreeNode[];
   namespace: string;
   slug: string;
+  /** Per-request CSP nonce — required so the toggle script passes `script-src`. */
+  nonce: string;
 }
+
+/**
+ * Expand/collapse-all wiring for `.file-tree-toggle-btn`, CSP-safe (no inline
+ * handler). Delegated from `document` behind a global flag so rendering more
+ * than one FileTree on a page never double-binds the buttons.
+ */
+const FILE_TREE_SCRIPT = `
+(function () {
+  if (window.__stratumFileTreeWired) return;
+  window.__stratumFileTreeWired = true;
+  document.addEventListener('click', function (e) {
+    var target = e.target;
+    if (!target || !target.closest) return;
+    var btn = target.closest('.file-tree-toggle-btn');
+    if (!btn) return;
+    var t = btn.closest('.file-tree');
+    if (!t) return;
+    var ds = t.querySelectorAll('details');
+    var open = Array.from(ds).some(function (d) { return d.open; });
+    ds.forEach(function (d) { d.open = !open; });
+    btn.textContent = open ? 'Expand all' : 'Collapse all';
+  });
+})();
+`;
 
 interface NodeProps {
   node: FileTreeNode;
@@ -42,7 +68,7 @@ const FileTreeNodeItem: FC<NodeProps> = ({ node, namespace, slug, depth }) => {
   );
 };
 
-export const FileTree: FC<FileTreeProps> = ({ nodes, namespace, slug }) => {
+export const FileTree: FC<FileTreeProps> = ({ nodes, namespace, slug, nonce }) => {
   if (nodes.length === 0) {
     return (
       <div class="empty-state">
@@ -54,17 +80,14 @@ export const FileTree: FC<FileTreeProps> = ({ nodes, namespace, slug }) => {
   return (
     <div class="file-tree">
       <div class="file-tree-controls">
-        <button
-          type="button"
-          class="file-tree-toggle-btn"
-          onclick="(function(btn){var t=btn.closest('.file-tree');var ds=t.querySelectorAll('details');var open=Array.from(ds).some(function(d){return d.open});ds.forEach(function(d){d.open=!open});btn.textContent=open?'Expand all':'Collapse all'})(this)"
-        >
+        <button type="button" class="file-tree-toggle-btn">
           Expand all
         </button>
       </div>
       {nodes.map((node) => (
         <FileTreeNodeItem key={node.path} node={node} namespace={namespace} slug={slug} depth={0} />
       ))}
+      <script nonce={nonce} dangerouslySetInnerHTML={{ __html: FILE_TREE_SCRIPT }} />
     </div>
   );
 };

--- a/src/ui/components/import-progress.tsx
+++ b/src/ui/components/import-progress.tsx
@@ -378,7 +378,12 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
               var btn = document.getElementById('import-error-action');
               if (!btn) return;
               btn.addEventListener('click', function () {
-                window.open(btn.dataset.url, '_blank');
+                // 'noopener' is required here: unlike <a target="_blank">, which
+                // modern browsers treat as implicitly noopener, window.open()
+                // still hands the opened page a live window.opener reference.
+                // The URL is repository-supplied, so without this it could
+                // navigate this authenticated tab (reverse tabnabbing).
+                window.open(btn.dataset.url, '_blank', 'noopener,noreferrer');
               });
             })();
           `,

--- a/src/ui/components/import-progress.tsx
+++ b/src/ui/components/import-progress.tsx
@@ -21,6 +21,8 @@ interface ImportProgressProps {
   }>;
   sourceUrl: string;
   branch: string;
+  /** Per-request CSP nonce — required so the card's scripts pass `script-src`. */
+  nonce: string;
 }
 
 // Error classification and troubleshooting tips
@@ -29,9 +31,13 @@ interface ErrorInfo {
   title: string;
   description: string;
   tips: string[];
+  /**
+   * Optional action button. Clicking it opens the import's source URL in a new
+   * tab (wired via a nonce'd addEventListener script — CSP forbids inline
+   * `onclick=` handlers and eval'ing action strings).
+   */
   actionButton?: {
     label: string;
-    action: string;
   };
 }
 
@@ -58,7 +64,6 @@ function classifyError(errorMessage: string): ErrorInfo {
       ],
       actionButton: {
         label: "Check Repository Access",
-        action: "window.open('{sourceUrl}', '_blank')",
       },
     };
   }
@@ -103,7 +108,6 @@ function classifyError(errorMessage: string): ErrorInfo {
       ],
       actionButton: {
         label: "View Repository",
-        action: "window.open('{sourceUrl}', '_blank')",
       },
     };
   }
@@ -198,6 +202,7 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
   errors,
   sourceUrl,
   branch,
+  nonce,
 }) => {
   const isActive = ["queued", "cloning", "processing"].includes(status);
   const isComplete = status === "completed";
@@ -289,8 +294,9 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
             <div class="error-action">
               <button
                 type="button"
+                id="import-error-action"
                 class="btn btn-secondary"
-                onclick={errorInfo.actionButton.action.replace("{sourceUrl}", sourceUrl)}
+                data-url={sourceUrl}
               >
                 {errorInfo.actionButton.label}
               </button>
@@ -335,9 +341,9 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
       {isActive && (
         <div class="actions-section">
           <form
+            id="import-cancel-form"
             method="post"
             action={`/api/projects/${namespace}/${slug}/import/cancel`}
-            onsubmit="return confirm('Are you sure you want to cancel this import?');"
           >
             <button type="submit" class="btn btn-danger">
               Cancel Import
@@ -360,10 +366,40 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
         </div>
       )}
 
-      {isActive && (
+      {isFailed && errorInfo?.actionButton && (
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `
+            // Wire the error action button (replaces the former inline onclick).
+            (function () {
+              var btn = document.getElementById('import-error-action');
+              if (!btn) return;
+              btn.addEventListener('click', function () {
+                window.open(btn.dataset.url, '_blank');
+              });
+            })();
+          `,
+          }}
+        />
+      )}
+
+      {isActive && (
+        <script
+          nonce={nonce}
+          dangerouslySetInnerHTML={{
+            __html: `
+            // Confirm before cancelling the import (replaces the former inline onsubmit).
+            (function () {
+              var cancelForm = document.getElementById('import-cancel-form');
+              if (!cancelForm) return;
+              cancelForm.addEventListener('submit', function (event) {
+                if (!confirm('Are you sure you want to cancel this import?')) {
+                  event.preventDefault();
+                }
+              });
+            })();
+
             // Connect to SSE for real-time updates
             const evtSource = new EventSource('/api/projects/${safeNamespace}/${safeSlug}/import/stream');
             

--- a/src/ui/components/import-progress.tsx
+++ b/src/ui/components/import-progress.tsx
@@ -217,9 +217,11 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
         ? 50
         : 0;
 
-  // Safely escape for JavaScript string interpolation
-  const safeNamespace = JSON.stringify(namespace).slice(1, -1);
-  const safeSlug = JSON.stringify(slug).slice(1, -1);
+  // Safely escape for interpolation into a quoted string inside an inline
+  // <script> body — JSON.stringify alone doesn't escape "<", so a namespace
+  // or slug containing "</script>" could terminate the script tag early.
+  const safeNamespace = JSON.stringify(namespace).slice(1, -1).replace(/</g, "\\u003c");
+  const safeSlug = JSON.stringify(slug).slice(1, -1).replace(/</g, "\\u003c");
 
   // Get the main error for classification (use the last error or logs)
   const lastError = errors.length > 0 ? errors[errors.length - 1] : undefined;

--- a/src/ui/pages/new-project.tsx
+++ b/src/ui/pages/new-project.tsx
@@ -4,9 +4,35 @@ import { Layout } from "../layout";
 interface NewProjectProps {
   user?: { id: string; email: string; username: string } | null;
   error?: string;
+  /** Per-request CSP nonce — required so the import-form script passes `script-src`. */
+  nonce: string;
 }
 
-export const NewProjectPage: FC<NewProjectProps> = ({ user, error }) => {
+/**
+ * Rewrites the GitHub import form's action to the namespaced import endpoint on
+ * submit (or blocks it with a login prompt). CSP-safe replacement for the old
+ * inline `onsubmit=` handler — identical behavior: returning false became
+ * `event.preventDefault()`, the mutated `action` still submits normally.
+ */
+const IMPORT_FORM_SCRIPT = `
+(function () {
+  var form = document.getElementById('import-form');
+  if (!form) return;
+  form.addEventListener('submit', function (event) {
+    var name = form.querySelector('[name=name]').value;
+    var userData = document.getElementById('user-data');
+    var username = userData ? userData.dataset.username : '';
+    if (!username) {
+      alert('Please log in first');
+      event.preventDefault();
+      return;
+    }
+    form.action = '/api/projects/@' + encodeURIComponent(username) + '/' + encodeURIComponent(name) + '/import';
+  });
+})();
+`;
+
+export const NewProjectPage: FC<NewProjectProps> = ({ user, error, nonce }) => {
   // Always set username data, fallback to empty string if not available
   const username = user?.username || "";
 
@@ -109,10 +135,10 @@ export const NewProjectPage: FC<NewProjectProps> = ({ user, error }) => {
       <div class="card" style={{ marginTop: "1.5rem" }}>
         <h3 style={{ marginTop: 0 }}>Or import from GitHub</h3>
         <form
+          id="import-form"
           method="post"
           action="/api/projects/import"
           style={{ marginTop: "1rem" }}
-          onsubmit="const name = this.querySelector('[name=name]').value; const userData = document.getElementById('user-data'); const username = userData ? userData.dataset.username : ''; if (!username) { alert('Please log in first'); return false; } this.action = '/api/projects/@' + encodeURIComponent(username) + '/' + encodeURIComponent(name) + '/import'; return true;"
         >
           <div style="margin-bottom: 1rem;">
             <label style={{ display: "block", marginBottom: "0.5rem", color: "#888" }}>
@@ -188,6 +214,8 @@ export const NewProjectPage: FC<NewProjectProps> = ({ user, error }) => {
           </button>
         </form>
       </div>
+
+      <script nonce={nonce} dangerouslySetInnerHTML={{ __html: IMPORT_FORM_SCRIPT }} />
     </Layout>
   );
 };

--- a/src/ui/pages/repo.tsx
+++ b/src/ui/pages/repo.tsx
@@ -97,6 +97,8 @@ interface RepoProps {
   } | null;
   canSync?: boolean;
   isOwner?: boolean;
+  /** Per-request CSP nonce, threaded to every script-rendering child. */
+  nonce: string;
 }
 
 function getProviderIcon(provider?: GitProvider): string {
@@ -156,6 +158,7 @@ export const RepoPage: FC<RepoProps> = ({
   syncStatus,
   canSync,
   isOwner,
+  nonce,
 }) => {
   const hasSource = !!project.sourceUrl;
   const isSyncing = project.lastSyncStatus === "in_progress";
@@ -319,6 +322,7 @@ export const RepoPage: FC<RepoProps> = ({
           errors={importProgress.errors}
           sourceUrl={importProgress.sourceUrl}
           branch={importProgress.branch}
+          nonce={nonce}
         />
       )}
 
@@ -330,6 +334,7 @@ export const RepoPage: FC<RepoProps> = ({
               nodes={buildFileTree(files)}
               namespace={project.namespace}
               slug={project.slug}
+              nonce={nonce}
             />
           </div>
         </div>

--- a/src/ui/pages/sync.tsx
+++ b/src/ui/pages/sync.tsx
@@ -53,9 +53,11 @@ interface SyncPageProps {
     error?: string;
   }>;
   user?: { id: string; email: string; username: string } | null;
+  /** Per-request CSP nonce — required so the page script passes `script-src`. */
+  nonce: string;
 }
 
-export const SyncPage: FC<SyncPageProps> = ({ project, syncStatus, syncHistory, user }) => {
+export const SyncPage: FC<SyncPageProps> = ({ project, syncStatus, syncHistory, user, nonce }) => {
   const isSyncing = syncStatus.lastSyncStatus === "in_progress";
   const hasError = syncStatus.lastSyncStatus === "failed";
   const hasUpdates =
@@ -110,9 +112,9 @@ export const SyncPage: FC<SyncPageProps> = ({ project, syncStatus, syncHistory, 
               <div class="status-actions">
                 {!isSyncing && (
                   <form
+                    id="sync-form"
                     method="post"
                     action={`/api/projects/${project.namespace}/${project.slug}/sync`}
-                    onsubmit="event.preventDefault(); handleSyncSubmit(this);"
                   >
                     <button
                       type="submit"
@@ -178,18 +180,18 @@ export const SyncPage: FC<SyncPageProps> = ({ project, syncStatus, syncHistory, 
           <div class="card auto-sync-card">
             <h3>Auto-Sync Settings</h3>
             <form
+              id="sync-settings-form"
               method="post"
               action={`/api/projects/${project.namespace}/${project.slug}/sync/settings`}
               class="auto-sync-form"
-              onsubmit="event.preventDefault(); handleSettingsSubmit(this);"
             >
               <div class="form-group">
                 <label class="checkbox-label">
                   <input
                     type="checkbox"
+                    id="autoSyncEnabled"
                     name="autoSyncEnabled"
                     checked={syncStatus.autoSyncEnabled}
-                    onchange="toggleSyncFrequency(this)"
                   />
                   Enable automatic sync
                 </label>
@@ -287,8 +289,9 @@ export const SyncPage: FC<SyncPageProps> = ({ project, syncStatus, syncHistory, 
           )}
         </div>
 
-        {/* Client-side JavaScript for form handling */}
+        {/* Client-side JavaScript for form handling (nonce'd — CSP script-src) */}
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `
               async function handleSyncSubmit(form) {
@@ -446,6 +449,31 @@ export const SyncPage: FC<SyncPageProps> = ({ project, syncStatus, syncHistory, 
                   select.disabled = !checkbox.checked;
                 }
               }
+
+              // Event wiring (replaces the former inline onsubmit/onchange
+              // attributes, which a nonce-based script-src would block).
+              (function () {
+                var syncForm = document.getElementById('sync-form');
+                if (syncForm) {
+                  syncForm.addEventListener('submit', function (event) {
+                    event.preventDefault();
+                    handleSyncSubmit(syncForm);
+                  });
+                }
+                var settingsForm = document.getElementById('sync-settings-form');
+                if (settingsForm) {
+                  settingsForm.addEventListener('submit', function (event) {
+                    event.preventDefault();
+                    handleSettingsSubmit(settingsForm);
+                  });
+                }
+                var autoSyncCheckbox = document.getElementById('autoSyncEnabled');
+                if (autoSyncCheckbox) {
+                  autoSyncCheckbox.addEventListener('change', function () {
+                    toggleSyncFrequency(autoSyncCheckbox);
+                  });
+                }
+              })();
             `,
           }}
         />

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -29,3 +29,13 @@ export function escapeHtml(text: string): string {
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#039;");
 }
+
+/**
+ * JSON-encode a value for interpolation into an inline `<script>` body.
+ * `JSON.stringify` alone does not escape `<`, so a value containing
+ * `</script>` would terminate the script tag early and let the rest be
+ * parsed as HTML — escape it to `<` so the string stays inert.
+ */
+export function serializeForScript(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}

--- a/tests/csp-nonce-sweep.test.tsx
+++ b/tests/csp-nonce-sweep.test.tsx
@@ -29,17 +29,14 @@ vi.mock("../src/storage/agents", () => ({
 
 const NONCE = "sweep-test-nonce";
 
-/** All opening `<script …>` tags in the HTML. */
 function scriptTags(html: string): string[] {
   return [...html.matchAll(/<script\b[^>]*>/g)].map((m) => m[0]);
 }
 
-/** Opening script tags that do NOT carry the expected nonce attribute. */
 function scriptTagsWithoutNonce(html: string, nonce: string): string[] {
   return scriptTags(html).filter((tag) => !tag.includes(`nonce="${nonce}"`));
 }
 
-/** Inline event-handler attributes (onclick=", onsubmit=", …) in the HTML. */
 function inlineHandlerAttrs(html: string): string[] {
   return [...html.matchAll(/\son[a-z]+="/g)].map((m) => m[0].trim());
 }
@@ -216,6 +213,21 @@ describe("CSP nonce sweep — components", () => {
     expect(html).toContain('id="import-cancel-form"');
   });
 
+  it("ImportProgressCard: a namespace/slug containing </script> cannot terminate the nonce'd script", () => {
+    const html = renderToString(
+      <ImportProgressCard
+        {...importProgressBase}
+        namespace="@alice</script><script>window.pwned=1</script>"
+        slug="my-repo</script><script>window.pwned=1</script>"
+        status="processing"
+        nonce={NONCE}
+      />,
+    );
+    expectCspClean(html, { expectScripts: true });
+    expect(html).not.toContain("</script><script>window.pwned");
+    expect(html).toContain("\\u003c/script>");
+  });
+
   // Every error classification (with and without an action button) plus the
   // terminal statuses — none may emit an un-nonced script or inline handler.
   const failureMessages = [
@@ -284,6 +296,31 @@ describe("CSP nonce sweep — components", () => {
     expect(html).toContain('data-resolve-all="ours"');
     expect(html).toContain('data-resolve-all="theirs"');
     expect(html).toContain('id="manual-save-src_app_ts"');
+  });
+
+  it("ConflictResolution: a file path containing </script> cannot terminate the nonce'd script", () => {
+    const conflict: SyncConflict = {
+      id: "conf-1</script><script>window.pwned=1</script>",
+      namespace: "@alice",
+      slug: "my-repo",
+      sourceUrl: "https://github.com/acme/api",
+      sourceBranch: "main",
+      detectedAt: "2024-01-01T00:00:00Z",
+      conflicts: [
+        {
+          path: "src/</script><script>window.pwned=1</script>.ts",
+          ours: { content: "a", branch: "main", commit: "abc1234", timestamp: "2024-01-01" },
+          theirs: { content: "b", branch: "up", commit: "def5678", timestamp: "2024-01-02" },
+        },
+      ],
+    };
+    const html = renderToString(<ConflictResolution conflict={conflict} nonce={NONCE} />);
+    // expectCspClean is the real guarantee: if the payload broke out of the
+    // nonce'd script, it would inject an un-nonced <script> tag and this fails.
+    expectCspClean(html, { expectScripts: true });
+    expect(html).not.toContain("</script><script>window.pwned");
+    // The malicious payload only ever appears escaped inside the JS string.
+    expect(html).toContain("\\u003c/script>");
   });
 });
 

--- a/tests/csp-nonce-sweep.test.tsx
+++ b/tests/csp-nonce-sweep.test.tsx
@@ -259,6 +259,24 @@ describe("CSP nonce sweep — components", () => {
     });
   }
 
+  it("ImportProgressCard: the error-action window.open passes noopener", () => {
+    const html = renderToString(
+      <ImportProgressCard
+        {...importProgressBase}
+        status="failed"
+        errors={[{ file: "repo", error: "unauthorized", timestamp: "2024-01-01T00:00:00Z" }]}
+        nonce={NONCE}
+      />,
+    );
+    // The action button opens a repository-supplied URL. `window.open` — unlike
+    // `<a target="_blank">`, which browsers treat as implicitly noopener — hands
+    // the opened page a live `window.opener`, letting it navigate this
+    // authenticated tab. Assert the guard is actually in the emitted script.
+    expect(html).toContain("window.open");
+    expect(html).toMatch(/window\.open\([^)]*['"]noopener/);
+    expectCspClean(html);
+  });
+
   for (const status of ["completed", "cancelled"] as const) {
     it(`ImportProgressCard (${status}): CSP-clean`, () => {
       const html = renderToString(

--- a/tests/csp-nonce-sweep.test.tsx
+++ b/tests/csp-nonce-sweep.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * Issue #161 sweep: with `script-src 'nonce-…'` in the CSP, every `<script>`
+ * the UI renders MUST carry the per-request nonce, and no inline event-handler
+ * attributes (onclick=, onsubmit=, onchange=, …) may remain anywhere — a
+ * nonce'd policy blocks both un-nonced scripts and all inline handlers.
+ *
+ * Renders every page/component that historically shipped scripts or handlers
+ * and greps the emitted HTML.
+ */
+import { renderToString } from "hono/jsx/dom/server";
+import { describe, expect, it, vi } from "vitest";
+import app from "../src/index";
+import type { Env } from "../src/types";
+import { ConflictResolution, type SyncConflict } from "../src/ui/components/conflict-resolution";
+import { FileTree } from "../src/ui/components/file-tree";
+import { ImportProgressCard } from "../src/ui/components/import-progress";
+import { buildFileTree } from "../src/ui/file-tree";
+import { NewProjectPage } from "../src/ui/pages/new-project";
+import { RepoPage } from "../src/ui/pages/repo";
+import { SyncPage } from "../src/ui/pages/sync";
+
+vi.mock("../src/storage/users", () => ({
+  getUserByToken: vi.fn(async () => ({ success: false, error: { message: "not found" } })),
+  getUser: vi.fn(async () => ({ success: false, error: { message: "not found" } })),
+}));
+vi.mock("../src/storage/agents", () => ({
+  getAgentByToken: vi.fn(async () => ({ success: false, error: { message: "not found" } })),
+}));
+
+const NONCE = "sweep-test-nonce";
+
+/** All opening `<script …>` tags in the HTML. */
+function scriptTags(html: string): string[] {
+  return [...html.matchAll(/<script\b[^>]*>/g)].map((m) => m[0]);
+}
+
+/** Opening script tags that do NOT carry the expected nonce attribute. */
+function scriptTagsWithoutNonce(html: string, nonce: string): string[] {
+  return scriptTags(html).filter((tag) => !tag.includes(`nonce="${nonce}"`));
+}
+
+/** Inline event-handler attributes (onclick=", onsubmit=", …) in the HTML. */
+function inlineHandlerAttrs(html: string): string[] {
+  return [...html.matchAll(/\son[a-z]+="/g)].map((m) => m[0].trim());
+}
+
+function expectCspClean(html: string, opts: { expectScripts?: boolean } = {}): void {
+  expect(scriptTagsWithoutNonce(html, NONCE)).toEqual([]);
+  expect(inlineHandlerAttrs(html)).toEqual([]);
+  if (opts.expectScripts) {
+    expect(scriptTags(html).length).toBeGreaterThan(0);
+  }
+}
+
+const user = { id: "u1", email: "a@example.com", username: "alice" };
+
+const baseRepoProject = {
+  name: "my-repo",
+  namespace: "@alice",
+  slug: "my-repo",
+  remote: "git@stratum:alice/my-repo.git",
+  createdAt: "2024-01-01T00:00:00Z",
+  sourceUrl: "https://github.com/acme/api",
+  sourceProvider: "github" as const,
+  sourceOwner: "acme",
+  sourceRepo: "api",
+};
+
+const importProgressBase = {
+  namespace: "@alice",
+  slug: "my-repo",
+  progress: { totalFiles: 10, processedFiles: 4, currentFile: "src/a.ts" },
+  logs: [{ message: "cloning", level: "info" as const, timestamp: "2024-01-01T00:00:00Z" }],
+  errors: [],
+  sourceUrl: "https://github.com/acme/api",
+  branch: "main",
+};
+
+describe("CSP nonce sweep — pages", () => {
+  it("SyncPage: scripts are nonce'd, no inline handlers remain", () => {
+    const html = renderToString(
+      <SyncPage
+        project={{ namespace: "@alice", slug: "my-repo", name: "my-repo" }}
+        syncStatus={{
+          namespace: "@alice",
+          slug: "my-repo",
+          sourceUrl: "https://github.com/acme/api",
+          sourceBranch: "main",
+          lastSyncStatus: "success",
+          hasUpdates: true,
+          commitsBehind: 3,
+          autoSyncEnabled: true,
+          syncFrequency: 15,
+          lastCheckedAt: "2024-01-01T00:00:00Z",
+        }}
+        syncHistory={[
+          {
+            id: "s1",
+            startedAt: "2024-01-01T00:00:00Z",
+            completedAt: "2024-01-01T00:00:10Z",
+            status: "failed",
+            commitsSynced: 0,
+            error: "boom",
+          },
+        ]}
+        user={user}
+        nonce={NONCE}
+      />,
+    );
+    expectCspClean(html, { expectScripts: true });
+    // The former onsubmit/onchange targets are now wired by id.
+    expect(html).toContain('id="sync-form"');
+    expect(html).toContain('id="sync-settings-form"');
+    expect(html).toContain('id="autoSyncEnabled"');
+  });
+
+  // The page script renders in every state — including while a sync is in
+  // flight or after a failure — and must stay CSP-clean in all of them.
+  for (const lastSyncStatus of ["in_progress", "failed", "idle"] as const) {
+    it(`SyncPage (${lastSyncStatus}): CSP-clean`, () => {
+      const html = renderToString(
+        <SyncPage
+          project={{ namespace: "@alice", slug: "my-repo", name: "my-repo" }}
+          syncStatus={{
+            namespace: "@alice",
+            slug: "my-repo",
+            sourceUrl: lastSyncStatus === "idle" ? "" : "https://github.com/acme/api",
+            sourceBranch: "main",
+            lastSyncStatus,
+            lastSyncError: lastSyncStatus === "failed" ? "merge conflict" : undefined,
+            hasUpdates: false,
+            autoSyncEnabled: false,
+            lastCheckedAt: "2024-01-01T00:00:00Z",
+          }}
+          syncHistory={[]}
+          user={null}
+          nonce={NONCE}
+        />,
+      );
+      expectCspClean(html, { expectScripts: true });
+    });
+  }
+
+  it("NewProjectPage: import-form script is nonce'd, no inline handlers remain", () => {
+    const html = renderToString(<NewProjectPage user={user} nonce={NONCE} />);
+    expectCspClean(html, { expectScripts: true });
+    expect(html).toContain('id="import-form"');
+  });
+
+  it("RepoPage with files and an active import: all scripts nonce'd", () => {
+    const html = renderToString(
+      <RepoPage
+        project={baseRepoProject}
+        files={["src/index.ts", "README.md"]}
+        log={[]}
+        readme={null}
+        user={user}
+        importProgress={{ ...importProgressBase, status: "cloning" } as never}
+        syncStatus={{ hasUpdates: true, commitsBehind: 2 }}
+        canSync={true}
+        isOwner={true}
+        nonce={NONCE}
+      />,
+    );
+    expectCspClean(html, { expectScripts: true });
+  });
+
+  it("RepoPage with a failed import (error action button): all scripts nonce'd", () => {
+    const html = renderToString(
+      <RepoPage
+        project={baseRepoProject}
+        files={["src/index.ts"]}
+        log={[]}
+        readme={null}
+        user={user}
+        importProgress={
+          {
+            ...importProgressBase,
+            status: "failed",
+            errors: [
+              { file: "repo", error: "authentication failed", timestamp: "2024-01-01T00:00:00Z" },
+            ],
+          } as never
+        }
+        syncStatus={null}
+        canSync={false}
+        isOwner={false}
+        nonce={NONCE}
+      />,
+    );
+    expectCspClean(html, { expectScripts: true });
+    // The error action opens the source URL via a data attribute, not onclick.
+    expect(html).toContain('id="import-error-action"');
+    expect(html).toContain('data-url="https://github.com/acme/api"');
+  });
+});
+
+describe("CSP nonce sweep — components", () => {
+  it("FileTree: toggle script is nonce'd, no inline onclick", () => {
+    const html = renderToString(
+      <FileTree
+        nodes={buildFileTree(["src/index.ts", "README.md"])}
+        namespace="@alice"
+        slug="my-repo"
+        nonce={NONCE}
+      />,
+    );
+    expectCspClean(html, { expectScripts: true });
+  });
+
+  it("ImportProgressCard (active): SSE + cancel-confirm scripts are nonce'd", () => {
+    const html = renderToString(
+      <ImportProgressCard {...importProgressBase} status="processing" nonce={NONCE} />,
+    );
+    expectCspClean(html, { expectScripts: true });
+    expect(html).toContain('id="import-cancel-form"');
+  });
+
+  // Every error classification (with and without an action button) plus the
+  // terminal statuses — none may emit an un-nonced script or inline handler.
+  const failureMessages = [
+    "authentication failed (403)",
+    "network timeout while fetching",
+    "repository not found (404)",
+    "rate limit exceeded (429)",
+    "git clone failed",
+    "key already exists",
+    "disk quota exceeded",
+    "something inscrutable happened",
+    "",
+  ];
+  for (const message of failureMessages) {
+    it(`ImportProgressCard (failed: ${JSON.stringify(message).slice(0, 30)}…): CSP-clean`, () => {
+      const html = renderToString(
+        <ImportProgressCard
+          {...importProgressBase}
+          status="failed"
+          errors={
+            message === ""
+              ? []
+              : [{ file: "repo", error: message, timestamp: "2024-01-01T00:00:00Z" }]
+          }
+          nonce={NONCE}
+        />,
+      );
+      expectCspClean(html);
+    });
+  }
+
+  for (const status of ["completed", "cancelled"] as const) {
+    it(`ImportProgressCard (${status}): CSP-clean`, () => {
+      const html = renderToString(
+        <ImportProgressCard {...importProgressBase} status={status} nonce={NONCE} />,
+      );
+      expectCspClean(html);
+    });
+  }
+
+  it("ConflictResolution (unresolved, with manual edit): all scripts nonce'd", () => {
+    const conflict: SyncConflict = {
+      id: "conf-1",
+      namespace: "@alice",
+      slug: "my-repo",
+      sourceUrl: "https://github.com/acme/api",
+      sourceBranch: "main",
+      detectedAt: "2024-01-01T00:00:00Z",
+      conflicts: [
+        {
+          path: "src/app.ts",
+          ours: { content: "a", branch: "main", commit: "abc1234", timestamp: "2024-01-01" },
+          theirs: { content: "b", branch: "up", commit: "def5678", timestamp: "2024-01-02" },
+          base: { content: "c", commit: "0000000" },
+        },
+        {
+          path: "src/lib.ts",
+          ours: { content: "a2", branch: "main", commit: "abc1234", timestamp: "2024-01-01" },
+          theirs: { content: "b2", branch: "up", commit: "def5678", timestamp: "2024-01-02" },
+        },
+      ],
+    };
+    const html = renderToString(<ConflictResolution conflict={conflict} nonce={NONCE} />);
+    expectCspClean(html, { expectScripts: true });
+    // Buttons are wired via data attributes now.
+    expect(html).toContain('data-resolve-all="ours"');
+    expect(html).toContain('data-resolve-all="theirs"');
+    expect(html).toContain('id="manual-save-src_app_ts"');
+  });
+});
+
+describe("CSP nonce sweep — full responses", () => {
+  function makeEnv(): Env {
+    return {
+      ARTIFACTS: { get: vi.fn(), create: vi.fn() } as unknown as Env["ARTIFACTS"],
+      STATE: {
+        get: vi.fn(async () => null),
+        put: vi.fn(async () => undefined),
+      } as unknown as KVNamespace,
+      DB: {} as D1Database,
+    } as unknown as Env;
+  }
+
+  it("GET /auth/signup: rendered script nonce matches the CSP header nonce", async () => {
+    const res = await app.fetch(new Request("http://localhost/auth/signup"), makeEnv());
+    expect(res.status).toBe(200);
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    const nonce = /'nonce-([^']+)'/.exec(csp)?.[1];
+    expect(nonce).toBeTruthy();
+    const html = await res.text();
+    const tags = scriptTags(html);
+    expect(tags.length).toBeGreaterThan(0);
+    expect(tags.filter((t) => !t.includes(`nonce="${nonce}"`))).toEqual([]);
+    expect(inlineHandlerAttrs(html)).toEqual([]);
+  });
+});

--- a/tests/file-tree-component.test.tsx
+++ b/tests/file-tree-component.test.tsx
@@ -3,29 +3,39 @@ import { describe, expect, it } from "vitest";
 import { FileTree } from "../src/ui/components/file-tree";
 import { buildFileTree } from "../src/ui/file-tree";
 
+const NONCE = "test-nonce";
+
 describe("FileTree component", () => {
   it("renders empty state when nodes is empty", () => {
-    const html = renderToString(<FileTree nodes={[]} namespace="@user" slug="repo" />);
+    const html = renderToString(
+      <FileTree nodes={[]} namespace="@user" slug="repo" nonce={NONCE} />,
+    );
     expect(html).toContain("No files");
   });
 
   it("renders a file as a link with correct href", () => {
     const nodes = buildFileTree(["README.md"]);
-    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    const html = renderToString(
+      <FileTree nodes={nodes} namespace="@user" slug="repo" nonce={NONCE} />,
+    );
     expect(html).toContain('href="/@user/repo/blob/README.md"');
     expect(html).toContain("README.md");
   });
 
   it("percent-encodes spaces in file paths", () => {
     const nodes = buildFileTree(["my file.ts"]);
-    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    const html = renderToString(
+      <FileTree nodes={nodes} namespace="@user" slug="repo" nonce={NONCE} />,
+    );
     expect(html).toContain("my%20file.ts");
     expect(html).not.toContain('href="/@user/repo/blob/my file.ts"');
   });
 
   it("renders a directory as a details element with summary", () => {
     const nodes = buildFileTree(["src/index.ts"]);
-    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    const html = renderToString(
+      <FileTree nodes={nodes} namespace="@user" slug="repo" nonce={NONCE} />,
+    );
     expect(html).toContain("<details");
     expect(html).toContain("<summary");
     expect(html).toContain("src");
@@ -33,27 +43,35 @@ describe("FileTree component", () => {
 
   it("all dirs are collapsed by default (no open attribute)", () => {
     const nodes = buildFileTree(["src/index.ts"]);
-    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    const html = renderToString(
+      <FileTree nodes={nodes} namespace="@user" slug="repo" nonce={NONCE} />,
+    );
     expect(html).not.toMatch(/<details[^>]*open[^>]*>/);
   });
 
   it("renders collapse/expand all button", () => {
     const nodes = buildFileTree(["src/index.ts"]);
-    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    const html = renderToString(
+      <FileTree nodes={nodes} namespace="@user" slug="repo" nonce={NONCE} />,
+    );
     expect(html).toContain("file-tree-toggle-btn");
     expect(html).toContain("Expand all");
   });
 
   it("escapes special characters in file names", () => {
     const nodes = buildFileTree(["<script>.ts"]);
-    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    const html = renderToString(
+      <FileTree nodes={nodes} namespace="@user" slug="repo" nonce={NONCE} />,
+    );
     expect(html).not.toContain("<script>");
     expect(html).toContain("&lt;script&gt;");
   });
 
   it("renders multiple files under a shared directory", () => {
     const nodes = buildFileTree(["src/a.ts", "src/b.ts"]);
-    const html = renderToString(<FileTree nodes={nodes} namespace="@user" slug="repo" />);
+    const html = renderToString(
+      <FileTree nodes={nodes} namespace="@user" slug="repo" nonce={NONCE} />,
+    );
     expect(html).toContain("src/a.ts");
     expect(html).toContain("src/b.ts");
   });

--- a/tests/repo-page-fork-ui.test.tsx
+++ b/tests/repo-page-fork-ui.test.tsx
@@ -18,6 +18,7 @@ const baseProps = {
   importProgress: null,
   syncStatus: null,
   canSync: false,
+  nonce: "test-nonce",
 };
 
 describe("RepoPage — sync card provider label", () => {

--- a/tests/security-headers.test.ts
+++ b/tests/security-headers.test.ts
@@ -1,10 +1,12 @@
 /**
  * SEC-7: response security headers. The UI/API carry a conservative header set
- * and a non-`script-src` CSP (inline handlers in the server-rendered UI must
- * keep working). Git smart-HTTP responses are left untouched.
+ * and a nonce-based `script-src` CSP (issue #161) — every inline script the UI
+ * renders carries the per-request nonce. Git smart-HTTP responses are left
+ * untouched.
  */
 import { describe, expect, it, vi } from "vitest";
 import app from "../src/index";
+import { contentSecurityPolicy, generateCspNonce } from "../src/middleware/security-headers";
 import type { Env } from "../src/types";
 
 vi.mock("../src/storage/users", () => ({
@@ -38,16 +40,54 @@ describe("SEC-7: security headers", () => {
     expect(csp).toContain("base-uri 'self'");
   });
 
-  it("restricts form targets and framing without touching scripts", async () => {
+  it("restricts form targets and framing", async () => {
     const res = await app.fetch(new Request("http://localhost/health"), makeEnv());
     const csp = res.headers.get("Content-Security-Policy");
     expect(csp).toContain("form-action 'self'");
     expect(csp).toContain("frame-src 'none'");
   });
 
-  it("ships no script-src directive (inline UI handlers must keep working; issue #161)", async () => {
+  it("ships a nonce-based script-src directive (issue #161)", async () => {
     const res = await app.fetch(new Request("http://localhost/health"), makeEnv());
-    expect(res.headers.get("Content-Security-Policy")).not.toContain("script-src");
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    // Base64 nonce of 16 random bytes (24 chars with padding).
+    expect(csp).toMatch(/script-src 'nonce-[A-Za-z0-9+/]{22}=='/);
+  });
+
+  it("uses a fresh nonce per request", async () => {
+    const extract = (csp: string | null) => /'nonce-([^']+)'/.exec(csp ?? "")?.[1];
+    const first = await app.fetch(new Request("http://localhost/health"), makeEnv());
+    const second = await app.fetch(new Request("http://localhost/health"), makeEnv());
+    const a = extract(first.headers.get("Content-Security-Policy"));
+    const b = extract(second.headers.get("Content-Security-Policy"));
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(a).not.toBe(b);
+  });
+
+  it("never falls back to 'unsafe-inline' (or 'strict-dynamic'/'unsafe-eval')", async () => {
+    const res = await app.fetch(new Request("http://localhost/health"), makeEnv());
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(csp).not.toContain("unsafe-inline");
+    expect(csp).not.toContain("unsafe-eval");
+    expect(csp).not.toContain("strict-dynamic");
+  });
+
+  it("generateCspNonce returns unique, base64, 128-bit values", () => {
+    const a = generateCspNonce();
+    const b = generateCspNonce();
+    expect(a).toMatch(/^[A-Za-z0-9+/]{22}==$/);
+    expect(a).not.toBe(b);
+  });
+
+  it("contentSecurityPolicy embeds the given nonce and keeps the existing directives", () => {
+    const csp = contentSecurityPolicy("abc123==");
+    expect(csp).toContain("script-src 'nonce-abc123=='");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("form-action 'self'");
+    expect(csp).toContain("frame-src 'none'");
   });
 
   it("applies the same CSP to 500 error responses (error boundary parity)", async () => {
@@ -59,6 +99,9 @@ describe("SEC-7: security headers", () => {
     expect(csp).toContain("form-action 'self'");
     expect(csp).toContain("frame-src 'none'");
     expect(csp).toContain("frame-ancestors 'none'");
+    // The error boundary re-asserts headers on the same context, so the 500's
+    // script-src still carries the request's (single) nonce.
+    expect(csp).toMatch(/script-src 'nonce-[A-Za-z0-9+/]{22}=='/);
   });
 
   it("sets HSTS only over HTTPS", async () => {


### PR DESCRIPTION
## Summary

The CSP shipped without `script-src` because the server-rendered UI used inline scripts and inline event handlers. This PR adds a per-request nonce policy and converts every inline script and handler in the app:

- **CSP now emitted per request:** `frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-src 'none'; script-src 'nonce-<128-bit base64>'`. Plain nonce policy — no `'strict-dynamic'` (the UI loads no external scripts, so transitive trust would only widen the policy) and no `'unsafe-inline'` fallback (it only aids pre-2016 CSP1-only browsers while advertising an inline escape hatch to scanners).
- **Nonce plumbing:** generated in the security-headers middleware (`crypto.getRandomValues`, 16 bytes, base64), cached on the Hono context (`cspNonce`) so route handlers and the error boundary emit one identical policy per request, and threaded as an explicit required `nonce` prop to every `<script>`.
- **Inventory converted:** 5 inline `<script>` blocks now carry the nonce, plus 3 new nonce'd wiring scripts; all **13** inline event handlers (`onclick`/`onsubmit`/`onchange` across sync, new-project, conflict-resolution, file-tree, and import-progress) were converted to `addEventListener` keyed by ids/data attributes, with `dataset.wired` guards so repeated component instances never double-bind. `import-progress`'s eval-style `actionButton.action` string was replaced by a declarative `data-url` + `window.open` listener (behavior unchanged). Zero inline handlers remain.
- `default-src` is deliberately left out: its fallback would govern style/img/connect, and the UI still uses inline `style=` attributes, `<style>` blocks, and `data:` favicons — tightening those is a separate refactor.

## Related issues

Closes #161

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Other: security hardening

## How was this verified?

56 tests across 5 files, including a new sweep test (`tests/csp-nonce-sweep.test.tsx`) that renders every script-bearing page/component in all states (active/failed/cancelled imports, every error classification, syncing/failed/idle sync, resolved/unresolved conflicts) plus a real `GET /auth/signup` response, asserting zero `<script>` tags without the request's nonce and zero `on*=` attributes. Nonce uniqueness per request and CSP contents asserted in `tests/security-headers.test.ts`. Coverage: `security-headers.ts` at 100% across all metrics; touched components 97–100% statements. Full suite: 1263 passed, 0 failures.

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript — existing behavior moved to nonce'd blocks, no new client behavior

---
_Generated by [Claude Code](https://claude.ai/code/session_015dp67PBbFT666GnMLuxvm1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Enhancements**
  - Added unique per-request Content Security Policy nonces for inline scripts.
  - Replaced inline event handlers with safer event listeners and protected embedded script data.
  - Error responses now retain the appropriate security policy.

- **Bug Fixes**
  - Preserved import, synchronization, file tree, and conflict-resolution interactions under stricter security policies.

- **Tests**
  - Added comprehensive coverage for nonce handling, script protection, security headers, and interactive UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->