### PR TITLE
MemoryFS: preserve symlinks and file modes through server-side git round trips

### DIFF
--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -1229,11 +1229,17 @@ async function clearConflictingPathShape(
   const parts = path.split("/");
   for (let i = 1; i < parts.length; i++) {
     const ancestor = `${projectDir}/${parts.slice(0, i).join("/")}`;
+    let stat: { isDirectory(): boolean };
     try {
-      await fs.promises.readlink(ancestor);
+      stat = await fs.promises.lstat(ancestor);
     } catch {
-      continue; // absent, or a real directory
+      continue; // absent: the write creates it
     }
+    // Anything that is not a directory blocks a descendant write. `lstat`
+    // catches files and symlinks alike and does not follow links; probing with
+    // `readlink` would miss a plain file, which fails the write with ENOTDIR
+    // just as surely as a symlink redirects it.
+    if (stat.isDirectory()) continue;
     await fs.promises.unlink(ancestor).catch(() => {});
   }
   await removeSubtree(fs, `${projectDir}/${path}`);
@@ -1331,7 +1337,26 @@ export async function squashMerge(
     // The worktree removal is conditional; the index removal below never is.
     // Whatever happened on disk, the entry has to leave the index or the squash
     // tree keeps a path the workspace does not have.
-    if (!workspaceDirs.has(path)) {
+    //
+    // Skip the unlink when the path -- or any ancestor of it -- is something
+    // the workspace now owns, because the entry no longer means what the
+    // project tree said it meant.
+    //
+    // Defensive rather than a fix for a reproducible bug: `MemoryFS.unlink`
+    // resolves paths literally and does not follow a symlink ancestor, so with
+    // `lib` replaced by a link, removing `lib/old.ts` returns ENOENT and leaves
+    // the link target alone (verified). `squashMerge` takes the `NodeFS`
+    // interface though, and node's own `fs` *does* traverse -- there the same
+    // unlink would delete a same-named file inside the target that was never
+    // part of this merge. The guard costs nothing and removes that dependency
+    // on which implementation is behind the interface.
+    const supersededByWorkspace =
+      workspaceDirs.has(path) ||
+      path
+        .split("/")
+        .slice(0, -1)
+        .some((_, i, all) => workspaceMap.has(all.slice(0, i + 1).join("/")));
+    if (!supersededByWorkspace) {
       try {
         await projectFs.promises.unlink(`${projectDir}/${path}`);
       } catch (error) {

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -1184,17 +1184,28 @@ export async function batchMergeStagedTrees(
 /**
  * Removes a real directory subtree, leaf-first.
  *
- * `readdir` reports ENOTDIR for both files and symlinks and never follows a
- * link, so recursion only ever descends into genuine directories — a symlink
- * encountered here is left for the caller to unlink rather than having its
- * target emptied.
+ * The `lstat` gate is load-bearing, not a fast path. `MemoryFS.readdir` happens
+ * to report ENOTDIR for a symlink, but node's own `readdir` FOLLOWS a directory
+ * symlink — and `squashMerge` takes the `NodeFS` interface, not `MemoryFS`.
+ * Recursing on `readdir` alone would therefore walk into a link's target and
+ * delete files that were never part of this merge. Checking the entry first and
+ * descending only into real directories leaves any symlink for the caller to
+ * unlink, whichever implementation is behind the interface.
  */
 async function removeSubtree(fs: NodeFS, full: string): Promise<void> {
+  let stat: { isDirectory(): boolean };
+  try {
+    stat = await fs.promises.lstat(full);
+  } catch {
+    return; // absent
+  }
+  if (!stat.isDirectory()) return; // file or symlink: the caller's unlink handles it
+
   let entries: string[];
   try {
     entries = await fs.promises.readdir(full);
   } catch {
-    return; // not a directory: the caller's unlink handles it
+    return;
   }
   for (const entry of entries) {
     const child = `${full}/${entry}`;

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -1181,6 +1181,64 @@ export async function batchMergeStagedTrees(
   return ok(results);
 }
 
+/**
+ * Removes a real directory subtree, leaf-first.
+ *
+ * `readdir` reports ENOTDIR for both files and symlinks and never follows a
+ * link, so recursion only ever descends into genuine directories — a symlink
+ * encountered here is left for the caller to unlink rather than having its
+ * target emptied.
+ */
+async function removeSubtree(fs: NodeFS, full: string): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fs.promises.readdir(full);
+  } catch {
+    return; // not a directory: the caller's unlink handles it
+  }
+  for (const entry of entries) {
+    const child = `${full}/${entry}`;
+    await removeSubtree(fs, child);
+    await fs.promises.unlink(child).catch(() => {});
+  }
+  await fs.promises.rmdir(full).catch(() => {});
+}
+
+/**
+ * Clears anything whose *path shape* conflicts with what is about to be written.
+ *
+ * Two transitions corrupt the worktree if the old shape is left in place, and
+ * neither is caught by unlinking the target path alone:
+ *
+ * - A symlink at an ANCESTOR silently redirects the write. With `lib` a symlink
+ *   to `real/`, writing `lib/file.ts` lands at `real/file.ts` — verified
+ *   against MemoryFS, which resolves the link during the write. The merge then
+ *   reports success having written to the wrong path.
+ * - Replacing a directory with a symlink leaves the directory's children behind.
+ *   MemoryFS's `unlink` succeeds on a directory without removing descendants, so
+ *   `lib/a.ts` stays readable *through* the new `lib` symlink.
+ *
+ * Ancestors are probed with `readlink` because the `NodeFS` shape has no
+ * `isSymbolicLink()`; it throws for anything that is not a link.
+ */
+async function clearConflictingPathShape(
+  fs: NodeFS,
+  projectDir: string,
+  path: string,
+): Promise<void> {
+  const parts = path.split("/");
+  for (let i = 1; i < parts.length; i++) {
+    const ancestor = `${projectDir}/${parts.slice(0, i).join("/")}`;
+    try {
+      await fs.promises.readlink(ancestor);
+    } catch {
+      continue; // absent, or a real directory
+    }
+    await fs.promises.unlink(ancestor).catch(() => {});
+  }
+  await removeSubtree(fs, `${projectDir}/${path}`);
+}
+
 /** Exported for tests (the workdir copy must preserve file modes and symlinks). */
 export async function squashMerge(
   projectFs: NodeFS,
@@ -1211,6 +1269,16 @@ export async function squashMerge(
     return projectEntry?.oid !== hash || projectEntry?.mode !== mode;
   });
   const deleted = projectFiles.filter(([path]) => !workspaceMap.has(path));
+  // Every directory the workspace tree needs. A project path that is now one of
+  // these is not really deleted -- its *shape* changed. `lib` as a symlink in
+  // the project and `lib/file.ts` in the workspace makes `lib` look deleted,
+  // but writing the file recreates `lib` as a real directory, and unlinking it
+  // afterwards would either fail with EISDIR or destroy what was just written.
+  const workspaceDirs = new Set<string>();
+  for (const [path] of workspaceFiles) {
+    const parts = path.split("/");
+    for (let i = 1; i < parts.length; i++) workspaceDirs.add(parts.slice(0, i).join("/"));
+  }
 
   for (const [path, , mode] of changed) {
     const blobResult = await fromPromise(
@@ -1231,7 +1299,10 @@ export async function squashMerge(
     const fullPath = `${projectDir}/${path}`;
     try {
       // Drop whatever is at the path first so file<->symlink transitions and
-      // stale exec bits can't leak through the overwrite.
+      // stale exec bits can't leak through the overwrite. The shape clear has
+      // to come first: unlinking `fullPath` cannot fix a symlink ancestor that
+      // would redirect the write, nor a directory whose children outlive it.
+      await clearConflictingPathShape(projectFs, projectDir, path);
       await projectFs.promises.unlink(fullPath).catch(() => {});
       if (mode === MODE_SYMLINK) {
         await projectFs.promises.symlink(new TextDecoder().decode(blob), fullPath);
@@ -1257,12 +1328,25 @@ export async function squashMerge(
   }
 
   for (const [path] of deleted) {
-    try {
-      await projectFs.promises.unlink(`${projectDir}/${path}`);
-    } catch (error) {
-      const appError = error instanceof Error ? error : new Error(String(error));
-      logger.error("Failed to unlink file during squash merge", appError, { path, projectRemote });
-      return err(new AppError(`Failed to unlink file: ${path}`, "FS_ERROR", 500));
+    // The worktree removal is conditional; the index removal below never is.
+    // Whatever happened on disk, the entry has to leave the index or the squash
+    // tree keeps a path the workspace does not have.
+    if (!workspaceDirs.has(path)) {
+      try {
+        await projectFs.promises.unlink(`${projectDir}/${path}`);
+      } catch (error) {
+        // Already gone is the desired end state, not a failure:
+        // `clearConflictingPathShape` above may have removed this path while
+        // making room for a changed one.
+        if (!(error instanceof AppError && error.code === "ENOENT")) {
+          const appError = error instanceof Error ? error : new Error(String(error));
+          logger.error("Failed to unlink file during squash merge", appError, {
+            path,
+            projectRemote,
+          });
+          return err(new AppError(`Failed to unlink file: ${path}`, "FS_ERROR", 500));
+        }
+      }
     }
 
     const removeResult = await fromPromise(

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -6,7 +6,7 @@ import type { Logger } from "../utils/logger";
 import type { PhaseTimer } from "../utils/phase-timer";
 import { type Result, err, fromPromise, ok } from "../utils/result";
 import { commitObject } from "./git-objects";
-import { MemoryFS } from "./memory-fs";
+import { MODE_SYMLINK, MemoryFS } from "./memory-fs";
 import { packObjects, placeLooseObject, unpackObjects } from "./object-loader";
 
 // Custom HTTP client for Cloudflare Workers
@@ -95,13 +95,15 @@ const DIR = "/";
 export interface NodeFS {
   promises: {
     readFile(path: string, options?: { encoding?: string }): Promise<string | Uint8Array>;
-    writeFile(path: string, data: string | Uint8Array): Promise<void>;
+    writeFile(path: string, data: string | Uint8Array, options?: { mode?: number }): Promise<void>;
     unlink(path: string): Promise<void>;
     readdir(path: string): Promise<string[]>;
     mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
     rmdir(path: string): Promise<void>;
     stat(path: string): Promise<{ isDirectory(): boolean; isFile(): boolean }>;
     lstat(path: string): Promise<{ isDirectory(): boolean; isFile(): boolean }>;
+    readlink(path: string): Promise<string>;
+    symlink(target: string, path: string): Promise<void>;
   };
 }
 
@@ -1123,7 +1125,8 @@ export async function batchMergeStagedTrees(
   return ok(results);
 }
 
-async function squashMerge(
+/** Exported for tests (the workdir copy must preserve file modes and symlinks). */
+export async function squashMerge(
   projectFs: NodeFS,
   projectDir: string,
   workspaceSha: string,
@@ -1142,20 +1145,42 @@ async function squashMerge(
 
   const workspaceFiles = workspaceFilesResult.data;
   const projectFiles = projectFilesResult.data;
-  const workspaceMap = new Map(workspaceFiles);
+  const workspaceMap = new Map(workspaceFiles.map(([path, oid]) => [path, oid]));
 
-  const changed = workspaceFiles.filter(([path, hash]) => {
-    const projectHash = projectFiles.find(([p]) => p === path)?.[1];
-    return projectHash !== hash;
+  // Compare oid AND mode so a mode-only change (chmod +x, file<->symlink) is
+  // carried over — the blob oid alone is identical in that case.
+  const changed = workspaceFiles.filter(([path, hash, mode]) => {
+    const projectEntry = projectFiles.find(([p]) => p === path);
+    return projectEntry?.[1] !== hash || projectEntry?.[2] !== mode;
   });
   const deleted = projectFiles.filter(([path]) => !workspaceMap.has(path));
 
-  for (const [path] of changed) {
-    const contentResult = await readFileAtCommit(projectFs, workspaceSha, path, logger);
-    if (!contentResult.success) return err(contentResult.error);
+  for (const [path, , mode] of changed) {
+    const blobResult = await fromPromise(
+      git.readBlob({ fs: projectFs, dir: DIR, oid: workspaceSha, filepath: path }),
+    );
+    if (!blobResult.success) {
+      logger.error("Failed to read file at commit", blobResult.error, { workspaceSha, path });
+      return err(
+        new ExternalServiceError(
+          "Git",
+          `Failed to read file: ${path} at commit: ${workspaceSha}`,
+          blobResult.error,
+        ),
+      );
+    }
+    const blob = blobResult.data.blob;
 
+    const fullPath = `${projectDir}/${path}`;
     try {
-      await projectFs.promises.writeFile(`${projectDir}/${path}`, contentResult.data);
+      // Drop whatever is at the path first so file<->symlink transitions and
+      // stale exec bits can't leak through the overwrite.
+      await projectFs.promises.unlink(fullPath).catch(() => {});
+      if (mode === MODE_SYMLINK) {
+        await projectFs.promises.symlink(new TextDecoder().decode(blob), fullPath);
+      } else {
+        await projectFs.promises.writeFile(fullPath, blob, { mode });
+      }
     } catch (error) {
       const appError = error instanceof Error ? error : new Error(String(error));
       logger.error("Failed to write file during squash merge", appError, { path, projectRemote });
@@ -1469,8 +1494,8 @@ async function listFilesAtCommit(
   fs: NodeFS,
   ref: string,
   logger: Logger,
-): Promise<Result<[path: string, oid: string][], AppError>> {
-  const files: [string, string][] = [];
+): Promise<Result<[path: string, oid: string, mode: number][], AppError>> {
+  const files: [string, string, number][] = [];
   const walkResult = await fromPromise(
     git.walk({
       fs,
@@ -1481,7 +1506,8 @@ async function listFilesAtCommit(
         const type = await entry.type();
         if (type === "blob") {
           const oid = await entry.oid();
-          files.push([filepath, oid]);
+          const mode = await entry.mode();
+          files.push([filepath, oid, mode]);
         }
       },
     }),
@@ -1705,7 +1731,9 @@ async function walkDir(
       const fullPath = base === "/" ? `/${entry}` : `${base}/${entry}`;
 
       try {
-        const stat = await fs.promises.stat(fullPath);
+        // lstat: a symlink is a leaf entry (its own tree object), never recursed
+        // into — and a dangling link must not fail the whole walk via ENOENT.
+        const stat = await fs.promises.lstat(fullPath);
         if (stat.isDirectory()) {
           const subFilesResult = await walkDir(fs, fullPath, `${prefix}${entry}/`, logger);
           if (!subFilesResult.success) return err(subFilesResult.error);

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -1146,12 +1146,13 @@ export async function squashMerge(
   const workspaceFiles = workspaceFilesResult.data;
   const projectFiles = projectFilesResult.data;
   const workspaceMap = new Map(workspaceFiles.map(([path, oid]) => [path, oid]));
+  const projectMap = new Map(projectFiles.map(([path, oid, mode]) => [path, { oid, mode }]));
 
   // Compare oid AND mode so a mode-only change (chmod +x, file<->symlink) is
   // carried over — the blob oid alone is identical in that case.
   const changed = workspaceFiles.filter(([path, hash, mode]) => {
-    const projectEntry = projectFiles.find(([p]) => p === path);
-    return projectEntry?.[1] !== hash || projectEntry?.[2] !== mode;
+    const projectEntry = projectMap.get(path);
+    return projectEntry?.oid !== hash || projectEntry?.mode !== mode;
   });
   const deleted = projectFiles.filter(([path]) => !workspaceMap.has(path));
 
@@ -1508,6 +1509,12 @@ async function listFilesAtCommit(
           const oid = await entry.oid();
           const mode = await entry.mode();
           files.push([filepath, oid, mode]);
+        } else if (type === "commit") {
+          // Gitlink (submodule reference) — MemoryFS has no checked-out submodule
+          // behind it (see MemoryStats.mode), so silently omitting it here would
+          // let squashMerge's diff miss an added/changed/removed submodule
+          // pointer. Fail closed instead of losing it.
+          throw new Error(`Gitlink (submodule) entry at "${filepath}" is not supported`);
         }
       },
     }),
@@ -1714,7 +1721,8 @@ export async function revertToCommit(
   return ok(revertSha);
 }
 
-async function walkDir(
+/** Exported for tests (mirrors real symlink-as-leaf traversal, no local copy). */
+export async function walkDir(
   fs: NodeFS,
   base: string,
   prefix: string,

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -1218,8 +1218,11 @@ async function removeSubtree(fs: NodeFS, full: string): Promise<void> {
  *   MemoryFS's `unlink` succeeds on a directory without removing descendants, so
  *   `lib/a.ts` stays readable *through* the new `lib` symlink.
  *
- * Ancestors are probed with `readlink` because the `NodeFS` shape has no
- * `isSymbolicLink()`; it throws for anything that is not a link.
+ * Ancestors are probed with `lstat` and removed unless they are directories.
+ * The `NodeFS` shape has no `isSymbolicLink()`, but it does not need one here:
+ * a plain file blocks a descendant write exactly as a symlink redirects it, so
+ * "not a directory" is the whole test. `readlink` would be the narrower probe
+ * and misses the file case entirely -- it throws EINVAL there.
  */
 async function clearConflictingPathShape(
   fs: NodeFS,

--- a/src/storage/memory-fs.ts
+++ b/src/storage/memory-fs.ts
@@ -167,11 +167,24 @@ export class MemoryFS {
       if (!mkdirResult.success) return mkdirResult;
     }
 
-    if (this.entries.has(target)) return ok(undefined);
+    const existing = this.entries.get(target);
+    if (existing !== undefined) {
+      // Only an existing *directory* makes mkdir a no-op. Returning ok for a
+      // file or symlink here is what let `writeFile` proceed past a
+      // non-directory parent and strand an entry underneath it.
+      if (existing.kind === "dir") return ok(undefined);
+      return err(fsError("ENOTDIR", `ENOTDIR: not a directory: ${path}`));
+    }
 
-    this.entries.set(target, { kind: "dir", children: new Set(), mtimeMs: Date.now() });
+    // Validate the parent BEFORE mutating. The reverse order leaves the new
+    // entry in `entries` when the parent turns out not to be a directory: the
+    // call reports ENOTDIR while a later read of the same path succeeds, and
+    // `readdir` never lists it because the parent's child set was never
+    // updated. A symlink parent is rejected the same way -- it is not a
+    // directory, and mkdir does not follow links.
     const dirResult = this.getDirResult(parentPath);
     if (!dirResult.success) return dirResult;
+    this.entries.set(target, { kind: "dir", children: new Set(), mtimeMs: Date.now() });
     dirResult.data.children.add(this.basename(target));
     return ok(undefined);
   }
@@ -211,9 +224,10 @@ export class MemoryFS {
           ? existing.mode
           : MODE_FILE;
 
-    this.entries.set(target, { kind: "file", data: bytes, mode, mtimeMs: Date.now() });
+    // Same ordering rule as mkdir: a failed write must leave nothing readable.
     const dirResult = this.getDirResult(parentPath);
     if (!dirResult.success) return dirResult;
+    this.entries.set(target, { kind: "file", data: bytes, mode, mtimeMs: Date.now() });
     dirResult.data.children.add(this.basename(target));
     return ok(undefined);
   }

--- a/src/storage/memory-fs.ts
+++ b/src/storage/memory-fs.ts
@@ -1,9 +1,20 @@
 import { AppError } from "../utils/errors";
 import { type Result, err, ok } from "../utils/result";
 
-type FileEntry = { kind: "file"; data: Uint8Array; mtimeMs: number };
+type FileEntry = { kind: "file"; data: Uint8Array; mode: number; mtimeMs: number };
+type SymlinkEntry = { kind: "symlink"; target: string; mtimeMs: number };
 type DirEntry = { kind: "dir"; children: Set<string>; mtimeMs: number };
-type Entry = FileEntry | DirEntry;
+type Entry = FileEntry | SymlinkEntry | DirEntry;
+
+// Git tree-entry modes (the only file modes git records).
+export const MODE_FILE = 0o100644;
+export const MODE_EXEC = 0o100755;
+export const MODE_SYMLINK = 0o120000;
+export const MODE_DIR = 0o040000;
+export const MODE_GITLINK = 0o160000;
+
+// Matches Linux's SYMLOOP_MAX-style cap so a symlink cycle errors instead of spinning.
+const MAX_SYMLINK_HOPS = 40;
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -13,10 +24,17 @@ function fsError(code: string, message: string): AppError {
 }
 
 class MemoryStats {
+  // isomorphic-git assigns stats.mode after lstat during checkout (0o755 for
+  // executables — a Windows workaround — and 0o160000 for gitlinks); the override
+  // honors those writes on this stats instance so the index records the intended mode.
+  private modeOverride?: number;
+
   constructor(private readonly entry: Entry) {}
 
   get size(): number {
-    return this.entry.kind === "file" ? this.entry.data.byteLength : 0;
+    if (this.entry.kind === "file") return this.entry.data.byteLength;
+    if (this.entry.kind === "symlink") return encoder.encode(this.entry.target).byteLength;
+    return 0;
   }
 
   get mtimeMs(): number {
@@ -28,12 +46,22 @@ class MemoryStats {
   }
 
   get mode(): number {
-    return this.entry.kind === "file" ? 0o100644 : 0o040000;
+    if (this.modeOverride !== undefined) return this.modeOverride;
+    if (this.entry.kind === "file") return this.entry.mode;
+    if (this.entry.kind === "symlink") return MODE_SYMLINK;
+    return MODE_DIR;
   }
 
-  // isomorphic-git sets mode after stat() during checkout; the no-op setter prevents
-  // "Cannot set property mode … only a getter" TypeErrors on those writes.
-  set mode(_value: number) {}
+  set mode(value: number) {
+    if (value === MODE_GITLINK) {
+      // Gitlinks (submodules) are recorded in the index but MemoryFS has no
+      // checked-out submodule behind them — surface it instead of failing silently.
+      console.warn(
+        "MemoryFS: gitlink (submodule) entry encountered; submodules are not fully supported",
+      );
+    }
+    this.modeOverride = value;
+  }
 
   isFile(): boolean {
     return this.entry.kind === "file";
@@ -44,7 +72,7 @@ class MemoryStats {
   }
 
   isSymbolicLink(): boolean {
-    return false;
+    return this.entry.kind === "symlink";
   }
 }
 
@@ -109,6 +137,23 @@ export class MemoryFS {
     return ok(entry);
   }
 
+  /**
+   * Follow a trailing symlink chain to its final path (Node stat/readFile/writeFile
+   * semantics; the final path need not exist). Intermediate components are not
+   * resolved — git working trees never require traversing through symlinked dirs.
+   */
+  private resolveLink(path: string): Result<string, AppError> {
+    let current = this.normalize(path);
+    for (let hops = 0; hops < MAX_SYMLINK_HOPS; hops++) {
+      const entry = this.entries.get(current);
+      if (entry?.kind !== "symlink") return ok(current);
+      current = entry.target.startsWith("/")
+        ? this.normalize(entry.target)
+        : this.normalize(`${this.parent(current)}/${entry.target}`);
+    }
+    return err(fsError("ELOOP", `ELOOP: too many symbolic links encountered: ${path}`));
+  }
+
   async mkdir(path: string, options?: { recursive?: boolean }): Promise<Result<void, AppError>> {
     const target = this.normalize(path);
     if (target === "/") return ok(undefined);
@@ -134,8 +179,11 @@ export class MemoryFS {
   async writeFile(
     path: string,
     data: string | Uint8Array | ArrayBuffer,
+    options?: { mode?: number },
   ): Promise<Result<void, AppError>> {
-    const target = this.normalize(path);
+    const resolved = this.resolveLink(path);
+    if (!resolved.success) return resolved;
+    const target = resolved.data;
     const parentPath = this.parent(target);
     const mkdirResult = await this.mkdir(parentPath, { recursive: true });
     if (!mkdirResult.success) return mkdirResult;
@@ -147,10 +195,23 @@ export class MemoryFS {
           ? data
           : new Uint8Array(data);
 
-    if (this.getEntry(target)?.kind === "dir")
+    const existing = this.entries.get(target);
+    if (existing?.kind === "dir")
       return err(fsError("EISDIR", `EISDIR: illegal operation on a directory: ${path}`));
 
-    this.entries.set(target, { kind: "file", data: bytes, mtimeMs: Date.now() });
+    // isomorphic-git's checkout passes { mode: 0o777 } for executable blobs; git
+    // only records the exec bit, so any exec bit maps to 100755. Without an
+    // explicit mode an overwrite keeps the file's existing mode (Node semantics).
+    const mode =
+      options?.mode !== undefined
+        ? options.mode & 0o111
+          ? MODE_EXEC
+          : MODE_FILE
+        : existing?.kind === "file"
+          ? existing.mode
+          : MODE_FILE;
+
+    this.entries.set(target, { kind: "file", data: bytes, mode, mtimeMs: Date.now() });
     const dirResult = this.getDirResult(parentPath);
     if (!dirResult.success) return dirResult;
     dirResult.data.children.add(this.basename(target));
@@ -161,7 +222,9 @@ export class MemoryFS {
     path: string,
     options?: string | { encoding?: string },
   ): Promise<Result<string | Uint8Array, AppError>> {
-    const entryResult = this.getEntryResult(path);
+    const resolved = this.resolveLink(path);
+    if (!resolved.success) return resolved;
+    const entryResult = this.getEntryResult(resolved.data);
     if (!entryResult.success) return entryResult;
     const entry = entryResult.data;
     if (entry.kind !== "file")
@@ -182,7 +245,7 @@ export class MemoryFS {
     const entryResult = this.getEntryResult(target);
     if (!entryResult.success) return entryResult;
     const entry = entryResult.data;
-    if (entry.kind !== "file")
+    if (entry.kind === "dir")
       return err(fsError("EISDIR", `EISDIR: illegal operation on a directory: ${path}`));
     this.entries.delete(target);
     const dirResult = this.getDirResult(this.parent(target));
@@ -206,22 +269,46 @@ export class MemoryFS {
   }
 
   async stat(path: string): Promise<Result<MemoryStats, AppError>> {
-    const entryResult = this.getEntryResult(path);
+    const resolved = this.resolveLink(path);
+    if (!resolved.success) return resolved;
+    const entryResult = this.getEntryResult(resolved.data);
     if (!entryResult.success) return entryResult;
     return ok(new MemoryStats(entryResult.data));
   }
 
   async lstat(path: string): Promise<Result<MemoryStats, AppError>> {
-    return this.stat(path);
+    const entryResult = this.getEntryResult(path);
+    if (!entryResult.success) return entryResult;
+    return ok(new MemoryStats(entryResult.data));
   }
 
-  // isomorphic-git requires readlink/symlink to be present. Symlinks aren't representable
-  // in MemoryFS, so silently skip them — the symlink entry is dropped but the clone continues.
   async readlink(path: string): Promise<Result<string, AppError>> {
-    return err(fsError("EINVAL", `EINVAL: invalid argument, readlink '${path}'`));
+    const entryResult = this.getEntryResult(path);
+    if (!entryResult.success) return entryResult;
+    if (entryResult.data.kind !== "symlink")
+      return err(fsError("EINVAL", `EINVAL: invalid argument, readlink '${path}'`));
+    return ok(entryResult.data.target);
   }
 
-  async symlink(_target: string, _path: string): Promise<Result<void, AppError>> {
+  async symlink(target: string, path: string): Promise<Result<void, AppError>> {
+    const linkPath = this.normalize(path);
+    const parentPath = this.parent(linkPath);
+    const mkdirResult = await this.mkdir(parentPath, { recursive: true });
+    if (!mkdirResult.success) return mkdirResult;
+
+    const existing = this.entries.get(linkPath);
+    if (existing?.kind === "dir")
+      return err(
+        fsError("EEXIST", `EEXIST: file already exists, symlink '${target}' -> '${path}'`),
+      );
+
+    // Node's symlink() fails EEXIST on any existing entry, but isomorphic-git's
+    // checkout rewrites a changed symlink in place (writelink without an unlink),
+    // so an existing file/symlink is replaced instead.
+    this.entries.set(linkPath, { kind: "symlink", target, mtimeMs: Date.now() });
+    const dirResult = this.getDirResult(parentPath);
+    if (!dirResult.success) return dirResult;
+    dirResult.data.children.add(this.basename(linkPath));
     return ok(undefined);
   }
 
@@ -235,7 +322,11 @@ export class MemoryFS {
         path: string,
         options?: string | { encoding?: string },
       ) => Promise<string | Uint8Array>;
-      writeFile: (path: string, data: string | Uint8Array) => Promise<void>;
+      writeFile: (
+        path: string,
+        data: string | Uint8Array,
+        options?: { mode?: number },
+      ) => Promise<void>;
       unlink: (path: string) => Promise<void>;
       readdir: (path: string) => Promise<string[]>;
       mkdir: (path: string, options?: { recursive?: boolean }) => Promise<void>;
@@ -253,8 +344,8 @@ export class MemoryFS {
           if (!result.success) throw result.error;
           return result.data;
         },
-        writeFile: async (path: string, data: string | Uint8Array) => {
-          const result = await this.writeFile(path, data);
+        writeFile: async (path: string, data: string | Uint8Array, options?: { mode?: number }) => {
+          const result = await this.writeFile(path, data, options);
           if (!result.success) throw result.error;
         },
         unlink: async (path: string) => {

--- a/src/storage/memory-fs.ts
+++ b/src/storage/memory-fs.ts
@@ -154,6 +154,17 @@ export class MemoryFS {
     return err(fsError("ELOOP", `ELOOP: too many symbolic links encountered: ${path}`));
   }
 
+  /**
+   * Creates a directory, optionally creating missing ancestors.
+   *
+   * Only an existing *directory* makes this a no-op. An existing file or
+   * symlink is ENOTDIR, because callers treat success here as "a directory is
+   * now at this path" -- `writeFile` in particular calls this for the parent
+   * before writing, and returning ok for a file let writes land underneath a
+   * non-directory.
+   *
+   * Does not follow symlinks: a link is not a directory for this purpose.
+   */
   async mkdir(path: string, options?: { recursive?: boolean }): Promise<Result<void, AppError>> {
     const target = this.normalize(path);
     if (target === "/") return ok(undefined);
@@ -189,6 +200,19 @@ export class MemoryFS {
     return ok(undefined);
   }
 
+  /**
+   * Writes a file, creating parent directories as needed.
+   *
+   * The parent is validated before `entries` is touched. The reverse order
+   * strands the new entry when the parent turns out not to be a directory: the
+   * call reports ENOTDIR while a later read of the same path succeeds, and
+   * `readdir` never lists it because the parent's child set is only updated on
+   * the success path.
+   *
+   * Mode follows git rather than POSIX -- git records only the exec bit, so any
+   * exec bit becomes 100755. An overwrite without an explicit mode keeps the
+   * file's existing mode, matching Node.
+   */
   async writeFile(
     path: string,
     data: string | Uint8Array | ArrayBuffer,

--- a/src/storage/object-loader.ts
+++ b/src/storage/object-loader.ts
@@ -7,7 +7,7 @@
  * inflated content, so any valid zlib stream works (compression level is free).
  */
 
-interface FsLike {
+export interface FsLike {
   promises: {
     writeFile(path: string, data: Uint8Array): Promise<void>;
     mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;

--- a/tests/git-ops.test.ts
+++ b/tests/git-ops.test.ts
@@ -4,6 +4,7 @@ import {
   buildUnifiedDiff,
   extractTokenSecret,
   freshRepoToken,
+  walkDir,
 } from "../src/storage/git-ops";
 import { MemoryFS } from "../src/storage/memory-fs";
 import type { ArtifactsNamespace } from "../src/types";
@@ -137,11 +138,13 @@ describe("MemoryFS walkDir (via manual test)", () => {
     await fs.promises.writeFile("/src/utils/helpers.ts", "export {}");
     await fs.promises.writeFile("/README.md", "# Hello");
 
-    const files = await walkDir(fs, "/", "");
-    expect(files).toContain("src/index.ts");
-    expect(files).toContain("src/utils/helpers.ts");
-    expect(files).toContain("README.md");
-    expect(files.some((f) => f.startsWith(".git"))).toBe(false);
+    const result = await walkDir(fs.toNodeFS(), "/", "", noopLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toContain("src/index.ts");
+    expect(result.data).toContain("src/utils/helpers.ts");
+    expect(result.data).toContain("README.md");
+    expect(result.data.some((f) => f.startsWith(".git"))).toBe(false);
   });
 
   it("lists symlinks as leaf entries without recursing or failing on dangling links", async () => {
@@ -151,34 +154,17 @@ describe("MemoryFS walkDir (via manual test)", () => {
     await fs.promises.symlink("missing.ts", "/src/dangling.ts");
     await fs.promises.symlink("/src", "/srclink");
 
-    const files = await walkDir(fs, "/", "");
-    expect(files).toContain("src/index.ts");
-    expect(files).toContain("src/alias.ts");
-    expect(files).toContain("src/dangling.ts");
+    const result = await walkDir(fs.toNodeFS(), "/", "", noopLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toContain("src/index.ts");
+    expect(result.data).toContain("src/alias.ts");
+    expect(result.data).toContain("src/dangling.ts");
     // A symlink to a directory is a leaf, never recursed into.
-    expect(files).toContain("srclink");
-    expect(files.some((f) => f.startsWith("srclink/"))).toBe(false);
+    expect(result.data).toContain("srclink");
+    expect(result.data.some((f) => f.startsWith("srclink/"))).toBe(false);
   });
 });
-
-// Mirrors src/storage/git-ops.ts walkDir (lstat so symlinks are leaves).
-async function walkDir(fs: MemoryFS, base: string, prefix: string): Promise<string[]> {
-  const nodeFS = fs.toNodeFS();
-  const entries = await nodeFS.promises.readdir(base === "/" ? "/" : base);
-
-  const files: string[] = [];
-  for (const entry of entries) {
-    if (entry === ".git") continue;
-    const fullPath = base === "/" ? `/${entry}` : `${base}/${entry}`;
-    const stat = await nodeFS.promises.lstat(fullPath);
-    if (stat.isDirectory()) {
-      files.push(...(await walkDir(fs, fullPath, `${prefix}${entry}/`)));
-    } else {
-      files.push(`${prefix}${entry}`);
-    }
-  }
-  return files;
-}
 
 describe("commitAndPush path construction", () => {
   it("writeFile path is correct when dir has trailing slash", async () => {

--- a/tests/git-ops.test.ts
+++ b/tests/git-ops.test.ts
@@ -143,8 +143,25 @@ describe("MemoryFS walkDir (via manual test)", () => {
     expect(files).toContain("README.md");
     expect(files.some((f) => f.startsWith(".git"))).toBe(false);
   });
+
+  it("lists symlinks as leaf entries without recursing or failing on dangling links", async () => {
+    const fs = new MemoryFS();
+    await fs.promises.writeFile("/src/index.ts", "export {}");
+    await fs.promises.symlink("index.ts", "/src/alias.ts");
+    await fs.promises.symlink("missing.ts", "/src/dangling.ts");
+    await fs.promises.symlink("/src", "/srclink");
+
+    const files = await walkDir(fs, "/", "");
+    expect(files).toContain("src/index.ts");
+    expect(files).toContain("src/alias.ts");
+    expect(files).toContain("src/dangling.ts");
+    // A symlink to a directory is a leaf, never recursed into.
+    expect(files).toContain("srclink");
+    expect(files.some((f) => f.startsWith("srclink/"))).toBe(false);
+  });
 });
 
+// Mirrors src/storage/git-ops.ts walkDir (lstat so symlinks are leaves).
 async function walkDir(fs: MemoryFS, base: string, prefix: string): Promise<string[]> {
   const nodeFS = fs.toNodeFS();
   const entries = await nodeFS.promises.readdir(base === "/" ? "/" : base);
@@ -153,7 +170,7 @@ async function walkDir(fs: MemoryFS, base: string, prefix: string): Promise<stri
   for (const entry of entries) {
     if (entry === ".git") continue;
     const fullPath = base === "/" ? `/${entry}` : `${base}/${entry}`;
-    const stat = await nodeFS.promises.stat(fullPath);
+    const stat = await nodeFS.promises.lstat(fullPath);
     if (stat.isDirectory()) {
       files.push(...(await walkDir(fs, fullPath, `${prefix}${entry}/`)));
     } else {

--- a/tests/memory-fs.test.ts
+++ b/tests/memory-fs.test.ts
@@ -63,6 +63,67 @@ describe("MemoryFS", () => {
     });
   });
 
+  // A failed operation must not leave anything behind. Because the parent's
+  // child set is only updated on success, a stranded entry is invisible to
+  // readdir while still being readable by path -- the worst shape for a bug,
+  // since nothing enumerating the tree would ever surface it.
+  describe("failed writes leave no observable entry", () => {
+    it("writeFile below a file parent fails and strands nothing", async () => {
+      await fs.writeFile("/f.txt", "iam a file");
+      const write = await fs.writeFile("/f.txt/child", "x");
+      expect(write.success).toBe(false);
+      if (!write.success) expect(write.error.code).toBe("ENOTDIR");
+
+      const read = await fs.readFile("/f.txt/child", "utf8");
+      expect(read.success).toBe(false);
+      const stat = await fs.stat("/f.txt/child");
+      expect(stat.success).toBe(false);
+    });
+
+    it("recursive mkdir below a file parent fails and strands nothing", async () => {
+      await fs.writeFile("/f.txt", "iam a file");
+      const made = await fs.mkdir("/f.txt/sub", { recursive: true });
+      expect(made.success).toBe(false);
+      if (!made.success) expect(made.error.code).toBe("ENOTDIR");
+
+      const stat = await fs.stat("/f.txt/sub");
+      expect(stat.success).toBe(false);
+    });
+
+    it("mkdir over an existing file reports ENOTDIR rather than succeeding", async () => {
+      await fs.writeFile("/f.txt", "iam a file");
+      const made = await fs.mkdir("/f.txt", { recursive: true });
+      expect(made.success).toBe(false);
+      if (!made.success) expect(made.error.code).toBe("ENOTDIR");
+      // The file is untouched.
+      const read = await fs.readFile("/f.txt", "utf8");
+      expect(read.success && read.data === "iam a file").toBe(true);
+    });
+
+    // mkdir does not follow links, so a symlink parent is a non-directory.
+    it("writeFile below a symlink parent fails and strands nothing", async () => {
+      await fs.mkdir("/real");
+      await fs.symlink("real", "/link");
+      const write = await fs.writeFile("/link/nested/file.ts", "x");
+      expect(write.success).toBe(false);
+
+      const stat = await fs.stat("/link/nested/file.ts");
+      expect(stat.success).toBe(false);
+      // Nothing leaked into the link's target either.
+      const leaked = await fs.readFile("/real/nested/file.ts", "utf8");
+      expect(leaked.success).toBe(false);
+    });
+
+    it("mkdir over an existing directory stays a no-op", async () => {
+      await fs.mkdir("/d");
+      await fs.writeFile("/d/keep.txt", "kept");
+      const again = await fs.mkdir("/d", { recursive: true });
+      expect(again.success).toBe(true);
+      const read = await fs.readFile("/d/keep.txt", "utf8");
+      expect(read.success && read.data === "kept").toBe(true);
+    });
+  });
+
   describe("writeFile / readFile", () => {
     it("writes and reads a string", async () => {
       const writeResult = await fs.writeFile("/hello.txt", "hello");

--- a/tests/memory-fs.test.ts
+++ b/tests/memory-fs.test.ts
@@ -2,7 +2,7 @@ import git from "isomorphic-git";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { blobObject, commitObject, treeObject } from "../src/storage/git-objects";
 import { MemoryFS } from "../src/storage/memory-fs";
-import { placeLooseObject } from "../src/storage/object-loader";
+import { type FsLike, placeLooseObject } from "../src/storage/object-loader";
 
 describe("MemoryFS", () => {
   let fs: MemoryFS;
@@ -492,8 +492,10 @@ describe("MemoryFS", () => {
       expect(result.success).toBe(false);
       if (!result.success) expect(result.error.code).toBe("ENOTDIR");
     });
+  });
 
-    it("toNodeFS rmdir and writeFile throw on failure", async () => {
+  describe("toNodeFS", () => {
+    it("rmdir and writeFile throw on failure", async () => {
       const nodeFS = fs.toNodeFS();
       await expect(nodeFS.promises.rmdir("/missing")).rejects.toMatchObject({ code: "ENOENT" });
       await fs.mkdir("/dir");
@@ -502,7 +504,7 @@ describe("MemoryFS", () => {
       });
     });
 
-    it("toNodeFS symlink and readlink throw on failure", async () => {
+    it("symlink and readlink throw on failure", async () => {
       const nodeFS = fs.toNodeFS();
       await nodeFS.promises.writeFile("/f.txt", "x");
       await expect(nodeFS.promises.readlink("/f.txt")).rejects.toMatchObject({ code: "EINVAL" });
@@ -574,7 +576,7 @@ describe("MemoryFS + isomorphic-git round trips", () => {
       timestamp: 1700000000,
     });
     for (const o of [fileBlob, execBlob, linkBlob, tree, base]) {
-      await placeLooseObject(fs as never, gitdir, o.oid, o.bytes);
+      await placeLooseObject(fs as unknown as FsLike, gitdir, o.oid, o.bytes);
     }
     await git.writeRef({ fs, dir, ref: "refs/heads/main", value: base.oid, force: true });
     await git.checkout({ fs, dir, ref: "main" });

--- a/tests/memory-fs.test.ts
+++ b/tests/memory-fs.test.ts
@@ -1,5 +1,8 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import git from "isomorphic-git";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { blobObject, commitObject, treeObject } from "../src/storage/git-objects";
 import { MemoryFS } from "../src/storage/memory-fs";
+import { placeLooseObject } from "../src/storage/object-loader";
 
 describe("MemoryFS", () => {
   let fs: MemoryFS;
@@ -51,6 +54,13 @@ describe("MemoryFS", () => {
       const result = await fs.mkdir("/foo", { recursive: true });
       expect(result.success).toBe(true);
     });
+
+    it("fails recursively under a file ancestor", async () => {
+      await fs.writeFile("/f.txt", "x");
+      const result = await fs.mkdir("/f.txt/a/b", { recursive: true });
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error.code).toBe("ENOTDIR");
+    });
   });
 
   describe("writeFile / readFile", () => {
@@ -69,6 +79,17 @@ describe("MemoryFS", () => {
       const writeResult = await fs.writeFile("/bin.dat", data);
       expect(writeResult.success).toBe(true);
       const result = await fs.readFile("/bin.dat");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(data);
+      }
+    });
+
+    it("writes an ArrayBuffer", async () => {
+      const data = new Uint8Array([4, 5, 6]);
+      const writeResult = await fs.writeFile("/buf.dat", data.buffer);
+      expect(writeResult.success).toBe(true);
+      const result = await fs.readFile("/buf.dat");
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data).toEqual(data);
@@ -106,6 +127,14 @@ describe("MemoryFS", () => {
     it("returns error when reading a directory", async () => {
       await fs.mkdir("/dir");
       const result = await fs.readFile("/dir");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("EISDIR");
+      }
+    });
+
+    it("returns error when writing to the root directory", async () => {
+      const result = await fs.writeFile("/", "x");
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error.code).toBe("EISDIR");
@@ -219,5 +248,354 @@ describe("MemoryFS", () => {
         expect(stat.data.size).toBe(lstat.data.size);
       }
     });
+
+    it("honors an assigned mode override on the stats instance", async () => {
+      await fs.writeFile("/f.txt", "x");
+      const s = await fs.stat("/f.txt");
+      expect(s.success).toBe(true);
+      if (s.success) {
+        s.data.mode = 0o755;
+        expect(s.data.mode).toBe(0o755);
+      }
+    });
+
+    it("warns when a gitlink mode is assigned (submodules unsupported)", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        await fs.mkdir("/sub");
+        const s = await fs.lstat("/sub");
+        expect(s.success).toBe(true);
+        if (s.success) {
+          s.data.mode = 0o160000;
+          expect(s.data.mode).toBe(0o160000);
+        }
+        expect(warn).toHaveBeenCalledOnce();
+        expect(warn.mock.calls[0]?.[0]).toContain("gitlink");
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
+
+  describe("file modes", () => {
+    it("defaults new files to 100644", async () => {
+      await fs.writeFile("/f.txt", "x");
+      const s = await fs.lstat("/f.txt");
+      expect(s.success).toBe(true);
+      if (s.success) expect(s.data.mode).toBe(0o100644);
+    });
+
+    it("stores 100755 when written with an executable mode", async () => {
+      await fs.writeFile("/run.sh", "#!/bin/sh\n", { mode: 0o777 });
+      const s = await fs.lstat("/run.sh");
+      expect(s.success).toBe(true);
+      if (s.success) expect(s.data.mode).toBe(0o100755);
+    });
+
+    it("normalizes any exec bit to 100755 and none to 100644", async () => {
+      await fs.writeFile("/a.sh", "a", { mode: 0o100 });
+      await fs.writeFile("/b.txt", "b", { mode: 0o644 });
+      const a = await fs.lstat("/a.sh");
+      const b = await fs.lstat("/b.txt");
+      expect(a.success && a.data.mode === 0o100755).toBe(true);
+      expect(b.success && b.data.mode === 0o100644).toBe(true);
+    });
+
+    it("preserves the existing mode on overwrite without an explicit mode", async () => {
+      await fs.writeFile("/run.sh", "v1", { mode: 0o755 });
+      await fs.writeFile("/run.sh", "v2");
+      const s = await fs.lstat("/run.sh");
+      expect(s.success).toBe(true);
+      if (s.success) expect(s.data.mode).toBe(0o100755);
+    });
+
+    it("changes the mode on overwrite with an explicit mode", async () => {
+      await fs.writeFile("/run.sh", "v1", { mode: 0o755 });
+      await fs.writeFile("/run.sh", "v2", { mode: 0o644 });
+      const s = await fs.lstat("/run.sh");
+      expect(s.success).toBe(true);
+      if (s.success) expect(s.data.mode).toBe(0o100644);
+    });
+
+    it("returns error when writing under a file parent", async () => {
+      await fs.writeFile("/f.txt", "x");
+      const result = await fs.writeFile("/f.txt/child", "y");
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error.code).toBe("ENOTDIR");
+      const deep = await fs.writeFile("/f.txt/sub/child", "y");
+      expect(deep.success).toBe(false);
+      if (!deep.success) expect(deep.error.code).toBe("ENOTDIR");
+    });
+  });
+
+  describe("symlinks", () => {
+    it("round-trips symlink → readlink", async () => {
+      await fs.writeFile("/target.txt", "hello");
+      const linkResult = await fs.symlink("target.txt", "/link");
+      expect(linkResult.success).toBe(true);
+      const target = await fs.readlink("/link");
+      expect(target.success).toBe(true);
+      if (target.success) expect(target.data).toBe("target.txt");
+    });
+
+    it("lstat reports isSymbolicLink and mode 120000", async () => {
+      await fs.symlink("target.txt", "/link");
+      const s = await fs.lstat("/link");
+      expect(s.success).toBe(true);
+      if (s.success) {
+        expect(s.data.isSymbolicLink()).toBe(true);
+        expect(s.data.isFile()).toBe(false);
+        expect(s.data.isDirectory()).toBe(false);
+        expect(s.data.mode).toBe(0o120000);
+        expect(s.data.size).toBe("target.txt".length);
+        expect(s.data.mtimeMs).toBeGreaterThan(0);
+        expect(s.data.ctimeMs).toBe(s.data.mtimeMs);
+      }
+    });
+
+    it("stat follows the link to the target", async () => {
+      await fs.writeFile("/target.txt", "hello");
+      await fs.symlink("target.txt", "/link");
+      const s = await fs.stat("/link");
+      expect(s.success).toBe(true);
+      if (s.success) {
+        expect(s.data.isSymbolicLink()).toBe(false);
+        expect(s.data.isFile()).toBe(true);
+        expect(s.data.size).toBe(5);
+      }
+    });
+
+    it("readFile follows relative links (within a subdirectory)", async () => {
+      await fs.writeFile("/dir/target.txt", "content");
+      await fs.symlink("target.txt", "/dir/link");
+      const result = await fs.readFile("/dir/link", "utf8");
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toBe("content");
+    });
+
+    it("readFile follows absolute links", async () => {
+      await fs.writeFile("/target.txt", "abs");
+      await fs.symlink("/target.txt", "/dir/link");
+      const result = await fs.readFile("/dir/link", "utf8");
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toBe("abs");
+    });
+
+    it("follows chained links", async () => {
+      await fs.writeFile("/target.txt", "end");
+      await fs.symlink("target.txt", "/a");
+      await fs.symlink("a", "/b");
+      const result = await fs.readFile("/b", "utf8");
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toBe("end");
+    });
+
+    it("stat on a dangling link returns ENOENT", async () => {
+      await fs.symlink("missing.txt", "/link");
+      const s = await fs.stat("/link");
+      expect(s.success).toBe(false);
+      if (!s.success) expect(s.error.code).toBe("ENOENT");
+    });
+
+    it("returns ELOOP for a symlink cycle", async () => {
+      await fs.symlink("b", "/a");
+      await fs.symlink("a", "/b");
+      const read = await fs.readFile("/a");
+      expect(read.success).toBe(false);
+      if (!read.success) expect(read.error.code).toBe("ELOOP");
+      const stat = await fs.stat("/a");
+      expect(stat.success).toBe(false);
+      if (!stat.success) expect(stat.error.code).toBe("ELOOP");
+      const write = await fs.writeFile("/a", "x");
+      expect(write.success).toBe(false);
+      if (!write.success) expect(write.error.code).toBe("ELOOP");
+    });
+
+    it("readlink on a regular file returns EINVAL", async () => {
+      await fs.writeFile("/f.txt", "x");
+      const result = await fs.readlink("/f.txt");
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error.code).toBe("EINVAL");
+    });
+
+    it("readlink on a missing path returns ENOENT", async () => {
+      const result = await fs.readlink("/nope");
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error.code).toBe("ENOENT");
+    });
+
+    it("symlink over a directory returns EEXIST", async () => {
+      await fs.mkdir("/dir");
+      const result = await fs.symlink("target", "/dir");
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error.code).toBe("EEXIST");
+    });
+
+    it("symlink under a file parent returns ENOTDIR", async () => {
+      await fs.writeFile("/f.txt", "x");
+      const result = await fs.symlink("target", "/f.txt/link");
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error.code).toBe("ENOTDIR");
+    });
+
+    it("replaces an existing symlink in place (checkout update semantics)", async () => {
+      await fs.symlink("old.txt", "/link");
+      const result = await fs.symlink("new.txt", "/link");
+      expect(result.success).toBe(true);
+      const target = await fs.readlink("/link");
+      expect(target.success).toBe(true);
+      if (target.success) expect(target.data).toBe("new.txt");
+    });
+
+    it("writeFile through a link writes the target file", async () => {
+      await fs.writeFile("/target.txt", "old");
+      await fs.symlink("target.txt", "/link");
+      const writeResult = await fs.writeFile("/link", "new");
+      expect(writeResult.success).toBe(true);
+      const targetContent = await fs.readFile("/target.txt", "utf8");
+      expect(targetContent.success).toBe(true);
+      if (targetContent.success) expect(targetContent.data).toBe("new");
+      const s = await fs.lstat("/link");
+      expect(s.success && s.data.isSymbolicLink()).toBe(true);
+    });
+
+    it("writeFile through a dangling link creates the target", async () => {
+      await fs.symlink("missing.txt", "/link");
+      await fs.writeFile("/link", "created");
+      const result = await fs.readFile("/missing.txt", "utf8");
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toBe("created");
+    });
+
+    it("unlink removes the link, not the target", async () => {
+      await fs.writeFile("/target.txt", "keep");
+      await fs.symlink("target.txt", "/link");
+      const unlinkResult = await fs.unlink("/link");
+      expect(unlinkResult.success).toBe(true);
+      expect((await fs.lstat("/link")).success).toBe(false);
+      expect((await fs.readFile("/target.txt", "utf8")).success).toBe(true);
+      const entries = await fs.readdir("/");
+      expect(entries.success).toBe(true);
+      if (entries.success) expect(entries.data).not.toContain("link");
+    });
+
+    it("readdir lists symlinks", async () => {
+      await fs.symlink("t", "/link");
+      const entries = await fs.readdir("/");
+      expect(entries.success).toBe(true);
+      if (entries.success) expect(entries.data).toContain("link");
+    });
+
+    it("symlink deep under a file parent returns ENOTDIR", async () => {
+      await fs.writeFile("/f.txt", "x");
+      const result = await fs.symlink("target", "/f.txt/sub/link");
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error.code).toBe("ENOTDIR");
+    });
+
+    it("toNodeFS rmdir and writeFile throw on failure", async () => {
+      const nodeFS = fs.toNodeFS();
+      await expect(nodeFS.promises.rmdir("/missing")).rejects.toMatchObject({ code: "ENOENT" });
+      await fs.mkdir("/dir");
+      await expect(nodeFS.promises.writeFile("/dir", "x")).rejects.toMatchObject({
+        code: "EISDIR",
+      });
+    });
+
+    it("toNodeFS symlink and readlink throw on failure", async () => {
+      const nodeFS = fs.toNodeFS();
+      await nodeFS.promises.writeFile("/f.txt", "x");
+      await expect(nodeFS.promises.readlink("/f.txt")).rejects.toMatchObject({ code: "EINVAL" });
+      await fs.mkdir("/dir");
+      await expect(nodeFS.promises.symlink("t", "/dir")).rejects.toMatchObject({ code: "EEXIST" });
+      await nodeFS.promises.symlink("f.txt", "/link");
+      await expect(nodeFS.promises.readlink("/link")).resolves.toBe("f.txt");
+    });
+  });
+});
+
+describe("MemoryFS + isomorphic-git round trips", () => {
+  const enc = (s: string) => new TextEncoder().encode(s);
+  const author = { name: "Stratum", email: "system@usestratum.dev" };
+  const dir = "/";
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("preserves 100755 and symlinks in a commit created from MemoryFS", async () => {
+    const raw = new MemoryFS();
+    const fs = raw.toNodeFS() as unknown as Parameters<typeof git.init>[0]["fs"];
+    await git.init({ fs, dir, defaultBranch: "main" });
+
+    await raw.promises.writeFile("/README.md", "docs\n");
+    await raw.promises.writeFile("/run.sh", "#!/bin/sh\necho hi\n", { mode: 0o755 });
+    await raw.promises.symlink("README.md", "/link.md");
+
+    for (const filepath of ["README.md", "run.sh", "link.md"]) {
+      await git.add({ fs, dir, filepath });
+    }
+    const sha = await git.commit({ fs, dir, message: "modes", author });
+
+    const commit = await git.readCommit({ fs, dir, oid: sha });
+    const tree = await git.readTree({ fs, dir, oid: commit.commit.tree });
+    const byPath = new Map(tree.tree.map((e) => [e.path, e]));
+    expect(byPath.get("README.md")?.mode).toBe("100644");
+    expect(byPath.get("run.sh")?.mode).toBe("100755");
+    expect(byPath.get("link.md")?.mode).toBe("120000");
+
+    // The symlink blob is its target path.
+    const linkOid = byPath.get("link.md")?.oid;
+    expect(linkOid).toBeDefined();
+    if (linkOid) {
+      const blob = await git.readBlob({ fs, dir, oid: linkOid });
+      expect(new TextDecoder().decode(blob.blob)).toBe("README.md");
+    }
+  });
+
+  it("checkout of a tree with symlink + exec file survives a full round trip", async () => {
+    const raw = new MemoryFS();
+    const fs = raw.toNodeFS() as unknown as Parameters<typeof git.init>[0]["fs"];
+    const gitdir = "/.git";
+    await git.init({ fs, dir, defaultBranch: "main" });
+
+    const fileBlob = await blobObject(enc("plain\n"));
+    const execBlob = await blobObject(enc("#!/bin/sh\nexit 0\n"));
+    const linkBlob = await blobObject(enc("file.txt"));
+    const tree = await treeObject([
+      { mode: "100644", name: "file.txt", oid: fileBlob.oid },
+      { mode: "100755", name: "run.sh", oid: execBlob.oid },
+      { mode: "120000", name: "link", oid: linkBlob.oid },
+    ]);
+    const base = await commitObject({
+      tree: tree.oid,
+      parents: [],
+      message: "base",
+      timestamp: 1700000000,
+    });
+    for (const o of [fileBlob, execBlob, linkBlob, tree, base]) {
+      await placeLooseObject(fs as never, gitdir, o.oid, o.bytes);
+    }
+    await git.writeRef({ fs, dir, ref: "refs/heads/main", value: base.oid, force: true });
+    await git.checkout({ fs, dir, ref: "main" });
+
+    // Checkout materialized the symlink and kept the exec bit.
+    const linkStat = await raw.promises.lstat("/link");
+    expect(linkStat.success && linkStat.data.isSymbolicLink()).toBe(true);
+    const target = await raw.promises.readlink("/link");
+    expect(target.success && target.data === "file.txt").toBe(true);
+    const followed = await raw.promises.readFile("/link", "utf8");
+    expect(followed.success && followed.data === "plain\n").toBe(true);
+    const execStat = await raw.promises.lstat("/run.sh");
+    expect(execStat.success && execStat.data.mode === 0o100755).toBe(true);
+
+    // Round trip: re-stage the checked-out workdir and commit; modes must survive.
+    for (const filepath of ["file.txt", "run.sh", "link"]) {
+      await git.add({ fs, dir, filepath });
+    }
+    const sha = await git.commit({ fs, dir, message: "round trip", author });
+    const commit = await git.readCommit({ fs, dir, oid: sha });
+    // Identical content and modes must produce the identical tree.
+    expect(commit.commit.tree).toBe(tree.oid);
   });
 });

--- a/tests/squash-merge-modes.test.ts
+++ b/tests/squash-merge-modes.test.ts
@@ -60,7 +60,10 @@ function stubReceivePackServer(mainOid: string) {
     if (url.endsWith("/git-receive-pack")) {
       const report = concat(pkt("unpack ok\n"), pkt("ok refs/heads/main\n"), FLUSH);
       const channel1 = new Uint8Array(1 + report.length);
-      channel1[0] = 1; // side-band channel 1: pack/report data
+      // The advertisement above offers side-band-64k, so the client negotiates
+      // it and demultiplexes the response. The report has to be wrapped in
+      // channel 1 or the client never sees it and the push hangs.
+      channel1[0] = 1;
       channel1.set(report, 1);
       const body = concat(pkt(channel1), FLUSH);
       return new Response(body, {
@@ -171,6 +174,138 @@ describe("squashMerge preserves file modes and symlinks", () => {
     expect(scriptStat.success && scriptStat.data.mode === 0o100755).toBe(true);
   });
 
+  // Both directions of a path-shape change. Unlinking the target path alone
+  // cannot fix either: a symlink ANCESTOR redirects the write somewhere else
+  // entirely, and MemoryFS's unlink succeeds on a directory without removing
+  // its children, so they outlive the directory they belonged to.
+  it("replaces a directory with a symlink without leaving its children behind", async () => {
+    const raw = new MemoryFS();
+    const fs = raw.toNodeFS() as unknown as NodeFS;
+    const gitfs = fs as unknown as Parameters<typeof git.init>[0]["fs"];
+    const dir = "/";
+    const gitdir = "/.git";
+    await git.init({ fs: gitfs, dir, defaultBranch: "main" });
+
+    // Base: lib/ is a real directory holding one file.
+    const childBlob = await blobObject(enc("child\n"));
+    const libTree = await treeObject([{ mode: "100644", name: "a.ts", oid: childBlob.oid }]);
+    const baseTree = await treeObject([{ mode: "40000", name: "lib", oid: libTree.oid }]);
+    const base = await commitObject({
+      tree: baseTree.oid,
+      parents: [],
+      message: "base",
+      timestamp: 1700000000,
+    });
+
+    // Workspace: lib is a symlink instead.
+    const linkBlob = await blobObject(enc("vendor"));
+    const wsTree = await treeObject([{ mode: "120000", name: "lib", oid: linkBlob.oid }]);
+    const ws = await commitObject({
+      tree: wsTree.oid,
+      parents: [base.oid],
+      message: "workspace",
+      timestamp: 1700000001,
+    });
+
+    for (const o of [childBlob, libTree, baseTree, base, linkBlob, wsTree, ws]) {
+      await placeLooseObject(fs as FsLike, gitdir, o.oid, o.bytes);
+    }
+    await git.writeRef({ fs: gitfs, dir, ref: "refs/heads/main", value: base.oid, force: true });
+    await git.checkout({ fs: gitfs, dir, ref: "main" });
+
+    stubReceivePackServer(base.oid);
+    const result = await squashMerge(
+      fs,
+      dir,
+      ws.oid,
+      "https://example.test/git/project.git",
+      "token",
+      author,
+      logger,
+    );
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const commit = await git.readCommit({ fs: gitfs, dir, oid: result.data });
+    expect(commit.commit.tree).toBe(wsTree.oid);
+    // The orphaned child must not survive underneath the new symlink.
+    const orphan = await raw.promises.readFile("/lib/a.ts");
+    expect(orphan.success).toBe(false);
+  });
+
+  it("writes a file under a path whose old shape was a symlink, not through it", async () => {
+    const raw = new MemoryFS();
+    const fs = raw.toNodeFS() as unknown as NodeFS;
+    const gitfs = fs as unknown as Parameters<typeof git.init>[0]["fs"];
+    const dir = "/";
+    const gitdir = "/.git";
+    await git.init({ fs: gitfs, dir, defaultBranch: "main" });
+
+    // Base: lib is a symlink to the real/ directory.
+    const decoyBlob = await blobObject(enc("decoy\n"));
+    const realTree = await treeObject([{ mode: "100644", name: "keep.ts", oid: decoyBlob.oid }]);
+    const libLink = await blobObject(enc("real"));
+    const baseTree = await treeObject([
+      { mode: "120000", name: "lib", oid: libLink.oid },
+      { mode: "40000", name: "real", oid: realTree.oid },
+    ]);
+    const base = await commitObject({
+      tree: baseTree.oid,
+      parents: [],
+      message: "base",
+      timestamp: 1700000000,
+    });
+
+    // Workspace: lib becomes a real directory containing file.ts.
+    const fileBlob = await blobObject(enc("content\n"));
+    const newLibTree = await treeObject([{ mode: "100644", name: "file.ts", oid: fileBlob.oid }]);
+    const wsTree = await treeObject([
+      { mode: "40000", name: "lib", oid: newLibTree.oid },
+      { mode: "40000", name: "real", oid: realTree.oid },
+    ]);
+    const ws = await commitObject({
+      tree: wsTree.oid,
+      parents: [base.oid],
+      message: "workspace",
+      timestamp: 1700000001,
+    });
+
+    for (const o of [
+      decoyBlob,
+      realTree,
+      libLink,
+      baseTree,
+      base,
+      fileBlob,
+      newLibTree,
+      wsTree,
+      ws,
+    ]) {
+      await placeLooseObject(fs as FsLike, gitdir, o.oid, o.bytes);
+    }
+    await git.writeRef({ fs: gitfs, dir, ref: "refs/heads/main", value: base.oid, force: true });
+    await git.checkout({ fs: gitfs, dir, ref: "main" });
+
+    stubReceivePackServer(base.oid);
+    const result = await squashMerge(
+      fs,
+      dir,
+      ws.oid,
+      "https://example.test/git/project.git",
+      "token",
+      author,
+      logger,
+    );
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const commit = await git.readCommit({ fs: gitfs, dir, oid: result.data });
+    expect(commit.commit.tree).toBe(wsTree.oid);
+    // The write must not have followed the stale link into real/.
+    const leaked = await raw.promises.readFile("/real/file.ts");
+    expect(leaked.success).toBe(false);
+  });
+
   it("returns the current head untouched when nothing changed", async () => {
     const raw = new MemoryFS();
     const fs = raw.toNodeFS() as unknown as NodeFS;
@@ -234,9 +369,13 @@ describe("squashMerge preserves file modes and symlinks", () => {
     });
     // A gitlink (submodule reference): mode 160000, oid is the submodule's
     // commit — never read as a blob, so it doesn't need to exist as an object.
+    // It lives inside a real `vendor` subtree because a tree entry name cannot
+    // contain a slash; a flat "vendor/lib" entry is a tree git cannot produce,
+    // so the walker would not be exercised the way it is in practice.
+    const vendorTree = await treeObject([{ mode: "160000", name: "lib", oid: "a".repeat(40) }]);
     const wsTree = await treeObject([
       { mode: "100644", name: "file.txt", oid: fileBlob.oid },
-      { mode: "160000", name: "vendor/lib", oid: "a".repeat(40) },
+      { mode: "40000", name: "vendor", oid: vendorTree.oid },
     ]);
     const ws = await commitObject({
       tree: wsTree.oid,
@@ -244,7 +383,7 @@ describe("squashMerge preserves file modes and symlinks", () => {
       message: "add submodule",
       timestamp: 1700000001,
     });
-    for (const o of [fileBlob, baseTree, base, wsTree, ws]) {
+    for (const o of [fileBlob, baseTree, base, vendorTree, wsTree, ws]) {
       await placeLooseObject(fs as FsLike, gitdir, o.oid, o.bytes);
     }
     await git.writeRef({ fs: gitfs, dir, ref: "refs/heads/main", value: base.oid, force: true });

--- a/tests/squash-merge-modes.test.ts
+++ b/tests/squash-merge-modes.test.ts
@@ -431,6 +431,107 @@ describe("squashMerge preserves file modes and symlinks", () => {
     expect(victim.success && victim.data === "do not delete\n").toBe(true);
   });
 
+  // squashMerge takes the NodeFS interface, and node's readdir FOLLOWS a
+  // directory symlink where MemoryFS's reports ENOTDIR. This wrapper gives the
+  // node semantics so the subtree walk is exercised the way it would behave on
+  // a real filesystem: without the lstat gate, removeSubtree recurses into the
+  // link's target and deletes files that were never part of the merge.
+  function withNativeReaddir(raw: MemoryFS, fs: NodeFS): NodeFS {
+    // Resolve symlinks along `count` leading components, node-style. readdir
+    // follows the whole path including a trailing link; unlink resolves the
+    // ancestors but removes the link itself rather than its target.
+    const resolve = async (path: string, keepLast: boolean): Promise<string> => {
+      const parts = path.split("/").filter(Boolean);
+      const limit = keepLast ? parts.length - 1 : parts.length;
+      let cur = "";
+      for (let i = 0; i < parts.length; i++) {
+        const next = `${cur}/${parts[i]}`;
+        if (i >= limit) {
+          cur = next;
+          continue;
+        }
+        const link = await raw.readlink(next);
+        cur = link.success ? `${cur}/${link.data}` : next;
+      }
+      return cur || "/";
+    };
+    return {
+      promises: {
+        ...fs.promises,
+        readdir: async (path: string) => fs.promises.readdir(await resolve(path, false)),
+        unlink: async (path: string) => fs.promises.unlink(await resolve(path, true)),
+      },
+    } as NodeFS;
+  }
+
+  it("does not empty a symlink's target when replacing a directory", async () => {
+    const raw = new MemoryFS();
+    const base = raw.toNodeFS() as unknown as NodeFS;
+    const fs = withNativeReaddir(raw, base);
+    const gitfs = base as unknown as Parameters<typeof git.init>[0]["fs"];
+    const dir = "/";
+    const gitdir = "/.git";
+    await git.init({ fs: gitfs, dir, defaultBranch: "main" });
+
+    // Base: `lib` is a symlink to vendor/, and vendor/ holds a file that must
+    // survive. The workspace turns `lib` into a real directory.
+    const keepBlob = await blobObject(enc("must survive\n"));
+    const vendorTree = await treeObject([{ mode: "100644", name: "keep.ts", oid: keepBlob.oid }]);
+    const linkBlob = await blobObject(enc("vendor"));
+    const baseTree = await treeObject([
+      { mode: "120000", name: "lib", oid: linkBlob.oid },
+      { mode: "40000", name: "vendor", oid: vendorTree.oid },
+    ]);
+    const baseCommit = await commitObject({
+      tree: baseTree.oid,
+      parents: [],
+      message: "base",
+      timestamp: 1700000000,
+    });
+
+    // `lib` itself becomes a regular file, so clearConflictingPathShape calls
+    // removeSubtree directly ON the symlink -- the only path where a following
+    // readdir would descend into vendor/.
+    const newBlob = await blobObject(enc("now a file\n"));
+    const wsTree = await treeObject([
+      { mode: "100644", name: "lib", oid: newBlob.oid },
+      { mode: "40000", name: "vendor", oid: vendorTree.oid },
+    ]);
+    const ws = await commitObject({
+      tree: wsTree.oid,
+      parents: [baseCommit.oid],
+      message: "workspace",
+      timestamp: 1700000001,
+    });
+
+    for (const o of [keepBlob, vendorTree, linkBlob, baseTree, baseCommit, newBlob, wsTree, ws]) {
+      await placeLooseObject(base as FsLike, gitdir, o.oid, o.bytes);
+    }
+    await git.writeRef({
+      fs: gitfs,
+      dir,
+      ref: "refs/heads/main",
+      value: baseCommit.oid,
+      force: true,
+    });
+    await git.checkout({ fs: gitfs, dir, ref: "main" });
+
+    stubReceivePackServer(baseCommit.oid);
+    const result = await squashMerge(
+      fs,
+      dir,
+      ws.oid,
+      "https://example.test/git/project.git",
+      "token",
+      author,
+      logger,
+    );
+    expect(result.success).toBe(true);
+    // The link target's contents must be untouched.
+    const survivor = await raw.readFile("/vendor/keep.ts", "utf8");
+    expect(survivor.success && survivor.data === "must survive\n").toBe(true);
+  });
+
   it("returns the current head untouched when nothing changed", async () => {
     const raw = new MemoryFS();
     const fs = raw.toNodeFS() as unknown as NodeFS;

--- a/tests/squash-merge-modes.test.ts
+++ b/tests/squash-merge-modes.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { blobObject, commitObject, treeObject } from "../src/storage/git-objects";
 import { type NodeFS, squashMerge } from "../src/storage/git-ops";
 import { MemoryFS } from "../src/storage/memory-fs";
-import { placeLooseObject } from "../src/storage/object-loader";
+import { type FsLike, placeLooseObject } from "../src/storage/object-loader";
 import type { Logger } from "../src/utils/logger";
 
 const enc = (s: string) => new TextEncoder().encode(s);
@@ -122,10 +122,10 @@ describe("squashMerge preserves file modes and symlinks", () => {
     });
 
     for (const o of [fileBlob, scriptBlob, linkToFile, goneBlob, baseTree, base]) {
-      await placeLooseObject(fs as never, gitdir, o.oid, o.bytes);
+      await placeLooseObject(fs as FsLike, gitdir, o.oid, o.bytes);
     }
     for (const o of [linkToScript, wsTree, ws]) {
-      await placeLooseObject(fs as never, gitdir, o.oid, o.bytes);
+      await placeLooseObject(fs as FsLike, gitdir, o.oid, o.bytes);
     }
     await git.writeRef({ fs: gitfs, dir, ref: "refs/heads/main", value: base.oid, force: true });
     await git.checkout({ fs: gitfs, dir, ref: "main" });
@@ -194,7 +194,7 @@ describe("squashMerge preserves file modes and symlinks", () => {
       timestamp: 1700000001,
     });
     for (const o of [fileBlob, tree, base, ws]) {
-      await placeLooseObject(fs as never, gitdir, o.oid, o.bytes);
+      await placeLooseObject(fs as FsLike, gitdir, o.oid, o.bytes);
     }
     await git.writeRef({ fs: gitfs, dir, ref: "refs/heads/main", value: base.oid, force: true });
     await git.checkout({ fs: gitfs, dir, ref: "main" });
@@ -213,6 +213,56 @@ describe("squashMerge preserves file modes and symlinks", () => {
     expect(result.success).toBe(true);
     if (result.success) expect(result.data).toBe(base.oid);
     // No changes -> no push.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on a gitlink (submodule) entry instead of silently dropping it", async () => {
+    const raw = new MemoryFS();
+    const fs = raw.toNodeFS() as unknown as NodeFS;
+    const gitfs = fs as unknown as Parameters<typeof git.init>[0]["fs"];
+    const dir = "/";
+    const gitdir = "/.git";
+    await git.init({ fs: gitfs, dir, defaultBranch: "main" });
+
+    const fileBlob = await blobObject(enc("base\n"));
+    const baseTree = await treeObject([{ mode: "100644", name: "file.txt", oid: fileBlob.oid }]);
+    const base = await commitObject({
+      tree: baseTree.oid,
+      parents: [],
+      message: "base",
+      timestamp: 1700000000,
+    });
+    // A gitlink (submodule reference): mode 160000, oid is the submodule's
+    // commit — never read as a blob, so it doesn't need to exist as an object.
+    const wsTree = await treeObject([
+      { mode: "100644", name: "file.txt", oid: fileBlob.oid },
+      { mode: "160000", name: "vendor/lib", oid: "a".repeat(40) },
+    ]);
+    const ws = await commitObject({
+      tree: wsTree.oid,
+      parents: [base.oid],
+      message: "add submodule",
+      timestamp: 1700000001,
+    });
+    for (const o of [fileBlob, baseTree, base, wsTree, ws]) {
+      await placeLooseObject(fs as FsLike, gitdir, o.oid, o.bytes);
+    }
+    await git.writeRef({ fs: gitfs, dir, ref: "refs/heads/main", value: base.oid, force: true });
+    await git.checkout({ fs: gitfs, dir, ref: "main" });
+
+    const fetchSpy = stubReceivePackServer(base.oid);
+
+    const result = await squashMerge(
+      fs,
+      dir,
+      ws.oid,
+      "https://example.test/git/project.git",
+      "token",
+      author,
+      logger,
+    );
+    expect(result.success).toBe(false);
+    // Fails before ever pushing — the unsupported gitlink is never silently merged.
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/squash-merge-modes.test.ts
+++ b/tests/squash-merge-modes.test.ts
@@ -306,6 +306,131 @@ describe("squashMerge preserves file modes and symlinks", () => {
     expect(leaked.success).toBe(false);
   });
 
+  it("replaces a file ancestor so a nested descendant can be written", async () => {
+    const raw = new MemoryFS();
+    const fs = raw.toNodeFS() as unknown as NodeFS;
+    const gitfs = fs as unknown as Parameters<typeof git.init>[0]["fs"];
+    const dir = "/";
+    const gitdir = "/.git";
+    await git.init({ fs: gitfs, dir, defaultBranch: "main" });
+
+    // Base: `lib` is a plain FILE, not a symlink. It blocks a nested write with
+    // ENOTDIR exactly as a symlink would, but readlink cannot detect it.
+    const libFileBlob = await blobObject(enc("i am a file\n"));
+    const baseTree = await treeObject([{ mode: "100644", name: "lib", oid: libFileBlob.oid }]);
+    const base = await commitObject({
+      tree: baseTree.oid,
+      parents: [],
+      message: "base",
+      timestamp: 1700000000,
+    });
+
+    const nestedBlob = await blobObject(enc("nested\n"));
+    const libDirTree = await treeObject([{ mode: "100644", name: "file.ts", oid: nestedBlob.oid }]);
+    const wsTree = await treeObject([{ mode: "40000", name: "lib", oid: libDirTree.oid }]);
+    const ws = await commitObject({
+      tree: wsTree.oid,
+      parents: [base.oid],
+      message: "workspace",
+      timestamp: 1700000001,
+    });
+
+    for (const o of [libFileBlob, baseTree, base, nestedBlob, libDirTree, wsTree, ws]) {
+      await placeLooseObject(fs as FsLike, gitdir, o.oid, o.bytes);
+    }
+    await git.writeRef({ fs: gitfs, dir, ref: "refs/heads/main", value: base.oid, force: true });
+    await git.checkout({ fs: gitfs, dir, ref: "main" });
+
+    stubReceivePackServer(base.oid);
+    const result = await squashMerge(
+      fs,
+      dir,
+      ws.oid,
+      "https://example.test/git/project.git",
+      "token",
+      author,
+      logger,
+    );
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const commit = await git.readCommit({ fs: gitfs, dir, oid: result.data });
+    expect(commit.commit.tree).toBe(wsTree.oid);
+  });
+
+  it("does not delete through a replacement symlink when removing an obsolete path", async () => {
+    const raw = new MemoryFS();
+    const fs = raw.toNodeFS() as unknown as NodeFS;
+    const gitfs = fs as unknown as Parameters<typeof git.init>[0]["fs"];
+    const dir = "/";
+    const gitdir = "/.git";
+    await git.init({ fs: gitfs, dir, defaultBranch: "main" });
+
+    // Base: lib/ is a directory holding old.ts. The target dir already contains
+    // a file of the SAME NAME, which is what an unlink through the replacement
+    // symlink would destroy.
+    const oldBlob = await blobObject(enc("old\n"));
+    const victimBlob = await blobObject(enc("do not delete\n"));
+    const libTree = await treeObject([{ mode: "100644", name: "old.ts", oid: oldBlob.oid }]);
+    const vendorTree = await treeObject([{ mode: "100644", name: "old.ts", oid: victimBlob.oid }]);
+    const baseTree = await treeObject([
+      { mode: "40000", name: "lib", oid: libTree.oid },
+      { mode: "40000", name: "vendor", oid: vendorTree.oid },
+    ]);
+    const base = await commitObject({
+      tree: baseTree.oid,
+      parents: [],
+      message: "base",
+      timestamp: 1700000000,
+    });
+
+    // Workspace: lib becomes a symlink to vendor; lib/old.ts is gone.
+    const linkBlob = await blobObject(enc("vendor"));
+    const wsTree = await treeObject([
+      { mode: "120000", name: "lib", oid: linkBlob.oid },
+      { mode: "40000", name: "vendor", oid: vendorTree.oid },
+    ]);
+    const ws = await commitObject({
+      tree: wsTree.oid,
+      parents: [base.oid],
+      message: "workspace",
+      timestamp: 1700000001,
+    });
+
+    for (const o of [
+      oldBlob,
+      victimBlob,
+      libTree,
+      vendorTree,
+      baseTree,
+      base,
+      linkBlob,
+      wsTree,
+      ws,
+    ]) {
+      await placeLooseObject(fs as FsLike, gitdir, o.oid, o.bytes);
+    }
+    await git.writeRef({ fs: gitfs, dir, ref: "refs/heads/main", value: base.oid, force: true });
+    await git.checkout({ fs: gitfs, dir, ref: "main" });
+
+    stubReceivePackServer(base.oid);
+    const result = await squashMerge(
+      fs,
+      dir,
+      ws.oid,
+      "https://example.test/git/project.git",
+      "token",
+      author,
+      logger,
+    );
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const commit = await git.readCommit({ fs: gitfs, dir, oid: result.data });
+    expect(commit.commit.tree).toBe(wsTree.oid);
+    // The same-named file inside the link's target must survive untouched.
+    const victim = await raw.promises.readFile("/vendor/old.ts", "utf8");
+    expect(victim.success && victim.data === "do not delete\n").toBe(true);
+  });
+
   it("returns the current head untouched when nothing changed", async () => {
     const raw = new MemoryFS();
     const fs = raw.toNodeFS() as unknown as NodeFS;

--- a/tests/squash-merge-modes.test.ts
+++ b/tests/squash-merge-modes.test.ts
@@ -1,0 +1,218 @@
+import git from "isomorphic-git";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { blobObject, commitObject, treeObject } from "../src/storage/git-objects";
+import { type NodeFS, squashMerge } from "../src/storage/git-ops";
+import { MemoryFS } from "../src/storage/memory-fs";
+import { placeLooseObject } from "../src/storage/object-loader";
+import type { Logger } from "../src/utils/logger";
+
+const enc = (s: string) => new TextEncoder().encode(s);
+const author = { name: "Stratum", email: "system@usestratum.dev" };
+
+const logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => logger,
+} as unknown as Logger;
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+/** Encode one git pkt-line (4-hex-digit length prefix covering itself). */
+function pkt(payload: string | Uint8Array): Uint8Array {
+  const bytes = typeof payload === "string" ? enc(payload) : payload;
+  const len = (bytes.length + 4).toString(16).padStart(4, "0");
+  return concat(enc(len), bytes);
+}
+
+const FLUSH = enc("0000");
+
+/**
+ * Minimal git smart-HTTP receive-pack server: advertises `main` at `mainOid`
+ * and accepts any push with report-status over side-band-64k. Just enough for
+ * isomorphic-git's `git.push` to complete against a stubbed `fetch`.
+ */
+function stubReceivePackServer(mainOid: string) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.includes("/info/refs?service=git-receive-pack")) {
+      const body = concat(
+        pkt("# service=git-receive-pack\n"),
+        FLUSH,
+        pkt(`${mainOid} refs/heads/main\0report-status side-band-64k\n`),
+        FLUSH,
+      );
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "application/x-git-receive-pack-advertisement" },
+      });
+    }
+    if (url.endsWith("/git-receive-pack")) {
+      const report = concat(pkt("unpack ok\n"), pkt("ok refs/heads/main\n"), FLUSH);
+      const channel1 = new Uint8Array(1 + report.length);
+      channel1[0] = 1; // side-band channel 1: pack/report data
+      channel1.set(report, 1);
+      const body = concat(pkt(channel1), FLUSH);
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "application/x-git-receive-pack-result" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+}
+
+describe("squashMerge preserves file modes and symlinks", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("carries exec bits, symlink changes, and additions into the squash commit", async () => {
+    const raw = new MemoryFS();
+    const fs = raw.toNodeFS() as unknown as NodeFS;
+    const gitfs = fs as unknown as Parameters<typeof git.init>[0]["fs"];
+    const dir = "/";
+    const gitdir = "/.git";
+    await git.init({ fs: gitfs, dir, defaultBranch: "main" });
+
+    // Base tree: plain file, non-exec script, symlink -> file.txt, and a file
+    // the workspace deletes.
+    const fileBlob = await blobObject(enc("base\n"));
+    const scriptBlob = await blobObject(enc("#!/bin/sh\nexit 0\n"));
+    const linkToFile = await blobObject(enc("file.txt"));
+    const goneBlob = await blobObject(enc("bye\n"));
+    const baseTree = await treeObject([
+      { mode: "100644", name: "file.txt", oid: fileBlob.oid },
+      { mode: "100644", name: "script.sh", oid: scriptBlob.oid },
+      { mode: "120000", name: "link", oid: linkToFile.oid },
+      { mode: "100644", name: "gone.txt", oid: goneBlob.oid },
+    ]);
+    const base = await commitObject({
+      tree: baseTree.oid,
+      parents: [],
+      message: "base",
+      timestamp: 1700000000,
+    });
+
+    // Workspace tree: script.sh becomes executable (same blob — a mode-only
+    // change), the symlink is retargeted, a new symlink appears, gone.txt is
+    // deleted, file.txt is untouched.
+    const linkToScript = await blobObject(enc("script.sh"));
+    const wsTree = await treeObject([
+      { mode: "100644", name: "file.txt", oid: fileBlob.oid },
+      { mode: "100755", name: "script.sh", oid: scriptBlob.oid },
+      { mode: "120000", name: "link", oid: linkToScript.oid },
+      { mode: "120000", name: "newlink", oid: linkToFile.oid },
+    ]);
+    const ws = await commitObject({
+      tree: wsTree.oid,
+      parents: [base.oid],
+      message: "workspace",
+      timestamp: 1700000001,
+    });
+
+    for (const o of [fileBlob, scriptBlob, linkToFile, goneBlob, baseTree, base]) {
+      await placeLooseObject(fs as never, gitdir, o.oid, o.bytes);
+    }
+    for (const o of [linkToScript, wsTree, ws]) {
+      await placeLooseObject(fs as never, gitdir, o.oid, o.bytes);
+    }
+    await git.writeRef({ fs: gitfs, dir, ref: "refs/heads/main", value: base.oid, force: true });
+    await git.checkout({ fs: gitfs, dir, ref: "main" });
+
+    stubReceivePackServer(base.oid);
+
+    const result = await squashMerge(
+      fs,
+      dir,
+      ws.oid,
+      "https://example.test/git/project.git",
+      "token",
+      author,
+      logger,
+    );
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const commit = await git.readCommit({ fs: gitfs, dir, oid: result.data });
+    expect(commit.commit.parent).toEqual([base.oid]);
+    const tree = await git.readTree({ fs: gitfs, dir, oid: commit.commit.tree });
+    const byPath = new Map(tree.tree.map((e) => [e.path, e]));
+
+    // Exec bit carried over even though the blob is unchanged.
+    expect(byPath.get("script.sh")?.mode).toBe("100755");
+    expect(byPath.get("script.sh")?.oid).toBe(scriptBlob.oid);
+    // Retargeted symlink stays a symlink with the new target.
+    expect(byPath.get("link")?.mode).toBe("120000");
+    expect(byPath.get("link")?.oid).toBe(linkToScript.oid);
+    // New symlink created as a symlink.
+    expect(byPath.get("newlink")?.mode).toBe("120000");
+    expect(byPath.get("newlink")?.oid).toBe(linkToFile.oid);
+    // Untouched + deleted files behave as before.
+    expect(byPath.get("file.txt")?.mode).toBe("100644");
+    expect(byPath.get("gone.txt")).toBeUndefined();
+    // The squash tree equals the workspace tree exactly — full fidelity.
+    expect(commit.commit.tree).toBe(wsTree.oid);
+
+    // The workdir mirrors the commit.
+    const linkTarget = await raw.promises.readlink("/link");
+    expect(linkTarget.success && linkTarget.data === "script.sh").toBe(true);
+    const scriptStat = await raw.promises.lstat("/script.sh");
+    expect(scriptStat.success && scriptStat.data.mode === 0o100755).toBe(true);
+  });
+
+  it("returns the current head untouched when nothing changed", async () => {
+    const raw = new MemoryFS();
+    const fs = raw.toNodeFS() as unknown as NodeFS;
+    const gitfs = fs as unknown as Parameters<typeof git.init>[0]["fs"];
+    const dir = "/";
+    const gitdir = "/.git";
+    await git.init({ fs: gitfs, dir, defaultBranch: "main" });
+
+    const fileBlob = await blobObject(enc("same\n"));
+    const tree = await treeObject([{ mode: "100644", name: "file.txt", oid: fileBlob.oid }]);
+    const base = await commitObject({
+      tree: tree.oid,
+      parents: [],
+      message: "base",
+      timestamp: 1700000000,
+    });
+    const ws = await commitObject({
+      tree: tree.oid,
+      parents: [base.oid],
+      message: "no-op",
+      timestamp: 1700000001,
+    });
+    for (const o of [fileBlob, tree, base, ws]) {
+      await placeLooseObject(fs as never, gitdir, o.oid, o.bytes);
+    }
+    await git.writeRef({ fs: gitfs, dir, ref: "refs/heads/main", value: base.oid, force: true });
+    await git.checkout({ fs: gitfs, dir, ref: "main" });
+
+    const fetchSpy = stubReceivePackServer(base.oid);
+
+    const result = await squashMerge(
+      fs,
+      dir,
+      ws.oid,
+      "https://example.test/git/project.git",
+      "token",
+      author,
+      logger,
+    );
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe(base.oid);
+    // No changes -> no push.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`MemoryFS` silently dropped symlinks (`symlink()` was a success-returning no-op, `readlink()` always `EINVAL`) and synthesized `0o100644` for every file — so any server-side materialization (merge, conflict resolution, backup, REST commit) lost symlinks and executable bits, breaking checkouts downstream.

Now:

- **Symlinks:** `symlink()` creates a real link entry, `readlink()` returns the target, `lstat()` reports `isSymbolicLink()`/`0o120000`; `stat`/`readFile`/`writeFile` follow trailing link chains with an ELOOP cap.
- **Modes:** `writeFile` accepts `{mode}` (any exec bit → 100755); overwrites without a mode keep the existing mode; the `stats.mode` setter is honored (isomorphic-git's exec workaround and gitlink marker) instead of being a no-op. Gitlinks (0o160000) round-trip through the index correctly and emit an explicit warning — full submodule support remains out of scope.
- **`squashMerge`** copies changed entries with tree fidelity: raw blob bytes (no lossy utf-8 decode), explicit modes, symlinks recreated as symlinks, and mode-only chmod/file↔symlink changes detected even when the blob oid is unchanged.
- **`walkDir`** uses `lstat`, so dangling or directory-targeted symlinks no longer abort or wrongly recurse the walk.

**Round trips that now preserve fidelity:** clone→checkout→add/commit→push (proven by a test that re-commits a symlink+exec tree to the *identical tree oid*), the staged-commit/staged-tree merge paths, `squashMerge`, and the object-level paths (3-way merge, backup, staged-tree extraction) that are no longer at risk from the broken workdir.

**Known remaining gaps** (data shapes are plain `{path: content}` string maps; carrying modes there would redesign public APIs — documented for follow-up): new files created via `initAndPush`/`commitAndPush` (REST commits) are 100644 and can't be symlinks; `resolveConflict` reads content as utf-8 text; `readRepoFiles`→sandbox materializes symlinks as target content and drops exec bits; bench-only synthetic trees hardcode 100644.

## Related issues

Closes #184

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

37 new MemoryFS tests including isomorphic-git round trips (checkout of a symlink+exec tree re-commits to the identical tree oid), plus a new `tests/squash-merge-modes.test.ts` exercising `squashMerge` fidelity against a minimal fake git receive-pack server: exec bits, symlink retarget/addition, mode-only changes, deletions. Coverage on `memory-fs.ts`: 100% statements/lines/functions, 98.2% branches (remaining are pre-existing unreachable defensive guards). Full suite: 1273 passed, 0 failures.

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript

---
_Generated by [Claude Code](https://claude.ai/code/session_015dp67PBbFT666GnMLuxvm1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for symbolic links, including valid and dangling links.
  * Preserved executable file permissions during Git operations.
  * Improved handling of links, file modes, and path replacement.

* **Bug Fixes**
  * Directory listings now include symlinks without traversing them.
  * Symlink and executable-mode information is preserved through merges and checkouts.
  * Unsupported Git link entries are safely rejected.
  * Prevented unsafe writes and deletions when paths change type.

* **Tests**
  * Expanded coverage for symlinks, file modes, filesystem operations, and squash merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->