### PR TITLE
Pin the R2/group-commit fast path to the evaluated sha (REPO_DO_ENABLED prerequisite)

### DIFF
--- a/src/queue/repo-do.ts
+++ b/src/queue/repo-do.ts
@@ -5,6 +5,7 @@ import { blobObject, commitObject, treeObject } from "../storage/git-objects";
 import {
   type NodeFS,
   type StagedItemResult,
+  type StagedTree,
   type StagedTreeItem,
   batchMergeStagedTrees,
   cloneRepo,
@@ -12,6 +13,8 @@ import {
   freshRepoToken,
   loadStagedTree,
   mergeWorkspaceIntoProject,
+  stagedTreeKey,
+  stagedTreeShaKey,
 } from "../storage/git-ops";
 import { type CommitOutcome, commitPhasesFromSpans, recordCommitMetrics } from "../storage/metrics";
 import { putObject } from "../storage/object-store";
@@ -229,15 +232,37 @@ export class RepoDO extends DurableObject<Env> {
       return { success: false, error: "Project owner is being deleted" };
     }
 
-    const key = `repos/${project.id}/ws/${change.workspace}`;
-    const staged = await loadStagedTree(bucket, key);
-    if (!staged) return { fallback: true }; // not staged → cold path
+    const latestKey = stagedTreeKey(project.id, change.workspace);
+    // #124: the merge must consume the tree of the EVALUATED commit, not the
+    // latest staged tip (which every re-push overwrites). The pinned sha is the
+    // commit the change was evaluated against (#115/#123 cold-path pinning).
+    const pinnedSha = change.workspaceHeadSha ?? change.evaluatedSha;
+    const shaKey =
+      pinnedSha !== undefined
+        ? stagedTreeShaKey(project.id, change.workspace, pinnedSha)
+        : undefined;
 
-    // SEC-2: content-address the tree we are about to land against what was
-    // evaluated. This closes the residual TOCTOU between the route's pre-merge
-    // tip check and this staged-tree read: if the workspace was re-committed in
-    // that window, the staged tree oid won't match the evaluated tree oid.
-    // Legacy changes (pre-migration 026) have no evaluatedTreeOid and skip it.
+    let staged: StagedTree | null = null;
+    if (shaKey !== undefined) staged = await loadStagedTree(bucket, shaKey);
+    if (!staged) {
+      const latest = await loadStagedTree(bucket, latestKey);
+      if (!latest) return { fallback: true }; // not staged → cold path
+      if (pinnedSha !== undefined) {
+        // No sha-keyed tree (staged before sha-keying shipped, or evicted). The
+        // latest tree is only usable when it provably IS the evaluated content;
+        // otherwise fall back to the git-based path, which merges the pinned
+        // sha (fastForwardMerge / mergeWorkspaceIntoProject both pin, #123/#124).
+        if (change.evaluatedTreeOid === undefined || latest.treeOid !== change.evaluatedTreeOid) {
+          return { fallback: true };
+        }
+      }
+      staged = latest;
+    }
+
+    // SEC-2 + #124: content-address the tree we are about to land against what
+    // was evaluated. Closes the residual TOCTOU between the route's pre-merge
+    // tip check and this staged-tree read, and guards a corrupt sha-keyed
+    // object. Legacy changes (pre-migration 026) have no evaluatedTreeOid and skip it.
     if (change.evaluatedTreeOid !== undefined && staged.treeOid !== change.evaluatedTreeOid) {
       return {
         success: false,
@@ -249,12 +274,24 @@ export class RepoDO extends DurableObject<Env> {
     this.projectRemote = project.remote;
     let result: StagedItemResult;
     try {
-      result = await this.r2Coordinator().submit({ changeId, baseSha: change.baseSha, staged });
+      result = await this.r2Coordinator().submit({
+        changeId,
+        baseSha: change.baseSha,
+        staged,
+        // Re-validated inside the batch merge, right where the synthetic commit
+        // is built (#124 defense in depth; O(1) string compare).
+        ...(change.evaluatedTreeOid !== undefined
+          ? { expectedTreeOid: change.evaluatedTreeOid }
+          : {}),
+      });
     } catch (err) {
       return { success: false, error: err instanceof Error ? err.message : String(err) };
     }
     if (!result.merged || !result.commit) {
-      return { success: false, error: "Merge conflict: change could not be auto-merged" };
+      return {
+        success: false,
+        error: result.reason ?? "Merge conflict: change could not be auto-merged",
+      };
     }
 
     // Keep the cached head fresh so a later change that falls back to advance()
@@ -296,13 +333,21 @@ export class RepoDO extends DurableObject<Env> {
       log.error("Failed to record provenance after R2 merge", provenanceResult.error);
     }
 
-    // GC the staged tree now that it has landed (Task 6).
-    await bucket.delete(key).catch((error) => {
-      log.warn("Failed to delete staged tree", {
-        key,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    });
+    // GC the staged tree now that it has landed (Task 6) — both the latest-tip
+    // key and the merged commit's sha-keyed copy (#124). A newer, unmerged
+    // commit keeps its own sha-keyed copy, so deleting the latest key only ever
+    // costs a later merge its fast path, never its correctness.
+    const gcKeys = shaKey !== undefined ? [latestKey, shaKey] : [latestKey];
+    await Promise.all(
+      gcKeys.map((k) =>
+        bucket.delete(k).catch((error) => {
+          log.warn("Failed to delete staged tree", {
+            key: k,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }),
+      ),
+    );
     return { success: true, commit: result.commit, transitioned };
   }
 
@@ -450,6 +495,11 @@ export class RepoDO extends DurableObject<Env> {
       let commit: string | undefined;
       let outcome: CommitOutcome = "cold_fallback";
 
+      // #124: the commit this merge must land — the sha the change was evaluated
+      // against (#115/#123). Both fields pin the same revision; legacy changes
+      // (pre-migration 024/026) have neither and merge the live tip.
+      const pinnedSha = change.workspaceHeadSha ?? change.evaluatedSha;
+
       // Fast-forward fast path: only when we believe the project head is still the
       // change's base. A wrong cache cannot corrupt anything — the non-force push
       // inside fastForwardMerge rejects, and we cold-merge below.
@@ -462,8 +512,15 @@ export class RepoDO extends DurableObject<Env> {
           expectedParent,
           log,
           timer,
-          change.evaluatedSha,
+          pinnedSha,
         );
+        if (!ff.success && ff.error.code === "PINNED_SHA_UNREACHABLE") {
+          // The evaluated commit is gone from the workspace (force-push rewound
+          // it). No verifiable merge target exists — fail closed with the clear
+          // error instead of cold-merging, which would re-clone only to fail the
+          // same pinned-sha check.
+          return { success: false, error: ff.error.message, code: ff.error.code };
+        }
         if (ff.success && ff.data.fastForwarded && ff.data.commit) {
           commit = ff.data.commit;
           outcome = "fast_forward";
@@ -482,8 +539,10 @@ export class RepoDO extends DurableObject<Env> {
           {
             strategy: "merge",
             timer,
-            // SEC-2: pin the merged tip to the evaluated sha on the RepoDO cold
-            // fallback too. Legacy changes with no evaluatedSha skip it.
+            // Merge the exact evaluated commit (#115/#124) AND assert the pinned
+            // revision matches what was evaluated (SEC-2) — the same pinning the
+            // cold route/MergeQueue paths apply. Legacy changes skip both.
+            ...(change.workspaceHeadSha ? { workspaceSha: change.workspaceHeadSha } : {}),
             ...(change.evaluatedSha !== undefined
               ? { expectedWorkspaceSha: change.evaluatedSha }
               : {}),

--- a/src/queue/repo-do.ts
+++ b/src/queue/repo-do.ts
@@ -242,10 +242,31 @@ export class RepoDO extends DurableObject<Env> {
         ? stagedTreeShaKey(project.id, change.workspace, pinnedSha)
         : undefined;
 
+    // parseStagedTree throws on a truncated header or a malformed tree oid, and
+    // the sha-keyed object is written best-effort by the commit route, so a
+    // partial write is reachable. Nothing up the stack catches it — the caller
+    // in `routes/changes.ts` awaits mergeViaR2 bare — so an unguarded parse
+    // turns one corrupt object into a 500 on an otherwise mergeable change.
+    // The batch route already skips such items; do the equivalent here by
+    // treating a corrupt object as "not staged" and falling back to the git
+    // path, which merges the pinned sha and does not depend on R2 at all.
+    const readStaged = async (key: string): Promise<StagedTree | null> => {
+      try {
+        return await loadStagedTree(bucket, key);
+      } catch (error) {
+        log.error("Corrupt staged tree; falling back to the git path", undefined, {
+          key,
+          changeId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+      }
+    };
+
     let staged: StagedTree | null = null;
-    if (shaKey !== undefined) staged = await loadStagedTree(bucket, shaKey);
+    if (shaKey !== undefined) staged = await readStaged(shaKey);
     if (!staged) {
-      const latest = await loadStagedTree(bucket, latestKey);
+      const latest = await readStaged(latestKey);
       if (!latest) return { fallback: true }; // not staged → cold path
       if (pinnedSha !== undefined) {
         // No sha-keyed tree (staged before sha-keying shipped, or evicted). The
@@ -542,7 +563,12 @@ export class RepoDO extends DurableObject<Env> {
             // Merge the exact evaluated commit (#115/#124) AND assert the pinned
             // revision matches what was evaluated (SEC-2) — the same pinning the
             // cold route/MergeQueue paths apply. Legacy changes skip both.
-            ...(change.workspaceHeadSha ? { workspaceSha: change.workspaceHeadSha } : {}),
+            // pinnedSha, not workspaceHeadSha: a change carrying only
+            // evaluatedSha would otherwise get a pinned fast-forward but an
+            // unpinned cold merge. expectedWorkspaceSha keeps that fail-closed
+            // rather than unsafe, but the cold path could not land the
+            // evaluated commit the fast path lands. Same value, both paths.
+            ...(pinnedSha !== undefined ? { workspaceSha: pinnedSha } : {}),
             ...(change.evaluatedSha !== undefined
               ? { expectedWorkspaceSha: change.evaluatedSha }
               : {}),

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -34,6 +34,8 @@ import {
   getDiffBetweenRepos,
   mergeWorkspaceIntoProject,
   parseStagedTree,
+  stagedTreeKey,
+  stagedTreeShaKey,
 } from "../storage/git-ops";
 import { recordProvenance } from "../storage/provenance";
 import { getProject, getWorkspace } from "../storage/state";
@@ -980,7 +982,14 @@ app.post("/projects/:name/changes/merge-batch", async (c) => {
       skipped.push({ changeId: m.changeId, reason: "workspace changed since evaluation" });
       continue;
     }
-    items.push({ changeId: m.changeId, baseSha: m.baseSha, staged });
+    items.push({
+      changeId: m.changeId,
+      baseSha: m.baseSha,
+      staged,
+      // #124 defense in depth: re-validated inside batchMergeStagedTrees, right
+      // where the synthetic commit is built (O(1) string compare).
+      ...(evaluatedTreeOid !== undefined ? { expectedTreeOid: evaluatedTreeOid } : {}),
+    });
   }
   if (items.length === 0) {
     clonePromise.catch(() => {});
@@ -1019,8 +1028,15 @@ app.post("/projects/:name/changes/merge-batch", async (c) => {
     }
     const change = changeById.get(r.changeId);
     landed.push({ changeId: r.changeId, commit: r.commit, change });
-    gcKeys.push(`repos/${project.id}/ws/${change?.workspace}`);
-    if (change?.workspace) mergedWorkspaces.push(change.workspace);
+    if (change?.workspace) {
+      gcKeys.push(stagedTreeKey(project.id, change.workspace));
+      // #124: GC the merged commit's immutable sha-keyed staged-tree copy too.
+      const pinnedSha = change.workspaceHeadSha ?? change.evaluatedSha;
+      if (pinnedSha !== undefined) {
+        gcKeys.push(stagedTreeShaKey(project.id, change.workspace, pinnedSha));
+      }
+      mergedWorkspaces.push(change.workspace);
+    }
     merged.push(r.changeId);
   }
   const mergedAt = new Date().toISOString();

--- a/src/routes/workspaces.ts
+++ b/src/routes/workspaces.ts
@@ -7,6 +7,8 @@ import {
   commitAndPush,
   freshRepoToken,
   stageWorkspaceTree,
+  stagedTreeKey,
+  stagedTreeShaKey,
 } from "../storage/git-ops";
 import {
   deleteWorkspace,
@@ -284,7 +286,7 @@ app.post("/:name/commit", async (c) => {
   if (c.env.REPO_DO_ENABLED === "true" && c.env.REPO_OBJECTS) {
     const stageResult = await stageWorkspaceTree(
       c.env.REPO_OBJECTS,
-      `repos/${project.id}/ws/${workspaceName}`,
+      stagedTreeKey(project.id, workspaceName),
       fs,
       dir,
       commitResult.data,
@@ -294,20 +296,37 @@ app.post("/:name/commit", async (c) => {
       logger.warn("Failed to stage workspace tree to R2; merge will use cold path", {
         workspaceName,
       });
-    } else if (c.env.REPO_DO) {
-      // Also seed the per-repo DO's local hot index so the batch-merge path reads
-      // staged trees from SQLite (microseconds) instead of R2 (~30ms/change).
-      const stub = c.env.REPO_DO.get(c.env.REPO_DO.idFromName(project.id)) as unknown as {
-        stageTree(workspace: string, value: ArrayBuffer): Promise<void>;
-      };
-      await stub
-        .stageTree(workspaceName, stageResult.data.value.buffer as ArrayBuffer)
-        .catch((error) => {
-          logger.warn("Failed to seed DO hot index; batch merge will skip this change", {
-            workspaceName,
-            error: error instanceof Error ? error.message : String(error),
-          });
+    } else {
+      // #124: also store the tree under an immutable sha-keyed copy. The
+      // latest-tip key above is overwritten by every commit; the merge path
+      // reads the sha-keyed copy for the change's pinned workspace_head_sha, so
+      // a re-push between evaluation and merge cannot change what gets merged.
+      // Best-effort like the rest of staging: on failure the merge falls back
+      // to the git-based pinned path.
+      await c.env.REPO_OBJECTS.put(
+        stagedTreeShaKey(project.id, workspaceName, commitResult.data),
+        stageResult.data.value,
+      ).catch((error) => {
+        logger.warn("Failed to write sha-keyed staged tree; merge will use pinned git path", {
+          workspaceName,
+          error: error instanceof Error ? error.message : String(error),
         });
+      });
+      if (c.env.REPO_DO) {
+        // Also seed the per-repo DO's local hot index so the batch-merge path reads
+        // staged trees from SQLite (microseconds) instead of R2 (~30ms/change).
+        const stub = c.env.REPO_DO.get(c.env.REPO_DO.idFromName(project.id)) as unknown as {
+          stageTree(workspace: string, value: ArrayBuffer): Promise<void>;
+        };
+        await stub
+          .stageTree(workspaceName, stageResult.data.value.buffer as ArrayBuffer)
+          .catch((error) => {
+            logger.warn("Failed to seed DO hot index; batch merge will skip this change", {
+              workspaceName,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
+      }
     }
   }
 

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -589,16 +589,21 @@ export interface FastForwardResult {
 }
 
 /**
- * Attempt a fast-forward of the project's main to the workspace tip, skipping the
- * project clone and the in-memory 3-way merge that {@link mergeWorkspaceIntoProject}
- * performs. Correctness does not depend on a cached head: the non-force push is
- * accepted by Artifacts only when the project ref is still `expectedParent` (a
- * true fast-forward). Any race or non-descendant tip returns `fastForwarded:
- * false` so the caller falls back to the proven cold merge.
+ * Attempt a fast-forward of the project's main to the pinned workspace commit
+ * (the evaluated sha, #124) — or the workspace tip for legacy unpinned changes —
+ * skipping the project clone and the in-memory 3-way merge that
+ * {@link mergeWorkspaceIntoProject} performs. Correctness does not depend on a
+ * cached head: the non-force push is accepted by Artifacts only when the project
+ * ref is still `expectedParent` (a true fast-forward). Any race or non-descendant
+ * target returns `fastForwarded: false` so the caller falls back to the proven
+ * cold merge.
  *
  * Note: this still fetches the workspace fork (its objects live in a separate
  * Artifacts repo); what it removes is the project clone (`depth:50`) + `git.merge`.
  */
+/** Local ref used to push a pinned (non-tip) workspace commit to the project. */
+const PINNED_MERGE_REF = "refs/heads/stratum-pinned-merge";
+
 export async function fastForwardMerge(
   projectRemote: string,
   projectToken: string,
@@ -607,10 +612,14 @@ export async function fastForwardMerge(
   expectedParent: string,
   logger: Logger,
   timer?: PhaseTimer,
-  /** SEC-2: if set, refuse to fast-forward unless the workspace tip equals this
-   * (the evaluated sha), so a re-committed workspace can't be FF-merged
-   * unevaluated. On mismatch the caller cold-merges, which rejects it. */
-  expectedWorkspaceSha?: string,
+  /** #124: the evaluated workspace commit (`change.workspace_head_sha`). When
+   * set, the fast-forward TARGETS this sha: if the live tip moved past it
+   * (re-push between evaluation and merge), the PINNED sha is pushed — not the
+   * unevaluated tip. If the pinned sha is no longer present in the fetched
+   * workspace history (force-push rewound it), the merge fails closed with
+   * `PINNED_SHA_UNREACHABLE`. Omit for legacy live-tip behavior (changes that
+   * predate migration 024). */
+  pinnedWorkspaceSha?: string,
 ): Promise<Result<FastForwardResult, AppError>> {
   const measure = <T>(name: string, fn: () => Promise<T>): Promise<T> =>
     timer ? timer.measure(name, fn) : fn();
@@ -627,21 +636,40 @@ export async function fastForwardMerge(
   }
   const workspaceTip = tipResult.data;
 
-  // SEC-2: don't fast-forward a workspace that moved since evaluation. Fall back
-  // to cold merge (pinned) which returns STALE_WORKSPACE.
-  if (expectedWorkspaceSha !== undefined && workspaceTip !== expectedWorkspaceSha) {
-    logger.warn("Workspace tip changed since evaluation; refusing fast-forward", {
+  // The commit this merge will land. Defaults to the live tip (legacy changes
+  // with no pinned sha); a pinned change always lands its EVALUATED commit.
+  let target = workspaceTip;
+  if (pinnedWorkspaceSha !== undefined && pinnedWorkspaceSha !== workspaceTip) {
+    // Re-push between evaluation and merge. The merge gate is only sound if the
+    // commit that lands is the one that was evaluated (#123/#124), so merge the
+    // pinned sha — after proving it still exists in the fetched history.
+    const pinnedResult = await fromPromise(git.readCommit({ fs, dir, oid: pinnedWorkspaceSha }));
+    if (!pinnedResult.success) {
+      logger.error("Pinned workspace sha not reachable in workspace; failing closed", undefined, {
+        workspaceRemote,
+        pinnedWorkspaceSha,
+        workspaceTip,
+      });
+      return err(
+        new AppError(
+          "Evaluated workspace commit is no longer present in the workspace history; re-evaluate the change before merging",
+          "PINNED_SHA_UNREACHABLE",
+          409,
+        ),
+      );
+    }
+    logger.warn("Workspace tip moved since evaluation; fast-forwarding to the pinned sha", {
       workspaceRemote,
-      expected: expectedWorkspaceSha,
-      actual: workspaceTip,
+      pinned: pinnedWorkspaceSha,
+      tip: workspaceTip,
     });
-    return ok({ fastForwarded: false });
+    target = pinnedWorkspaceSha;
   }
 
-  // A fast-forward is only possible if the workspace tip descends from the
+  // A fast-forward is only possible if the merge target descends from the
   // project's current head. If not (or history is too shallow to tell), cold-merge.
   const descResult = await fromPromise(
-    git.isDescendent({ fs, dir, oid: workspaceTip, ancestor: expectedParent, depth: -1 }),
+    git.isDescendent({ fs, dir, oid: target, ancestor: expectedParent, depth: -1 }),
   );
   if (!descResult.success) {
     // Most commonly: expectedParent is older than the shallow workspace clone, so
@@ -649,13 +677,29 @@ export async function fastForwardMerge(
     // never fast-forwards and would otherwise look like the FF path "works".
     logger.warn("Could not determine workspace descent; falling back to cold merge", {
       workspaceRemote,
-      workspaceTip,
+      target,
       expectedParent,
     });
     return ok({ fastForwarded: false });
   }
   if (descResult.data !== true) {
     return ok({ fastForwarded: false });
+  }
+
+  // Push the target. The common case (target === tip) pushes the clone's `main`
+  // exactly as before; a pinned non-tip target is pushed via a local ref written
+  // at the pinned commit — O(1) extra work, no additional network round trips.
+  let pushRef = "main";
+  if (target !== workspaceTip) {
+    const writeRefResult = await fromPromise(
+      git.writeRef({ fs, dir, ref: PINNED_MERGE_REF, value: target, force: true }),
+    );
+    if (!writeRefResult.success) {
+      return err(
+        new ExternalServiceError("Git", "Failed to write pinned merge ref", writeRefResult.error),
+      );
+    }
+    pushRef = PINNED_MERGE_REF;
   }
 
   const pushResult = await measure("pushMs", () =>
@@ -665,7 +709,7 @@ export async function fastForwardMerge(
         dir,
         http,
         url: projectRemote,
-        ref: "main",
+        ref: pushRef,
         remoteRef: "main",
         onAuth: makeAuth(projectToken),
       }),
@@ -676,8 +720,11 @@ export async function fastForwardMerge(
     return ok({ fastForwarded: false });
   }
 
-  logger.info("Fast-forwarded project to workspace tip", { projectRemote, sha: workspaceTip });
-  return ok({ fastForwarded: true, commit: workspaceTip });
+  logger.info("Fast-forwarded project to evaluated workspace commit", {
+    projectRemote,
+    sha: target,
+  });
+  return ok({ fastForwarded: true, commit: target });
 }
 
 export interface BatchWorkspace {
@@ -940,8 +987,10 @@ const TREE_OID_HEX_LEN = 40;
 
 /**
  * Stage a workspace's tip TREE to R2 (ADR 004 Task 3): one value =
- * `[40-byte tipTreeOid][packed tree objects]`. Recomputed on every commit so the
- * merge always sees the LIVE tip (no stale snapshot) without fetching the fork.
+ * `[40-byte tipTreeOid][packed tree objects]`. Recomputed on every commit. The
+ * caller stores it under both the latest-tip key (overwritten per commit) and a
+ * sha-keyed copy (`<key>/sha/<commitSha>`, #124) so the merge can consume the
+ * tree of the EVALUATED commit even if the workspace was re-pushed since.
  */
 export async function stageWorkspaceTree(
   bucket: R2Bucket,
@@ -997,6 +1046,18 @@ export function parseStagedTree(value: Uint8Array): StagedTree {
   return { treeOid, objects };
 }
 
+/** R2 key of the latest-tip staged tree for a workspace (overwritten per commit). */
+export function stagedTreeKey(projectId: string, workspace: string): string {
+  return `repos/${projectId}/ws/${workspace}`;
+}
+
+/** #124: sha-keyed staged-tree copy — immutable per workspace commit, so the
+ * merge can read the EVALUATED commit's tree after a re-push overwrote the
+ * latest-tip key. */
+export function stagedTreeShaKey(projectId: string, workspace: string, sha: string): string {
+  return `${stagedTreeKey(projectId, workspace)}/sha/${sha}`;
+}
+
 /** Load a workspace's staged tip tree from R2 (see stageWorkspaceTree). */
 export async function loadStagedTree(bucket: R2Bucket, key: string): Promise<StagedTree | null> {
   const obj = await bucket.get(key);
@@ -1008,13 +1069,23 @@ export interface StagedTreeItem {
   changeId: string;
   baseSha: string;
   staged: StagedTree;
+  /** #124: tree oid the change was evaluated against. When set, the synthetic
+   * commit is only built and merged if the staged tree matches — validating at
+   * the merge layer that what lands is exactly the evaluated content. */
+  expectedTreeOid?: string;
 }
 
 export interface StagedItemResult {
   changeId: string;
   merged: boolean;
   commit?: string;
+  /** Why the item did not merge (validation failure vs plain conflict). */
+  reason?: string;
 }
+
+/** Reason reported when a staged tree fails the evaluated-tree validation. */
+export const STALE_STAGED_TREE_REASON =
+  "Workspace changed since evaluation: staged tree does not match the evaluated revision";
 
 /**
  * Group-commit batch over R2-staged workspace trees (ADR 004 Task 5): operates on
@@ -1035,33 +1106,52 @@ export async function batchMergeStagedTrees(
 ): Promise<Result<StagedItemResult[], AppError>> {
   const gitdir = `${dir === "/" ? "" : dir}/.git`;
 
+  // #124 validation (O(1) per item — a string compare): a staged tree that does
+  // not match the tree the change was evaluated against must not be synthesized
+  // into a commit, let alone merged. Sha-keyed staging makes this a corruption
+  // guard rather than a common path.
+  const eligible = items.map(
+    (item) => item.expectedTreeOid === undefined || item.staged.treeOid === item.expectedTreeOid,
+  );
+
   // Phase 1 (off the merge critical path): place every item's objects, then build
   // the synthetic commits. The synth SHA-1 (`commitObject`) is async crypto with real
   // per-call overhead — running them sequentially inside the merge loop was the
   // dominant cost; `Promise.all` lets the crypto overlap. (Placement stays sequential:
   // concurrent writes race on MemoryFS object-dir creation.)
-  for (const item of items) {
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (!item || !eligible[i]) continue;
     for (const o of item.staged.objects) await placeLooseObject(fs, gitdir, o.oid, o.bytes);
   }
   const synths = await Promise.all(
-    items.map((item) =>
-      commitObject({
-        tree: item.staged.treeOid,
-        parents: [item.baseSha],
-        message: `change ${item.changeId}`,
-        timestamp: Math.floor(Date.now() / 1000),
-      }),
+    items.map((item, i) =>
+      eligible[i]
+        ? commitObject({
+            tree: item.staged.treeOid,
+            parents: [item.baseSha],
+            message: `change ${item.changeId}`,
+            timestamp: Math.floor(Date.now() / 1000),
+          })
+        : Promise.resolve(null),
     ),
   );
-  for (const synth of synths) await placeLooseObject(fs, gitdir, synth.oid, synth.bytes);
+  for (const synth of synths) {
+    if (synth) await placeLooseObject(fs, gitdir, synth.oid, synth.bytes);
+  }
 
   // Phase 2: serial merge loop (the ref advance must be serialized). Checkpoint/
   // restore around each so a conflict can't dirty the next.
   const results: StagedItemResult[] = [];
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
+    if (!item) continue;
+    if (!eligible[i]) {
+      results.push({ changeId: item.changeId, merged: false, reason: STALE_STAGED_TREE_REASON });
+      continue;
+    }
     const synthOid = synths[i]?.oid;
-    if (!item || !synthOid) continue;
+    if (!synthOid) continue;
     const checkpoint = await fromPromise(git.resolveRef({ fs, dir, ref: "main" }));
     if (!checkpoint.success) {
       results.push({ changeId: item.changeId, merged: false });

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -719,6 +719,9 @@ export interface FastForwardResult {
   commit?: string;
 }
 
+/** Local ref used to push a pinned (non-tip) workspace commit to the project. */
+const PINNED_MERGE_REF = "refs/heads/stratum-pinned-merge";
+
 /**
  * Attempt a fast-forward of the project's main to the pinned workspace commit
  * (the evaluated sha, #124) — or the workspace tip for legacy unpinned changes —
@@ -732,9 +735,6 @@ export interface FastForwardResult {
  * Note: this still fetches the workspace fork (its objects live in a separate
  * Artifacts repo); what it removes is the project clone (`depth:50`) + `git.merge`.
  */
-/** Local ref used to push a pinned (non-tip) workspace commit to the project. */
-const PINNED_MERGE_REF = "refs/heads/stratum-pinned-merge";
-
 export async function fastForwardMerge(
   projectRemote: string,
   projectToken: string,

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -1856,9 +1856,63 @@ describe("POST /api/projects/:name/changes/merge-batch", () => {
     const body = (await res.json()) as { skipped: { changeId: string; reason: string }[] };
     const skippedB2 = body.skipped.find((s) => s.changeId === "chg_b2");
     expect(skippedB2?.reason).toBe("workspace changed since evaluation");
-    // Only chg_b1 reaches the merge.
-    const items = vi.mocked(batchMergeStagedTrees).mock.calls[0]?.[4] as { changeId: string }[];
+    // Only chg_b1 reaches the merge, carrying its evaluated tree oid so the
+    // merge layer re-validates right where the synthetic commit is built (#124).
+    const items = vi.mocked(batchMergeStagedTrees).mock.calls[0]?.[4] as {
+      changeId: string;
+      expectedTreeOid?: string;
+    }[];
     expect(items.map((i) => i.changeId)).toEqual(["chg_b1"]);
+    expect(items[0]?.expectedTreeOid).toBe("a".repeat(40));
+  });
+
+  it("#124: GCs both the latest and the sha-keyed staged-tree copies of a merged pinned change", async () => {
+    vi.mocked(getChangesByIds).mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: "chg_b1",
+          project: "my-project",
+          workspace: "fix-bug",
+          status: "approved",
+          baseSha: "base1",
+          workspaceHeadSha: "wshead1",
+          evaluatedSha: "wshead1",
+          evaluatedTreeOid: "a".repeat(40),
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal Change stub
+    } as any);
+    vi.mocked(batchMergeStagedTrees).mockResolvedValue({
+      success: true,
+      data: [{ changeId: "chg_b1", merged: true, commit: "merge-1" }],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal result stub
+    } as any);
+    const r2Deletes: string[] = [];
+    env.REPO_OBJECTS = {
+      delete: vi.fn(async (k: string) => {
+        r2Deletes.push(k);
+      }),
+      // biome-ignore lint/suspicious/noExplicitAny: minimal R2 stub
+    } as any;
+
+    const res = await app.fetch(
+      request(
+        "POST",
+        "/api/projects/my-project/changes/merge-batch",
+        { changeIds: ["chg_b1"], force: true },
+        USER_AUTH,
+      ),
+      env,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal ExecutionContext
+      exec() as any,
+    );
+    expect(res.status).toBe(200);
+    await Promise.all(waitUntils);
+    expect(r2Deletes.sort()).toEqual([
+      "repos/proj_test123/ws/fix-bug",
+      "repos/proj_test123/ws/fix-bug/sha/wshead1",
+    ]);
   });
 
   it("rejects a batch above the size cap", async () => {

--- a/tests/fastpath-sha-pinning.test.ts
+++ b/tests/fastpath-sha-pinning.test.ts
@@ -1,0 +1,343 @@
+/**
+ * #124: the R2/group-commit fast path must land the EVALUATED commit
+ * (change.workspace_head_sha), never the workspace's live tip or the latest
+ * staged tree. Exercises the real git logic (isomorphic-git over MemoryFS);
+ * only the network legs — `git.clone` (builds a scripted workspace history
+ * with deterministic oids) and `git.push` (records what would be pushed) —
+ * are stubbed.
+ */
+import git from "isomorphic-git";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  STALE_STAGED_TREE_REASON,
+  batchMergeStagedTrees,
+  extractTreeObjects,
+  fastForwardMerge,
+} from "../src/storage/git-ops";
+import { MemoryFS } from "../src/storage/memory-fs";
+import { createLogger } from "../src/utils/logger";
+
+const state = vi.hoisted(() => ({
+  build: undefined as undefined | ((fs: unknown, dir: string) => Promise<unknown>),
+  pushes: [] as { url?: string; ref?: string; remoteRef?: string; oid?: string }[],
+  rejectPush: false,
+}));
+
+vi.mock("isomorphic-git", async (importActual) => {
+  const actual = await importActual<typeof import("isomorphic-git")>();
+  const real = actual.default;
+  return {
+    ...actual,
+    default: {
+      ...real,
+      clone: vi.fn(async (args: { fs: unknown; dir: string }) => {
+        if (!state.build) throw new Error("no repo builder configured for git.clone");
+        await state.build(args.fs, args.dir);
+      }),
+      push: vi.fn(
+        async (args: {
+          fs: never;
+          dir: string;
+          url?: string;
+          ref?: string;
+          remoteRef?: string;
+        }) => {
+          if (state.rejectPush) throw new Error("push rejected (non-fast-forward)");
+          const oid = await real.resolveRef({
+            fs: args.fs,
+            dir: args.dir,
+            ref: args.ref ?? "HEAD",
+          });
+          state.pushes.push({ url: args.url, ref: args.ref, remoteRef: args.remoteRef, oid });
+          return { ok: true, error: null, refs: {} };
+        },
+      ),
+    },
+  };
+});
+
+const logger = createLogger({ component: "test" });
+const AUTHOR = { name: "Stratum", email: "system@usestratum.dev" };
+
+type AnyFS = never;
+
+/**
+ * Deterministic workspace history: commit 0 = base (expectedParent), commit 1 =
+ * the evaluated (pinned) commit, commit 2 = a re-push that moved the tip past
+ * the evaluated sha. Fixed author timestamps -> identical oids on every build,
+ * so tests can precompute the shas the mocked `git.clone` will produce.
+ */
+async function buildHistory(fsAny: unknown, dir: string, commits: number): Promise<string[]> {
+  const fs = fsAny as AnyFS;
+  const oids: string[] = [];
+  await git.init({ fs, dir, defaultBranch: "main" });
+  const files = ["README.md", "evaluated.txt", "newer.txt"];
+  const prefix = dir === "/" ? "" : dir;
+  for (let i = 0; i < commits; i++) {
+    const path = files[i] ?? `f${i}.txt`;
+    await (
+      fsAny as { promises: { writeFile(p: string, d: string): Promise<void> } }
+    ).promises.writeFile(`${prefix}/${path}`, `content ${i}\n`);
+    await git.add({ fs, dir, filepath: path });
+    oids.push(
+      await git.commit({
+        fs,
+        dir,
+        message: `c${i}`,
+        author: { ...AUTHOR, timestamp: 1700000000 + i, timezoneOffset: 0 },
+      }),
+    );
+  }
+  return oids;
+}
+
+async function precomputeOids(commits: number): Promise<string[]> {
+  return buildHistory(new MemoryFS().toNodeFS(), "/pre", commits);
+}
+
+describe("fastForwardMerge pinned-sha targeting (#124)", () => {
+  beforeEach(() => {
+    state.build = undefined;
+    state.pushes = [];
+    state.rejectPush = false;
+  });
+
+  const callFF = (expectedParent: string, pinned?: string) =>
+    fastForwardMerge(
+      "https://proj.example/repo.git",
+      "ptok",
+      "https://ws.example/repo.git",
+      "wtok",
+      expectedParent,
+      logger,
+      undefined,
+      pinned,
+    );
+
+  it("no re-push (tip === pinned): fast-forwards main to the tip exactly as before", async () => {
+    const [base, evaluated] = await precomputeOids(2);
+    state.build = (fs, dir) => buildHistory(fs, dir, 2);
+
+    const result = await callFF(base as string, evaluated);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toEqual({ fastForwarded: true, commit: evaluated });
+    expect(state.pushes).toHaveLength(1);
+    expect(state.pushes[0]).toMatchObject({ ref: "main", remoteRef: "main", oid: evaluated });
+  });
+
+  it("re-push between eval and merge: pushes the PINNED sha, not the moved tip", async () => {
+    const [base, evaluated, newer] = await precomputeOids(3);
+    state.build = (fs, dir) => buildHistory(fs, dir, 3);
+
+    const result = await callFF(base as string, evaluated);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    // The evaluated commit lands — the unevaluated tip does not.
+    expect(result.data.fastForwarded).toBe(true);
+    expect(result.data.commit).toBe(evaluated);
+    expect(result.data.commit).not.toBe(newer);
+    expect(state.pushes).toHaveLength(1);
+    expect(state.pushes[0]?.oid).toBe(evaluated);
+    expect(state.pushes[0]?.remoteRef).toBe("main");
+    expect(state.pushes[0]?.ref).not.toBe("main"); // pinned commit rides a local ref
+  });
+
+  it("pinned sha absent from the workspace history: fails closed with a clear error, nothing pushed", async () => {
+    const [base] = await precomputeOids(2);
+    state.build = (fs, dir) => buildHistory(fs, dir, 2);
+
+    const result = await callFF(base as string, "0123456789abcdef0123456789abcdef01234567");
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe("PINNED_SHA_UNREACHABLE");
+    expect(result.error.message).toMatch(/no longer present/);
+    expect(state.pushes).toHaveLength(0);
+  });
+
+  it("pinned sha that does not descend from the expected parent: declines the fast-forward (cold fallback)", async () => {
+    const [, evaluated, newer] = await precomputeOids(3);
+    state.build = (fs, dir) => buildHistory(fs, dir, 3);
+
+    // expectedParent = the tip itself; the (older) pinned commit cannot be a
+    // fast-forward of it.
+    const result = await callFF(newer as string, evaluated);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.fastForwarded).toBe(false);
+    expect(state.pushes).toHaveLength(0);
+  });
+
+  it("declines the fast-forward when descent from the expected parent cannot be proven", async () => {
+    const [, evaluated] = await precomputeOids(2);
+    state.build = (fs, dir) => buildHistory(fs, dir, 2);
+
+    // expectedParent unknown to the clone (e.g. beyond the shallow history):
+    // isDescendent cannot prove ancestry -> cold fallback, nothing pushed.
+    const result = await callFF("9999999999999999999999999999999999999999", evaluated);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.fastForwarded).toBe(false);
+    expect(state.pushes).toHaveLength(0);
+  });
+
+  it("legacy change with no pinned sha: fast-forwards to the live tip (behavior unchanged)", async () => {
+    const [base, , newer] = await precomputeOids(3);
+    state.build = (fs, dir) => buildHistory(fs, dir, 3);
+
+    const result = await callFF(base as string, undefined);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toEqual({ fastForwarded: true, commit: newer });
+    expect(state.pushes[0]).toMatchObject({ ref: "main", oid: newer });
+  });
+
+  it("push rejection still degrades to the cold fallback", async () => {
+    const [base, evaluated] = await precomputeOids(2);
+    state.build = (fs, dir) => buildHistory(fs, dir, 2);
+    state.rejectPush = true;
+
+    const result = await callFF(base as string, evaluated);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.fastForwarded).toBe(false);
+  });
+});
+
+describe("batchMergeStagedTrees evaluated-tree validation (#124)", () => {
+  beforeEach(() => {
+    state.build = undefined;
+    state.pushes = [];
+    state.rejectPush = false;
+  });
+
+  /** Project repo (base commit) + a workspace commit whose tree we stage. */
+  async function setup() {
+    const fsNode = new MemoryFS().toNodeFS();
+    const fs = fsNode as AnyFS;
+    const dir = "/proj";
+    await git.init({ fs, dir, defaultBranch: "main" });
+    const write = async (path: string, content: string) => {
+      await (
+        fsNode as { promises: { writeFile(p: string, d: string): Promise<void> } }
+      ).promises.writeFile(`${dir}/${path}`, content);
+      await git.add({ fs, dir, filepath: path });
+    };
+    await write("README.md", "base\n");
+    const base = await git.commit({
+      fs,
+      dir,
+      message: "base",
+      author: { ...AUTHOR, timestamp: 1700000000, timezoneOffset: 0 },
+    });
+    // Workspace branch from base: add ws.txt — its tree is what gets staged.
+    await git.branch({ fs, dir, ref: "ws", object: base });
+    await git.checkout({ fs, dir, ref: "ws" });
+    await write("ws.txt", "ws\n");
+    const wsTip = await git.commit({
+      fs,
+      dir,
+      message: "ws",
+      author: { ...AUTHOR, timestamp: 1700000001, timezoneOffset: 0 },
+    });
+    await git.checkout({ fs, dir, ref: "main" });
+    const wsTreeOid = (await git.readCommit({ fs, dir, oid: wsTip })).commit.tree;
+    const objects = await extractTreeObjects(fsNode as never, dir, wsTreeOid);
+    return { fsNode, dir, base, wsTreeOid, objects };
+  }
+
+  it("a staged tree that mismatches the evaluated tree oid is refused at the merge layer; nothing pushed", async () => {
+    const { fsNode, dir, base, wsTreeOid, objects } = await setup();
+
+    const result = await batchMergeStagedTrees(
+      fsNode as never,
+      dir,
+      "https://proj.example/repo.git",
+      "ptok",
+      [
+        {
+          changeId: "chg_stale",
+          baseSha: base,
+          staged: { treeOid: wsTreeOid, objects },
+          expectedTreeOid: "b".repeat(40), // evaluated against a different tree
+        },
+      ],
+      logger,
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toEqual([
+      { changeId: "chg_stale", merged: false, reason: STALE_STAGED_TREE_REASON },
+    ]);
+    expect(state.pushes).toHaveLength(0);
+    // main untouched.
+    const files = await git.listFiles({ fs: fsNode as AnyFS, dir, ref: "main" });
+    expect(files).toEqual(["README.md"]);
+  });
+
+  it("a matching staged tree merges; a stale one in the same batch is refused without dirtying it", async () => {
+    const { fsNode, dir, base, wsTreeOid, objects } = await setup();
+
+    const result = await batchMergeStagedTrees(
+      fsNode as never,
+      dir,
+      "https://proj.example/repo.git",
+      "ptok",
+      [
+        {
+          changeId: "chg_stale",
+          baseSha: base,
+          staged: { treeOid: wsTreeOid, objects },
+          expectedTreeOid: "b".repeat(40),
+        },
+        {
+          changeId: "chg_ok",
+          baseSha: base,
+          staged: { treeOid: wsTreeOid, objects },
+          expectedTreeOid: wsTreeOid, // matches the evaluated tree
+        },
+      ],
+      logger,
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data[0]).toEqual({
+      changeId: "chg_stale",
+      merged: false,
+      reason: STALE_STAGED_TREE_REASON,
+    });
+    expect(result.data[1]?.merged).toBe(true);
+    expect(result.data[1]?.commit).toBeDefined();
+    expect(state.pushes).toHaveLength(1);
+    // The evaluated content landed on main.
+    const files = await git.listFiles({ fs: fsNode as AnyFS, dir, ref: "main" });
+    expect(files.sort()).toEqual(["README.md", "ws.txt"]);
+  });
+
+  it("items without an expectedTreeOid (legacy) merge exactly as before", async () => {
+    const { fsNode, dir, base, wsTreeOid, objects } = await setup();
+
+    const result = await batchMergeStagedTrees(
+      fsNode as never,
+      dir,
+      "https://proj.example/repo.git",
+      "ptok",
+      [{ changeId: "chg_legacy", baseSha: base, staged: { treeOid: wsTreeOid, objects } }],
+      logger,
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data[0]?.merged).toBe(true);
+    expect(state.pushes).toHaveLength(1);
+  });
+});

--- a/tests/repo-do.test.ts
+++ b/tests/repo-do.test.ts
@@ -327,6 +327,32 @@ describe("RepoDO.advance sha pinning (#124)", () => {
     expect(vi.mocked(fastForwardMerge).mock.calls[0]?.[7]).toBe("eval-sha");
   });
 
+  it("cold fallback pins with evaluatedSha when workspaceHeadSha is absent", async () => {
+    // The fast path pins with `workspaceHeadSha ?? evaluatedSha`. The cold
+    // options used to read workspaceHeadSha alone, so an evaluatedSha-only
+    // change got a pinned fast-forward but an unpinned cold merge — fail-closed
+    // via expectedWorkspaceSha, but unable to land the very commit the fast
+    // path lands. Both paths must pin the same revision.
+    setChange("base1", { evaluatedSha: "eval-sha" });
+    vi.mocked(fastForwardMerge).mockResolvedValue({
+      success: true,
+      data: { fastForwarded: false },
+    });
+    const { ctx, store } = makeCtx();
+    store.set("head", "base1");
+    const repo = new RepoDO(ctx, env);
+
+    await repo.advance("chg_1");
+
+    expect(mergeWorkspaceIntoProject).toHaveBeenCalledTimes(1);
+    const opts = vi.mocked(mergeWorkspaceIntoProject).mock.calls[0]?.[5] as {
+      workspaceSha?: string;
+      expectedWorkspaceSha?: string;
+    };
+    expect(opts.workspaceSha).toBe("eval-sha");
+    expect(opts.expectedWorkspaceSha).toBe("eval-sha");
+  });
+
   it("legacy change (no pinned fields): fast-forward runs unpinned (live tip)", async () => {
     setChange("base1");
     const { ctx, store } = makeCtx();
@@ -448,6 +474,42 @@ describe("RepoDO.mergeViaR2 sha-keyed staged trees (#124)", () => {
     // Head cache advanced; both staged-tree copies GC'd.
     expect(store.get("head")).toBe("r2-commit");
     expect(deleted.sort()).toEqual([LATEST_KEY, SHA_KEY].sort());
+  });
+
+  it("corrupt sha-keyed object falls back to the git path instead of throwing", async () => {
+    // parseStagedTree throws on a truncated header or malformed oid, and
+    // nothing up the stack catches it — routes/changes.ts awaits mergeViaR2
+    // bare — so an unguarded parse turned one corrupt object into a 500 on an
+    // otherwise mergeable change. The batch route already skips such items.
+    vi.mocked(loadStagedTree).mockImplementation(async (_bucket, key: string) => {
+      if (key === SHA_KEY) throw new Error("Invalid staged tree: truncated header");
+      return { treeOid: NEWER_TREE, objects: [] };
+    });
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, r2env);
+
+    const result = await repo.mergeViaR2("chg_1");
+
+    // Falls back to the git path, which merges the pinned sha without R2.
+    expect(result).toEqual({ fallback: true });
+    expect(batchMergeStagedTrees).not.toHaveBeenCalled();
+    expect(markChangeMerged).not.toHaveBeenCalled();
+    // Nothing GC'd: no merge happened.
+    expect(deleted).toEqual([]);
+  });
+
+  it("corrupt LATEST object also falls back rather than throwing", async () => {
+    vi.mocked(loadStagedTree).mockImplementation(async (_bucket, key: string) => {
+      if (key === SHA_KEY) return null;
+      throw new Error("Invalid staged tree: malformed tree oid");
+    });
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, r2env);
+
+    const result = await repo.mergeViaR2("chg_1");
+
+    expect(result).toEqual({ fallback: true });
+    expect(batchMergeStagedTrees).not.toHaveBeenCalled();
   });
 
   it("sha key missing and latest tree is NOT the evaluated content: falls back (nothing merged via R2)", async () => {

--- a/tests/repo-do.test.ts
+++ b/tests/repo-do.test.ts
@@ -22,6 +22,13 @@ vi.mock("../src/storage/git-ops", () => ({
   freshRepoToken: vi.fn(async () => ({ success: true, data: "tok" })),
   fastForwardMerge: vi.fn(),
   mergeWorkspaceIntoProject: vi.fn(),
+  cloneRepo: vi.fn(async () => ({ success: true, data: { fs: {}, dir: "/" } })),
+  batchMergeStagedTrees: vi.fn(),
+  loadStagedTree: vi.fn(async () => null),
+  // Real key layout (pure helpers) so key-construction assertions are meaningful.
+  stagedTreeKey: (projectId: string, workspace: string) => `repos/${projectId}/ws/${workspace}`,
+  stagedTreeShaKey: (projectId: string, workspace: string, sha: string) =>
+    `repos/${projectId}/ws/${workspace}/sha/${sha}`,
 }));
 vi.mock("../src/storage/provenance", () => ({
   recordProvenance: vi.fn(async () => ({ success: true, data: undefined })),
@@ -33,7 +40,12 @@ vi.mock("../src/storage/metrics", () => ({
 
 import { RepoDO } from "../src/queue/repo-do";
 import { getChange, markChangeMerged } from "../src/storage/changes";
-import { fastForwardMerge, mergeWorkspaceIntoProject } from "../src/storage/git-ops";
+import {
+  batchMergeStagedTrees,
+  fastForwardMerge,
+  loadStagedTree,
+  mergeWorkspaceIntoProject,
+} from "../src/storage/git-ops";
 import { recordCommitMetrics } from "../src/storage/metrics";
 import { recordProvenance } from "../src/storage/provenance";
 import { getProject, getWorkspace } from "../src/storage/state";
@@ -72,10 +84,17 @@ function makeCtx(): { ctx: DurableObjectState; store: Map<string, unknown> } {
   return { ctx, store };
 }
 
-function setChange(baseSha?: string) {
+function setChange(baseSha?: string, extra: Record<string, unknown> = {}) {
   vi.mocked(getChange).mockResolvedValue({
     success: true,
-    data: { id: "chg_1", project: "acme/web", workspace: "ws_1", status: "approved", baseSha },
+    data: {
+      id: "chg_1",
+      project: "acme/web",
+      workspace: "ws_1",
+      status: "approved",
+      baseSha,
+      ...extra,
+    },
     // biome-ignore lint/suspicious/noExplicitAny: minimal Change stub
   } as any);
 }
@@ -275,5 +294,281 @@ describe("RepoDO hot index (staged trees in local SQLite)", () => {
     await repo.stageTree("a", bytes([1]));
     await repo.gcStagedTrees([]);
     expect(await repo.getStagedTrees(["a"])).toHaveLength(1);
+  });
+});
+
+// #124: the fast paths must land the EVALUATED commit (change.workspace_head_sha),
+// not the workspace's live tip / latest staged tree.
+describe("RepoDO.advance sha pinning (#124)", () => {
+  it("threads the pinned workspace_head_sha into fastForwardMerge and lands it", async () => {
+    setChange("base1", { workspaceHeadSha: "pinned-sha", evaluatedSha: "pinned-sha" });
+    vi.mocked(fastForwardMerge).mockResolvedValue({
+      success: true,
+      data: { fastForwarded: true, commit: "pinned-sha" },
+    });
+    const { ctx, store } = makeCtx();
+    store.set("head", "base1");
+    const repo = new RepoDO(ctx, env);
+
+    const result = await repo.advance("chg_1");
+
+    expect(result).toEqual({ success: true, commit: "pinned-sha", transitioned: true });
+    expect(vi.mocked(fastForwardMerge).mock.calls[0]?.[7]).toBe("pinned-sha");
+    expect(mergeWorkspaceIntoProject).not.toHaveBeenCalled();
+    expect(store.get("head")).toBe("pinned-sha");
+  });
+
+  it("falls back to evaluatedSha as the pin when workspaceHeadSha is absent", async () => {
+    setChange("base1", { evaluatedSha: "eval-sha" });
+    const { ctx, store } = makeCtx();
+    store.set("head", "base1");
+    const repo = new RepoDO(ctx, env);
+    await repo.advance("chg_1");
+    expect(vi.mocked(fastForwardMerge).mock.calls[0]?.[7]).toBe("eval-sha");
+  });
+
+  it("legacy change (no pinned fields): fast-forward runs unpinned (live tip)", async () => {
+    setChange("base1");
+    const { ctx, store } = makeCtx();
+    store.set("head", "base1");
+    const repo = new RepoDO(ctx, env);
+    const result = await repo.advance("chg_1");
+    expect(result.success).toBe(true);
+    expect(vi.mocked(fastForwardMerge).mock.calls[0]?.[7]).toBeUndefined();
+  });
+
+  it("fails closed (nothing merged, no cold retry) when the pinned sha is gone from the workspace", async () => {
+    setChange("base1", { workspaceHeadSha: "pinned-sha", evaluatedSha: "pinned-sha" });
+    vi.mocked(fastForwardMerge).mockResolvedValue({
+      success: false,
+      error: {
+        message: "Evaluated workspace commit is no longer present in the workspace history",
+        code: "PINNED_SHA_UNREACHABLE",
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: minimal AppError stub
+    } as any);
+    const { ctx, store } = makeCtx();
+    store.set("head", "base1");
+    const repo = new RepoDO(ctx, env);
+
+    const result = await repo.advance("chg_1");
+
+    expect(result.success).toBe(false);
+    expect(result.code).toBe("PINNED_SHA_UNREACHABLE");
+    expect(result.error).toMatch(/no longer present/);
+    expect(mergeWorkspaceIntoProject).not.toHaveBeenCalled();
+    expect(markChangeMerged).not.toHaveBeenCalled();
+    expect(store.get("head")).toBe("base1"); // head not advanced
+  });
+
+  it("still cold-merges on any other fast-forward error", async () => {
+    setChange("base1", { workspaceHeadSha: "pinned-sha", evaluatedSha: "pinned-sha" });
+    vi.mocked(fastForwardMerge).mockResolvedValue({
+      success: false,
+      error: { message: "network sad", code: "EXTERNAL_SERVICE_ERROR" },
+      // biome-ignore lint/suspicious/noExplicitAny: minimal AppError stub
+    } as any);
+    const { ctx, store } = makeCtx();
+    store.set("head", "base1");
+    const repo = new RepoDO(ctx, env);
+    const result = await repo.advance("chg_1");
+    expect(result).toEqual({ success: true, commit: "merge-commit", transitioned: true });
+    expect(mergeWorkspaceIntoProject).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins the cold fallback the same way the cold route/queue paths do", async () => {
+    setChange("base1", { workspaceHeadSha: "pinned-sha", evaluatedSha: "pinned-sha" });
+    vi.mocked(fastForwardMerge).mockResolvedValue({
+      success: true,
+      data: { fastForwarded: false },
+    });
+    const { ctx, store } = makeCtx();
+    store.set("head", "base1");
+    const repo = new RepoDO(ctx, env);
+
+    const result = await repo.advance("chg_1");
+
+    expect(result.success).toBe(true);
+    const opts = vi.mocked(mergeWorkspaceIntoProject).mock.calls[0]?.[5];
+    expect(opts?.workspaceSha).toBe("pinned-sha");
+    expect(opts?.expectedWorkspaceSha).toBe("pinned-sha");
+  });
+});
+
+describe("RepoDO.mergeViaR2 sha-keyed staged trees (#124)", () => {
+  const EVAL_TREE = "e".repeat(40);
+  const NEWER_TREE = "f".repeat(40);
+  const LATEST_KEY = "repos/proj_1/ws/ws_1";
+  const SHA_KEY = "repos/proj_1/ws/ws_1/sha/pinned-sha";
+
+  let deleted: string[];
+  let bucket: { delete: ReturnType<typeof vi.fn> };
+  let r2env: Env;
+
+  beforeEach(() => {
+    deleted = [];
+    bucket = {
+      delete: vi.fn(async (k: string) => {
+        deleted.push(k);
+      }),
+    };
+    r2env = { ...env, REPO_OBJECTS: bucket } as unknown as Env;
+    setChange("base1", {
+      workspaceHeadSha: "pinned-sha",
+      evaluatedSha: "pinned-sha",
+      evaluatedTreeOid: EVAL_TREE,
+    });
+    vi.mocked(batchMergeStagedTrees).mockImplementation(
+      // biome-ignore lint/suspicious/noExplicitAny: mirrors the mocked signature
+      async (_fs: any, _dir: any, _remote: any, _tok: any, items: any[]) => ({
+        success: true,
+        data: items.map((it) => ({ changeId: it.changeId, merged: true, commit: "r2-commit" })),
+      }),
+    );
+  });
+
+  it("re-push between eval and merge: consumes the sha-keyed (evaluated) tree, not the newer latest tree", async () => {
+    vi.mocked(loadStagedTree).mockImplementation(async (_bucket, key: string) =>
+      key === SHA_KEY ? { treeOid: EVAL_TREE, objects: [] } : { treeOid: NEWER_TREE, objects: [] },
+    );
+    const { ctx, store } = makeCtx();
+    const repo = new RepoDO(ctx, r2env);
+
+    const result = await repo.mergeViaR2("chg_1");
+
+    expect(result).toEqual({ success: true, commit: "r2-commit", transitioned: true });
+    // The sha-keyed copy was preferred and its (evaluated) tree was merged.
+    expect(vi.mocked(loadStagedTree).mock.calls[0]?.[1]).toBe(SHA_KEY);
+    const items = vi.mocked(batchMergeStagedTrees).mock.calls[0]?.[4] as {
+      staged: { treeOid: string };
+      expectedTreeOid?: string;
+    }[];
+    expect(items[0]?.staged.treeOid).toBe(EVAL_TREE);
+    expect(items[0]?.expectedTreeOid).toBe(EVAL_TREE);
+    // Head cache advanced; both staged-tree copies GC'd.
+    expect(store.get("head")).toBe("r2-commit");
+    expect(deleted.sort()).toEqual([LATEST_KEY, SHA_KEY].sort());
+  });
+
+  it("sha key missing and latest tree is NOT the evaluated content: falls back (nothing merged via R2)", async () => {
+    vi.mocked(loadStagedTree).mockImplementation(async (_bucket, key: string) =>
+      key === SHA_KEY ? null : { treeOid: NEWER_TREE, objects: [] },
+    );
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, r2env);
+
+    const result = await repo.mergeViaR2("chg_1");
+
+    expect(result).toEqual({ fallback: true });
+    expect(batchMergeStagedTrees).not.toHaveBeenCalled();
+    expect(markChangeMerged).not.toHaveBeenCalled();
+    expect(deleted).toEqual([]);
+  });
+
+  it("sha key missing but latest tree IS the evaluated content: merges it", async () => {
+    vi.mocked(loadStagedTree).mockImplementation(async (_bucket, key: string) =>
+      key === SHA_KEY ? null : { treeOid: EVAL_TREE, objects: [] },
+    );
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, r2env);
+    const result = await repo.mergeViaR2("chg_1");
+    expect(result).toMatchObject({ success: true, commit: "r2-commit" });
+  });
+
+  it("sha-keyed tree that mismatches the evaluated tree oid: clear failure, nothing merged", async () => {
+    vi.mocked(loadStagedTree).mockImplementation(async (_bucket, key: string) =>
+      key === SHA_KEY ? { treeOid: NEWER_TREE, objects: [] } : null,
+    );
+    const { ctx, store } = makeCtx();
+    const repo = new RepoDO(ctx, r2env);
+
+    const result = await repo.mergeViaR2("chg_1");
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error?: string }).error).toMatch(/does not match the evaluated revision/);
+    expect(batchMergeStagedTrees).not.toHaveBeenCalled();
+    expect(markChangeMerged).not.toHaveBeenCalled();
+    expect(store.get("head")).toBeUndefined();
+    expect(deleted).toEqual([]);
+  });
+
+  it("no staged tree anywhere: falls back to the git-based path", async () => {
+    vi.mocked(loadStagedTree).mockResolvedValue(null);
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, r2env);
+    const result = await repo.mergeViaR2("chg_1");
+    expect(result).toEqual({ fallback: true });
+  });
+
+  it("legacy change (no pinned fields): reads only the latest key, normal flow unchanged", async () => {
+    setChange("base1");
+    vi.mocked(loadStagedTree).mockResolvedValue({ treeOid: NEWER_TREE, objects: [] });
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, r2env);
+
+    const result = await repo.mergeViaR2("chg_1");
+
+    expect(result).toMatchObject({ success: true, commit: "r2-commit" });
+    expect(loadStagedTree).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(loadStagedTree).mock.calls[0]?.[1]).toBe(LATEST_KEY);
+    // No sha key to GC — only the latest key.
+    expect(deleted).toEqual([LATEST_KEY]);
+  });
+
+  it("surfaces the batch validation reason when the merge layer rejects a stale tree", async () => {
+    vi.mocked(loadStagedTree).mockImplementation(async (_bucket, key: string) =>
+      key === SHA_KEY ? { treeOid: EVAL_TREE, objects: [] } : null,
+    );
+    vi.mocked(batchMergeStagedTrees).mockResolvedValue({
+      success: true,
+      data: [
+        {
+          changeId: "chg_1",
+          merged: false,
+          reason: "Workspace changed since evaluation: staged tree does not match",
+        },
+      ],
+    });
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, r2env);
+
+    const result = await repo.mergeViaR2("chg_1");
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error?: string }).error).toMatch(/staged tree does not match/);
+    expect(markChangeMerged).not.toHaveBeenCalled();
+  });
+
+  it("a failed batch (e.g. push rejected) surfaces the error and merges nothing", async () => {
+    vi.mocked(loadStagedTree).mockImplementation(async (_bucket, key: string) =>
+      key === SHA_KEY ? { treeOid: EVAL_TREE, objects: [] } : null,
+    );
+    vi.mocked(batchMergeStagedTrees).mockResolvedValue({
+      success: false,
+      error: { message: "Batch push failed" },
+      // biome-ignore lint/suspicious/noExplicitAny: minimal error stub
+    } as any);
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, r2env);
+
+    const result = await repo.mergeViaR2("chg_1");
+
+    expect(result).toMatchObject({ success: false, error: "Batch push failed" });
+    expect(markChangeMerged).not.toHaveBeenCalled();
+    expect(deleted).toEqual([]);
+  });
+
+  it("falls back when the change has no baseSha (no synthetic-merge parent)", async () => {
+    setChange(undefined, { workspaceHeadSha: "pinned-sha", evaluatedTreeOid: EVAL_TREE });
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, r2env);
+    expect(await repo.mergeViaR2("chg_1")).toEqual({ fallback: true });
+    expect(loadStagedTree).not.toHaveBeenCalled();
+  });
+
+  it("falls back when REPO_OBJECTS is not bound", async () => {
+    const { ctx } = makeCtx();
+    const repo = new RepoDO(ctx, env); // env without REPO_OBJECTS
+    expect(await repo.mergeViaR2("chg_1")).toEqual({ fallback: true });
   });
 });

--- a/tests/workspace-authz.test.ts
+++ b/tests/workspace-authz.test.ts
@@ -40,10 +40,13 @@ vi.mock("../src/storage/git-ops", () => ({
   commitAndPush: vi.fn(async () => ({ success: true, data: "sha_new" })),
   freshRepoToken: vi.fn(async () => ({ success: true, data: "tok" })),
   stageWorkspaceTree: vi.fn(),
+  stagedTreeKey: (projectId: string, workspace: string) => `repos/${projectId}/ws/${workspace}`,
+  stagedTreeShaKey: (projectId: string, workspace: string, sha: string) =>
+    `repos/${projectId}/ws/${workspace}/sha/${sha}`,
 }));
 vi.mock("../src/queue/events", () => ({ emitEvent: vi.fn(async () => undefined) }));
 
-import { commitAndPush } from "../src/storage/git-ops";
+import { commitAndPush, stageWorkspaceTree } from "../src/storage/git-ops";
 import { getProjectById, getWorkspace } from "../src/storage/state";
 import { canWriteProject, canWriteWorkspace } from "../src/utils/authz";
 
@@ -120,6 +123,45 @@ describe("POST /api/workspaces/:name/commit — authorization", () => {
     );
     expect(res.status).toBe(200);
     expect(commitAndPush).toHaveBeenCalled();
+  });
+
+  it("#124: stages the tip tree under BOTH the latest key and an immutable sha-keyed copy", async () => {
+    vi.mocked(canWriteProject).mockResolvedValue(true);
+    const stagedValue = new Uint8Array([1, 2, 3]);
+    vi.mocked(stageWorkspaceTree).mockResolvedValue({
+      success: true,
+      data: { treeOid: "t".repeat(40), objectCount: 1, value: stagedValue },
+      // biome-ignore lint/suspicious/noExplicitAny: minimal stage result stub
+    } as any);
+    const puts: { key: string; value: unknown }[] = [];
+    const stageTree = vi.fn(async () => {});
+    const env = {
+      ...makeEnv(),
+      REPO_DO_ENABLED: "true",
+      REPO_OBJECTS: {
+        put: vi.fn(async (key: string, value: unknown) => {
+          puts.push({ key, value });
+        }),
+      },
+      REPO_DO: { idFromName: (n: string) => n, get: () => ({ stageTree }) },
+    } as unknown as Env;
+
+    const res = await makeApp().fetch(
+      new Request("http://localhost/api/workspaces/fix-bug/commit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...WRITER },
+        body: JSON.stringify(body),
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+
+    // Latest-tip staging (existing behavior) ...
+    expect(vi.mocked(stageWorkspaceTree).mock.calls[0]?.[1]).toBe("repos/proj_1/ws/fix-bug");
+    // ... plus the sha-keyed copy of the same value, keyed by the new commit sha.
+    expect(puts).toEqual([{ key: "repos/proj_1/ws/fix-bug/sha/sha_new", value: stagedValue }]);
+    // The DO hot index is still seeded.
+    expect(stageTree).toHaveBeenCalledTimes(1);
   });
 
   it("rejects an oversized file map before doing any work", async () => {


### PR DESCRIPTION
## Summary

Closes the TOCTOU that #123 fixed for the cold path but that remained on the fast paths: a re-push between evaluation and merge could change what lands on `main` when `REPO_DO_ENABLED=true`. (Main had already evolved past the issue text — #133 added assert-only `evaluatedSha`/`evaluatedTreeOid` checks that made a moved tip a hard failure; this PR closes the remaining gap by *merging the pinned sha* instead of refusing or racing.)

**Advance/FF path:** `fastForwardMerge` now takes `change.workspace_head_sha` (falling back to `evaluatedSha`) as its target. Tip unchanged → identical behavior (one string compare added). Tip moved past the pin → the pinned commit is `readCommit`-verified, proven descendant of the expected parent, and the **pinned** sha is pushed to project `main` via a local ref — the unevaluated tip never lands. Pinned sha gone (force-push) → fails closed with `PINNED_SHA_UNREACHABLE`, head/status untouched. RepoDO's cold fallback is now pinned identically to the cold route/MergeQueue paths.

**R2 path:** the commit route stores the staged tree under both the latest key and an immutable `repos/<pid>/ws/<ws>/sha/<commitSha>` copy. `mergeViaR2` reads the sha-keyed copy for the change's pinned sha first, so a re-push (which overwrites the latest key) cannot change what merges; on sha-key miss the latest tree is used only when it content-addresses to `evaluatedTreeOid`, otherwise it falls back to the git-based pinned path; a corrupt sha-keyed object fails closed. `batchMergeStagedTrees` re-validates each item's tree against the evaluated oid at synthetic-commit build time. Merged changes GC both copies.

**Perf:** O(1) extra work per merge on every hot path — no extra clones or round trips. Common case: one string compare (FF), the same single R2 GET (sha key instead of latest key), one extra parallel R2 PUT per workspace commit.

**Benchmark status:** the local throughput model (`tests/group-commit.test.ts`) passes unchanged at 431.1 c/s vs the 22.6 c/s floor (`GroupCommitCoordinator` untouched). The real staging benchmark (`scripts/bench-commit-throughput.ts` against a deployed Worker) **must be re-run before/after deploying this and before `REPO_DO_ENABLED=true` ships to prod** — it cannot run in this environment.

Reviewer notes: a re-push during the merge race window now lands the *pinned* sha on the fast paths instead of erroring `STALE_WORKSPACE` (matching the cold path's existing semantics; the route-level pre-merge freshness check still 409s stale non-forced merges). Sha-keyed staged trees for never-merged changes accumulate (same lifecycle gap as other `repos/<pid>/` objects) — an R2 lifecycle rule is a follow-up.

## Related issues

Closes #124

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

121 tests across the new `tests/fastpath-sha-pinning.test.ts` and extended repo-do/changes/workspace suites: re-push → pinned sha / sha-keyed tree merged (real-git assertions on the pushed oid), pinned-sha-missing → clear failure with nothing merged, tree-mismatch validation at both layers, legacy/no-re-push flows unchanged. 100% of the new logic is exercised; every uncovered line in the touched regions is a pre-existing error/restore path. Full suite: 1265 passed, 0 failed.

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript

---
_Generated by [Claude Code](https://claude.ai/code/session_015dp67PBbFT666GnMLuxvm1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Merges now consistently use the evaluated workspace commit, preventing newer workspace changes from being merged accidentally.
  * Stale, corrupt, or unreachable staged content is rejected safely instead of being merged.
  * Merge failures now provide more specific reasons.
  * Cleanup removes both current and immutable staged data after successful merges.

* **Improvements**
  * Workspace staging now preserves immutable commit snapshots and improves merge reliability.
  * Evaluated tree validation helps ensure only the intended staged changes are merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->