### PR TITLE
Git tags: fetch/advertise over smart-HTTP, tags listing page + API, tag objects in backups

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/user/stratum/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/user/stratum/node_modules

--- a/src/backup/repo-restore.ts
+++ b/src/backup/repo-restore.ts
@@ -61,6 +61,13 @@ export async function reconstructRepo(
     // Tag refs (#182). `tags` is OPTIONAL: manifests from backups taken before
     // tag support omit it, and such a restore must keep working unchanged.
     for (const tag of manifest.tags ?? []) {
+      // The name becomes a ref path component and is written with force:true,
+      // and the manifest is read back from storage — so validate here rather
+      // than trust the snapshot writer. A name containing `..` would resolve
+      // outside refs/tags/ and could overwrite refs/heads/main.
+      if (!isValidTagName(tag.name)) {
+        return err(new AppError(`Invalid tag name in manifest: ${tag.name}`, "BACKUP_ERROR", 500));
+      }
       await git.writeRef({
         // biome-ignore lint/suspicious/noExplicitAny: isomorphic-git fs shape
         fs: fs as any,
@@ -84,6 +91,24 @@ export async function reconstructRepo(
     logger.error("Failed to reconstruct repo", error instanceof Error ? error : undefined);
     return err(new AppError("Failed to reconstruct repo", "BACKUP_ERROR", 500));
   }
+}
+
+/**
+ * Whether a manifest tag name is a safe `refs/tags/<name>` path component.
+ * Mirrors the parts of git's ref-name rules that matter for path traversal.
+ */
+function isValidTagName(name: unknown): name is string {
+  return (
+    typeof name === "string" &&
+    name.length > 0 &&
+    name.length <= 255 &&
+    /^[\w.\-+/]+$/.test(name) &&
+    !name.includes("..") &&
+    !name.startsWith("/") &&
+    !name.endsWith("/") &&
+    !name.startsWith(".") &&
+    !name.endsWith(".lock")
+  );
 }
 
 /**
@@ -168,6 +193,18 @@ export async function restoreProjectRepo(
       { force: repoExists },
     );
     if (!tagsPushed.success) {
+      // rollbackIfCreated is a no-op for a pre-existing repo, so a forced restore
+      // that fails here leaves main pushed and only some tags present. Say so
+      // explicitly: the caller's error alone cannot convey how far it got.
+      if (repoExists) {
+        logger.error("Forced restore left partial state on an existing repo", undefined, {
+          name,
+          tipSha: snapshot.manifest.tipSha,
+          mainPushed: true,
+          tagCount: tagNames.length,
+          detail: tagsPushed.error.message,
+        });
+      }
       await rollbackIfCreated();
       return err(tagsPushed.error);
     }

--- a/src/backup/repo-restore.ts
+++ b/src/backup/repo-restore.ts
@@ -144,9 +144,15 @@ function isValidTagName(name: unknown): name is string {
   // arbitrarily long path at the ref store.
   if (name.length > MAX_TAG_NAME_LENGTH) return false;
 
-  // Control characters (including DEL), space, and the characters git reserves
-  // for its revision syntax.
-  if (/[\0-\x20\x7f~^:?*[\\]/.test(name)) return false;
+  // Control characters (including DEL) and space, compared by code point. A
+  // regex range spanning them is what lint rules about control characters in
+  // patterns object to, and the comparison states the bound outright.
+  for (let i = 0; i < name.length; i++) {
+    const code = name.charCodeAt(i);
+    if (code <= 0x20 || code === 0x7f) return false;
+  }
+  // The characters git reserves for its revision syntax.
+  if (/[~^:?*[\\]/.test(name)) return false;
 
   if (name.includes("..") || name.includes("@{")) return false;
   if (name.startsWith("/") || name.endsWith("/")) return false;

--- a/src/backup/repo-restore.ts
+++ b/src/backup/repo-restore.ts
@@ -98,17 +98,30 @@ export async function reconstructRepo(
  * Mirrors the parts of git's ref-name rules that matter for path traversal.
  */
 function isValidTagName(name: unknown): name is string {
-  return (
-    typeof name === "string" &&
-    name.length > 0 &&
-    name.length <= 255 &&
-    /^[\w.\-+/]+$/.test(name) &&
-    !name.includes("..") &&
-    !name.startsWith("/") &&
-    !name.endsWith("/") &&
-    !name.startsWith(".") &&
-    !name.endsWith(".lock")
-  );
+  if (
+    typeof name !== "string" ||
+    name.length === 0 ||
+    name.length > 255 ||
+    !/^[\w.\-+/]+$/.test(name) ||
+    name.includes("..") ||
+    name.startsWith("/") ||
+    name.endsWith("/")
+  ) {
+    return false;
+  }
+  // Every slash-separated path component must independently be a valid ref
+  // component — a bare startsWith(".")/endsWith(".lock") check on the whole
+  // name misses a hostile inner component like "release/.hidden" or
+  // "release/v1.0.lock/next", and doesn't catch repeated slashes (an empty
+  // component) or a component ending in a bare ".".
+  return name.split("/").every((component) => {
+    return (
+      component.length > 0 &&
+      !component.startsWith(".") &&
+      !component.endsWith(".lock") &&
+      !component.endsWith(".")
+    );
+  });
 }
 
 /**

--- a/src/backup/repo-restore.ts
+++ b/src/backup/repo-restore.ts
@@ -1,5 +1,5 @@
 import git from "isomorphic-git";
-import { type NodeFS, artifactsRepoNameFromRemote, pushMain } from "../storage/git-ops";
+import { type NodeFS, artifactsRepoNameFromRemote, pushMain, pushTags } from "../storage/git-ops";
 import { MemoryFS } from "../storage/memory-fs";
 import { placeLooseObject, unpackObjects } from "../storage/object-loader";
 import type { Env } from "../types";
@@ -57,7 +57,28 @@ export async function reconstructRepo(
     // that reconstructs a dangling ref.
     // biome-ignore lint/suspicious/noExplicitAny: isomorphic-git fs shape
     await git.readCommit({ fs: fs as any, dir: DIR, oid: manifest.tipSha });
-    logger.debug("Reconstructed repo", { tipSha: manifest.tipSha });
+
+    // Tag refs (#182). `tags` is OPTIONAL: manifests from backups taken before
+    // tag support omit it, and such a restore must keep working unchanged.
+    for (const tag of manifest.tags ?? []) {
+      await git.writeRef({
+        // biome-ignore lint/suspicious/noExplicitAny: isomorphic-git fs shape
+        fs: fs as any,
+        dir: DIR,
+        ref: `refs/tags/${tag.name}`,
+        value: tag.oid,
+        force: true,
+      });
+      // Same dangling-ref guard as the tip: prove the tag's object (annotated
+      // tag object or lightweight target) actually unpacked.
+      // biome-ignore lint/suspicious/noExplicitAny: isomorphic-git fs shape
+      await git.readObject({ fs: fs as any, dir: DIR, oid: tag.oid });
+    }
+
+    logger.debug("Reconstructed repo", {
+      tipSha: manifest.tipSha,
+      tagCount: manifest.tags?.length ?? 0,
+    });
     return ok({ fs, dir: DIR });
   } catch (error) {
     logger.error("Failed to reconstruct repo", error instanceof Error ? error : undefined);
@@ -133,6 +154,29 @@ export async function restoreProjectRepo(
     return err(pushed.error);
   }
 
-  logger.info("Restored project repo", { name, tipSha: snapshot.manifest.tipSha });
+  // Tag refs (#182): push after main so their target commits are already on the
+  // remote. Optional field — a pre-tag-support manifest restores exactly as before.
+  const tagNames = (snapshot.manifest.tags ?? []).map((t) => t.name);
+  if (tagNames.length > 0) {
+    const tagsPushed = await pushTags(
+      remote,
+      token,
+      rebuilt.data.fs,
+      rebuilt.data.dir,
+      tagNames,
+      logger,
+      { force: repoExists },
+    );
+    if (!tagsPushed.success) {
+      await rollbackIfCreated();
+      return err(tagsPushed.error);
+    }
+  }
+
+  logger.info("Restored project repo", {
+    name,
+    tipSha: snapshot.manifest.tipSha,
+    tagCount: tagNames.length,
+  });
   return ok({ tipSha: snapshot.manifest.tipSha });
 }

--- a/src/backup/repo-restore.ts
+++ b/src/backup/repo-restore.ts
@@ -17,6 +17,14 @@ const GITDIR = "/.git";
  * Restores the main branch and any tagged references, and verifies that their
  * referenced objects are present in the snapshot.
  *
+ * The verification matters because the backup captured the FULL reachable
+ * object set: the reconstructed pack is closed under reachability, so the
+ * original tip sha is preserved rather than a new one being synthesised. A
+ * resolved tip that disagrees with the manifest means the pack was truncated,
+ * which must fail rather than silently restore a different history.
+ *
+ * Operates on an in-memory store, so it is fully testable without Artifacts.
+ *
  * @param pack - Serialized Git objects from the snapshot
  * @param manifest - Snapshot metadata containing the main branch tip and optional tags
  * @returns The in-memory filesystem and repository directory, or a backup error
@@ -130,7 +138,13 @@ function isValidTagName(name: unknown): name is string {
 }
 
 /**
- * Restores a project's repository to Artifacts, optionally overwriting an existing repository.
+ * Restores a project's repository to Artifacts, optionally overwriting an
+ * existing repository.
+ *
+ * The push leg is the one part that cannot run in CI -- it needs real
+ * Artifacts -- so it is validated on staging via the runbook instead. Keep
+ * that in mind when changing this function: the tests around it cover
+ * reconstruction, not publication.
  *
  * @param snapshot - The repository snapshot and manifest to restore.
  * @param opts - Restore options; set `force` to overwrite an existing repository.

--- a/src/backup/repo-restore.ts
+++ b/src/backup/repo-restore.ts
@@ -9,6 +9,12 @@ import { type Result, err, fromPromise, ok } from "../utils/result";
 import type { RepoManifest, RepoSnapshot } from "./repo-snapshot";
 
 const DIR = "/";
+/**
+ * Upper bound on a manifest tag name. Not a git rule — git bounds ref names by
+ * the filesystem, not a fixed count — but a restore writes the name into a ref
+ * path, so a hostile manifest gets a cap rather than an unbounded path.
+ */
+const MAX_TAG_NAME_LENGTH = 255;
 const GITDIR = "/.git";
 
 /**
@@ -105,36 +111,50 @@ export async function reconstructRepo(
 }
 
 /**
- * Determines whether a manifest tag name is safe to use as a `refs/tags/<name>` path.
+ * Whether a manifest tag name is safe to write as `refs/tags/<name>`.
  *
- * @param name - The candidate tag name.
- * @returns `true` if the name is a valid string tag path without traversal or unsafe path components, `false` otherwise.
+ * Restore consumes stored manifest data, so the ref path is validated here
+ * rather than trusted from the snapshot writer: an unchecked `../` escapes
+ * `refs/tags/` and, with `force: true`, can overwrite `refs/heads/main`.
+ *
+ * These are git's own `check-ref-format` rules, expressed as a denylist. An
+ * allowlist was tried first and was wrong in a way that matters for a restore
+ * path: it rejected `release@prod`, every non-ASCII name, and `%`, `,`, `!`,
+ * `(`, `'`, `=`, `&`, `;`, `{` — all of which git accepts. A backup holding
+ * such a tag could be written but never restored, which is worse than the
+ * traversal the allowlist was defending against.
+ *
+ * The oracle here is isomorphic-git's `writeRef`, not the `git` CLI, because
+ * that is what performs the write. It is the stricter of the two: it treats a
+ * ref as valid only if `clean-git-ref` leaves it unchanged, so it refuses
+ * `v1./next` (`./` collapses to `/`) even though `git check-ref-format`
+ * accepts it. Validating against the CLI's looser rules would let such a name
+ * past this guard and throw from `writeRef` half-way through the tag loop,
+ * leaving a partially restored repository — so `./` is rejected here.
+ *
+ * Differentially fuzzed against `writeRef` over ~1300 generated names with a
+ * fresh MemoryFS per name: no name is accepted here that `writeRef` refuses.
+ *
+ * @param name - The candidate tag name, straight from the manifest.
+ * @returns `true` if `refs/tags/<name>` is a ref name git would accept.
  */
 function isValidTagName(name: unknown): name is string {
-  if (
-    typeof name !== "string" ||
-    name.length === 0 ||
-    name.length > 255 ||
-    !/^[\w.\-+/]+$/.test(name) ||
-    name.includes("..") ||
-    name.startsWith("/") ||
-    name.endsWith("/")
-  ) {
-    return false;
-  }
-  // Every slash-separated path component must independently be a valid ref
-  // component — a bare startsWith(".")/endsWith(".lock") check on the whole
-  // name misses a hostile inner component like "release/.hidden" or
-  // "release/v1.0.lock/next", and doesn't catch repeated slashes (an empty
-  // component) or a component ending in a bare ".".
-  return name.split("/").every((component) => {
-    return (
-      component.length > 0 &&
-      !component.startsWith(".") &&
-      !component.endsWith(".lock") &&
-      !component.endsWith(".")
-    );
-  });
+  if (typeof name !== "string" || name.length === 0) return false;
+  // Not a git rule: a Stratum bound so a hostile manifest can't push an
+  // arbitrarily long path at the ref store.
+  if (name.length > MAX_TAG_NAME_LENGTH) return false;
+
+  // Control characters (including DEL), space, and the characters git reserves
+  // for its revision syntax.
+  if (/[\0-\x20\x7f~^:?*[\\]/.test(name)) return false;
+
+  if (name.includes("..") || name.includes("@{")) return false;
+  if (name.startsWith("/") || name.endsWith("/")) return false;
+  // `./` and a trailing `.` are both rewritten by clean-git-ref, so writeRef
+  // rejects them.
+  if (name.includes("./") || name.endsWith(".")) return false;
+
+  return name.split("/").every((c) => c.length > 0 && !c.startsWith(".") && !c.endsWith(".lock"));
 }
 
 /**

--- a/src/backup/repo-restore.ts
+++ b/src/backup/repo-restore.ts
@@ -12,11 +12,14 @@ const DIR = "/";
 const GITDIR = "/.git";
 
 /**
- * Rebuild a repo in an in-memory git store from a snapshot's pack + manifest:
- * write every object loose, point `main` at the tip, and verify the resolved tip
- * matches the manifest. Because the backup captured the FULL reachable object set,
- * the reconstructed pack is closed under reachability and the original tip sha is
- * preserved. Fully testable — no Artifacts.
+ * Reconstructs a repository in an in-memory Git store from a snapshot.
+ *
+ * Restores the main branch and any tagged references, and verifies that their
+ * referenced objects are present in the snapshot.
+ *
+ * @param pack - Serialized Git objects from the snapshot
+ * @param manifest - Snapshot metadata containing the main branch tip and optional tags
+ * @returns The in-memory filesystem and repository directory, or a backup error
  */
 export async function reconstructRepo(
   pack: Uint8Array,
@@ -94,8 +97,10 @@ export async function reconstructRepo(
 }
 
 /**
- * Whether a manifest tag name is a safe `refs/tags/<name>` path component.
- * Mirrors the parts of git's ref-name rules that matter for path traversal.
+ * Determines whether a manifest tag name is safe to use as a `refs/tags/<name>` path.
+ *
+ * @param name - The candidate tag name.
+ * @returns `true` if the name is a valid string tag path without traversal or unsafe path components, `false` otherwise.
  */
 function isValidTagName(name: unknown): name is string {
   if (
@@ -125,9 +130,11 @@ function isValidTagName(name: unknown): name is string {
 }
 
 /**
- * Restore a project's repo into Artifacts: create the repo (or reuse with
- * `force`), reconstruct the objects, and push. The push against real Artifacts is
- * the one leg that can't run in CI — it is validated on staging via the runbook.
+ * Restores a project's repository to Artifacts, optionally overwriting an existing repository.
+ *
+ * @param snapshot - The repository snapshot and manifest to restore.
+ * @param opts - Restore options; set `force` to overwrite an existing repository.
+ * @returns The restored manifest tip SHA.
  */
 export async function restoreProjectRepo(
   env: Env,

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -46,15 +46,12 @@ interface WalkResult {
 }
 
 /**
- * Collect the FULL set of objects reachable from HEAD (every commit + its tree +
- * blobs, deduped) so the resulting pack is reachability-closed and restores to a
- * faithful repo (original tip sha, parents present). Also walks every
- * refs/tags/* tip (#182): annotated tag objects themselves plus anything
- * reachable only from a tag land in the pack, and the tag refs are returned for
- * the manifest. Aborts with a "too large" skip once the running byte total
- * exceeds `maxBytes`, before packing — the guard bounds the pack we build,
- * though a pathological repo can still OOM the clone. Operates on an
- * already-cloned fs so it is testable without Artifacts.
+ * Collects all objects reachable from the repository tip and tags.
+ *
+ * @param fs - The filesystem containing the cloned repository
+ * @param dir - The repository directory
+ * @param maxBytes - Maximum total size of collected objects
+ * @returns A result containing the walked objects and tag references, an empty or oversized status, or a Git error
  */
 export async function walkRepoObjects(
   fs: NodeFS,
@@ -197,7 +194,14 @@ export async function walkRepoObjects(
   }
 }
 
-/** Assemble a snapshot from a walked object set. Pure — the unit under test. */
+/**
+ * Builds a repository snapshot from walked objects and project metadata.
+ *
+ * @param project - The project associated with the snapshot
+ * @param walk - The collected repository objects, tip commit, and tag references
+ * @param capturedAt - The snapshot capture timestamp
+ * @returns A packed repository snapshot with its manifest
+ */
 export function buildSnapshot(
   project: ProjectEntry,
   walk: WalkResult,
@@ -219,9 +223,11 @@ export function buildSnapshot(
 }
 
 /**
- * Snapshot one project's repo: clone (the sole Artifacts-coupled call), walk the
- * full reachable object set, and pack it with a manifest carrying the tip sha and
- * full identity. Returns a skip (not an error) for empty or over-cap repos.
+ * Creates a full-history repository snapshot with its manifest and tag references.
+ *
+ * @param project - The project whose repository is being snapshotted
+ * @param capturedAt - Timestamp recorded in the snapshot manifest
+ * @returns A successful snapshot, a skipped result for empty or oversized repositories, or an application error
  */
 export async function snapshotRepo(
   env: Env,

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -102,9 +102,13 @@ export async function walkRepoObjects(
       return add(oid, obj.object as Uint8Array);
     };
 
-    /** Add a commit's full history (commits + trees + blobs); false = over budget. */
-    const addCommitHistory = async (tip: string): Promise<boolean> => {
-      const entries = await git.log({ fs, dir, ref: tip, depth: -1 });
+    /** Add a commit's full history (commits + trees + blobs); false = over budget.
+     * `prefetched` lets the HEAD traversal reuse the log it already read. */
+    const addCommitHistory = async (
+      tip: string,
+      prefetched?: Awaited<ReturnType<typeof git.log>>,
+    ): Promise<boolean> => {
+      const entries = prefetched ?? (await git.log({ fs, dir, ref: tip, depth: -1 }));
       for (const entry of entries) {
         if (seen.has(entry.oid)) continue;
         if (!(await addWrapped(entry.oid))) return false;
@@ -115,14 +119,7 @@ export async function walkRepoObjects(
       return true;
     };
 
-    for (const entry of log) {
-      if (seen.has(entry.oid)) continue;
-      if (!(await addWrapped(entry.oid))) return ok({ tooLarge: true });
-      const treeObjects = await extractTreeObjects(fs, dir, entry.commit.tree);
-      for (const o of treeObjects) {
-        if (!add(o.oid, o.bytes)) return ok({ tooLarge: true });
-      }
-    }
+    if (!(await addCommitHistory(tipSha, log))) return ok({ tooLarge: true });
 
     // Tags: walk every refs/tags/* tip too. A tag whose objects are missing
     // locally (e.g. the clone could not deliver them) is SKIPPED with a warning
@@ -132,7 +129,13 @@ export async function walkRepoObjects(
     let tagNames: string[] = [];
     try {
       tagNames = await git.listTags({ fs, dir });
-    } catch {
+    } catch (error) {
+      // No tags is normal; an unreadable ref store is not. Log so the two are
+      // distinguishable, then back up the repo without tags rather than failing.
+      logger.warn("Failed to list tags for snapshot; backing up without tag refs", {
+        dir,
+        error: error instanceof Error ? error.message : String(error),
+      });
       tagNames = [];
     }
     for (const name of [...tagNames].sort()) {

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -180,6 +180,42 @@ export async function walkRepoObjects(
       return true;
     };
 
+    /**
+     * Add a commit and its ancestry, stopping at commits already collected.
+     *
+     * `addCommitHistory` walks the whole history via `git.log` every time it is
+     * called. That is right for HEAD, which is walked once from an already
+     * fetched log, but wrong per tag: N tags on a long history cost N full
+     * walks even when nearly every commit is already collected.
+     *
+     * The stop condition is a frontier, not a single boundary. A merge commit
+     * can have one parent already collected and another not, so every parent is
+     * enqueued and each path stops independently. Stopping at the first
+     * already-collected commit would silently drop the unseen side.
+     *
+     * Sound because whatever added a commit added its full ancestry at the same
+     * time, so an already-collected commit needs no re-walk.
+     */
+    const addCommitAncestry = async (tip: string): Promise<void> => {
+      const queue = [tip];
+      const queued = new Set<string>([tip]);
+      while (queue.length > 0) {
+        const oid = queue.shift() as string;
+        if (has(oid)) continue;
+        const read = await git.readCommit({ fs, dir, oid });
+        await addWrapped(oid);
+        for (const o of await extractTreeObjects(fs, dir, read.commit.tree)) {
+          add(o.oid, o.bytes);
+        }
+        for (const parent of read.commit.parent) {
+          if (!queued.has(parent)) {
+            queued.add(parent);
+            queue.push(parent);
+          }
+        }
+      }
+    };
+
     if (!(await addCommitHistory(tipSha, log))) return ok({ tooLarge: true });
 
     // Tags: walk every refs/tags/* tip too. A tag whose objects are missing
@@ -219,6 +255,9 @@ export async function walkRepoObjects(
         // tag-of-tag chain still snapshots correctly instead of being dropped.
         let current = refOid;
         let target: string | null = null;
+        // The peel already read the target and knows its type; re-reading it
+        // afterwards was a second decode of the same object.
+        let targetType: Awaited<ReturnType<typeof git.readObject>>["type"] | null = null;
         const visited = new Set<string>();
         while (target === null) {
           if (visited.has(current)) throw new Error(`tag ${name}: cyclic tag chain`);
@@ -229,11 +268,11 @@ export async function walkRepoObjects(
             current = (parsed.object as { object: string }).object;
           } else {
             target = current;
+            targetType = parsed.type;
           }
         }
-        const targetType = (await git.readObject({ fs, dir, oid: target })).type;
         if (targetType === "commit") {
-          await addCommitHistory(target);
+          await addCommitAncestry(target);
         } else if (targetType === "tree") {
           for (const o of await extractTreeObjects(fs, dir, target)) {
             add(o.oid, o.bytes);

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -8,6 +8,13 @@ import { type Result, err, ok } from "../utils/result";
 
 export const DEFAULT_MAX_BACKUP_BYTES = 128 * 1024 * 1024;
 
+/** A tag ref captured in a snapshot: refs/tags/<name> → oid (the annotated tag
+ * object for annotated tags, the target itself for lightweight ones). */
+export interface TagRefRecord {
+  name: string;
+  oid: string;
+}
+
 export interface RepoManifest {
   projectId: string;
   /** Full identity so restore can recreate the correctly-named Artifacts repo
@@ -17,6 +24,10 @@ export interface RepoManifest {
   objectCount: number;
   byteCount: number;
   capturedAt: string;
+  /** Tag refs captured with the pack (#182). OPTIONAL for backward
+   * compatibility: manifests written before tag support omit it, and restore
+   * must treat a missing field as "no tags". */
+  tags?: TagRefRecord[];
 }
 
 export interface RepoSnapshot {
@@ -31,15 +42,19 @@ export type SnapshotResult =
 interface WalkResult {
   objects: { oid: string; bytes: Uint8Array }[];
   tipSha: string;
+  tags: TagRefRecord[];
 }
 
 /**
  * Collect the FULL set of objects reachable from HEAD (every commit + its tree +
  * blobs, deduped) so the resulting pack is reachability-closed and restores to a
- * faithful repo (original tip sha, parents present). Aborts with a "too large"
- * skip once the running byte total exceeds `maxBytes`, before packing — the guard
- * bounds the pack we build, though a pathological repo can still OOM the clone.
- * Operates on an already-cloned fs so it is testable without Artifacts.
+ * faithful repo (original tip sha, parents present). Also walks every
+ * refs/tags/* tip (#182): annotated tag objects themselves plus anything
+ * reachable only from a tag land in the pack, and the tag refs are returned for
+ * the manifest. Aborts with a "too large" skip once the running byte total
+ * exceeds `maxBytes`, before packing — the guard bounds the pack we build,
+ * though a pathological repo can still OOM the clone. Operates on an
+ * already-cloned fs so it is testable without Artifacts.
  */
 export async function walkRepoObjects(
   fs: NodeFS,
@@ -81,18 +96,94 @@ export async function walkRepoObjects(
       return byteCount <= maxBytes;
     };
 
-    for (const entry of log) {
-      const commitObj = await git.readObject({ fs, dir, oid: entry.oid, format: "wrapped" });
-      if (!add(entry.oid, commitObj.object as Uint8Array)) return ok({ tooLarge: true });
+    /** Add one object's wrapped bytes; false = over budget. */
+    const addWrapped = async (oid: string): Promise<boolean> => {
+      const obj = await git.readObject({ fs, dir, oid, format: "wrapped" });
+      return add(oid, obj.object as Uint8Array);
+    };
 
+    /** Add a commit's full history (commits + trees + blobs); false = over budget. */
+    const addCommitHistory = async (tip: string): Promise<boolean> => {
+      const entries = await git.log({ fs, dir, ref: tip, depth: -1 });
+      for (const entry of entries) {
+        if (seen.has(entry.oid)) continue;
+        if (!(await addWrapped(entry.oid))) return false;
+        for (const o of await extractTreeObjects(fs, dir, entry.commit.tree)) {
+          if (!add(o.oid, o.bytes)) return false;
+        }
+      }
+      return true;
+    };
+
+    for (const entry of log) {
+      if (seen.has(entry.oid)) continue;
+      if (!(await addWrapped(entry.oid))) return ok({ tooLarge: true });
       const treeObjects = await extractTreeObjects(fs, dir, entry.commit.tree);
       for (const o of treeObjects) {
         if (!add(o.oid, o.bytes)) return ok({ tooLarge: true });
       }
     }
 
-    logger.debug("Walked repo objects", { tipSha, objectCount: objects.length, byteCount });
-    return ok({ objects, tipSha });
+    // Tags: walk every refs/tags/* tip too. A tag whose objects are missing
+    // locally (e.g. the clone could not deliver them) is SKIPPED with a warning
+    // rather than recorded — recording it would restore a dangling ref, and the
+    // pack must stay closed under reachability.
+    const tags: TagRefRecord[] = [];
+    let tagNames: string[] = [];
+    try {
+      tagNames = await git.listTags({ fs, dir });
+    } catch {
+      tagNames = [];
+    }
+    for (const name of [...tagNames].sort()) {
+      let refOid: string;
+      try {
+        refOid = await git.resolveRef({ fs, dir, ref: `refs/tags/${name}` });
+      } catch {
+        logger.warn("Backup: skipping unreadable tag ref", { name });
+        continue;
+      }
+      try {
+        // Peel annotated tags (adding each tag object in the chain) down to the
+        // target, then close the pack over the target's reachability.
+        let current = refOid;
+        let target: string | null = null;
+        for (let hop = 0; hop < 10 && target === null; hop++) {
+          const parsed = await git.readObject({ fs, dir, oid: current });
+          if (parsed.type === "tag") {
+            if (!(await addWrapped(current))) return ok({ tooLarge: true });
+            current = (parsed.object as { object: string }).object;
+          } else {
+            target = current;
+          }
+        }
+        if (target === null) throw new Error(`tag ${name}: peel chain too deep`);
+        const targetType = (await git.readObject({ fs, dir, oid: target })).type;
+        if (targetType === "commit") {
+          if (!(await addCommitHistory(target))) return ok({ tooLarge: true });
+        } else if (targetType === "tree") {
+          for (const o of await extractTreeObjects(fs, dir, target)) {
+            if (!add(o.oid, o.bytes)) return ok({ tooLarge: true });
+          }
+        } else if (!(await addWrapped(target))) {
+          return ok({ tooLarge: true });
+        }
+        tags.push({ name, oid: refOid });
+      } catch (error) {
+        logger.warn("Backup: skipping unresolvable tag", {
+          name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    logger.debug("Walked repo objects", {
+      tipSha,
+      objectCount: objects.length,
+      byteCount,
+      tagCount: tags.length,
+    });
+    return ok({ objects, tipSha, tags });
   } catch (error) {
     logger.error("Failed to walk repo objects", error instanceof Error ? error : undefined);
     return err(new AppError("Failed to walk repo objects", "GIT_ERROR", 500));
@@ -115,6 +206,7 @@ export function buildSnapshot(
       objectCount: walk.objects.length,
       byteCount,
       capturedAt,
+      tags: walk.tags,
     },
   };
 }
@@ -139,7 +231,8 @@ export async function snapshotRepo(
   if (!token.success) return err(token.error);
 
   // Full history: a shallow clone would drop ancestors past depth 50, yielding a
-  // pack that can't restore the repo to its true tip.
+  // pack that can't restore the repo to its true tip. Tags are fetched too
+  // (#182) so refs/tags/* and their objects land in the snapshot.
   //
   // Known trade-off: `maxBytes` is enforced by walkRepoObjects AFTER the clone,
   // so an over-cap repo is loaded into MemoryFS before it is skipped. This is
@@ -151,6 +244,7 @@ export async function snapshotRepo(
   // Worker's memory budget so a normal repo never approaches it.
   const clone = await cloneRepo(project.remote, token.data, logger, undefined, {
     fullHistory: true,
+    includeTags: true,
   });
   if (!clone.success) return err(clone.error);
 

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -48,6 +48,18 @@ interface WalkResult {
 /**
  * Collects all objects reachable from the repository tip and tags.
  *
+ * The FULL reachable set is collected -- every commit, its tree, and its blobs,
+ * deduped -- so the resulting pack is closed under reachability and restores to
+ * a faithful repo with the original tip sha and its parents present. Every
+ * `refs/tags/*` tip is walked too (#182): annotated tag objects themselves, and
+ * anything reachable only from a tag, would otherwise be missing from the pack.
+ *
+ * Aborts with a "too large" skip once the running byte total exceeds `maxBytes`,
+ * before packing. That bounds the pack being built, not the clone -- a
+ * pathological repo can still exhaust memory earlier, during the clone itself.
+ *
+ * Operates on an already-cloned fs, so it is testable without Artifacts.
+ *
  * @param fs - The filesystem containing the cloned repository
  * @param dir - The repository directory
  * @param maxBytes - Maximum total size of collected objects
@@ -197,6 +209,11 @@ export async function walkRepoObjects(
 /**
  * Builds a repository snapshot from walked objects and project metadata.
  *
+ * Pure, and the unit most of the snapshot tests exercise directly. The manifest
+ * carries `tipSha` and the whole project record rather than just an id, because
+ * restore has to work without consulting live state -- a snapshot must stay
+ * restorable after the project entry has changed or been deleted.
+ *
  * @param project - The project associated with the snapshot
  * @param walk - The collected repository objects, tip commit, and tag references
  * @param capturedAt - The snapshot capture timestamp
@@ -223,7 +240,13 @@ export function buildSnapshot(
 }
 
 /**
- * Creates a full-history repository snapshot with its manifest and tag references.
+ * Creates a full-history repository snapshot with its manifest and tag
+ * references.
+ *
+ * The clone is the sole Artifacts-coupled call in the snapshot path. Empty and
+ * over-cap repositories return a *skip*, not an error: neither is a fault, and
+ * failing the whole backup run because one repo is empty or oversized would
+ * lose the snapshots of every other project in the same run.
  *
  * @param project - The project whose repository is being snapshotted
  * @param capturedAt - Timestamp recorded in the snapshot manifest

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -97,15 +97,67 @@ export async function walkRepoObjects(
     const objects: { oid: string; bytes: Uint8Array }[] = [];
     let byteCount = 0;
 
+    /**
+     * Staging layer for one tag's traversal.
+     *
+     * A tag is only recorded once its whole closure resolves, but the objects
+     * were being added as the walk went. When a later read failed, the tag was
+     * skipped while its objects and bytes stayed behind — junk in the pack that
+     * nothing references, and, worse, bytes that could push `byteCount` past
+     * `maxBytes` and turn a skippable tag into a whole-backup `tooLarge`.
+     *
+     * While staged, `add` never reports over-budget: whether the tag resolves
+     * at all is what decides between `tooLarge` and skipping it, and that is
+     * only known once the walk finishes. The verdict moves to `commitStaged`.
+     */
+    let staged: {
+      seen: Set<string>;
+      objects: { oid: string; bytes: Uint8Array }[];
+      bytes: number;
+      over: boolean;
+    } | null = null;
+
+    const beginStaged = (): void => {
+      staged = { seen: new Set(), objects: [], bytes: 0, over: false };
+    };
+    const rollbackStaged = (): void => {
+      staged = null;
+    };
+    /** Merge the staged objects into the snapshot; false = over budget. */
+    const commitStaged = (): boolean => {
+      const s = staged;
+      staged = null;
+      if (!s || s.over) return !s;
+      for (const o of s.objects) {
+        seen.add(o.oid);
+        objects.push(o);
+        byteCount += o.bytes.byteLength;
+      }
+      return true;
+    };
+
+    const has = (oid: string): boolean => seen.has(oid) || staged?.seen.has(oid) === true;
+
     const add = (oid: string, bytes: Uint8Array): boolean => {
-      if (seen.has(oid)) return true;
+      if (has(oid)) return true;
+      if (staged) {
+        staged.seen.add(oid);
+        // Past the budget we stop retaining bytes but keep walking, so memory
+        // stays bounded while the walk still settles whether the tag resolves.
+        if (!staged.over) {
+          staged.objects.push({ oid, bytes });
+          staged.bytes += bytes.byteLength;
+          if (byteCount + staged.bytes > maxBytes) staged.over = true;
+        }
+        return true;
+      }
       seen.add(oid);
       objects.push({ oid, bytes });
       byteCount += bytes.byteLength;
       return byteCount <= maxBytes;
     };
 
-    /** Add one object's wrapped bytes; false = over budget. */
+    /** Add one object's wrapped bytes; false = over budget (never while staged). */
     const addWrapped = async (oid: string): Promise<boolean> => {
       const obj = await git.readObject({ fs, dir, oid, format: "wrapped" });
       return add(oid, obj.object as Uint8Array);
@@ -119,7 +171,7 @@ export async function walkRepoObjects(
     ): Promise<boolean> => {
       const entries = prefetched ?? (await git.log({ fs, dir, ref: tip, depth: -1 }));
       for (const entry of entries) {
-        if (seen.has(entry.oid)) continue;
+        if (has(entry.oid)) continue;
         if (!(await addWrapped(entry.oid))) return false;
         for (const o of await extractTreeObjects(fs, dir, entry.commit.tree)) {
           if (!add(o.oid, o.bytes)) return false;
@@ -155,6 +207,11 @@ export async function walkRepoObjects(
         logger.warn("Backup: skipping unreadable tag ref", { name });
         continue;
       }
+      // Staged: nothing this tag adds reaches the snapshot until its whole
+      // closure resolves, so a tag skipped below leaves no objects and spends
+      // no budget. The over-budget verdict comes from commitStaged, not from
+      // the add calls, which is why none of them are checked here.
+      beginStaged();
       try {
         // Peel annotated tags (adding each tag object in the chain) down to the
         // target, then close the pack over the target's reachability. A
@@ -168,7 +225,7 @@ export async function walkRepoObjects(
           visited.add(current);
           const parsed = await git.readObject({ fs, dir, oid: current });
           if (parsed.type === "tag") {
-            if (!(await addWrapped(current))) return ok({ tooLarge: true });
+            await addWrapped(current);
             current = (parsed.object as { object: string }).object;
           } else {
             target = current;
@@ -176,16 +233,19 @@ export async function walkRepoObjects(
         }
         const targetType = (await git.readObject({ fs, dir, oid: target })).type;
         if (targetType === "commit") {
-          if (!(await addCommitHistory(target))) return ok({ tooLarge: true });
+          await addCommitHistory(target);
         } else if (targetType === "tree") {
           for (const o of await extractTreeObjects(fs, dir, target)) {
-            if (!add(o.oid, o.bytes)) return ok({ tooLarge: true });
+            add(o.oid, o.bytes);
           }
-        } else if (!(await addWrapped(target))) {
-          return ok({ tooLarge: true });
+        } else {
+          await addWrapped(target);
         }
+        // The tag resolved, so its bytes are real and the budget applies.
+        if (!commitStaged()) return ok({ tooLarge: true });
         tags.push({ name, oid: refOid });
       } catch (error) {
+        rollbackStaged();
         logger.warn("Backup: skipping unresolvable tag", {
           name,
           error: error instanceof Error ? error.message : String(error),

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -148,10 +148,15 @@ export async function walkRepoObjects(
       }
       try {
         // Peel annotated tags (adding each tag object in the chain) down to the
-        // target, then close the pack over the target's reachability.
+        // target, then close the pack over the target's reachability. A
+        // visited-oid set (not a fixed hop cap) so a valid, unusually long
+        // tag-of-tag chain still snapshots correctly instead of being dropped.
         let current = refOid;
         let target: string | null = null;
-        for (let hop = 0; hop < 10 && target === null; hop++) {
+        const visited = new Set<string>();
+        while (target === null) {
+          if (visited.has(current)) throw new Error(`tag ${name}: cyclic tag chain`);
+          visited.add(current);
           const parsed = await git.readObject({ fs, dir, oid: current });
           if (parsed.type === "tag") {
             if (!(await addWrapped(current))) return ok({ tooLarge: true });
@@ -160,7 +165,6 @@ export async function walkRepoObjects(
             target = current;
           }
         }
-        if (target === null) throw new Error(`tag ${name}: peel chain too deep`);
         const targetType = (await git.readObject({ fs, dir, oid: target })).type;
         if (targetType === "commit") {
           if (!(await addCommitHistory(target))) return ok({ tooLarge: true });

--- a/src/routes/git-http.ts
+++ b/src/routes/git-http.ts
@@ -29,7 +29,10 @@ import { createLogger } from "../utils/logger";
  *    change is created + evaluated, and the client gets a truthful per-ref
  *    `ng` carrying the change id (main only moves through the merge gate).
  *    With the flag off — and for multi-ref/delete/non-default pushes — the
- *    push is refused in-protocol with sideband guidance.
+ *    push is refused in-protocol with sideband guidance. Refs are proxied
+ *    unfiltered on the read path, so refs/tags/* are advertised and fetchable;
+ *    tag pushes to the project remote are refused with tag-specific guidance
+ *    (#182 — the change gate cannot represent a tag).
  *  - Workspace URL `/@ns/slug/workspaces/<ws>.git` — clone/fetch (read) AND
  *    `git push` (write), proxied verbatim to the workspace's Artifacts fork.
  *    The client clones the workspace, so ref/old-oid semantics line up and
@@ -593,6 +596,29 @@ gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
         sideband,
       }),
     );
+
+  // Tag policy (#182): tag READS work everywhere — info/refs and upload-pack are
+  // proxied unfiltered, so refs/tags/* are advertised and fetchable on both the
+  // project and workspace remotes, and tag PUSHES to workspace forks proxy
+  // verbatim. A tag push to the PROJECT remote, however, is refused explicitly:
+  // the project repo's refs only move through Stratum's gates, and the change
+  // gate cannot represent a tag (a change is an evaluated diff against the
+  // default branch; a tag ref has nothing to evaluate or merge). Refusing with a
+  // tag-specific reason beats the generic branch guidance, which would
+  // misleadingly suggest the gate could carry the tag through.
+  const tagRefs = commands.filter((cmd) => cmd.ref.startsWith("refs/tags/"));
+  if (tagRefs.length > 0) {
+    logger.info("Refusing project tag push in-protocol", {
+      refs: tagRefs.map((cmd) => cmd.ref),
+    });
+    return refuseAll(
+      "tag pushes to the project remote are not supported — push tags to a workspace remote",
+      [
+        "Project tags are read-only over this remote (clone/fetch delivers them).",
+        `Push tags to a workspace remote instead: /${namespace}/${slug}/workspaces/<ws>.git`,
+      ],
+    );
+  }
 
   const gatedEnabled = c.env.GIT_PUSH_GATED_ENABLED === "true";
   // Same default-branch resolution the merge/sync paths use — a repo imported

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -12,6 +12,7 @@ import {
   importFromGitHub,
   initAndPush,
   listFilesInRepo,
+  listRepoTags,
 } from "../storage/git-ops";
 import { buildAuthConfig } from "../storage/git-providers";
 import {
@@ -945,6 +946,52 @@ app.get("/:namespace/:slug/log", async (c) => {
     slug,
     path: `/${namespace}/${slug}`,
     log: logResult.data,
+  });
+});
+
+// GET /projects/:namespace/:slug/tags - List git tags (annotated + lightweight).
+// Annotated tags are dereferenced to their target commit; a tag whose target
+// lies outside the shallow clone window comes back with `unresolvable: true`
+// rather than failing the listing (#182).
+app.get("/:namespace/:slug/tags", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const { namespace, slug } = c.req.param();
+
+  const projectResult = await getProjectByPath(c.env.STATE, namespace, slug, logger);
+  if (!projectResult.success) {
+    if (projectResult.error.code === "NOT_FOUND") {
+      return notFound("Project", `${namespace}/${slug}`);
+    }
+    logger.error("Failed to get project", projectResult.error);
+    return internalError(projectResult.error.message);
+  }
+  const project = projectResult.data;
+
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId)))
+    return notFound("Project", `${project.namespace}/${project.slug}`);
+
+  const readToken = await freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger);
+  if (!readToken.success) return internalError(readToken.error.message);
+  const tagsResult = await listRepoTags(project.remote, readToken.data, logger);
+  if (!tagsResult.success) {
+    logger.error("Failed to list tags", tagsResult.error);
+    return internalError(tagsResult.error.message);
+  }
+
+  logger.info("Tags retrieved", { namespace, slug, tagCount: tagsResult.data.length });
+  return ok({
+    namespace,
+    slug,
+    path: `/${namespace}/${slug}`,
+    tags: tagsResult.data,
   });
 });
 

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -876,7 +876,12 @@ app.get("/:namespace/:slug/tags", async (c) => {
   );
 });
 
-// Shared loader for issue pages: validates path, loads user + project, checks read access.
+/**
+ * Loads the authenticated user and project context for an issue page after validating the project path and read access.
+ *
+ * @param c - The request context containing route parameters, authentication identifiers, environment services, and request metadata.
+ * @returns The project page context, or an error status when the path is invalid or the project is unavailable or inaccessible.
+ */
 async function loadIssuePageContext(c: {
   env: Env;
   get(key: "userId" | "agentOwnerId"): string | undefined;

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -11,6 +11,7 @@ import {
   getCommitLog,
   getDiffBetweenRepos,
   listFilesInRepo,
+  listRepoTags,
   readFileFromRepo,
 } from "../storage/git-ops";
 import { getImportProgress } from "../storage/imports";
@@ -39,6 +40,7 @@ import { NewProjectPage } from "../ui/pages/new-project";
 import { RepoPage } from "../ui/pages/repo";
 import { SettingsPage } from "../ui/pages/settings";
 import { SyncPage } from "../ui/pages/sync";
+import { TagsPage } from "../ui/pages/tags";
 import { WebhooksPage } from "../ui/pages/webhooks";
 import { WorkspacesPage } from "../ui/pages/workspaces";
 import { canReadProject, canWriteProject, filterMemberProjects } from "../utils/authz";
@@ -806,6 +808,69 @@ app.get("/:namespace/:slug/activity", async (c) => {
     <ActivityPage
       project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
       events={eventsResult.data}
+      user={userResult}
+    />,
+  );
+});
+
+// GET /:namespace/:slug/tags — Tags listing (annotated + lightweight, #182)
+app.get("/:namespace/:slug/tags", async (c) => {
+  const { namespace, slug } = c.req.param();
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const logger = createLogger({ path: c.req.path, userId });
+
+  if (!isValidNamespace(namespace) || !isValidSlug(slug)) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">Invalid project path.</div>,
+      400,
+    );
+  }
+
+  const [userResult, projectResult] = await Promise.all([
+    getCurrentUser(c, logger),
+    getProjectByPath(c.env.STATE, namespace, slug, logger),
+  ]);
+
+  if (!projectResult.success) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Project '{namespace}/{slug}' not found.
+      </div>,
+      404,
+    );
+  }
+  const project = projectResult.data;
+
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
+    return c.html(
+      <div style="padding:2rem;font-family:monospace;color:#f87171;">
+        Project '{namespace}/{slug}' not found.
+      </div>,
+      404,
+    );
+  }
+
+  const tagsError = (
+    <div style="padding:2rem;font-family:monospace;color:#f87171;">
+      Error loading tags. Please try again.
+    </div>
+  );
+  const readToken = await freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger);
+  if (!readToken.success) {
+    logger.error("Failed to mint read token for tags page", readToken.error);
+    return c.html(tagsError, 500);
+  }
+  const tagsResult = await listRepoTags(project.remote, readToken.data, logger);
+  if (!tagsResult.success) {
+    logger.error("Failed to list tags", tagsResult.error);
+    return c.html(tagsError, 500);
+  }
+
+  return c.html(
+    <TagsPage
+      project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
+      tags={tagsResult.data}
       user={userResult}
     />,
   );

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -887,10 +887,14 @@ app.get("/:namespace/:slug/tags", async (c) => {
 });
 
 /**
- * Loads the authenticated user and project context for an issue page after validating the project path and read access.
+ * Three issue routes share the same preamble, and getting it wrong leaks
+ * project existence. A private project must 404 rather than 403, so an
+ * unreadable project is indistinguishable from a missing one — that is why
+ * both the lookup miss and the authz failure return the same 404 here, and
+ * why this is one helper rather than three copies that could drift apart.
  *
- * @param c - The request context containing route parameters, authentication identifiers, environment services, and request metadata.
- * @returns The project page context, or an error status when the path is invalid or the project is unavailable or inaccessible.
+ * Returns `{ errorStatus }` instead of throwing so each caller renders the
+ * error in its own page shell.
  */
 async function loadIssuePageContext(c: {
   env: Env;

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -221,6 +221,10 @@ export async function freshRepoToken(
 /**
  * Publishes the local `main` branch to an Artifacts remote.
  *
+ * Used by backup restore to publish a reconstructed repo. `force` overwrites a
+ * non-empty remote, so it stays an explicit opt-in for restore-over-existing
+ * rather than a default -- a defaulted force here would destroy a live repo.
+ *
  * @param remote - The Artifacts remote URL
  * @param opts - Controls whether an existing remote branch may be overwritten
  * @returns An empty result on success, or an application error if publishing fails
@@ -253,7 +257,11 @@ export async function pushMain(
 }
 
 /**
- * Pushes local tags to an Artifacts remote, optionally replacing existing remote tags.
+ * Pushes local `refs/tags/*` to an Artifacts remote.
+ *
+ * Runs after `pushMain` during backup restore so a restored repo carries its
+ * tags; `force` mirrors the same restore-over-existing opt-in `pushMain` uses,
+ * for the same reason.
  *
  * @param tagNames - The tag names to push.
  * @param opts - Controls whether existing remote tags may be replaced.
@@ -562,7 +570,14 @@ export async function collectRepoTags(
 }
 
 /**
- * Lists the tags in a repository, including entries whose targets cannot be resolved from the cloned history.
+ * Lists the tags in a repository, including entries whose targets cannot be
+ * resolved from the cloned history.
+ *
+ * The clone is shallow but fetches tag refs, so a tag whose target lies outside
+ * the shallow window is reported with `unresolvable: true` rather than raising:
+ * a tag pointing into unfetched history is expected here, not a failure, and
+ * erroring would make the whole listing unavailable because of one old tag.
+ * See `collectRepoTags`.
  *
  * @param remote - The repository's remote URL
  * @param token - The authentication token for the remote

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -219,9 +219,11 @@ export async function freshRepoToken(
 }
 
 /**
- * Push the local `main` ref (its objects + the ref) to an Artifacts remote.
- * Used by backup restore to publish a reconstructed repo. `force` overwrites a
- * non-empty remote (restore-over-existing behind an explicit opt-in).
+ * Publishes the local `main` branch to an Artifacts remote.
+ *
+ * @param remote - The Artifacts remote URL
+ * @param opts - Controls whether an existing remote branch may be overwritten
+ * @returns An empty result on success, or an application error if publishing fails
  */
 export async function pushMain(
   remote: string,
@@ -251,9 +253,11 @@ export async function pushMain(
 }
 
 /**
- * Push a set of local refs/tags/* refs (their objects + the refs) to an
- * Artifacts remote. Used by backup restore after `pushMain` so a restored repo
- * carries its tags. `force` mirrors the restore-over-existing opt-in.
+ * Pushes local tags to an Artifacts remote, optionally replacing existing remote tags.
+ *
+ * @param tagNames - The tag names to push.
+ * @param opts - Controls whether existing remote tags may be replaced.
+ * @returns An empty result on success, or an error describing the first failed tag push.
  */
 export async function pushTags(
   remote: string,
@@ -304,6 +308,17 @@ export async function pushTags(
   return ok(undefined);
 }
 
+/**
+ * Initializes a repository, commits the specified files to `main`, and pushes the commit.
+ *
+ * @param remote - The Git remote URL.
+ * @param token - The authentication token for the remote.
+ * @param files - A mapping of repository file paths to their contents.
+ * @param message - The commit message.
+ * @param logger - The logger used for operation diagnostics.
+ * @param author - The commit author.
+ * @returns The SHA of the pushed commit, or an application error if initialization, file creation, staging, committing, or pushing fails.
+ */
 export async function initAndPush(
   remote: string,
   token: string,
@@ -367,6 +382,14 @@ export async function initAndPush(
   return ok(commitResult.data);
 }
 
+/**
+ * Clones the repository's `main` branch into an in-memory filesystem.
+ *
+ * @param remote - The repository URL
+ * @param token - The authentication token used for cloning
+ * @param opts - Clone options controlling history depth and tag fetching
+ * @returns The in-memory filesystem and working directory, or an application error
+ */
 export async function cloneRepo(
   remote: string,
   token: string,
@@ -539,9 +562,11 @@ export async function collectRepoTags(
 }
 
 /**
- * Clone a repo (shallow, with tag refs fetched) and list its tags. A tag whose
- * target lies outside the shallow window comes back `unresolvable: true` rather
- * than erroring — see `collectRepoTags`.
+ * Lists the tags in a repository, including entries whose targets cannot be resolved from the cloned history.
+ *
+ * @param remote - The repository's remote URL
+ * @param token - The authentication token for the remote
+ * @returns The repository's tag entries
  */
 export async function listRepoTags(
   remote: string,
@@ -566,6 +591,14 @@ export async function listRepoTags(
   return ok(collected.data);
 }
 
+/**
+ * Commits file changes to the local repository and pushes the `main` branch to the remote.
+ *
+ * @param changes - File paths and their updated contents
+ * @param message - Commit message
+ * @param author - Commit author metadata
+ * @returns The SHA of the created commit, or an application error if writing, staging, committing, or pushing fails
+ */
 export async function commitAndPush(
   fs: NodeFS,
   dir: string,

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -264,7 +264,12 @@ export async function pushTags(
   logger: Logger,
   opts?: { force?: boolean },
 ): Promise<Result<void, AppError>> {
-  for (const name of tagNames) {
+  // Tags are pushed one ref at a time, so a mid-list failure leaves earlier tags
+  // on the remote. Report exactly which ones landed: a forced restore over an
+  // existing repo is not rolled back, and an operator (or a retry, which is
+  // idempotent for already-pushed tags) needs to know how far it got.
+  const pushedTags: string[] = [];
+  for (const [index, name] of tagNames.entries()) {
     const ref = `refs/tags/${name}`;
     const res = await fromPromise(
       git.push({
@@ -279,11 +284,22 @@ export async function pushTags(
       }),
     );
     if (!res.success) {
-      logger.error("Failed to push tag during restore", res.error, { remote, ref });
+      logger.error("Failed to push tag during restore", res.error, {
+        remote,
+        ref,
+        failedTag: name,
+        pushedTags,
+        unpushedTags: tagNames.slice(index + 1),
+      });
       return err(
-        new ExternalServiceError("Git", `Failed to push tag ${name} during restore`, res.error),
+        new ExternalServiceError(
+          "Git",
+          `Failed to push tag ${name} during restore (${pushedTags.length}/${tagNames.length} tags pushed before the failure)`,
+          res.error,
+        ),
       );
     }
+    pushedTags.push(name);
   }
   return ok(undefined);
 }
@@ -441,15 +457,24 @@ export interface RepoTagEntry {
  * target outside the depth window — is returned with `unresolvable: true`
  * rather than failing the whole listing.
  */
-export async function collectRepoTags(fs: NodeFS, dir: string): Promise<RepoTagEntry[]> {
+export async function collectRepoTags(
+  fs: NodeFS,
+  dir: string,
+  logger?: Logger,
+): Promise<RepoTagEntry[]> {
   const names = await git.listTags({ fs, dir });
   const entries: RepoTagEntry[] = [];
   for (const name of [...names].sort()) {
     let oid: string;
     try {
       oid = await git.resolveRef({ fs, dir, ref: `refs/tags/${name}` });
-    } catch {
-      // Ref file unreadable — nothing meaningful to show for this tag.
+    } catch (error) {
+      // Ref file unreadable — nothing meaningful to show for this tag. Logged so
+      // a corrupt ref store is distinguishable from a repo that simply has none.
+      logger?.warn("Skipping tag with unresolvable ref", {
+        tag: name,
+        error: error instanceof Error ? error.message : String(error),
+      });
       continue;
     }
     const entry: RepoTagEntry = {
@@ -487,9 +512,16 @@ export async function collectRepoTags(fs: NodeFS, dir: string): Promise<RepoTagE
       }
       // A peel chain that never terminated (>10 hops) is unresolvable too.
       if (entry.targetSha === null) entry.unresolvable = true;
-    } catch {
+    } catch (error) {
       // The object at `current` is missing locally. If we peeled at least one
       // tag object, `current` names the intended target — record it, degraded.
+      // Expected for a target outside the shallow window; logged at debug so a
+      // corrupt object store is still traceable.
+      logger?.debug("Tag target not present locally; listing it as unresolvable", {
+        tag: name,
+        oid: current,
+        error: error instanceof Error ? error.message : String(error),
+      });
       entry.targetSha = current === oid ? null : current;
       entry.unresolvable = true;
     }
@@ -514,7 +546,9 @@ export async function listRepoTags(
   const cloneResult = await cloneRepo(remote, token, logger, httpClient, { includeTags: true });
   if (!cloneResult.success) return err(cloneResult.error);
 
-  const collected = await fromPromise(collectRepoTags(cloneResult.data.fs, cloneResult.data.dir));
+  const collected = await fromPromise(
+    collectRepoTags(cloneResult.data.fs, cloneResult.data.dir, logger),
+  );
   if (!collected.success) {
     logger.error("Failed to collect repo tags", collected.error, { remote });
     return err(new ExternalServiceError("Git", "Failed to list tags", collected.error));

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -489,7 +489,14 @@ export async function collectRepoTags(
     // still yields the intended sha from the tag object we did read.
     let current = oid;
     try {
-      for (let hop = 0; hop < 10 && entry.targetSha === null; hop++) {
+      // Peel until a non-tag target or a repeated oid (cycle) is hit — a
+      // visited-oid set rather than a fixed hop cap so a valid, unusually long
+      // tag-of-tag chain still resolves instead of being marked unresolvable.
+      const visited = new Set<string>();
+      let hop = 0;
+      while (entry.targetSha === null) {
+        if (visited.has(current)) break;
+        visited.add(current);
         const obj = await git.readObject({ fs, dir, oid: current });
         if (obj.type === "tag") {
           const tag = obj.object as {
@@ -506,11 +513,12 @@ export async function collectRepoTags(
             }
           }
           current = tag.object;
+          hop++;
         } else {
           entry.targetSha = current;
         }
       }
-      // A peel chain that never terminated (>10 hops) is unresolvable too.
+      // A peel chain that never terminated (cycle) is unresolvable too.
       if (entry.targetSha === null) entry.unresolvable = true;
     } catch (error) {
       // The object at `current` is missing locally. If we peeled at least one

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -250,6 +250,44 @@ export async function pushMain(
   return ok(undefined);
 }
 
+/**
+ * Push a set of local refs/tags/* refs (their objects + the refs) to an
+ * Artifacts remote. Used by backup restore after `pushMain` so a restored repo
+ * carries its tags. `force` mirrors the restore-over-existing opt-in.
+ */
+export async function pushTags(
+  remote: string,
+  token: string,
+  fs: NodeFS,
+  dir: string,
+  tagNames: string[],
+  logger: Logger,
+  opts?: { force?: boolean },
+): Promise<Result<void, AppError>> {
+  for (const name of tagNames) {
+    const ref = `refs/tags/${name}`;
+    const res = await fromPromise(
+      git.push({
+        fs,
+        dir,
+        http,
+        url: remote,
+        ref,
+        remoteRef: ref,
+        onAuth: makeAuth(token),
+        force: opts?.force ?? false,
+      }),
+    );
+    if (!res.success) {
+      logger.error("Failed to push tag during restore", res.error, { remote, ref });
+      return err(
+        new ExternalServiceError("Git", `Failed to push tag ${name} during restore`, res.error),
+      );
+    }
+  }
+  return ok(undefined);
+}
+
 export async function initAndPush(
   remote: string,
   token: string,
@@ -318,7 +356,7 @@ export async function cloneRepo(
   token: string,
   logger: Logger,
   httpClient: HttpClient = http,
-  opts: { fullHistory?: boolean } = {},
+  opts: { fullHistory?: boolean; includeTags?: boolean } = {},
 ): Promise<Result<{ fs: NodeFS; dir: string }, AppError>> {
   logger.debug("Cloning repository", { remote, fullHistory: opts.fullHistory ?? false });
 
@@ -345,8 +383,145 @@ export async function cloneRepo(
     return err(new ExternalServiceError("Git", "Failed to clone repository", cloneResult.error));
   }
 
+  // isomorphic-git's singleBranch clone requests ONLY the branch tip — tag refs
+  // are neither advertised locally nor are their objects fetched. Callers that
+  // need tags (tags listing, backup) opt in to a follow-up fetch of every remote
+  // ref with `tags: true`, which writes refs/tags/* and pulls the tag objects
+  // plus their targets (depth-limited unless fullHistory).
+  if (opts.includeTags) {
+    const tagFetch = await fromPromise(
+      git.fetch({
+        fs,
+        http: httpClient,
+        dir: DIR,
+        url: remote,
+        singleBranch: false,
+        tags: true,
+        ...(opts.fullHistory ? {} : { depth: 50 }),
+        onAuth: makeAuth(token),
+      }),
+    );
+    if (!tagFetch.success) {
+      logger.error("Failed to fetch tags after clone", tagFetch.error, { remote });
+      return err(new ExternalServiceError("Git", "Failed to fetch tags", tagFetch.error));
+    }
+  }
+
   logger.info("Successfully cloned repository", { remote });
   return ok({ fs: fs as unknown as NodeFS, dir: DIR });
+}
+
+/** A tag as listed from a cloned repo (see `collectRepoTags`). */
+export interface RepoTagEntry {
+  /** Tag name without the refs/tags/ prefix. */
+  name: string;
+  /** What refs/tags/<name> points at: the tag object for annotated tags, the
+   * target itself for lightweight ones. */
+  oid: string;
+  /** The peeled target (normally a commit sha), or null when it could not be
+   * determined (the tag object itself is missing locally). */
+  targetSha: string | null;
+  annotated: boolean;
+  /** Annotated-tag message (first tag object in a peel chain). */
+  message?: string;
+  /** Annotated-tag tagger as "Name <email>". */
+  tagger?: string;
+  /** Annotated-tag tagger timestamp (epoch seconds). */
+  timestamp?: number;
+  /** True when the tag's target object is not present locally — e.g. it points
+   * outside the shallow fetch window. The tag is still listed (degraded), never
+   * an error. */
+  unresolvable: boolean;
+}
+
+/**
+ * List every refs/tags/* in an already-cloned repo, dereferencing annotated tags
+ * to their target commit. Per-tag object reads are individually guarded: a tag
+ * whose object (or target) is missing locally — a shallow clone can drop a
+ * target outside the depth window — is returned with `unresolvable: true`
+ * rather than failing the whole listing.
+ */
+export async function collectRepoTags(fs: NodeFS, dir: string): Promise<RepoTagEntry[]> {
+  const names = await git.listTags({ fs, dir });
+  const entries: RepoTagEntry[] = [];
+  for (const name of [...names].sort()) {
+    let oid: string;
+    try {
+      oid = await git.resolveRef({ fs, dir, ref: `refs/tags/${name}` });
+    } catch {
+      // Ref file unreadable — nothing meaningful to show for this tag.
+      continue;
+    }
+    const entry: RepoTagEntry = {
+      name,
+      oid,
+      targetSha: null,
+      annotated: false,
+      unresolvable: false,
+    };
+    // Peel annotated tags (a chain, in the degenerate tag-of-tag case) down to
+    // the target object. `current` lives outside the try so a missing TARGET
+    // still yields the intended sha from the tag object we did read.
+    let current = oid;
+    try {
+      for (let hop = 0; hop < 10 && entry.targetSha === null; hop++) {
+        const obj = await git.readObject({ fs, dir, oid: current });
+        if (obj.type === "tag") {
+          const tag = obj.object as {
+            object: string;
+            message?: string;
+            tagger?: { name: string; email: string; timestamp: number };
+          };
+          entry.annotated = true;
+          if (hop === 0) {
+            if (typeof tag.message === "string") entry.message = tag.message.trim();
+            if (tag.tagger) {
+              entry.tagger = `${tag.tagger.name} <${tag.tagger.email}>`;
+              entry.timestamp = tag.tagger.timestamp;
+            }
+          }
+          current = tag.object;
+        } else {
+          entry.targetSha = current;
+        }
+      }
+      // A peel chain that never terminated (>10 hops) is unresolvable too.
+      if (entry.targetSha === null) entry.unresolvable = true;
+    } catch {
+      // The object at `current` is missing locally. If we peeled at least one
+      // tag object, `current` names the intended target — record it, degraded.
+      entry.targetSha = current === oid ? null : current;
+      entry.unresolvable = true;
+    }
+    entries.push(entry);
+  }
+  return entries;
+}
+
+/**
+ * Clone a repo (shallow, with tag refs fetched) and list its tags. A tag whose
+ * target lies outside the shallow window comes back `unresolvable: true` rather
+ * than erroring — see `collectRepoTags`.
+ */
+export async function listRepoTags(
+  remote: string,
+  token: string,
+  logger: Logger,
+  httpClient: HttpClient = http,
+): Promise<Result<RepoTagEntry[], AppError>> {
+  logger.debug("Listing repo tags", { remote });
+
+  const cloneResult = await cloneRepo(remote, token, logger, httpClient, { includeTags: true });
+  if (!cloneResult.success) return err(cloneResult.error);
+
+  const collected = await fromPromise(collectRepoTags(cloneResult.data.fs, cloneResult.data.dir));
+  if (!collected.success) {
+    logger.error("Failed to collect repo tags", collected.error, { remote });
+    return err(new ExternalServiceError("Git", "Failed to list tags", collected.error));
+  }
+
+  logger.info("Successfully listed repo tags", { remote, tagCount: collected.data.length });
+  return ok(collected.data);
 }
 
 export async function commitAndPush(

--- a/src/ui/pages/repo.tsx
+++ b/src/ui/pages/repo.tsx
@@ -201,6 +201,9 @@ export const RepoPage: FC<RepoProps> = ({
           <a class="btn" href={`/${project.namespace}/${project.slug}/activity`}>
             Activity
           </a>
+          <a class="btn" href={`/${project.namespace}/${project.slug}/tags`}>
+            Tags
+          </a>
           {isOwner && (
             <a class="btn" href={`/${project.namespace}/${project.slug}/webhooks`}>
               Webhooks

--- a/src/ui/pages/tags.tsx
+++ b/src/ui/pages/tags.tsx
@@ -1,0 +1,84 @@
+import type { FC } from "hono/jsx";
+import type { RepoTagEntry } from "../../storage/git-ops";
+import { Layout } from "../layout";
+
+interface TagsProps {
+  project: {
+    name: string;
+    namespace: string;
+    slug: string;
+  };
+  tags: RepoTagEntry[];
+  user?: { id: string; email: string; username: string } | null;
+}
+
+/** "12 Mar 2026" from a tagger timestamp (epoch seconds); empty when absent. */
+export function formatTagDate(timestamp: number | undefined): string {
+  if (timestamp === undefined) return "";
+  const date = new Date(timestamp * 1000);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+}
+
+export const TagsPage: FC<TagsProps> = ({ project, tags, user }) => {
+  return (
+    <Layout title={`Tags — ${project.name}`} user={user}>
+      <div class="page-header">
+        <h1>Tags</h1>
+        <a class="btn" href={`/${project.namespace}/${project.slug}`}>
+          Back to repo
+        </a>
+      </div>
+
+      {tags.length === 0 ? (
+        <div class="empty-state">
+          <p>No tags yet.</p>
+          <p class="empty-state-hint">
+            Push a tag to a workspace remote to create one — the project remote refuses tag pushes.
+          </p>
+        </div>
+      ) : (
+        <div class="card">
+          <div class="table-scroll">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Tag</th>
+                  <th>Type</th>
+                  <th>Target</th>
+                  <th>Message</th>
+                  <th>Tagged</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tags.map((tag) => (
+                  <tr key={tag.name}>
+                    <td class="mono">{tag.name}</td>
+                    <td>
+                      <span class={`badge ${tag.annotated ? "badge-open" : ""}`}>
+                        {tag.annotated ? "annotated" : "lightweight"}
+                      </span>
+                    </td>
+                    <td class="mono">
+                      {/* A tag pointing outside the shallow clone window is still
+                          shown, marked unresolvable, never an error. */}
+                      {tag.unresolvable ? (
+                        <span class="badge badge-rejected" title={tag.targetSha ?? tag.oid}>
+                          unresolvable
+                        </span>
+                      ) : (
+                        (tag.targetSha ?? tag.oid).slice(0, 7)
+                      )}
+                    </td>
+                    <td>{tag.message ?? ""}</td>
+                    <td>{formatTagDate(tag.timestamp)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </Layout>
+  );
+};

--- a/src/ui/pages/tags.tsx
+++ b/src/ui/pages/tags.tsx
@@ -12,7 +12,12 @@ interface TagsProps {
   user?: { id: string; email: string; username: string } | null;
 }
 
-/** "12 Mar 2026" from a tagger timestamp (epoch seconds); empty when absent. */
+/**
+ * Formats a tagger timestamp as a day, abbreviated month, and year.
+ *
+ * @param timestamp - The timestamp in epoch seconds.
+ * @returns The formatted date, or an empty string when the timestamp is absent or invalid.
+ */
 export function formatTagDate(timestamp: number | undefined): string {
   if (timestamp === undefined) return "";
   const date = new Date(timestamp * 1000);

--- a/src/ui/pages/tags.tsx
+++ b/src/ui/pages/tags.tsx
@@ -52,6 +52,7 @@ export const TagsPage: FC<TagsProps> = ({ project, tags, user }) => {
                   <th>Type</th>
                   <th>Target</th>
                   <th>Message</th>
+                  <th>Tagger</th>
                   <th>Tagged</th>
                 </tr>
               </thead>
@@ -76,6 +77,9 @@ export const TagsPage: FC<TagsProps> = ({ project, tags, user }) => {
                       )}
                     </td>
                     <td>{tag.message ?? ""}</td>
+                    {/* Lightweight tags carry no tagger; blank rather than a
+                        placeholder, matching the Message cell above. */}
+                    <td>{tag.tagger ?? ""}</td>
                     <td>{formatTagDate(tag.timestamp)}</td>
                   </tr>
                 ))}

--- a/tests/backup-tags.test.ts
+++ b/tests/backup-tags.test.ts
@@ -254,6 +254,53 @@ describe("restore round-trip with tags", () => {
     const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger);
     expect(rebuilt.success).toBe(false);
   });
+
+  // The manifest is read back from storage and its tag names are interpolated
+  // into `refs/tags/<name>` and written with force:true — a traversing name would
+  // resolve outside refs/tags/ and could overwrite refs/heads/main.
+  it.each([
+    ["path traversal into refs/heads", "../heads/main"],
+    ["absolute ref path", "/refs/heads/main"],
+    ["parent-dir segment", "v1/../../heads/main"],
+    ["leading dot", ".hidden"],
+    ["lock suffix", "v1.0.0.lock"],
+    ["empty name", ""],
+    ["control characters", "v1\u0000evil"],
+  ])("rejects a manifest tag name with %s", async (_label, tagName) => {
+    const { fs } = await buildRepo([{ "a.txt": "one" }]);
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    const snap = buildSnapshot(project, walk.data, "2026-08-18T00:00:00Z");
+    const tipSha = snap.manifest.tipSha;
+    // A real, present object id: only the NAME is hostile here.
+    snap.manifest.tags = [{ name: tagName, oid: tipSha }];
+
+    const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger);
+
+    expect(rebuilt.success).toBe(false);
+    if (rebuilt.success) throw new Error("expected rejection");
+    expect(rebuilt.error.message).toContain("Invalid tag name in manifest");
+  });
+
+  it("still reconstructs ordinary tag names containing dots and slashes", async () => {
+    const { fs } = await buildRepo([{ "a.txt": "one" }]);
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    const snap = buildSnapshot(project, walk.data, "2026-08-18T00:00:00Z");
+    snap.manifest.tags = [{ name: "release/v1.0.0", oid: snap.manifest.tipSha }];
+
+    const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger);
+
+    expect(rebuilt.success).toBe(true);
+    if (!rebuilt.success) return;
+    expect(
+      await git.resolveRef({
+        fs: rebuilt.data.fs,
+        dir: rebuilt.data.dir,
+        ref: "refs/tags/release/v1.0.0",
+      }),
+    ).toBe(snap.manifest.tipSha);
+  });
 });
 
 describe("restoreProjectRepo tag push", () => {
@@ -312,5 +359,48 @@ describe("restoreProjectRepo tag push", () => {
     const result = await restoreProjectRepo(env, snap, {}, logger);
     expect(result.success).toBe(false);
     expect(deleteFn).toHaveBeenCalledWith("repo");
+  });
+
+  /** A forced restore over an EXISTING repo is deliberately not rolled back, so a
+   * mid-list tag failure leaves main plus some tags on the remote. The failure has
+   * to say how far it got — otherwise the partial state is invisible. */
+  function makeExistingEnv(deleteFn = vi.fn(async () => true)) {
+    const env = {
+      ARTIFACTS: {
+        get: vi.fn(async () => ({
+          name: "repo",
+          remote: project.remote,
+          createToken: vi.fn(async () => ({ plaintext: "tok" })),
+        })),
+        create: vi.fn(),
+        delete: deleteFn,
+      } as unknown as Env["ARTIFACTS"],
+    } as Env;
+    return { env, deleteFn };
+  }
+
+  it("reports how many tags landed when a forced restore fails mid-list", async () => {
+    // main ok, first tag ok, second tag fails -> 1 of 2 tags pushed.
+    mockPush
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValueOnce(new Error("tag rejected"));
+    const { env, deleteFn } = makeExistingEnv();
+    const { snap } = await makeSnapshot();
+
+    const result = await restoreProjectRepo(env, snap, { force: true }, logger);
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("expected failure");
+    // Names the progress rather than a bare "tag push failed".
+    expect(result.error.message).toContain("1/2 tags pushed");
+    // The pre-existing repo is never deleted by the rollback path.
+    expect(deleteFn).not.toHaveBeenCalled();
+    // And the partial state is logged for an operator/retry.
+    expect(logger.error).toHaveBeenCalledWith(
+      "Forced restore left partial state on an existing repo",
+      undefined,
+      expect.objectContaining({ mainPushed: true, tagCount: 2 }),
+    );
   });
 });

--- a/tests/backup-tags.test.ts
+++ b/tests/backup-tags.test.ts
@@ -332,6 +332,20 @@ describe("restore round-trip with tags", () => {
     ["dot-prefixed inner component", "release/.hidden"],
     ["trailing-dot inner component", "release/v1."],
     ["lock-suffixed inner component", "release/v1.0.lock/next"],
+    ["tilde", "v1~1"],
+    ["caret", "v1^1"],
+    ["colon", "a:b"],
+    ["question mark", "a?b"],
+    ["asterisk", "a*b"],
+    ["open bracket", "a[b"],
+    ["backslash", "a\\b"],
+    ["reflog syntax", "v1@{0}"],
+    ["space", "release v1"],
+    ["DEL character", "v1\u007fevil"],
+    // Accepted by `git check-ref-format`, refused by isomorphic-git's writeRef:
+    // clean-git-ref collapses `./` to `/`. Rejecting it here keeps the failure
+    // in the guard instead of half-way through the tag-write loop.
+    ["a ./ sequence writeRef refuses", "v1./next"],
   ])("rejects a manifest tag name with %s", async (_label, tagName) => {
     const { fs } = await buildRepo([{ "a.txt": "one" }]);
     const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
@@ -346,6 +360,41 @@ describe("restore round-trip with tags", () => {
     expect(rebuilt.success).toBe(false);
     if (rebuilt.success) throw new Error("expected rejection");
     expect(rebuilt.error.message).toContain("Invalid tag name in manifest");
+  });
+
+  // Every name here is accepted by `git check-ref-format refs/tags/<name>` and
+  // was rejected by the previous allowlist. A backup holding one of these could
+  // be written but never restored.
+  it.each([
+    ["an @ sign", "release@prod"],
+    ["a comma", "v1,2"],
+    ["a percent sign", "a%b"],
+    ["an exclamation mark", "v1.0.0!"],
+    ["parentheses", "feature(x)"],
+    ["an equals sign", "v1=2"],
+    ["an ampersand", "a&b"],
+    ["an apostrophe", "tag'name"],
+    ["a brace that is not @{", "a{b"],
+    ["non-ASCII (CJK)", "\u7248\u672c1"],
+    ["non-ASCII (diacritics)", "\u00fcn\u00efcode"],
+  ])("reconstructs a tag name with %s", async (_label, tagName) => {
+    const { fs } = await buildRepo([{ "a.txt": "one" }]);
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    const snap = buildSnapshot(project, walk.data, "2026-08-18T00:00:00Z");
+    snap.manifest.tags = [{ name: tagName, oid: snap.manifest.tipSha }];
+
+    const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger);
+
+    expect(rebuilt.success).toBe(true);
+    if (!rebuilt.success) throw new Error(rebuilt.error.message);
+    expect(
+      await git.resolveRef({
+        fs: rebuilt.data.fs,
+        dir: rebuilt.data.dir,
+        ref: `refs/tags/${tagName}`,
+      }),
+    ).toBe(snap.manifest.tipSha);
   });
 
   it("still reconstructs ordinary tag names containing dots and slashes", async () => {

--- a/tests/backup-tags.test.ts
+++ b/tests/backup-tags.test.ts
@@ -236,6 +236,47 @@ describe("backup walk with tags", () => {
     return { fs };
   }
 
+  it("skips an unresolvable tag without spending its bytes against the cap", async () => {
+    // The tag's own object is large and reads fine; the target it points at is
+    // missing, so the tag is skipped. Those provisional bytes used to stay in
+    // the running total, and if they crossed maxBytes the whole backup came
+    // back tooLarge instead of just dropping the tag.
+    const headOnly = await buildRepo([{ "a.txt": "one" }]);
+    const headWalk = await walkRepoObjects(headOnly.fs, SRC, 10_000_000, logger);
+    if (!headWalk.success || !("objects" in headWalk.data)) throw new Error("walk failed");
+    const headBytes = headWalk.data.objects.reduce((n, o) => n + o.bytes.byteLength, 0);
+
+    const { fs } = await buildRepo([{ "a.txt": "one" }]);
+    const bloatedTagOid = await git.writeTag({
+      fs,
+      dir: SRC,
+      tag: {
+        object: MISSING_OID,
+        type: "commit",
+        tag: "bloat",
+        tagger: { name: "t", email: "t@x.io", timestamp: 0, timezoneOffset: 0 },
+        message: "z".repeat(5000),
+      },
+    });
+    await git.writeRef({ fs, dir: SRC, ref: "refs/tags/bloat", value: bloatedTagOid, force: true });
+
+    // A cap that HEAD fits inside but the extra tag object would blow past.
+    const walk = await walkRepoObjects(fs, SRC, headBytes + 64, logger);
+
+    expect(walk.success).toBe(true);
+    if (!walk.success) return;
+    // Skipped, not tooLarge.
+    expect("objects" in walk.data).toBe(true);
+    if (!("objects" in walk.data)) return;
+    expect(walk.data.tags).toEqual([]);
+    // Rolled back, not merely unrecorded: the tag object itself is gone too.
+    expect(walk.data.objects.map((o) => o.oid)).not.toContain(bloatedTagOid);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Backup: skipping unresolvable tag",
+      expect.objectContaining({ name: "bloat" }),
+    );
+  });
+
   it("aborts with tooLarge when a blob-only tag overflows the cap", async () => {
     const { fs } = await buildRepo([{ "a.txt": "one" }]);
     // A big blob referenced by NO commit — only the tag reaches it.

--- a/tests/backup-tags.test.ts
+++ b/tests/backup-tags.test.ts
@@ -236,6 +236,51 @@ describe("backup walk with tags", () => {
     return { fs };
   }
 
+  it("captures both sides of a merge when a tag's ancestry is walked", async () => {
+    // The tag walk stops at commits already collected. That stop has to be a
+    // frontier: a merge can have one parent already in and the other not, and
+    // halting at the first collected commit would drop the unseen side.
+    const { fs, shas } = await buildRepo([{ "a.txt": "one" }]);
+    const base = shas[0] as string;
+
+    // Two independent children of `base`, then a merge commit joining them.
+    // Parents are overridden explicitly; the tree comes from the index.
+    // biome-ignore lint/suspicious/noExplicitAny: isomorphic-git fs shape
+    await (fs as any).promises.writeFile(`${SRC}/left.txt`, "left");
+    await git.add({ fs, dir: SRC, filepath: "left.txt" });
+    const left = await git.commit({ fs, dir: SRC, message: "left", author, parent: [base] });
+
+    // biome-ignore lint/suspicious/noExplicitAny: isomorphic-git fs shape
+    await (fs as any).promises.writeFile(`${SRC}/right.txt`, "right");
+    await git.add({ fs, dir: SRC, filepath: "right.txt" });
+    const right = await git.commit({ fs, dir: SRC, message: "right", author, parent: [base] });
+
+    // `base` first, deliberately: it is already collected via HEAD, so a walk
+    // that stops the whole queue at the first collected commit — rather than
+    // stopping that path only — would drop `left` and `right` behind it.
+    const merge = await git.commit({
+      fs,
+      dir: SRC,
+      message: "merge",
+      author,
+      parent: [base, left, right],
+    });
+
+    // HEAD stays on `base`, so only the tag reaches the merge and its parents.
+    await git.writeRef({ fs, dir: SRC, ref: "refs/heads/main", value: base, force: true });
+    await git.tag({ fs, dir: SRC, ref: "merged", object: merge });
+
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+
+    const oids = walk.data.objects.map((o) => o.oid);
+    expect(oids).toContain(merge);
+    expect(oids).toContain(left);
+    expect(oids).toContain(right);
+    expect(oids).toContain(base);
+    expect(walk.data.tags.map((t) => t.name)).toEqual(["merged"]);
+  });
+
   it("skips an unresolvable tag without spending its bytes against the cap", async () => {
     // The tag's own object is large and reads fine; the target it points at is
     // missing, so the tag is skipped. Those provisional bytes used to stay in

--- a/tests/backup-tags.test.ts
+++ b/tests/backup-tags.test.ts
@@ -4,6 +4,7 @@ import { reconstructRepo, restoreProjectRepo } from "../src/backup/repo-restore"
 import { type RepoManifest, buildSnapshot, walkRepoObjects } from "../src/backup/repo-snapshot";
 import type { NodeFS } from "../src/storage/git-ops";
 import { MemoryFS } from "../src/storage/memory-fs";
+import { placeLooseObject } from "../src/storage/object-loader";
 import type { Env, ProjectEntry } from "../src/types";
 import type { Logger } from "../src/utils/logger";
 
@@ -151,6 +152,67 @@ describe("backup walk with tags", () => {
     );
   });
 
+  it("snapshots a tag-of-tag chain longer than the old fixed hop cap", async () => {
+    const { fs, shas } = await buildRepo([{ "a.txt": "one" }]);
+    const c1 = shas[0] as string;
+    let current = c1;
+    let currentType: "commit" | "tag" = "commit";
+    // 11 tag objects deep — one more than the old fixed 10-hop limit.
+    for (let i = 0; i < 11; i++) {
+      current = await git.writeTag({
+        fs,
+        dir: SRC,
+        tag: { object: current, type: currentType, tag: `t${i}`, tagger, message: `t${i}\n` },
+      });
+      currentType = "tag";
+    }
+    await git.writeRef({ fs, dir: SRC, ref: "refs/tags/deep", value: current, force: true });
+
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    expect(walk.data.tags).toEqual([{ name: "deep", oid: current }]);
+    const oids = walk.data.objects.map((o) => o.oid);
+    expect(oids).toContain(c1); // the chain's target commit made it into the pack
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      "Backup: skipping unresolvable tag",
+      expect.anything(),
+    );
+  });
+
+  it("skips (with a warning) a tag whose oid forms a cycle instead of looping forever", async () => {
+    const { fs, shas } = await buildRepo([{ "a.txt": "one" }]);
+    await git.tag({ fs, dir: SRC, ref: "good", object: shas[0] });
+    // A real tag-of-tag cycle can't exist through normal writes (an oid is a
+    // hash of content that would have to embed that same oid). Simulate the
+    // on-disk corruption the visited-oid guard defends against: place a loose
+    // tag object, at an oid we choose, whose own `object` field is that same
+    // oid — placeLooseObject bypasses hash verification, so this is a genuine
+    // self-reference once read back.
+    const selfOid = "c".repeat(40);
+    const content = new TextEncoder().encode(
+      `object ${selfOid}\ntype commit\ntag cycle\ntagger Test <test@x.com> 1700000000 +0000\n\nself-referential (corrupted fixture)\n`,
+    );
+    const header = new TextEncoder().encode(`tag ${content.length}\0`);
+    const bytes = new Uint8Array(header.length + content.length);
+    bytes.set(header, 0);
+    bytes.set(content, header.length);
+    await placeLooseObject(
+      fs as unknown as Parameters<typeof placeLooseObject>[0],
+      `${SRC}/.git`,
+      selfOid,
+      bytes,
+    );
+    await git.writeRef({ fs, dir: SRC, ref: "refs/tags/cycle", value: selfOid, force: true });
+
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    expect(walk.data.tags.map((t) => t.name)).toEqual(["good"]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Backup: skipping unresolvable tag",
+      expect.objectContaining({ name: "cycle" }),
+    );
+  });
+
   it("aborts with tooLarge when the tag walk pushes the byte total over the cap", async () => {
     // Measure the HEAD-only byte count first…
     const headOnly = await buildRepo([{ "a.txt": "one" }]);
@@ -266,6 +328,10 @@ describe("restore round-trip with tags", () => {
     ["lock suffix", "v1.0.0.lock"],
     ["empty name", ""],
     ["control characters", "v1\u0000evil"],
+    ["repeated slash (empty component)", "release//v1"],
+    ["dot-prefixed inner component", "release/.hidden"],
+    ["trailing-dot inner component", "release/v1."],
+    ["lock-suffixed inner component", "release/v1.0.lock/next"],
   ])("rejects a manifest tag name with %s", async (_label, tagName) => {
     const { fs } = await buildRepo([{ "a.txt": "one" }]);
     const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);

--- a/tests/backup-tags.test.ts
+++ b/tests/backup-tags.test.ts
@@ -1,0 +1,316 @@
+import git from "isomorphic-git";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { reconstructRepo, restoreProjectRepo } from "../src/backup/repo-restore";
+import { type RepoManifest, buildSnapshot, walkRepoObjects } from "../src/backup/repo-snapshot";
+import type { NodeFS } from "../src/storage/git-ops";
+import { MemoryFS } from "../src/storage/memory-fs";
+import type { Env, ProjectEntry } from "../src/types";
+import type { Logger } from "../src/utils/logger";
+
+// Only `push` (the sole Artifacts-coupled git call in the restore path) is
+// mocked; every other git function runs for real against MemoryFS so the
+// round-trip below proves genuine object stores, not stubs.
+const { mockPush } = vi.hoisted(() => ({ mockPush: vi.fn() }));
+
+vi.mock("isomorphic-git", async (importActual) => {
+  const actual = await importActual<typeof import("isomorphic-git")>();
+  return {
+    ...actual,
+    default: { ...actual.default, push: (args: unknown) => mockPush(args) },
+  };
+});
+
+const logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+} as unknown as Logger;
+
+const SRC = "/src";
+const author = { name: "t", email: "t@x.com", timestamp: 1_700_000_000, timezoneOffset: 0 };
+const tagger = { name: "tagger", email: "tag@x.com", timestamp: 1_700_000_100, timezoneOffset: 0 };
+const MISSING_OID = "f".repeat(40);
+
+const project: ProjectEntry = {
+  id: "p1",
+  name: "repo",
+  slug: "repo",
+  namespace: "@owner",
+  ownerId: "u1",
+  ownerType: "user",
+  remote: "https://acct.artifacts.cloudflare.net/git/@owner/repo.git",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+async function buildRepo(
+  commits: Record<string, string>[],
+): Promise<{ fs: NodeFS; shas: string[] }> {
+  const fs = new MemoryFS().toNodeFS() as unknown as NodeFS;
+  await git.init({ fs, dir: SRC, defaultBranch: "main" });
+  const shas: string[] = [];
+  for (const files of commits) {
+    for (const [path, content] of Object.entries(files)) {
+      // biome-ignore lint/suspicious/noExplicitAny: isomorphic-git fs shape
+      await (fs as any).promises.writeFile(`${SRC}/${path}`, content);
+      await git.add({ fs, dir: SRC, filepath: path });
+    }
+    shas.push(await git.commit({ fs, dir: SRC, message: "c", author }));
+  }
+  return { fs, shas };
+}
+
+/** A repo whose second commit is reachable ONLY via refs/tags/keep (an
+ * annotated tag): main is reset back to the first commit. */
+async function buildTaggedRepo(): Promise<{
+  fs: NodeFS;
+  c1: string;
+  c2: string;
+  keepOid: string;
+}> {
+  const { fs, shas } = await buildRepo([{ "a.txt": "one" }, { "side.txt": "tag-only" }]);
+  const [c1, c2] = shas as [string, string];
+  await git.annotatedTag({
+    fs,
+    dir: SRC,
+    ref: "keep",
+    object: c2,
+    message: "kept release\n",
+    tagger,
+  });
+  await git.tag({ fs, dir: SRC, ref: "lw", object: c1 });
+  // Rewind main so c2 is only reachable through the tag.
+  await git.writeRef({ fs, dir: SRC, ref: "refs/heads/main", value: c1, force: true });
+  const keepOid = await git.resolveRef({ fs, dir: SRC, ref: "refs/tags/keep" });
+  return { fs, c1, c2, keepOid };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("backup walk with tags", () => {
+  it("captures tag refs, annotated tag objects, and commits reachable only from tags", async () => {
+    const { fs, c1, c2, keepOid } = await buildTaggedRepo();
+
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    expect(walk.success).toBe(true);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+
+    // HEAD tip is still main's tip.
+    expect(walk.data.tipSha).toBe(c1);
+    // Both refs recorded (sorted), pointing at the tag object / target.
+    expect(walk.data.tags).toEqual([
+      { name: "keep", oid: keepOid },
+      { name: "lw", oid: c1 },
+    ]);
+    // The pack closes over the tag: the annotated tag object AND the tag-only
+    // commit (plus its tree/blob) are included.
+    const oids = walk.data.objects.map((o) => o.oid);
+    expect(oids).toContain(keepOid);
+    expect(oids).toContain(c2);
+    expect(oids).toContain(c1);
+    expect(new Set(oids).size).toBe(oids.length); // still deduped
+
+    const snap = buildSnapshot(project, walk.data, "2026-08-18T00:00:00Z");
+    expect(snap.manifest.tags).toEqual(walk.data.tags);
+  });
+
+  it("captures tags pointing at trees and blobs, not just commits", async () => {
+    const { fs, shas } = await buildRepo([{ "a.txt": "one" }]);
+    const c1 = shas[0] as string;
+    const commit = await git.readCommit({ fs, dir: SRC, oid: c1 });
+    const treeOid = commit.commit.tree;
+    const tree = await git.readTree({ fs, dir: SRC, oid: treeOid });
+    const blobOid = tree.tree[0]?.oid as string;
+    await git.tag({ fs, dir: SRC, ref: "tree-tag", object: treeOid });
+    await git.tag({ fs, dir: SRC, ref: "blob-tag", object: blobOid });
+
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    expect(walk.data.tags.map((t) => t.name)).toEqual(["blob-tag", "tree-tag"]);
+  });
+
+  it("skips (with a warning) a tag whose object is missing, keeping the pack closed", async () => {
+    const { fs, shas } = await buildRepo([{ "a.txt": "one" }]);
+    await git.writeRef({ fs, dir: SRC, ref: "refs/tags/ghost", value: MISSING_OID, force: true });
+    await git.tag({ fs, dir: SRC, ref: "good", object: shas[0] });
+
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    // The dangling ref is NOT recorded — restoring it would fail the readObject
+    // guard — but the healthy tag still is.
+    expect(walk.data.tags.map((t) => t.name)).toEqual(["good"]);
+    expect(walk.data.objects.map((o) => o.oid)).not.toContain(MISSING_OID);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Backup: skipping unresolvable tag",
+      expect.objectContaining({ name: "ghost" }),
+    );
+  });
+
+  it("aborts with tooLarge when the tag walk pushes the byte total over the cap", async () => {
+    // Measure the HEAD-only byte count first…
+    const headOnly = await buildRepo([{ "a.txt": "one" }]);
+    const headWalk = await walkRepoObjects(headOnly.fs, SRC, 10_000_000, logger);
+    if (!headWalk.success || !("objects" in headWalk.data)) throw new Error("walk failed");
+    const headBytes = headWalk.data.objects.reduce((n, o) => n + o.bytes.byteLength, 0);
+
+    // …then add a big tag-only commit and cap just above the HEAD walk.
+    const { fs } = await buildTaggedRepoWithBigTag();
+    const walk = await walkRepoObjects(fs, SRC, headBytes + 32, logger);
+    expect(walk.success).toBe(true);
+    if (!walk.success) return;
+    expect("tooLarge" in walk.data).toBe(true);
+  });
+
+  async function buildTaggedRepoWithBigTag(): Promise<{ fs: NodeFS }> {
+    const { fs, shas } = await buildRepo([{ "a.txt": "one" }, { "big.txt": "x".repeat(5000) }]);
+    const [c1, c2] = shas as [string, string];
+    await git.tag({ fs, dir: SRC, ref: "big", object: c2 });
+    await git.writeRef({ fs, dir: SRC, ref: "refs/heads/main", value: c1, force: true });
+    return { fs };
+  }
+
+  it("aborts with tooLarge when a blob-only tag overflows the cap", async () => {
+    const { fs } = await buildRepo([{ "a.txt": "one" }]);
+    // A big blob referenced by NO commit — only the tag reaches it.
+    const blobOid = await git.writeBlob({
+      fs,
+      dir: SRC,
+      blob: new TextEncoder().encode("y".repeat(5000)),
+    });
+    await git.writeRef({ fs, dir: SRC, ref: "refs/tags/fat-blob", value: blobOid, force: true });
+
+    const headWalk = await walkRepoObjects(
+      (await buildRepo([{ "a.txt": "one" }])).fs,
+      SRC,
+      10_000_000,
+      logger,
+    );
+    if (!headWalk.success || !("objects" in headWalk.data)) throw new Error("walk failed");
+    const headBytes = headWalk.data.objects.reduce((n, o) => n + o.bytes.byteLength, 0);
+
+    const walk = await walkRepoObjects(fs, SRC, headBytes + 32, logger);
+    expect(walk.success).toBe(true);
+    if (!walk.success) return;
+    expect("tooLarge" in walk.data).toBe(true);
+  });
+});
+
+describe("restore round-trip with tags", () => {
+  it("reconstructs tag refs alongside main and preserves annotated metadata", async () => {
+    const { fs, c1, c2, keepOid } = await buildTaggedRepo();
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    const snap = buildSnapshot(project, walk.data, "2026-08-18T00:00:00Z");
+
+    const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger);
+    expect(rebuilt.success).toBe(true);
+    if (!rebuilt.success) return;
+    const { fs: rfs, dir } = rebuilt.data;
+
+    expect(await git.resolveRef({ fs: rfs, dir, ref: "main" })).toBe(c1);
+    expect(await git.resolveRef({ fs: rfs, dir, ref: "refs/tags/keep" })).toBe(keepOid);
+    expect(await git.resolveRef({ fs: rfs, dir, ref: "refs/tags/lw" })).toBe(c1);
+
+    // The annotated tag object survived with its message and still peels to the
+    // tag-only commit, whose content is intact.
+    const tag = await git.readTag({ fs: rfs, dir, oid: keepOid });
+    expect(tag.tag.message.trim()).toBe("kept release");
+    expect(tag.tag.object).toBe(c2);
+    const files = await git.listFiles({ fs: rfs, dir, ref: c2 });
+    expect(files.sort()).toEqual(["a.txt", "side.txt"]);
+  });
+
+  it("still restores an OLD-format manifest without a tags field", async () => {
+    const { fs, shas } = await buildRepo([{ "a.txt": "one" }]);
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    const snap = buildSnapshot(project, walk.data, "2026-08-18T00:00:00Z");
+    // Simulate a manifest written before tag support (JSON round-trip drops the key).
+    const legacy = JSON.parse(JSON.stringify(snap.manifest)) as RepoManifest;
+    // biome-ignore lint/performance/noDelete: constructing the legacy shape exactly
+    delete legacy.tags;
+
+    const rebuilt = await reconstructRepo(snap.pack, legacy, logger);
+    expect(rebuilt.success).toBe(true);
+    if (!rebuilt.success) return;
+    expect(await git.resolveRef({ fs: rebuilt.data.fs, dir: rebuilt.data.dir, ref: "main" })).toBe(
+      shas[0],
+    );
+  });
+
+  it("fails reconstruction when a manifest tag's object is missing from the pack", async () => {
+    const { fs, shas } = await buildRepo([{ "a.txt": "one" }]);
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    const snap = buildSnapshot(project, walk.data, "2026-08-18T00:00:00Z");
+    snap.manifest.tags = [...(snap.manifest.tags ?? []), { name: "bogus", oid: MISSING_OID }];
+    void shas;
+
+    const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger);
+    expect(rebuilt.success).toBe(false);
+  });
+});
+
+describe("restoreProjectRepo tag push", () => {
+  function makeEnv(deleteFn = vi.fn(async () => true)): { env: Env; deleteFn: typeof deleteFn } {
+    const env = {
+      ARTIFACTS: {
+        get: vi.fn(async () => null),
+        create: vi.fn(async () => ({
+          name: "repo",
+          remote: project.remote,
+          token: "tok",
+        })),
+        delete: deleteFn,
+      } as unknown as Env["ARTIFACTS"],
+    } as Env;
+    return { env, deleteFn };
+  }
+
+  async function makeSnapshot() {
+    const { fs, keepOid } = await buildTaggedRepo();
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    return { snap: buildSnapshot(project, walk.data, "2026-08-18T00:00:00Z"), keepOid };
+  }
+
+  it("pushes main first, then every tag ref", async () => {
+    mockPush.mockResolvedValue({ ok: true });
+    const { env } = makeEnv();
+    const { snap } = await makeSnapshot();
+
+    const result = await restoreProjectRepo(env, snap, {}, logger);
+    expect(result.success).toBe(true);
+    const refs = mockPush.mock.calls.map((c) => (c[0] as { ref: string }).ref);
+    expect(refs).toEqual(["main", "refs/tags/keep", "refs/tags/lw"]);
+  });
+
+  it("pushes only main for an old-format manifest without tags", async () => {
+    mockPush.mockResolvedValue({ ok: true });
+    const { env } = makeEnv();
+    const { snap } = await makeSnapshot();
+    const legacy = JSON.parse(JSON.stringify(snap.manifest)) as RepoManifest;
+    // biome-ignore lint/performance/noDelete: constructing the legacy shape exactly
+    delete legacy.tags;
+
+    const result = await restoreProjectRepo(env, { pack: snap.pack, manifest: legacy }, {}, logger);
+    expect(result.success).toBe(true);
+    expect(mockPush.mock.calls.map((c) => (c[0] as { ref: string }).ref)).toEqual(["main"]);
+  });
+
+  it("rolls back a freshly created repo when a tag push fails", async () => {
+    // main push succeeds, the first tag push fails.
+    mockPush.mockResolvedValueOnce({ ok: true }).mockRejectedValueOnce(new Error("tag rejected"));
+    const { env, deleteFn } = makeEnv();
+    const { snap } = await makeSnapshot();
+
+    const result = await restoreProjectRepo(env, snap, {}, logger);
+    expect(result.success).toBe(false);
+    expect(deleteFn).toHaveBeenCalledWith("repo");
+  });
+});

--- a/tests/git-http-tags.test.ts
+++ b/tests/git-http-tags.test.ts
@@ -151,15 +151,19 @@ function pktLine(payload: string): string {
   return (payload.length + 4).toString(16).padStart(4, "0") + payload;
 }
 
+/** Real receive-pack framing: every command line ends with LF, and capabilities
+ * ride on the FIRST command only. Building it correctly keeps these fixtures from
+ * passing on parser tolerance that a real client would never exercise. */
 function pushBody(lines: string[]): Uint8Array {
   return new TextEncoder().encode(
-    `${lines.map((l) => pktLine(`${l}\0report-status`)).join("")}0000`,
+    `${lines
+      .map((line, index) => pktLine(`${line}${index === 0 ? "\0report-status" : ""}\n`))
+      .join("")}0000`,
   );
 }
 
 function singleRefPush(oldOid: string, newOid: string, ref: string): Uint8Array {
-  const line = `${oldOid} ${newOid} ${ref}\0report-status`;
-  return new TextEncoder().encode(`${pktLine(line)}0000`);
+  return pushBody([`${oldOid} ${newOid} ${ref}`]);
 }
 
 /** A realistic upload-pack advertisement carrying branch AND tag refs (with the
@@ -340,7 +344,7 @@ describe("project-remote tag PUSH policy: explicit in-protocol refusal", () => {
         headers: basic(OWNER_TOKEN),
         // side-band-64k so guidance is streamed as remote: lines
         body: new TextEncoder().encode(
-          `${pktLine(`${ZEROS} ${OID_TAG} refs/tags/v1.0.0\0report-status side-band-64k`)}0000`,
+          `${pktLine(`${ZEROS} ${OID_TAG} refs/tags/v1.0.0\0report-status side-band-64k\n`)}0000`,
         ),
       }),
       env,

--- a/tests/git-http-tags.test.ts
+++ b/tests/git-http-tags.test.ts
@@ -1,0 +1,381 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../src/index";
+import type { Env, ProjectEntry } from "../src/types";
+
+// Tag behavior over the git smart-HTTP proxy (#182):
+//  - READ: info/refs and upload-pack are proxied to Artifacts unfiltered, so
+//    refs/tags/* advertised upstream reach the client byte-identically and tag
+//    objects are fetchable. Proven below against a realistic advertisement.
+//  - WRITE (project remote): a push touching refs/tags/* is refused in-protocol
+//    with a tag-specific reason — the change gate cannot represent a tag.
+//  - WRITE (workspace remote): proxied verbatim; tags land on the fork.
+
+vi.mock("../src/storage/git-ops", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/git-ops")>();
+  return {
+    ...actual,
+    freshRepoToken: vi.fn(async () => ({ success: true, data: "secret?expires=9999999999" })),
+  };
+});
+
+vi.mock("../src/services/change-flow", async (importActual) => {
+  const actual = await importActual<typeof import("../src/services/change-flow")>();
+  return {
+    ...actual,
+    createWorkspaceFork: vi.fn(async () => ({
+      success: true,
+      data: {
+        name: "push-abcd1234",
+        remote: "https://acct.artifacts.cloudflare.net/git/@owner/push-abcd1234.git",
+      },
+    })),
+    createChangeWithEvaluation: vi.fn(async () => ({
+      success: true,
+      data: {
+        change: { id: "chg_push1", status: "accepted" },
+        evalResult: { score: 0.9, passed: true, reason: "clean" },
+        evalRuns: [],
+      },
+    })),
+  };
+});
+
+const OWNER_TOKEN = "stratum_user_owner000000000000000000";
+
+vi.mock("../src/storage/users", () => ({
+  getUserByToken: vi.fn(async (_db: unknown, token: string) => {
+    if (token === OWNER_TOKEN)
+      return { success: true, data: { id: "user_owner", email: "o@x.io", username: "owner" } };
+    return { success: false, error: { message: "not found" } };
+  }),
+  getUser: vi.fn(async () => ({ success: false, error: { message: "not found" } })),
+}));
+
+vi.mock("../src/storage/agents", () => ({
+  getAgentByToken: vi.fn(async () => ({ success: false, error: { message: "not found" } })),
+}));
+
+import { createWorkspaceFork } from "../src/services/change-flow";
+
+const ARTIFACTS_REMOTE = "https://acct.artifacts.cloudflare.net/git/@owner/repo.git";
+const WS_REMOTE = "https://acct.artifacts.cloudflare.net/git/@owner/myws.git";
+
+function makeKV(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+  } as unknown as KVNamespace;
+}
+
+function makeEnv(extra: Partial<Env> = {}): Env {
+  return {
+    ARTIFACTS: { delete: vi.fn(async () => {}) } as unknown as Env["ARTIFACTS"],
+    STATE: makeKV(),
+    DB: {} as D1Database,
+    ...extra,
+  } as Env;
+}
+
+async function seedProject(env: Env, overrides: Partial<ProjectEntry> = {}): Promise<ProjectEntry> {
+  const project: ProjectEntry = {
+    id: "proj_1",
+    name: "repo",
+    slug: "repo",
+    namespace: "@owner",
+    ownerId: "user_owner",
+    ownerType: "user",
+    remote: ARTIFACTS_REMOTE,
+    createdAt: new Date().toISOString(),
+    visibility: "private",
+    ...overrides,
+  };
+  await env.STATE.put(`project:${project.namespace}:${project.slug}`, JSON.stringify(project));
+  return project;
+}
+
+async function seedWorkspace(env: Env): Promise<void> {
+  await env.STATE.put(
+    "workspace:proj_1:myws",
+    JSON.stringify({
+      name: "myws",
+      remote: WS_REMOTE,
+      parent: "proj_1",
+      createdAt: new Date().toISOString(),
+      createdByUserId: "user_owner",
+    }),
+  );
+}
+
+function req(path: string, init: RequestInit = {}): Request {
+  return new Request(`http://localhost${path}`, init);
+}
+
+function basic(token: string): Record<string, string> {
+  return { Authorization: `Basic ${btoa(`x:${token}`)}` };
+}
+
+let originalFetch: typeof fetch;
+
+function stubFetch(impl: (url: string, init: RequestInit) => Response): ReturnType<typeof vi.fn> {
+  const mock = vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) =>
+    impl(String(input), init),
+  );
+  globalThis.fetch = mock as unknown as typeof fetch;
+  return mock;
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ── pkt-line helpers ─────────────────────────────────────────────────────────
+
+const OID_A = "a".repeat(40);
+const OID_B = "b".repeat(40);
+const OID_TAG = "c".repeat(40);
+const ZEROS = "0".repeat(40);
+
+function pktLine(payload: string): string {
+  return (payload.length + 4).toString(16).padStart(4, "0") + payload;
+}
+
+function pushBody(lines: string[]): Uint8Array {
+  return new TextEncoder().encode(
+    `${lines.map((l) => pktLine(`${l}\0report-status`)).join("")}0000`,
+  );
+}
+
+function singleRefPush(oldOid: string, newOid: string, ref: string): Uint8Array {
+  const line = `${oldOid} ${newOid} ${ref}\0report-status`;
+  return new TextEncoder().encode(`${pktLine(line)}0000`);
+}
+
+/** A realistic upload-pack advertisement carrying branch AND tag refs (with the
+ * peeled ^{} entry an annotated tag advertises). */
+const TAG_ADVERTISEMENT = [
+  pktLine("# service=git-upload-pack\n"),
+  "0000",
+  pktLine(`${OID_A} HEAD\0multi_ack side-band-64k symref=HEAD:refs/heads/main\n`),
+  pktLine(`${OID_A} refs/heads/main\n`),
+  pktLine(`${OID_TAG} refs/tags/v1.0.0\n`),
+  pktLine(`${OID_B} refs/tags/v1.0.0^{}\n`),
+  pktLine(`${OID_B} refs/tags/v0.9.0\n`),
+  "0000",
+].join("");
+
+const ADVERTISE = "/@owner/repo.git/info/refs?service=git-upload-pack";
+
+describe("smart-HTTP tag READS pass through the proxy unfiltered", () => {
+  it("advertises refs/tags/* byte-identically to the upstream advertisement", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    stubFetch(
+      () =>
+        new Response(TAG_ADVERTISEMENT, {
+          status: 200,
+          headers: { "Content-Type": "application/x-git-upload-pack-advertisement" },
+        }),
+    );
+
+    const res = await app.fetch(req(ADVERTISE), env);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    // The proxy performs no ref filtering: annotated tag, its peeled entry, and
+    // the lightweight tag all reach the client exactly as Artifacts sent them.
+    expect(body).toBe(TAG_ADVERTISEMENT);
+    expect(body).toContain("refs/tags/v1.0.0");
+    expect(body).toContain("refs/tags/v1.0.0^{}");
+    expect(body).toContain("refs/tags/v0.9.0");
+  });
+
+  it("forwards an upload-pack request wanting a tag oid verbatim", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    const fetchMock = stubFetch(
+      () =>
+        new Response("PACKDATA", {
+          status: 200,
+          headers: { "Content-Type": "application/x-git-upload-pack-result" },
+        }),
+    );
+
+    const want = `${pktLine(`want ${OID_TAG} side-band-64k\n`)}0000${pktLine("done\n")}`;
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-upload-pack", {
+        method: "POST",
+        body: want,
+        headers: { "Content-Type": "application/x-git-upload-pack-request" },
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("PACKDATA");
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe(`${ARTIFACTS_REMOTE}/git-upload-pack`);
+    expect(new TextDecoder().decode(init.body as ArrayBuffer)).toContain(`want ${OID_TAG}`);
+  });
+
+  it("workspace advertisement passes tags through too", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "public" });
+    await seedWorkspace(env);
+    stubFetch(
+      () =>
+        new Response(TAG_ADVERTISEMENT, {
+          status: 200,
+          headers: { "Content-Type": "application/x-git-upload-pack-advertisement" },
+        }),
+    );
+    const res = await app.fetch(
+      req("/@owner/repo/workspaces/myws.git/info/refs?service=git-upload-pack"),
+      env,
+    );
+    expect(await res.text()).toBe(TAG_ADVERTISEMENT);
+  });
+});
+
+describe("project-remote tag PUSH policy: explicit in-protocol refusal", () => {
+  const RECV = "/@owner/repo.git/git-receive-pack";
+
+  it("refuses a tag creation with a tag-specific ng and guidance (gated flag on)", async () => {
+    const env = makeEnv({ GIT_PUSH_GATED_ENABLED: "true" } as Partial<Env>);
+    await seedProject(env);
+    const fetchMock = stubFetch(() => new Response("nope", { status: 500 }));
+
+    const res = await app.fetch(
+      req(RECV, {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: singleRefPush(ZEROS, OID_TAG, "refs/tags/v1.0.0"),
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/x-git-receive-pack-result");
+    const text = await res.text();
+    expect(text).toContain("unpack ok\n");
+    expect(text).toContain("ng refs/tags/v1.0.0");
+    expect(text).toContain("tag pushes to the project remote are not supported");
+    // Never the misleading branch-gate guidance, never a fork, never upstream.
+    expect(text).not.toContain("only a single push to refs/heads/main");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(vi.mocked(createWorkspaceFork)).not.toHaveBeenCalled();
+  });
+
+  it("refuses the same way with the gated flag OFF", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    stubFetch(() => new Response("nope", { status: 500 }));
+    const res = await app.fetch(
+      req(RECV, {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: singleRefPush(ZEROS, OID_TAG, "refs/tags/v1.0.0"),
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("tag pushes to the project remote are not supported");
+    expect(text).not.toContain("project pushes are gated");
+  });
+
+  it("a mixed main+tag push is refused for BOTH refs with the tag reason", async () => {
+    const env = makeEnv({ GIT_PUSH_GATED_ENABLED: "true" } as Partial<Env>);
+    await seedProject(env);
+    stubFetch(() => new Response("nope", { status: 500 }));
+    const res = await app.fetch(
+      req(RECV, {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: pushBody([
+          `${OID_A} ${OID_B} refs/heads/main`,
+          `${ZEROS} ${OID_TAG} refs/tags/v1.0.0`,
+        ]),
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("ng refs/heads/main");
+    expect(text).toContain("ng refs/tags/v1.0.0");
+    expect(text).toContain("tag pushes to the project remote are not supported");
+    expect(vi.mocked(createWorkspaceFork)).not.toHaveBeenCalled();
+  });
+
+  it("a tag DELETION is refused with the same tag-specific reason", async () => {
+    const env = makeEnv({ GIT_PUSH_GATED_ENABLED: "true" } as Partial<Env>);
+    await seedProject(env);
+    stubFetch(() => new Response("nope", { status: 500 }));
+    const res = await app.fetch(
+      req(RECV, {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: singleRefPush(OID_TAG, ZEROS, "refs/tags/v1.0.0"),
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("ng refs/tags/v1.0.0");
+    expect(text).toContain("tag pushes to the project remote are not supported");
+  });
+
+  it("names the workspace remote in the guidance", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    stubFetch(() => new Response("nope", { status: 500 }));
+    const res = await app.fetch(
+      req(RECV, {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        // side-band-64k so guidance is streamed as remote: lines
+        body: new TextEncoder().encode(
+          `${pktLine(`${ZEROS} ${OID_TAG} refs/tags/v1.0.0\0report-status side-band-64k`)}0000`,
+        ),
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("workspaces/<ws>.git");
+  });
+});
+
+describe("workspace-remote tag pushes proxy verbatim (unchanged)", () => {
+  it("forwards a tag push to the fork and relays its report-status", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    await seedWorkspace(env);
+    const upstreamReport = "000eunpack ok\n0019ok refs/tags/v1.0.0\n0000";
+    const fetchMock = stubFetch(
+      () =>
+        new Response(upstreamReport, {
+          status: 200,
+          headers: { "Content-Type": "application/x-git-receive-pack-result" },
+        }),
+    );
+
+    const res = await app.fetch(
+      req("/@owner/repo/workspaces/myws.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: singleRefPush(ZEROS, OID_TAG, "refs/tags/v1.0.0"),
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(upstreamReport);
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe(`${WS_REMOTE}/git-receive-pack`);
+    expect(new TextDecoder().decode(init.body as ArrayBuffer)).toContain("refs/tags/v1.0.0");
+  });
+});

--- a/tests/git-tags-ops.test.ts
+++ b/tests/git-tags-ops.test.ts
@@ -1,0 +1,432 @@
+import git from "isomorphic-git";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { snapshotRepo, walkRepoObjects } from "../src/backup/repo-snapshot";
+import {
+  type NodeFS,
+  cloneRepo,
+  collectRepoTags,
+  listRepoTags,
+  pushTags,
+} from "../src/storage/git-ops";
+import { MemoryFS } from "../src/storage/memory-fs";
+import type { Env, ProjectEntry } from "../src/types";
+import type { Logger } from "../src/utils/logger";
+
+// Partial isomorphic-git mock: `clone`, `fetch`, and `push` are the only
+// network-coupled calls the code under test makes; everything else (init,
+// commit, tag, readObject, …) stays real so the tests exercise genuine git
+// object stores in MemoryFS.
+const { mockClone, mockFetch, mockPush, listTagsOverride } = vi.hoisted(() => ({
+  mockClone: vi.fn(),
+  mockFetch: vi.fn(),
+  mockPush: vi.fn(),
+  // When set, replaces git.listTags for a single test (reset in beforeEach).
+  listTagsOverride: { fn: null as null | ((args: unknown) => Promise<string[]>) },
+}));
+
+vi.mock("isomorphic-git", async (importActual) => {
+  const actual = await importActual<typeof import("isomorphic-git")>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      clone: (args: unknown) => mockClone(args),
+      fetch: (args: unknown) => mockFetch(args),
+      push: (args: unknown) => mockPush(args),
+      listTags: (args: unknown) =>
+        listTagsOverride.fn
+          ? listTagsOverride.fn(args)
+          : actual.default.listTags(args as Parameters<typeof actual.default.listTags>[0]),
+    },
+  };
+});
+
+const logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+} as unknown as Logger;
+
+const author = { name: "t", email: "t@x.com", timestamp: 1_700_000_000, timezoneOffset: 0 };
+const tagger = { name: "tagger", email: "tag@x.com", timestamp: 1_700_000_100, timezoneOffset: 0 };
+const MISSING_OID = "f".repeat(40);
+
+async function buildRepo(
+  dir: string,
+  commits: Record<string, string>[],
+  fs: NodeFS = new MemoryFS().toNodeFS() as unknown as NodeFS,
+): Promise<{ fs: NodeFS; shas: string[] }> {
+  await git.init({ fs, dir, defaultBranch: "main" });
+  const shas: string[] = [];
+  for (const files of commits) {
+    for (const [path, content] of Object.entries(files)) {
+      // biome-ignore lint/suspicious/noExplicitAny: isomorphic-git fs shape
+      await (fs as any).promises.writeFile(`${dir}/${path}`, content);
+      await git.add({ fs, dir, filepath: path });
+    }
+    shas.push(await git.commit({ fs, dir, message: "c", author }));
+  }
+  return { fs, shas };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listTagsOverride.fn = null;
+});
+
+describe("collectRepoTags", () => {
+  it("lists lightweight and annotated tags, dereferencing annotated ones", async () => {
+    const { fs, shas } = await buildRepo("/repo", [{ "a.txt": "one" }, { "b.txt": "two" }]);
+    const [c1, c2] = shas as [string, string];
+    await git.tag({ fs, dir: "/repo", ref: "lightweight", object: c2 });
+    await git.annotatedTag({
+      fs,
+      dir: "/repo",
+      ref: "ann",
+      object: c1,
+      message: "release one\n",
+      tagger,
+    });
+
+    const tags = await collectRepoTags(fs, "/repo");
+    expect(tags.map((t) => t.name)).toEqual(["ann", "lightweight"]); // sorted
+
+    const ann = tags[0];
+    expect(ann?.annotated).toBe(true);
+    expect(ann?.targetSha).toBe(c1);
+    expect(ann?.oid).not.toBe(c1); // the ref holds the tag object, not the commit
+    expect(ann?.message).toBe("release one");
+    expect(ann?.tagger).toBe("tagger <tag@x.com>");
+    expect(ann?.timestamp).toBe(tagger.timestamp);
+    expect(ann?.unresolvable).toBe(false);
+
+    const lw = tags[1];
+    expect(lw?.annotated).toBe(false);
+    expect(lw?.oid).toBe(c2);
+    expect(lw?.targetSha).toBe(c2);
+    expect(lw?.message).toBeUndefined();
+    expect(lw?.unresolvable).toBe(false);
+  });
+
+  it("returns an empty list for a repo without tags", async () => {
+    const { fs } = await buildRepo("/repo", [{ "a.txt": "one" }]);
+    expect(await collectRepoTags(fs, "/repo")).toEqual([]);
+  });
+
+  it("skips a listed tag whose ref cannot be resolved at all", async () => {
+    const { fs } = await buildRepo("/repo", [{ "a.txt": "one" }]);
+    // listTags names a tag that has no ref on disk (e.g. deleted between calls).
+    listTagsOverride.fn = async () => ["phantom"];
+    expect(await collectRepoTags(fs, "/repo")).toEqual([]);
+  });
+
+  it("marks a lightweight tag whose object is missing as unresolvable (shallow degrade)", async () => {
+    const { fs } = await buildRepo("/repo", [{ "a.txt": "one" }]);
+    await git.writeRef({
+      fs,
+      dir: "/repo",
+      ref: "refs/tags/ghost",
+      value: MISSING_OID,
+      force: true,
+    });
+
+    const tags = await collectRepoTags(fs, "/repo");
+    const ghost = tags.find((t) => t.name === "ghost");
+    expect(ghost).toBeDefined();
+    expect(ghost?.oid).toBe(MISSING_OID);
+    expect(ghost?.unresolvable).toBe(true);
+    expect(ghost?.targetSha).toBeNull(); // never learned the target
+  });
+
+  it("keeps an annotated tag's metadata when only its TARGET is missing", async () => {
+    const { fs } = await buildRepo("/repo", [{ "a.txt": "one" }]);
+    // A real tag object pointing at a commit that is not in the local store —
+    // exactly what a shallow fetch window produces.
+    const tagOid = await git.writeTag({
+      fs,
+      dir: "/repo",
+      tag: {
+        object: MISSING_OID,
+        type: "commit",
+        tag: "broken",
+        tagger,
+        message: "points outside the window\n",
+      },
+    });
+    await git.writeRef({ fs, dir: "/repo", ref: "refs/tags/broken", value: tagOid, force: true });
+
+    const tags = await collectRepoTags(fs, "/repo");
+    const broken = tags.find((t) => t.name === "broken");
+    expect(broken?.annotated).toBe(true);
+    expect(broken?.message).toBe("points outside the window");
+    expect(broken?.targetSha).toBe(MISSING_OID); // intended target is still reported
+    expect(broken?.unresolvable).toBe(true);
+  });
+
+  it("peels a tag-of-tag chain down to the commit", async () => {
+    const { fs, shas } = await buildRepo("/repo", [{ "a.txt": "one" }]);
+    const c1 = shas[0] as string;
+    const inner = await git.writeTag({
+      fs,
+      dir: "/repo",
+      tag: { object: c1, type: "commit", tag: "inner", tagger, message: "inner\n" },
+    });
+    const outer = await git.writeTag({
+      fs,
+      dir: "/repo",
+      tag: { object: inner, type: "tag", tag: "outer", tagger, message: "outer\n" },
+    });
+    await git.writeRef({ fs, dir: "/repo", ref: "refs/tags/outer", value: outer, force: true });
+
+    const tags = await collectRepoTags(fs, "/repo");
+    const entry = tags.find((t) => t.name === "outer");
+    expect(entry?.annotated).toBe(true);
+    expect(entry?.targetSha).toBe(c1);
+    expect(entry?.message).toBe("outer"); // first tag object in the chain wins
+    expect(entry?.unresolvable).toBe(false);
+  });
+});
+
+describe("cloneRepo includeTags", () => {
+  it("follows the singleBranch clone with a tags fetch (shallow by default)", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      await buildRepo(dir, [{ "a.txt": "one" }], fs);
+    });
+    mockFetch.mockResolvedValue({});
+
+    const result = await cloneRepo("https://r.example/repo.git", "tok", logger, undefined, {
+      includeTags: true,
+    });
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const args = mockFetch.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(args.tags).toBe(true);
+    expect(args.singleBranch).toBe(false);
+    expect(args.depth).toBe(50);
+    expect(args.url).toBe("https://r.example/repo.git");
+  });
+
+  it("fetches tags with full history when fullHistory is set (no depth)", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      await buildRepo(dir, [{ "a.txt": "one" }], fs);
+    });
+    mockFetch.mockResolvedValue({});
+
+    await cloneRepo("https://r.example/repo.git", "tok", logger, undefined, {
+      fullHistory: true,
+      includeTags: true,
+    });
+    const args = mockFetch.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect("depth" in args).toBe(false);
+    expect(args.tags).toBe(true);
+  });
+
+  it("does not fetch tags unless asked", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      await buildRepo(dir, [{ "a.txt": "one" }], fs);
+    });
+    const result = await cloneRepo("https://r.example/repo.git", "tok", logger);
+    expect(result.success).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("fails the clone when the tags fetch fails", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      await buildRepo(dir, [{ "a.txt": "one" }], fs);
+    });
+    mockFetch.mockRejectedValue(new Error("network down"));
+
+    const result = await cloneRepo("https://r.example/repo.git", "tok", logger, undefined, {
+      includeTags: true,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toContain("Failed to fetch tags");
+  });
+});
+
+describe("listRepoTags", () => {
+  it("clones with tags and returns the collected entries", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      const { shas } = await buildRepo(dir, [{ "a.txt": "one" }], fs);
+      await git.tag({ fs, dir, ref: "v1.0.0", object: shas[0] });
+      await git.annotatedTag({
+        fs,
+        dir,
+        ref: "v2.0.0",
+        object: shas[0],
+        message: "second\n",
+        tagger,
+      });
+    });
+    mockFetch.mockResolvedValue({});
+
+    const result = await listRepoTags("https://r.example/repo.git", "tok", logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.map((t) => t.name)).toEqual(["v1.0.0", "v2.0.0"]);
+    expect(result.data[1]?.annotated).toBe(true);
+    expect(result.data[1]?.message).toBe("second");
+  });
+
+  it("propagates a clone failure", async () => {
+    mockClone.mockRejectedValue(new Error("no such repo"));
+    const result = await listRepoTags("https://r.example/repo.git", "tok", logger);
+    expect(result.success).toBe(false);
+  });
+
+  it("maps a collection failure to a Git error", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      await buildRepo(dir, [{ "a.txt": "one" }], fs);
+    });
+    mockFetch.mockResolvedValue({});
+    listTagsOverride.fn = async () => {
+      throw new Error("refs are corrupt");
+    };
+    const result = await listRepoTags("https://r.example/repo.git", "tok", logger);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toContain("Failed to list tags");
+  });
+});
+
+// walkRepoObjects' listTags guards need the isomorphic-git mock, so they live
+// here rather than in the backup suite.
+describe("walkRepoObjects tag-listing guards", () => {
+  it("treats a listTags failure as 'no tags' instead of failing the walk", async () => {
+    const { fs } = await buildRepo("/repo", [{ "a.txt": "one" }]);
+    listTagsOverride.fn = async () => {
+      throw new Error("boom");
+    };
+    const walk = await walkRepoObjects(fs, "/repo", 10_000_000, logger);
+    expect(walk.success).toBe(true);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    expect(walk.data.tags).toEqual([]);
+  });
+
+  it("skips a listed tag whose ref does not resolve, with a warning", async () => {
+    const { fs } = await buildRepo("/repo", [{ "a.txt": "one" }]);
+    listTagsOverride.fn = async () => ["phantom"];
+    const walk = await walkRepoObjects(fs, "/repo", 10_000_000, logger);
+    expect(walk.success).toBe(true);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    expect(walk.data.tags).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledWith("Backup: skipping unreadable tag ref", {
+      name: "phantom",
+    });
+  });
+});
+
+describe("snapshotRepo clones with tags", () => {
+  const project: ProjectEntry = {
+    id: "p1",
+    name: "repo",
+    slug: "repo",
+    namespace: "@owner",
+    ownerId: "u1",
+    ownerType: "user",
+    remote: "https://acct.artifacts.cloudflare.net/git/@owner/repo.git",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  function makeEnv(): Env {
+    return {
+      ARTIFACTS: {
+        get: vi.fn(async () => ({
+          createToken: vi.fn(async () => ({ plaintext: "tok?expires=9999999999" })),
+        })),
+      } as unknown as Env["ARTIFACTS"],
+    } as Env;
+  }
+
+  it("passes includeTags+fullHistory to the clone and records tags in the manifest", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      const { shas } = await buildRepo(dir, [{ "a.txt": "one" }], fs);
+      await git.annotatedTag({
+        fs,
+        dir,
+        ref: "v1.0.0",
+        object: shas[0],
+        message: "release\n",
+        tagger,
+      });
+    });
+    mockFetch.mockResolvedValue({});
+
+    const result = await snapshotRepo(makeEnv(), project, "2026-08-18T00:00:00Z", logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.status).toBe("ok");
+    if (result.data.status !== "ok") return;
+    expect(result.data.snapshot.manifest.tags?.map((t) => t.name)).toEqual(["v1.0.0"]);
+
+    // The backup clone is full-history AND tag-fetching.
+    const cloneArgs = mockClone.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect("depth" in cloneArgs).toBe(false);
+    const fetchArgs = mockFetch.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(fetchArgs.tags).toBe(true);
+    expect("depth" in fetchArgs).toBe(false);
+  });
+
+  it("still skips an empty repo", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      await git.init({ fs, dir, defaultBranch: "main" });
+    });
+    mockFetch.mockResolvedValue({});
+    const result = await snapshotRepo(makeEnv(), project, "2026-08-18T00:00:00Z", logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toEqual({ status: "skipped", reason: "empty" });
+  });
+});
+
+describe("pushTags", () => {
+  it("pushes each refs/tags/* ref and mirrors the force flag", async () => {
+    mockPush.mockResolvedValue({ ok: true });
+    const fs = new MemoryFS().toNodeFS() as unknown as NodeFS;
+    const result = await pushTags(
+      "https://r.example/repo.git",
+      "tok",
+      fs,
+      "/",
+      ["v1", "v2"],
+      logger,
+      {
+        force: true,
+      },
+    );
+    expect(result.success).toBe(true);
+    expect(mockPush).toHaveBeenCalledTimes(2);
+    const first = mockPush.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(first.ref).toBe("refs/tags/v1");
+    expect(first.remoteRef).toBe("refs/tags/v1");
+    expect(first.force).toBe(true);
+    expect(first.url).toBe("https://r.example/repo.git");
+    const second = mockPush.mock.calls[1]?.[0] as Record<string, unknown>;
+    expect(second.ref).toBe("refs/tags/v2");
+  });
+
+  it("fails on the first tag that cannot be pushed, naming it", async () => {
+    mockPush.mockResolvedValueOnce({ ok: true }).mockRejectedValueOnce(new Error("rejected"));
+    const fs = new MemoryFS().toNodeFS() as unknown as NodeFS;
+    const result = await pushTags(
+      "https://r.example/repo.git",
+      "tok",
+      fs,
+      "/",
+      ["v1", "v2"],
+      logger,
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toContain("v2");
+  });
+
+  it("is a no-op for an empty tag list", async () => {
+    const fs = new MemoryFS().toNodeFS() as unknown as NodeFS;
+    const result = await pushTags("https://r.example/repo.git", "tok", fs, "/", [], logger);
+    expect(result.success).toBe(true);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/tests/git-tags-ops.test.ts
+++ b/tests/git-tags-ops.test.ts
@@ -9,6 +9,7 @@ import {
   pushTags,
 } from "../src/storage/git-ops";
 import { MemoryFS } from "../src/storage/memory-fs";
+import { placeLooseObject } from "../src/storage/object-loader";
 import type { Env, ProjectEntry } from "../src/types";
 import type { Logger } from "../src/utils/logger";
 
@@ -188,6 +189,58 @@ describe("collectRepoTags", () => {
     expect(entry?.targetSha).toBe(c1);
     expect(entry?.message).toBe("outer"); // first tag object in the chain wins
     expect(entry?.unresolvable).toBe(false);
+  });
+
+  it("resolves a tag-of-tag chain longer than the old fixed hop cap", async () => {
+    const { fs, shas } = await buildRepo("/repo", [{ "a.txt": "one" }]);
+    const c1 = shas[0] as string;
+    let current = c1;
+    let currentType: "commit" | "tag" = "commit";
+    // 11 tag objects deep — one more than the old fixed 10-hop limit.
+    for (let i = 0; i < 11; i++) {
+      current = await git.writeTag({
+        fs,
+        dir: "/repo",
+        tag: { object: current, type: currentType, tag: `t${i}`, tagger, message: `t${i}\n` },
+      });
+      currentType = "tag";
+    }
+    await git.writeRef({ fs, dir: "/repo", ref: "refs/tags/deep", value: current, force: true });
+
+    const tags = await collectRepoTags(fs, "/repo");
+    const entry = tags.find((t) => t.name === "deep");
+    expect(entry?.annotated).toBe(true);
+    expect(entry?.targetSha).toBe(c1);
+    expect(entry?.unresolvable).toBe(false);
+  });
+
+  it("marks a self-referential tag object unresolvable instead of looping forever", async () => {
+    const { fs } = await buildRepo("/repo", [{ "a.txt": "one" }]);
+    // A real tag-of-tag cycle can't exist through normal writes (an oid is a
+    // hash of content that would have to embed that same oid). Simulate the
+    // on-disk corruption the visited-oid guard defends against: place a loose
+    // tag object, at an oid we choose, whose own `object` field is that same
+    // oid — placeLooseObject bypasses hash verification, so this is a genuine
+    // self-reference once read back.
+    const selfOid = "c".repeat(40);
+    const content = new TextEncoder().encode(
+      `object ${selfOid}\ntype commit\ntag cycle\ntagger Test <test@x.com> 1700000000 +0000\n\nself-referential (corrupted fixture)\n`,
+    );
+    const header = new TextEncoder().encode(`tag ${content.length}\0`);
+    const bytes = new Uint8Array(header.length + content.length);
+    bytes.set(header, 0);
+    bytes.set(content, header.length);
+    await placeLooseObject(
+      fs as unknown as Parameters<typeof placeLooseObject>[0],
+      "/repo/.git",
+      selfOid,
+      bytes,
+    );
+    await git.writeRef({ fs, dir: "/repo", ref: "refs/tags/cycle", value: selfOid, force: true });
+
+    const tags = await collectRepoTags(fs, "/repo");
+    const entry = tags.find((t) => t.name === "cycle");
+    expect(entry?.unresolvable).toBe(true);
   });
 });
 

--- a/tests/tags-routes.test.ts
+++ b/tests/tags-routes.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../src/index";
+import { freshRepoToken, listRepoTags } from "../src/storage/git-ops";
+import type { Env, ProjectEntry } from "../src/types";
+import { AppError } from "../src/utils/errors";
+import { err } from "../src/utils/result";
+
+// Tags listing surfaces (#182): REST GET /api/projects/:ns/:slug/tags and the
+// UI page GET /:ns/:slug/tags. The git leg (clone + tag fetch) is mocked at the
+// git-ops boundary — it has its own suite (tests/git-tags-ops.test.ts).
+
+vi.mock("../src/storage/git-ops", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/git-ops")>();
+  return {
+    ...actual,
+    freshRepoToken: vi.fn(async () => ({ success: true, data: "mock-token" })),
+    listRepoTags: vi.fn(async () => ({
+      success: true,
+      data: [
+        {
+          name: "v1.0.0",
+          oid: "c".repeat(40),
+          targetSha: "b".repeat(40),
+          annotated: true,
+          message: "First stable release",
+          tagger: "tagger <tag@x.com>",
+          timestamp: 1_700_000_100,
+          unresolvable: false,
+        },
+        {
+          name: "v0.9.0",
+          oid: "b".repeat(40),
+          targetSha: "b".repeat(40),
+          annotated: false,
+          unresolvable: false,
+        },
+        {
+          name: "ancient",
+          oid: "d".repeat(40),
+          targetSha: null,
+          annotated: false,
+          unresolvable: true,
+        },
+        {
+          // Annotated tag whose TARGET is outside the shallow window: the
+          // intended target sha is known, but the commit itself is missing.
+          name: "deep",
+          oid: "e".repeat(40),
+          targetSha: "a".repeat(40),
+          annotated: true,
+          message: "too deep",
+          unresolvable: true,
+        },
+      ],
+    })),
+  };
+});
+
+const USER_TOKEN = "stratum_user_testtoken00000000000000000";
+
+vi.mock("../src/storage/users", () => ({
+  getUserByToken: vi.fn(async (_db: unknown, token: string) => {
+    if (token === USER_TOKEN)
+      return {
+        success: true,
+        data: { id: "user_test", email: "t@x.io", username: "testuser" },
+      };
+    return { success: false, error: { message: "not found" } };
+  }),
+  getUser: vi.fn(async () => ({ success: false, error: { message: "not found" } })),
+}));
+
+function makeKV(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    list: async () => ({ keys: [], list_complete: true, cursor: "" }),
+    getWithMetadata: async () => ({ value: null, metadata: null }),
+  } as unknown as KVNamespace;
+}
+
+function makeEnv(): Env {
+  return {
+    ARTIFACTS: {} as Env["ARTIFACTS"],
+    STATE: makeKV(),
+    DB: {} as D1Database,
+  } as Env;
+}
+
+async function seedProject(
+  env: Env,
+  visibility: "public" | "private" = "public",
+): Promise<ProjectEntry> {
+  const project: ProjectEntry = {
+    id: "proj_1",
+    name: "repo",
+    slug: "repo",
+    namespace: "@owner",
+    ownerId: "user_test",
+    ownerType: "user",
+    remote: "https://acct.artifacts.cloudflare.net/git/@owner/repo.git",
+    createdAt: new Date().toISOString(),
+    visibility,
+  };
+  await env.STATE.put(`project:${project.namespace}:${project.slug}`, JSON.stringify(project));
+  return project;
+}
+
+function req(path: string, headers: Record<string, string> = {}): Request {
+  return new Request(`http://localhost${path}`, { headers });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("REST GET /api/projects/:namespace/:slug/tags", () => {
+  it("lists tags for a public project (annotated, lightweight, unresolvable)", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    const res = await app.fetch(req("/api/projects/@owner/repo/tags"), env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      namespace: string;
+      slug: string;
+      tags: Array<Record<string, unknown>>;
+    };
+    expect(body.namespace).toBe("@owner");
+    expect(body.slug).toBe("repo");
+    expect(body.tags).toHaveLength(4);
+
+    const annotated = body.tags.find((t) => t.name === "v1.0.0");
+    expect(annotated?.annotated).toBe(true);
+    expect(annotated?.targetSha).toBe("b".repeat(40));
+    expect(annotated?.message).toBe("First stable release");
+
+    const lightweight = body.tags.find((t) => t.name === "v0.9.0");
+    expect(lightweight?.annotated).toBe(false);
+
+    // The shallow-degraded tag is delivered, flagged — never an error.
+    const unresolvable = body.tags.find((t) => t.name === "ancient");
+    expect(unresolvable?.unresolvable).toBe(true);
+    expect(unresolvable?.targetSha).toBeNull();
+  });
+
+  it("authorizes like the other repo reads: private project hides from anonymous", async () => {
+    const env = makeEnv();
+    await seedProject(env, "private");
+    const res = await app.fetch(req("/api/projects/@owner/repo/tags"), env);
+    expect(res.status).toBe(404);
+    expect(vi.mocked(listRepoTags)).not.toHaveBeenCalled();
+  });
+
+  it("serves the owner of a private project", async () => {
+    const env = makeEnv();
+    await seedProject(env, "private");
+    const res = await app.fetch(
+      req("/api/projects/@owner/repo/tags", { Authorization: `Bearer ${USER_TOKEN}` }),
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("404s a missing project", async () => {
+    const env = makeEnv();
+    const res = await app.fetch(req("/api/projects/@owner/nope/tags"), env);
+    expect(res.status).toBe(404);
+  });
+
+  it("maps a git failure to 500", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    vi.mocked(listRepoTags).mockResolvedValueOnce(
+      err(new AppError("Failed to list tags", "GIT_ERROR", 500)),
+    );
+    const res = await app.fetch(req("/api/projects/@owner/repo/tags"), env);
+    expect(res.status).toBe(500);
+  });
+
+  it("maps a corrupt project entry (non-NOT_FOUND lookup error) to 500, not 404", async () => {
+    const env = makeEnv();
+    await env.STATE.put("project:@owner:repo", "{corrupt json");
+    const res = await app.fetch(req("/api/projects/@owner/repo/tags"), env);
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("UI GET /:namespace/:slug/tags", () => {
+  it("renders the tags table with names, badges, target shas, and messages", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    const res = await app.fetch(req("/@owner/repo/tags"), env);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Tags");
+    expect(html).toContain("v1.0.0");
+    expect(html).toContain("annotated");
+    expect(html).toContain("First stable release");
+    expect(html).toContain("b".repeat(40).slice(0, 7)); // short target sha
+    expect(html).toContain("v0.9.0");
+    expect(html).toContain("lightweight");
+    // The shallow-degraded tags render, marked — the page does not error.
+    expect(html).toContain("ancient");
+    expect(html).toContain("unresolvable");
+    expect(html).toContain("deep");
+  });
+
+  it("renders an empty state when the repo has no tags", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    vi.mocked(listRepoTags).mockResolvedValueOnce({ success: true, data: [] });
+    const res = await app.fetch(req("/@owner/repo/tags"), env);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("No tags yet");
+  });
+
+  it("404s a missing or unreadable project", async () => {
+    const env = makeEnv();
+    const missing = await app.fetch(req("/@owner/nope/tags"), env);
+    expect(missing.status).toBe(404);
+
+    await seedProject(env, "private");
+    const hidden = await app.fetch(req("/@owner/repo/tags"), env);
+    expect(hidden.status).toBe(404);
+  });
+
+  it("400s an invalid project path", async () => {
+    const env = makeEnv();
+    const res = await app.fetch(req("/@bad__ns!/repo/tags"), env);
+    expect(res.status).toBe(400);
+  });
+
+  it("500s when the read token cannot be minted", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    vi.mocked(freshRepoToken).mockResolvedValueOnce(
+      err(new AppError("token mint failed", "EXTERNAL_SERVICE_ERROR", 502)),
+    );
+    const res = await app.fetch(req("/@owner/repo/tags"), env);
+    expect(res.status).toBe(500);
+    expect(await res.text()).toContain("Error loading tags");
+  });
+
+  it("500s when the tag listing fails", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    vi.mocked(listRepoTags).mockResolvedValueOnce(
+      err(new AppError("Failed to list tags", "GIT_ERROR", 500)),
+    );
+    const res = await app.fetch(req("/@owner/repo/tags"), env);
+    expect(res.status).toBe(500);
+    expect(await res.text()).toContain("Error loading tags");
+  });
+});
+
+describe("formatTagDate", () => {
+  it("formats an epoch-seconds timestamp and degrades on bad input", async () => {
+    const { formatTagDate } = await import("../src/ui/pages/tags");
+    expect(formatTagDate(1_700_000_100)).toContain("2023");
+    expect(formatTagDate(undefined)).toBe("");
+    expect(formatTagDate(Number.NaN)).toBe("");
+  });
+});

--- a/tests/tags-routes.test.ts
+++ b/tests/tags-routes.test.ts
@@ -192,7 +192,7 @@ describe("REST GET /api/projects/:namespace/:slug/tags", () => {
 });
 
 describe("UI GET /:namespace/:slug/tags", () => {
-  it("renders the tags table with names, badges, target shas, and messages", async () => {
+  it("renders the tags table with names, badges, target shas, messages, and taggers", async () => {
     const env = makeEnv();
     await seedProject(env);
     const res = await app.fetch(req("/@owner/repo/tags"), env);
@@ -209,6 +209,9 @@ describe("UI GET /:namespace/:slug/tags", () => {
     expect(html).toContain("ancient");
     expect(html).toContain("unresolvable");
     expect(html).toContain("deep");
+    // The collector preserves the annotated tagger, so the page must show it.
+    expect(html).toContain("Tagger");
+    expect(html).toContain("tag@x.com");
   });
 
   it("renders an empty state when the repo has no tags", async () => {


### PR DESCRIPTION
## Summary

Implements #182's suggested scope: reading/advertising tag refs over smart-HTTP, a tags listing, and tag objects in backups.

- **Smart-HTTP:** investigation confirmed the proxy forwards `info/refs` and `git-upload-pack` verbatim with no ref filtering, so tag advertisement and fetch already worked — now proven by tests (upstream `refs/tags/*` + peeled `^{}` entries reach the client byte-identically; `want ` bodies forward unchanged). **Project tag-push policy: explicit in-protocol rejection.** The merge gate cannot represent a tag (a change is an evaluated diff against the default branch; there is nothing to evaluate for a tag ref), so any push touching `refs/tags/*` on the project remote gets `unpack ok` + per-ref `ng` with a clear reason and sideband guidance — same behavior with the gate flag on or off. Workspace-remote pushes are untouched (the #130 policy branch, PR #216, governs those).
- **Tags listing:** `cloneRepo`'s `singleBranch` clone never fetches tags (verified in isomorphic-git source), so a new `includeTags` option adds a follow-up tags fetch (depth-50). `listRepoTags` dereferences annotated tags (peeling tag-of-tag chains) and returns name/oid/target/annotation metadata, degrading per-tag with `unresolvable: true` when a target lies outside the shallow window (tag still shown, never an error). Exposed as `GET /api/projects/:ns/:slug/tags` and a server-rendered `/:ns/:slug/tags` page (badges, message, tagger, short sha, empty state) with the same private→404 authz as existing pages.
- **Backup:** `walkRepoObjects` walks every `refs/tags/*` tip in addition to HEAD — annotated tag objects go in the pack, **history reachable only from tags** (that is: commits no branch reaches, but a tag does) is closed over with the byte cap enforced, and refs are recorded in a new **optional** `tags` manifest field. Each tag's traversal is staged, so a tag skipped as unresolvable leaves no objects behind and spends none of the byte budget. A dangling tag at backup time is skipped with a warning so the pack stays reachability-closed. Restore validates every manifest tag name against what `writeRef` will accept, writes `refs/tags/*` (with the same dangling-ref guard as the tip), and pushes tags after main; **old-format manifests without the `tags` field restore exactly as before** (tested).

Out of scope: tag creation UI and a releases feature.

**Also out of scope, tracked separately:** a repository with tags but *no resolvable HEAD* is still reported empty and skipped by backup (#251). That is a different thing from the tag-reachable history above, which this PR does capture. Supporting it means making `tipSha` optional across the manifest and the restore path, and deciding what a restored repo with no default branch means for the UI, git-http advertisement, and sync — a backup-format change rather than a feature fix. Bounding the tag listing is likewise tracked as #241.

## Related issues

Closes #182

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

50 tests across five files: smart-HTTP advertisement/fetch passthrough and the tag-push refusal matrix (create/delete/mixed main+tag, gate on and off), tag listing (annotated, lightweight, tag-of-tag chains, unresolvable-in-shallow), REST + UI routes with authz including the rendered tagger, and backup/restore round trips including old-manifest compatibility.

Three of those target defects found in review, each verified to fail against the code it replaced:

- Tag-name validation is differentially fuzzed against isomorphic-git's `writeRef` over ~1300 generated names with a fresh `MemoryFS` per name — 0 names accepted that `writeRef` refuses, 0 refused that it accepts. `writeRef` is the oracle rather than `git check-ref-format`, which is looser and would let `v1./next` through to fail mid-restore.
- An unresolvable tag whose own object is large, under a cap HEAD fits inside, asserting the walk skips the tag instead of returning `tooLarge` and that the tag object is absent from the pack.
- A merge whose first parent is already collected and whose other two are not, guarding the ancestry walk's early stop against both halting the queue instead of the path and following only the first parent.

Full suite: 1331 passed, 0 failures.

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript

---
_Generated by [Claude Code](https://claude.ai/code/session_015dp67PBbFT666GnMLuxvm1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository tag browsing through a dedicated Tags page, including annotated, lightweight, and unresolved tags.
  * Added tag listings to the project API and repository navigation.
  * Added backup and restore support for repository tags.
  * Git cloning and snapshots can now include tag references and related objects.

* **Bug Fixes**
  * Project repositories now reject tag push operations with clear guidance while preserving workspace tag behavior.

* **Tests**
  * Added comprehensive coverage for tag listings, backups, restores, Git operations, HTTP behavior, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->