### PR TITLE
Scope webhook management by project id (SA-1)

### DIFF
--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -984,7 +984,9 @@ app.get("/:namespace/:slug/webhooks", async (c) => {
     );
   }
 
-  const webhooksResult = await listWebhooks(c.env.DB, logger, project.name);
+  const webhooksResult = await listWebhooks(c.env.DB, logger, project.name, {
+    projectId: project.id,
+  });
   if (!webhooksResult.success) {
     logger.error("Failed to list webhooks", webhooksResult.error);
     return c.html(
@@ -996,7 +998,9 @@ app.get("/:namespace/:slug/webhooks", async (c) => {
   }
 
   const webhooks = await Promise.all(
-    webhooksResult.data.map(async (webhook) => {
+    // Strip the signing secret before it reaches the HTML — it is shown once on
+    // creation via the JSON API and must never render in the management page.
+    webhooksResult.data.map(async ({ secret: _secret, ...webhook }) => {
       const deliveriesResult = await listDeliveries(c.env.DB, logger, webhook.id, 5);
       return { webhook, deliveries: deliveriesResult.success ? deliveriesResult.data : [] };
     }),

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -8,6 +8,7 @@ import {
   listDeliveries,
   listWebhooks,
   setWebhookActive,
+  webhookBelongsToProject,
 } from "../storage/webhooks";
 import type { Env, ProjectEntry } from "../types";
 import { canWriteProject } from "../utils/authz";
@@ -160,7 +161,9 @@ app.get("/:namespace/:slug/webhooks", async (c) => {
   if ("response" in access) return access.response;
   const { project } = access;
 
-  const webhooksResult = await listWebhooks(c.env.DB, logger, project.name);
+  const webhooksResult = await listWebhooks(c.env.DB, logger, project.name, {
+    projectId: project.id,
+  });
   if (!webhooksResult.success) {
     return internalError(webhooksResult.error.message);
   }
@@ -189,7 +192,7 @@ app.get("/:namespace/:slug/webhooks/:id/deliveries", async (c) => {
     if (webhookResult.error.code === "NOT_FOUND") return notFound("Webhook", id);
     return internalError(webhookResult.error.message);
   }
-  if (webhookResult.data.project !== project.name) return notFound("Webhook", id);
+  if (!webhookBelongsToProject(webhookResult.data, project)) return notFound("Webhook", id);
 
   const deliveriesResult = await listDeliveries(c.env.DB, logger, id);
   if (!deliveriesResult.success) {
@@ -218,7 +221,7 @@ app.post("/:namespace/:slug/webhooks/:id/toggle", async (c) => {
     if (webhookResult.error.code === "NOT_FOUND") return notFound("Webhook", id);
     return internalError(webhookResult.error.message);
   }
-  if (webhookResult.data.project !== project.name) return notFound("Webhook", id);
+  if (!webhookBelongsToProject(webhookResult.data, project)) return notFound("Webhook", id);
 
   const updateResult = await setWebhookActive(c.env.DB, logger, id, !webhookResult.data.active);
   if (!updateResult.success) {
@@ -259,7 +262,7 @@ app.delete("/:namespace/:slug/webhooks/:id", async (c) => {
     if (webhookResult.error.code === "NOT_FOUND") return notFound("Webhook", id);
     return internalError(webhookResult.error.message);
   }
-  if (webhookResult.data.project !== project.name) return notFound("Webhook", id);
+  if (!webhookBelongsToProject(webhookResult.data, project)) return notFound("Webhook", id);
 
   const deleteResult = await deleteWebhook(c.env.DB, logger, id);
   if (!deleteResult.success) {
@@ -296,7 +299,7 @@ app.post("/:namespace/:slug/webhooks/:id/delete", async (c) => {
     if (webhookResult.error.code === "NOT_FOUND") return notFound("Webhook", id);
     return internalError(webhookResult.error.message);
   }
-  if (webhookResult.data.project !== project.name) return notFound("Webhook", id);
+  if (!webhookBelongsToProject(webhookResult.data, project)) return notFound("Webhook", id);
 
   const deleteResult = await deleteWebhook(c.env.DB, logger, id);
   if (!deleteResult.success) {

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -148,6 +148,11 @@ app.post("/:namespace/:slug/webhooks", async (c) => {
     // in the URL, no client JS) with a link back to the management page.
     const wh = webhookResult.data;
     const backUrl = `/${project.namespace}/${project.slug}/webhooks`;
+    // This is the only response that ever carries the signing secret, so it
+    // must not be retained anywhere: `no-store` keeps it out of the browser
+    // disk cache and any shared cache between here and the client. `no-cache`
+    // would still permit storage, which is the opposite of what is wanted.
+    c.header("Cache-Control", "no-store");
     return c.html(
       `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Webhook created</title><link rel="stylesheet" href="/ui.css"></head><body><main style="max-width:640px;margin:3rem auto;padding:0 1rem;font-family:monospace"><h1>Webhook created</h1><p><strong>Copy the signing secret now — it will not be shown again.</strong></p><p>URL: <code>${escapeHtml(wh.url)}</code></p><p>Signing secret: <code>${escapeHtml(wh.secret)}</code></p><p>Verify each delivery's <code>X-Stratum-Signature</code> (HMAC-SHA256) with this secret.</p><p><a href="${escapeHtml(backUrl)}">&larr; Back to webhooks</a></p></main></body></html>`,
       201,

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -12,6 +12,7 @@ import {
 } from "../storage/webhooks";
 import type { Env, ProjectEntry } from "../types";
 import { canWriteProject } from "../utils/authz";
+import { escapeHtml } from "../utils/html";
 import { createLogger } from "../utils/logger";
 import type { Logger } from "../utils/logger";
 import { badRequest, created, forbidden, internalError, notFound, ok } from "../utils/response";
@@ -142,7 +143,15 @@ app.post("/:namespace/:slug/webhooks", async (c) => {
   });
 
   if (!contentType.includes("application/json")) {
-    return c.redirect(`/${project.namespace}/${project.slug}/webhooks`, 302);
+    // The management page redacts the signing secret, so a form-based creator
+    // would otherwise never see it. Show it exactly once here (not persisted, not
+    // in the URL, no client JS) with a link back to the management page.
+    const wh = webhookResult.data;
+    const backUrl = `/${project.namespace}/${project.slug}/webhooks`;
+    return c.html(
+      `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Webhook created</title><link rel="stylesheet" href="/ui.css"></head><body><main style="max-width:640px;margin:3rem auto;padding:0 1rem;font-family:monospace"><h1>Webhook created</h1><p><strong>Copy the signing secret now — it will not be shown again.</strong></p><p>URL: <code>${escapeHtml(wh.url)}</code></p><p>Signing secret: <code>${escapeHtml(wh.secret)}</code></p><p>Verify each delivery's <code>X-Stratum-Signature</code> (HMAC-SHA256) with this secret.</p><p><a href="${escapeHtml(backUrl)}">&larr; Back to webhooks</a></p></main></body></html>`,
+      201,
+    );
   }
   // The secret is returned on creation; receivers verify X-Stratum-Signature with it.
   return created({ webhook: webhookResult.data });

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -142,24 +142,34 @@ app.post("/:namespace/:slug/webhooks", async (c) => {
     detail: { project: project.name, url: webhookResult.data.url },
   });
 
+  // Both responses below carry the signing secret: the HTML page renders it and
+  // the JSON body returns it. `no-store` keeps it out of the browser disk cache
+  // and any shared cache in between — `no-cache` would still permit storage,
+  // which is the opposite of what is wanted.
+  //
+  // Set on the Response rather than through `c.header()`, because `created()`
+  // returns a bare `Response.json(...)` that never passes through the Hono
+  // context — a context header would silently miss the JSON path.
+  const noStore = (res: Response): Response => {
+    res.headers.set("Cache-Control", "no-store");
+    return res;
+  };
+
   if (!contentType.includes("application/json")) {
     // The management page redacts the signing secret, so a form-based creator
     // would otherwise never see it. Show it exactly once here (not persisted, not
     // in the URL, no client JS) with a link back to the management page.
     const wh = webhookResult.data;
     const backUrl = `/${project.namespace}/${project.slug}/webhooks`;
-    // This is the only response that ever carries the signing secret, so it
-    // must not be retained anywhere: `no-store` keeps it out of the browser
-    // disk cache and any shared cache between here and the client. `no-cache`
-    // would still permit storage, which is the opposite of what is wanted.
-    c.header("Cache-Control", "no-store");
-    return c.html(
-      `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Webhook created</title><link rel="stylesheet" href="/ui.css"></head><body><main style="max-width:640px;margin:3rem auto;padding:0 1rem;font-family:monospace"><h1>Webhook created</h1><p><strong>Copy the signing secret now — it will not be shown again.</strong></p><p>URL: <code>${escapeHtml(wh.url)}</code></p><p>Signing secret: <code>${escapeHtml(wh.secret)}</code></p><p>Verify each delivery's <code>X-Stratum-Signature</code> (HMAC-SHA256) with this secret.</p><p><a href="${escapeHtml(backUrl)}">&larr; Back to webhooks</a></p></main></body></html>`,
-      201,
+    return noStore(
+      c.html(
+        `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Webhook created</title><link rel="stylesheet" href="/ui.css"></head><body><main style="max-width:640px;margin:3rem auto;padding:0 1rem;font-family:monospace"><h1>Webhook created</h1><p><strong>Copy the signing secret now — it will not be shown again.</strong></p><p>URL: <code>${escapeHtml(wh.url)}</code></p><p>Signing secret: <code>${escapeHtml(wh.secret)}</code></p><p>Verify each delivery's <code>X-Stratum-Signature</code> (HMAC-SHA256) with this secret.</p><p><a href="${escapeHtml(backUrl)}">&larr; Back to webhooks</a></p></main></body></html>`,
+        201,
+      ),
     );
   }
   // The secret is returned on creation; receivers verify X-Stratum-Signature with it.
-  return created({ webhook: webhookResult.data });
+  return noStore(created({ webhook: webhookResult.data }));
 });
 
 // GET /api/projects/:namespace/:slug/webhooks — List webhooks

--- a/src/storage/webhooks.ts
+++ b/src/storage/webhooks.ts
@@ -95,6 +95,22 @@ function toAppError(error: unknown, operation: string, context: Record<string, u
       );
 }
 
+/**
+ * Does this webhook belong to the given project?
+ *
+ * Scopes by the globally-unique project id when the webhook row carries one,
+ * and falls back to the free-form `project` name only for legacy rows written
+ * before project_id was backfilled. Comparing on name alone lets a same-named
+ * project in another namespace read or mutate this webhook (cross-tenant).
+ */
+export function webhookBelongsToProject(
+  webhook: Webhook,
+  project: { id: string; name: string },
+): boolean {
+  if (webhook.projectId != null) return webhook.projectId === project.id;
+  return webhook.project === project.name;
+}
+
 /** Does this webhook subscribe to the given event type? */
 export function webhookMatchesEvent(webhook: Webhook, eventType: string): boolean {
   if (webhook.events === "*") return true;

--- a/src/ui/pages/webhooks.tsx
+++ b/src/ui/pages/webhooks.tsx
@@ -8,7 +8,7 @@ interface WebhooksPageProps {
     namespace: string;
     slug: string;
   };
-  webhooks: Array<{ webhook: Webhook; deliveries: WebhookDelivery[] }>;
+  webhooks: Array<{ webhook: Omit<Webhook, "secret">; deliveries: WebhookDelivery[] }>;
   subscribableEvents: string[];
   user?: { id: string; email: string; username: string } | null;
 }
@@ -93,7 +93,7 @@ export const WebhooksPage: FC<WebhooksPageProps> = ({
               </div>
             </div>
             <p class="webhook-meta">
-              Events: <code>{webhook.events}</code> · Secret: <code>{webhook.secret}</code>
+              Events: <code>{webhook.events}</code> · Secret: <code>shown once on creation</code>
             </p>
             {deliveries.length > 0 && (
               <details class="webhook-deliveries">

--- a/tests/webhooks-routes.test.ts
+++ b/tests/webhooks-routes.test.ts
@@ -217,6 +217,29 @@ describe("webhook management routes — project-id scoping (SA-1)", () => {
     expect(res.headers.get("Cache-Control")).toBe("no-store");
   });
 
+  it("marks the JSON creation response no-store too — it also returns the secret", async () => {
+    vi.mocked(createWebhook).mockResolvedValue({
+      success: true,
+      data: webhook({ secret: "stm_whsec_0123456789abcdef0123456789abcdef" }),
+    });
+
+    const res = await makeApp().fetch(
+      new Request("http://localhost/@alice/api/webhooks", {
+        method: "POST",
+        headers: { ...AUTH, "Content-Type": "application/json" },
+        body: JSON.stringify({ url: "https://hooks.example.com/x" }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { webhook: { secret?: string } };
+    // The JSON body carries the secret, which is why the header cannot live on
+    // the HTML branch alone.
+    expect(body.webhook.secret).toBe("stm_whsec_0123456789abcdef0123456789abcdef");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
   it("falls back to the name for a legacy webhook with no project_id", async () => {
     vi.mocked(getWebhook).mockResolvedValue({
       success: true,

--- a/tests/webhooks-routes.test.ts
+++ b/tests/webhooks-routes.test.ts
@@ -212,6 +212,9 @@ describe("webhook management routes — project-id scoping (SA-1)", () => {
     // redacted management page.
     expect(html).toContain("stm_whsec_deadbeefdeadbeefdeadbeefdeadbeef");
     expect(html).toContain("will not be shown again");
+    // The only response that ever carries the secret must not be storable —
+    // `no-store`, not merely `no-cache`, which still permits storage.
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
   });
 
   it("falls back to the name for a legacy webhook with no project_id", async () => {

--- a/tests/webhooks-routes.test.ts
+++ b/tests/webhooks-routes.test.ts
@@ -10,6 +10,7 @@ vi.mock("../src/storage/webhooks", async (importActual) => {
   const actual = await importActual<typeof import("../src/storage/webhooks")>();
   return {
     ...actual,
+    createWebhook: vi.fn(),
     listWebhooks: vi.fn(),
     getWebhook: vi.fn(),
     listDeliveries: vi.fn(),
@@ -25,6 +26,7 @@ import { getProjectByPath } from "../src/storage/state";
 import { getUserByToken } from "../src/storage/users";
 import {
   type Webhook,
+  createWebhook,
   deleteWebhook,
   getWebhook,
   listDeliveries,
@@ -186,6 +188,30 @@ describe("webhook management routes — project-id scoping (SA-1)", () => {
 
     expect(res.status).toBe(404);
     expect(deleteWebhook).not.toHaveBeenCalled();
+  });
+
+  it("shows the signing secret once when a webhook is created via the HTML form", async () => {
+    vi.mocked(createWebhook).mockResolvedValue({
+      success: true,
+      data: webhook({ secret: "stm_whsec_deadbeefdeadbeefdeadbeefdeadbeef" }),
+    });
+
+    const form = new URLSearchParams({ url: "https://hooks.example.com/x" });
+    const res = await makeApp().fetch(
+      new Request("http://localhost/@alice/api/webhooks", {
+        method: "POST",
+        headers: { ...AUTH, "Content-Type": "application/x-www-form-urlencoded" },
+        body: form.toString(),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(201);
+    const html = await res.text();
+    // The secret is delivered exactly once on creation, not via a redirect to the
+    // redacted management page.
+    expect(html).toContain("stm_whsec_deadbeefdeadbeefdeadbeefdeadbeef");
+    expect(html).toContain("will not be shown again");
   });
 
   it("falls back to the name for a legacy webhook with no project_id", async () => {

--- a/tests/webhooks-routes.test.ts
+++ b/tests/webhooks-routes.test.ts
@@ -1,0 +1,210 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authMiddleware } from "../src/middleware/auth";
+import { webhooksRouter } from "../src/routes/webhooks";
+import type { Env, ProjectEntry } from "../src/types";
+
+// Keep the real webhookBelongsToProject (the route's ownership logic under test);
+// stub only the D1-backed storage calls.
+vi.mock("../src/storage/webhooks", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/webhooks")>();
+  return {
+    ...actual,
+    listWebhooks: vi.fn(),
+    getWebhook: vi.fn(),
+    listDeliveries: vi.fn(),
+    deleteWebhook: vi.fn(),
+    setWebhookActive: vi.fn(),
+  };
+});
+vi.mock("../src/storage/state", () => ({ getProjectByPath: vi.fn() }));
+vi.mock("../src/storage/audit", () => ({ recordAudit: vi.fn(async () => {}) }));
+vi.mock("../src/storage/users", () => ({ getUserByToken: vi.fn(), getUser: vi.fn() }));
+
+import { getProjectByPath } from "../src/storage/state";
+import { getUserByToken } from "../src/storage/users";
+import {
+  type Webhook,
+  deleteWebhook,
+  getWebhook,
+  listDeliveries,
+  listWebhooks,
+} from "../src/storage/webhooks";
+
+const AUTH = { Authorization: "Bearer stratum_user_testtoken00000000000000000" };
+
+// Two same-named projects in different namespaces — the cross-tenant collision.
+const ALICE: ProjectEntry = {
+  id: "proj_alice",
+  name: "api",
+  slug: "api",
+  namespace: "@alice",
+  ownerId: "user_test",
+  ownerType: "user",
+  remote: "https://acct.artifacts.cloudflare.net/git/@alice/api.git",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+function webhook(overrides: Partial<Webhook> = {}): Webhook {
+  return {
+    id: "wh_1",
+    project: "api",
+    projectId: "proj_alice",
+    url: "https://alice.example.com/hook",
+    secret: "stm_whsec_abcdef",
+    events: "*",
+    active: true,
+    createdBy: "user_test",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", authMiddleware);
+  app.route("/", webhooksRouter);
+  return app;
+}
+
+const env = { DB: {} as D1Database, STATE: {} as KVNamespace } as Env;
+
+describe("webhook management routes — project-id scoping (SA-1)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getUserByToken).mockResolvedValue({
+      success: true,
+      data: {
+        id: "user_test",
+        email: "t@x.io",
+        username: "test",
+        tokenHash: "h",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    vi.mocked(getProjectByPath).mockResolvedValue({ success: true, data: ALICE });
+  });
+
+  it("lists webhooks scoped by project id and strips the signing secret", async () => {
+    vi.mocked(listWebhooks).mockResolvedValue({ success: true, data: [webhook()] });
+
+    const res = await makeApp().fetch(
+      new Request("http://localhost/@alice/api/webhooks", { headers: AUTH }),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    // The list must be scoped by the unique project id, not just the name.
+    expect(listWebhooks).toHaveBeenCalledWith(env.DB, expect.any(Object), "api", {
+      projectId: "proj_alice",
+    });
+    const body = (await res.json()) as { webhooks: Array<Record<string, unknown>> };
+    expect(body.webhooks).toHaveLength(1);
+    expect(body.webhooks[0]).not.toHaveProperty("secret");
+  });
+
+  it("404s a delete of a webhook that belongs to a same-named project in another namespace", async () => {
+    // Victim's webhook: same project name "api", different id.
+    vi.mocked(getWebhook).mockResolvedValue({
+      success: true,
+      data: webhook({ id: "wh_victim", projectId: "proj_bob" }),
+    });
+
+    const res = await makeApp().fetch(
+      new Request("http://localhost/@alice/api/webhooks/wh_victim", {
+        method: "DELETE",
+        headers: AUTH,
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(404);
+    expect(deleteWebhook).not.toHaveBeenCalled();
+  });
+
+  it("404s reading deliveries of a cross-tenant webhook", async () => {
+    vi.mocked(getWebhook).mockResolvedValue({
+      success: true,
+      data: webhook({ id: "wh_victim", projectId: "proj_bob" }),
+    });
+
+    const res = await makeApp().fetch(
+      new Request("http://localhost/@alice/api/webhooks/wh_victim/deliveries", { headers: AUTH }),
+      env,
+    );
+
+    expect(res.status).toBe(404);
+    expect(listDeliveries).not.toHaveBeenCalled();
+  });
+
+  it("deletes a webhook that genuinely belongs to the project", async () => {
+    vi.mocked(getWebhook).mockResolvedValue({ success: true, data: webhook() });
+    vi.mocked(deleteWebhook).mockResolvedValue({ success: true, data: undefined });
+
+    const res = await makeApp().fetch(
+      new Request("http://localhost/@alice/api/webhooks/wh_1", {
+        method: "DELETE",
+        headers: AUTH,
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(deleteWebhook).toHaveBeenCalledWith(env.DB, expect.any(Object), "wh_1");
+  });
+
+  it("404s a toggle of a cross-tenant webhook", async () => {
+    vi.mocked(getWebhook).mockResolvedValue({
+      success: true,
+      data: webhook({ id: "wh_victim", projectId: "proj_bob" }),
+    });
+
+    const res = await makeApp().fetch(
+      new Request("http://localhost/@alice/api/webhooks/wh_victim/toggle", {
+        method: "POST",
+        headers: AUTH,
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("404s a form-post delete of a cross-tenant webhook", async () => {
+    vi.mocked(getWebhook).mockResolvedValue({
+      success: true,
+      data: webhook({ id: "wh_victim", projectId: "proj_bob" }),
+    });
+
+    const res = await makeApp().fetch(
+      new Request("http://localhost/@alice/api/webhooks/wh_victim/delete", {
+        method: "POST",
+        headers: AUTH,
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(404);
+    expect(deleteWebhook).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the name for a legacy webhook with no project_id", async () => {
+    vi.mocked(getWebhook).mockResolvedValue({
+      success: true,
+      data: webhook({ id: "wh_legacy", projectId: undefined }),
+    });
+    vi.mocked(deleteWebhook).mockResolvedValue({ success: true, data: undefined });
+
+    const res = await makeApp().fetch(
+      new Request("http://localhost/@alice/api/webhooks/wh_legacy", {
+        method: "DELETE",
+        headers: AUTH,
+      }),
+      env,
+    );
+
+    // project.name === webhook.project ("api") → allowed for legacy rows.
+    expect(res.status).toBe(200);
+    expect(deleteWebhook).toHaveBeenCalled();
+  });
+});

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -7,8 +7,10 @@ import {
   listDeliveries,
   listWebhooks,
   setWebhookActive,
+  webhookBelongsToProject,
   webhookMatchesEvent,
 } from "../src/storage/webhooks";
+import type { Webhook } from "../src/storage/webhooks";
 import type { Env } from "../src/types";
 import type { Logger } from "../src/utils/logger";
 import { validateWebhookUrl } from "../src/utils/validation";
@@ -80,6 +82,29 @@ describe("webhook storage", () => {
     if (!forAlice.success) return;
     expect(forAlice.data).toHaveLength(1);
     expect(forAlice.data[0]?.url).toBe("https://alice.example.com/hook");
+  });
+
+  it("webhookBelongsToProject scopes management by id, not the free-form name", () => {
+    const base: Webhook = {
+      id: "wh_1",
+      project: "api",
+      projectId: "proj_alice",
+      url: "https://alice.example.com/hook",
+      secret: "stm_whsec_x",
+      events: "*",
+      active: true,
+      createdBy: "alice",
+      createdAt: new Date().toISOString(),
+    };
+
+    // Same id → owned.
+    expect(webhookBelongsToProject(base, { id: "proj_alice", name: "api" })).toBe(true);
+    // A different project that merely shares the name must NOT own it (the leak).
+    expect(webhookBelongsToProject(base, { id: "proj_bob", name: "api" })).toBe(false);
+    // Legacy row with no project_id falls back to the name.
+    const legacy: Webhook = { ...base, projectId: undefined };
+    expect(webhookBelongsToProject(legacy, { id: "proj_bob", name: "api" })).toBe(true);
+    expect(webhookBelongsToProject(legacy, { id: "proj_bob", name: "other" })).toBe(false);
   });
 
   it("lists, toggles, and deletes webhooks", async () => {


### PR DESCRIPTION
## Summary

Webhook management (list / get-deliveries / toggle / delete) resolved project ownership by the free-form, user-supplied project **name** instead of the unique project **id**. Because project names collide across namespaces, this allowed cross-tenant access to another project's webhook rows — and the management page rendered the HMAC signing secret in plaintext. The delivery path was already scoped by `project_id` (with a regression test); this brings the management path to parity.

Changes:
- Add `webhookBelongsToProject(webhook, project)` — matches on the unique project id, falling back to the name only for legacy rows whose `project_id` predates the dual-write backfill.
- Pass `{ projectId }` to `listWebhooks` from both the API route and the UI route.
- Use the helper for the get/toggle/delete ownership checks (replacing the four `webhook.project !== project.name` comparisons).
- Strip the signing secret before it reaches the management HTML; it is still returned once on creation via the JSON API.

## Related issues

Fixes the issue tracked privately as advisory **SA-1** (details withheld from this public PR).

## Type of change

- [x] Bug fix (security)

## How was this verified?

- [x] `npm run typecheck` (clean)
- [x] `npm test` — `tests/webhooks.test.ts` (19 passed), incl. a new `webhookBelongsToProject` unit test covering same-name cross-tenant rejection and legacy fallback
- [x] `npm run lint` (clean on touched files)

## Checklist

- [x] Tests added or updated for the change
- [x] Docs updated where the change makes them inaccurate (n/a)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change stays server-rendered with no client-side JavaScript

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015rgmQChstLxpyb4Kf9339J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Webhook management and actions are now restricted to the correct project.
  * Cross-project access to webhook deliveries, settings, and deletion is blocked.
  * Webhook signing secrets are shown only once when initially created and are no longer displayed afterward.
  * Secret values are protected from unsafe rendering and creation responses aren’t cached.
  * Legacy webhooks continue to work with secure project ownership checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->