### PR TITLE
Reject soft-deleting accounts over git smart-HTTP (SA-8)

### DIFF
--- a/src/routes/git-http.ts
+++ b/src/routes/git-http.ts
@@ -8,7 +8,7 @@ import {
   freshRepoToken,
 } from "../storage/git-ops";
 import { deleteWorkspace, getProjectByPath, getWorkspace } from "../storage/state";
-import { getUserByToken } from "../storage/users";
+import { getUser, getUserByToken } from "../storage/users";
 import type { Env, ProjectEntry } from "../types";
 import { canReadProject, canWriteProject, canWriteWorkspace } from "../utils/authz";
 import {
@@ -153,10 +153,21 @@ async function authenticate(
 
   if (token.startsWith("stratum_user_")) {
     const result = await getUserByToken(c.env.DB, token, logger);
-    return result.success ? { userId: result.data.id } : null;
+    // A soft-deleting account's credentials stop working immediately over git
+    // too — the HTTP middleware rejects it, but git smart-HTTP owns its own auth
+    // and must apply the same gate, or an erasure-requested user keeps clone/push
+    // access until the cascade lands.
+    if (!result.success || result.data.deletingAt) return null;
+    return { userId: result.data.id };
   }
   const result = await getAgentByToken(c.env.DB, token, logger);
-  return result.success ? { agentId: result.data.id, agentOwnerId: result.data.ownerId } : null;
+  if (!result.success) return null;
+  // An agent inherits its owner's access, so a deleting owner's agent must stop
+  // working too — otherwise it's an authenticated git write channel that outlives
+  // the account it belongs to.
+  const owner = await getUser(c.env.DB, result.data.ownerId, logger);
+  if (owner.success && owner.data.deletingAt) return null;
+  return { agentId: result.data.id, agentOwnerId: result.data.ownerId };
 }
 
 function basicAuthHeader(artifactsToken: string): string {

--- a/src/routes/git-http.ts
+++ b/src/routes/git-http.ts
@@ -164,9 +164,20 @@ async function authenticate(
   if (!result.success) return null;
   // An agent inherits its owner's access, so a deleting owner's agent must stop
   // working too — otherwise it's an authenticated git write channel that outlives
-  // the account it belongs to.
-  const owner = await getUser(c.env.DB, result.data.ownerId, logger);
-  if (owner.success && owner.data.deletingAt) return null;
+  // the account it belongs to. Fail CLOSED on the owner lookup: an unresolved or
+  // deleting owner yields no identity. getUser can reject on a D1 error, which
+  // would otherwise escape authenticate's documented no-500 contract, so catch it.
+  let owner: Awaited<ReturnType<typeof getUser>>;
+  try {
+    owner = await getUser(c.env.DB, result.data.ownerId, logger);
+  } catch (err) {
+    logger.warn("Agent owner lookup threw during git auth; failing closed", {
+      ownerId: result.data.ownerId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+  if (!owner.success || owner.data.deletingAt) return null;
   return { agentId: result.data.id, agentOwnerId: result.data.ownerId };
 }
 

--- a/tests/git-http.test.ts
+++ b/tests/git-http.test.ts
@@ -24,6 +24,8 @@ const INVALID_TOKEN = "stratum_user_invalid0000000000000000";
 // A soft-deleting owner (SA-8) and an agent owned by them: both must lose git access.
 const DELETING_TOKEN = "stratum_user_deleting00000000000000";
 const DELETING_AGENT_TOKEN = "stratum_agent_deleting0000000000000";
+// An agent whose owner cannot be resolved — auth must fail closed.
+const GHOST_AGENT_TOKEN = "stratum_agent_ghost000000000000000";
 
 // The gated-push handler calls the change-flow service; mock its two entry
 // points so these tests exercise the wire protocol, not the eval pipeline
@@ -64,6 +66,8 @@ vi.mock("../src/storage/users", () => ({
     return { success: false, error: { message: "not found" } };
   }),
   getUser: vi.fn(async (_db: unknown, id: string) => {
+    if (id === "user_owner")
+      return { success: true, data: { id, email: "o@x.io", username: "owner" } };
     if (id === "user_deleting_owner")
       return {
         success: true,
@@ -79,6 +83,8 @@ vi.mock("../src/storage/agents", () => ({
       return { success: true, data: { id: "agent_1", ownerId: "user_owner" } };
     if (token === DELETING_AGENT_TOKEN)
       return { success: true, data: { id: "agent_2", ownerId: "user_deleting_owner" } };
+    if (token === GHOST_AGENT_TOKEN)
+      return { success: true, data: { id: "agent_3", ownerId: "user_ghost" } };
     return { success: false, error: { message: "not found" } };
   }),
 }));
@@ -314,6 +320,15 @@ describe("git smart-HTTP proxy — auth & authorization truth table (Task 2)", (
     await seedProject(env, { visibility: "private" });
     const fetchMock = stubFetch(() => okUpstream());
     const res = await app.fetch(req(ADVERTISE, { headers: basic(DELETING_AGENT_TOKEN) }), env);
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("agent whose owner cannot be resolved + private → fails closed (401)", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "private" });
+    const fetchMock = stubFetch(() => okUpstream());
+    const res = await app.fetch(req(ADVERTISE, { headers: basic(GHOST_AGENT_TOKEN) }), env);
     expect(res.status).toBe(401);
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/tests/git-http.test.ts
+++ b/tests/git-http.test.ts
@@ -21,6 +21,9 @@ const OWNER_TOKEN = "stratum_user_owner000000000000000000";
 const OTHER_TOKEN = "stratum_user_other000000000000000000";
 const AGENT_TOKEN = "stratum_agent_agent00000000000000000";
 const INVALID_TOKEN = "stratum_user_invalid0000000000000000";
+// A soft-deleting owner (SA-8) and an agent owned by them: both must lose git access.
+const DELETING_TOKEN = "stratum_user_deleting00000000000000";
+const DELETING_AGENT_TOKEN = "stratum_agent_deleting0000000000000";
 
 // The gated-push handler calls the change-flow service; mock its two entry
 // points so these tests exercise the wire protocol, not the eval pipeline
@@ -53,15 +56,29 @@ vi.mock("../src/storage/users", () => ({
       return { success: true, data: { id: "user_owner", email: "o@x.io", username: "owner" } };
     if (token === OTHER_TOKEN)
       return { success: true, data: { id: "user_other", email: "t@x.io", username: "other" } };
+    if (token === DELETING_TOKEN)
+      return {
+        success: true,
+        data: { id: "user_owner", email: "o@x.io", username: "owner", deletingAt: "2026-01-01" },
+      };
     return { success: false, error: { message: "not found" } };
   }),
-  getUser: vi.fn(async () => ({ success: false, error: { message: "not found" } })),
+  getUser: vi.fn(async (_db: unknown, id: string) => {
+    if (id === "user_deleting_owner")
+      return {
+        success: true,
+        data: { id, email: "d@x.io", username: "deleter", deletingAt: "2026-01-01" },
+      };
+    return { success: false, error: { message: "not found" } };
+  }),
 }));
 
 vi.mock("../src/storage/agents", () => ({
   getAgentByToken: vi.fn(async (_db: unknown, token: string) => {
     if (token === AGENT_TOKEN)
       return { success: true, data: { id: "agent_1", ownerId: "user_owner" } };
+    if (token === DELETING_AGENT_TOKEN)
+      return { success: true, data: { id: "agent_2", ownerId: "user_deleting_owner" } };
     return { success: false, error: { message: "not found" } };
   }),
 }));
@@ -281,6 +298,24 @@ describe("git smart-HTTP proxy — auth & authorization truth table (Task 2)", (
     stubFetch(() => okUpstream());
     const res = await app.fetch(req(ADVERTISE, { headers: basic(AGENT_TOKEN) }), env);
     expect(res.status).toBe(200);
+  });
+
+  it("soft-deleting owner token + private → treated as anonymous (401), no upstream call", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "private" });
+    const fetchMock = stubFetch(() => okUpstream());
+    const res = await app.fetch(req(ADVERTISE, { headers: basic(DELETING_TOKEN) }), env);
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("agent whose owner is soft-deleting + private → treated as anonymous (401)", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "private" });
+    const fetchMock = stubFetch(() => okUpstream());
+    const res = await app.fetch(req(ADVERTISE, { headers: basic(DELETING_AGENT_TOKEN) }), env);
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("non-owner token + private → 404, byte-identical to authed+missing", async () => {


### PR DESCRIPTION
## Summary

The HTTP auth middleware rejects a soft-deleting user (or an agent whose owner is soft-deleting) *before* binding any request context. But git smart-HTTP has its own `authenticate()` in `git-http.ts`, and it never checked `deletingAt`. As a result, a user who requested account deletion (GDPR erasure) retained `git clone` / `git push` access until the deletion cascade finished.

Change:
- In `git-http.ts` `authenticate()`, mirror the middleware: a user token whose user has `deletingAt` set → no identity; an agent token whose owner has `deletingAt` set → no identity. "No identity" flows into the existing access truth table as anonymous (401 challenge on private repos), never a 500.

## Related issues

Fixes the issue tracked privately as advisory **SA-8**.

## Type of change

- [x] Bug fix (security)

## How was this verified?

- [x] `npm run typecheck` (clean)
- [x] `npm test` — `tests/git-http.test.ts` (65 passed), +2 cases: deleting owner token and agent-owned-by-deleting-owner are both treated as anonymous (401) with no upstream call
- [x] `npm run lint` (clean on touched files)

## Checklist

- [x] Tests added or updated for the change
- [x] Docs updated where the change makes them inaccurate (n/a)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015rgmQChstLxpyb4Kf9339J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Private Git access is now blocked for accounts undergoing deletion.
  * Agent credentials are also denied when their owning account is being deleted or cannot be verified.
  * Blocked requests return an authentication error without contacting the upstream repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->