### PR TITLE
Don't let a GitHub review promote a Change to mergeable (SA-4)

### DIFF
--- a/src/github/webhooks.ts
+++ b/src/github/webhooks.ts
@@ -306,23 +306,22 @@ export async function handlePullRequestReview(
     return;
   }
 
-  let newStatus: "accepted" | "needs_changes" | undefined;
-  if (reviewState === "approved") {
-    newStatus = "accepted";
-  } else if (reviewState === "changes_requested") {
-    newStatus = "needs_changes";
-  }
-
-  if (!newStatus) {
-    logger.debug("Unhandled review state", { reviewState });
+  // A GitHub "approved" review must NOT move a Change into a mergeable state.
+  // The reviewer is an arbitrary GitHub identity with no mapping to an authorized
+  // Stratum human, so honoring it would let a GitHub review satisfy the
+  // human-only approval invariant (approvals are recorded as change_reviews rows
+  // attributed to verified Stratum users, never inferred from GitHub). Approval
+  // is informational here; only the restrictive "changes_requested" signal —
+  // which can block but never enable a merge — updates status.
+  if (reviewState !== "changes_requested") {
+    logger.debug("GitHub review does not change Stratum status", { reviewState });
     return;
   }
 
-  await updateChangeStatus(env.DB, logger, existing.id, newStatus);
-  logger.info("Updated Change status from PR review", {
+  await updateChangeStatus(env.DB, logger, existing.id, "needs_changes");
+  logger.info("Marked Change needs_changes from GitHub changes-requested review", {
     changeId: existing.id,
     reviewState,
-    newStatus,
   });
 }
 

--- a/tests/pr-webhook-changes.test.ts
+++ b/tests/pr-webhook-changes.test.ts
@@ -296,11 +296,12 @@ describe("handlePullRequestReview", () => {
     };
   }
 
-  it("approved updates Change status to accepted", async () => {
+  it("approved does NOT promote the Change (approval is human-only in Stratum)", async () => {
     const env = makeEnv();
     await handlePullRequestReview(env, makeReviewPayload("approved"), logger);
 
-    expect(updateChangeStatus).toHaveBeenCalledWith(env.DB, logger, CHANGE.id, "accepted");
+    // A GitHub approval must never move a Change into a mergeable state (SA-4).
+    expect(updateChangeStatus).not.toHaveBeenCalled();
   });
 
   it("changes_requested updates Change status to needs_changes", async () => {


### PR DESCRIPTION
## Summary

An inbound GitHub `pull_request_review` with `state=approved` moved the linked Change to `accepted` (a mergeable status) via a bare `updateChangeStatus` — with **no mapping between the GitHub reviewer and an authorized Stratum human, no `change_reviews` row, and no evaluator re-check**. That let a GitHub review satisfy the product's human-only approval invariant.

Change (`handlePullRequestReview`):
- Stop honoring GitHub `approved` reviews for status changes — approval is informational only. Stratum approvals stay human-only, recorded as `change_reviews` rows attributed to verified Stratum identities.
- Keep the restrictive `changes_requested → needs_changes` signal, which can block a merge but never enable one, so it carries no bypass risk.

## Related issues

Fixes the issue tracked privately as advisory **SA-4**.

## Type of change

- [x] Bug fix (security)

## How was this verified?

- [x] `npm run typecheck` (clean)
- [x] `npm test` — `tests/pr-webhook-changes.test.ts` (11 passed); the former "approved → accepted" test now asserts approval makes **no** status change; `changes_requested → needs_changes` and `dismissed → no-op` unchanged
- [x] `npm run lint` (clean on touched files)

## Checklist

- [x] Tests added or updated for the change
- [x] Docs updated where the change makes them inaccurate (n/a)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015rgmQChstLxpyb4Kf9339J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - GitHub pull-request approvals no longer automatically move Changes to **Accepted**.
  - Changes are moved to **Needs Changes** only when review feedback requests changes.
  - Other review states leave the Change status unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->