### PR TITLE
Add a per-IP cap to magic-link sends (SA-7)

### DIFF
--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -58,7 +58,6 @@ async function getRateLimitKey(email: string): Promise<string> {
   return `magic_link_rate:${emailHash}:${hour}`;
 }
 
-// Per-IP rate limit key for the current hour window.
 function getIpRateLimitKey(ip: string): string {
   const hour = Math.floor(Date.now() / 1000 / MAGIC_LINK_RATE_WINDOW);
   return `magic_link_ip_rate:${ip}:${hour}`;
@@ -415,7 +414,6 @@ app.post("/send-signup", async (c) => {
     return emailAuthRedirect(c, "error", "username_taken", "/auth/signup");
   }
 
-  // Enforce per-email and per-IP magic-link caps.
   const rateLimit = await checkMagicLinkRateLimits(c, email, logger);
   if (rateLimit.blocked) {
     logger.warn("Magic link rate limit exceeded", { emailHash });
@@ -423,7 +421,6 @@ app.post("/send-signup", async (c) => {
   }
 
   try {
-    // Bump both rate-limit counters (per-email + per-IP) now that we are sending.
     await rateLimit.commit();
 
     // Generate secure magic link token
@@ -508,7 +505,6 @@ app.post("/send-login", async (c) => {
   // send-only-for-real-accounts branch isn't a cheap oracle.
   const existingUser = await getUserByEmail(c.env.DB, email, logger);
 
-  // Enforce per-email and per-IP magic-link caps.
   const rateLimit = await checkMagicLinkRateLimits(c, email, logger);
   if (rateLimit.blocked) {
     logger.warn("Magic link rate limit exceeded", { emailHash });
@@ -516,7 +512,6 @@ app.post("/send-login", async (c) => {
   }
 
   try {
-    // Bump both rate-limit counters (per-email + per-IP) now that we are sending.
     await rateLimit.commit();
 
     if (existingUser.success) {
@@ -599,7 +594,6 @@ app.post("/send", async (c) => {
     return emailAuthRedirect(c, "error", "auth_config_incomplete");
   }
 
-  // Enforce per-email and per-IP magic-link caps.
   const rateLimit = await checkMagicLinkRateLimits(c, email, logger);
   if (rateLimit.blocked) {
     logger.warn("Magic link rate limit exceeded", { emailHash });
@@ -607,7 +601,6 @@ app.post("/send", async (c) => {
   }
 
   try {
-    // Bump both rate-limit counters (per-email + per-IP) now that we are sending.
     await rateLimit.commit();
 
     // Check if user exists to determine intent

--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -87,6 +87,13 @@ async function checkMagicLinkRateLimits(
     emailCount = Number.parseInt((await c.env.STATE.get(emailKey)) ?? "0");
     ipCount = Number.parseInt((await c.env.STATE.get(ipKey)) ?? "0");
   } catch (err) {
+    // Fail open means fail open for *both* caps. These are assigned in sequence,
+    // so a throw on the second read would otherwise leave a populated count from
+    // the first standing against a zero from the second — and an exhausted email
+    // bucket would block the request on a transient KV blip, which is precisely
+    // the lockout this contract exists to prevent. Reset both.
+    emailCount = 0;
+    ipCount = 0;
     logger.warn("Failed to read magic-link rate limits, allowing request", { error: err });
   }
   const blocked = emailCount >= MAGIC_LINK_RATE_LIMIT || ipCount >= MAGIC_LINK_IP_RATE_LIMIT;

--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -9,6 +9,7 @@ import { consumeMagicLink, createMagicLink } from "../storage/magic-links";
 import { createSession } from "../storage/sessions";
 import { createUser, getUserByEmail, getUserByUsername } from "../storage/users";
 import type { Env } from "../types";
+import { hashToken } from "../utils/crypto";
 import { escapeHtml } from "../utils/html";
 import { type Logger, createLogger } from "../utils/logger";
 import { validateUsername } from "../utils/username-validation";
@@ -30,10 +31,30 @@ function generateSecureToken(): string {
   return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
-// Get rate limit key for an email (uses hashed email for privacy)
-function getRateLimitKey(email: string): string {
+/**
+ * Rate-limit bucket key for an email address, in the current hour window.
+ *
+ * SHA-256 rather than hashEmail(): that helper is a 32-bit Java-style string
+ * hash, and collisions in it are constructible rather than merely possible —
+ * a collider for a chosen address turns up within a few thousand candidates
+ * ("cg1@acme.com" collides with "ceo@acme.com"). Sharing a bucket with an
+ * address the attacker picks is a targeted lockout: five POSTs to
+ * /auth/send-login naming the collider exhaust the victim's five sends for the
+ * hour. Those five requests cost nothing and send no mail, because the counter
+ * is committed even when no such user exists — deliberately, so the endpoint is
+ * not an account-enumeration oracle.
+ *
+ * The digest is unsalted, which makes it a collision-resistant bucket key and
+ * not a secret: anyone holding a candidate address can confirm whether it maps
+ * here. Salting would need a key that is always configured, and every secret on
+ * Env is optional today. hashEmail() stays for log lines, where a short opaque
+ * token is all that is wanted and a collision costs nothing.
+ *
+ * Changing the key shape resets in-flight hourly counters once, on deploy.
+ */
+async function getRateLimitKey(email: string): Promise<string> {
   const hour = Math.floor(Date.now() / 1000 / MAGIC_LINK_RATE_WINDOW);
-  const emailHash = hashEmail(email);
+  const emailHash = await hashToken(email);
   return `magic_link_rate:${emailHash}:${hour}`;
 }
 
@@ -57,7 +78,7 @@ async function checkMagicLinkRateLimits(
   email: string,
   logger: Logger,
 ): Promise<{ blocked: boolean; commit: () => Promise<void> }> {
-  const emailKey = getRateLimitKey(email);
+  const emailKey = await getRateLimitKey(email);
   const ip = c.req.header("CF-Connecting-IP") ?? "unknown";
   const ipKey = getIpRateLimitKey(ip);
   let emailCount = 0;

--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -18,6 +18,9 @@ const app = new Hono<{ Bindings: Env }>();
 
 // Rate limiting constants
 const MAGIC_LINK_RATE_LIMIT = 5; // max 5 requests per hour per email
+// Per-IP cap so one client can't mail links to unlimited addresses (the
+// per-email limit alone leaves a mail-bombing / send-cost amplification vector).
+const MAGIC_LINK_IP_RATE_LIMIT = 20; // max 20 magic-link sends per hour per IP
 const MAGIC_LINK_RATE_WINDOW = 60 * 60; // 1 hour in seconds
 
 // Generate a secure random token (32 bytes = 64 hex chars)
@@ -32,6 +35,49 @@ function getRateLimitKey(email: string): string {
   const hour = Math.floor(Date.now() / 1000 / MAGIC_LINK_RATE_WINDOW);
   const emailHash = hashEmail(email);
   return `magic_link_rate:${emailHash}:${hour}`;
+}
+
+// Per-IP rate limit key for the current hour window.
+function getIpRateLimitKey(ip: string): string {
+  const hour = Math.floor(Date.now() / 1000 / MAGIC_LINK_RATE_WINDOW);
+  return `magic_link_ip_rate:${ip}:${hour}`;
+}
+
+/**
+ * Enforce both magic-link caps: per-email AND per-IP. The per-email limit alone
+ * lets a single client mail links to unlimited addresses (one per email), so we
+ * also bound sends per source IP. Reads fail open on a KV error (matching the
+ * historical behavior — an auth path must not lock users out on a KV blip); both
+ * caps re-apply on the next request once KV recovers. Returns `blocked`, plus a
+ * `commit()` the caller invokes once it decides to actually send, which bumps
+ * both counters together.
+ */
+async function checkMagicLinkRateLimits(
+  c: Context<{ Bindings: Env }>,
+  email: string,
+  logger: Logger,
+): Promise<{ blocked: boolean; commit: () => Promise<void> }> {
+  const emailKey = getRateLimitKey(email);
+  const ip = c.req.header("CF-Connecting-IP") ?? "unknown";
+  const ipKey = getIpRateLimitKey(ip);
+  let emailCount = 0;
+  let ipCount = 0;
+  try {
+    emailCount = Number.parseInt((await c.env.STATE.get(emailKey)) ?? "0");
+    ipCount = Number.parseInt((await c.env.STATE.get(ipKey)) ?? "0");
+  } catch (err) {
+    logger.warn("Failed to read magic-link rate limits, allowing request", { error: err });
+  }
+  const blocked = emailCount >= MAGIC_LINK_RATE_LIMIT || ipCount >= MAGIC_LINK_IP_RATE_LIMIT;
+  const commit = async () => {
+    await c.env.STATE.put(emailKey, String(emailCount + 1), {
+      expirationTtl: MAGIC_LINK_RATE_WINDOW,
+    });
+    await c.env.STATE.put(ipKey, String(ipCount + 1), {
+      expirationTtl: MAGIC_LINK_RATE_WINDOW,
+    });
+  };
+  return { blocked, commit };
 }
 
 const ERROR_MESSAGES: Record<string, string> = {
@@ -341,25 +387,16 @@ app.post("/send-signup", async (c) => {
     return emailAuthRedirect(c, "error", "username_taken", "/auth/signup");
   }
 
-  // Check rate limit (fail open if KV fails)
-  const rateLimitKey = getRateLimitKey(email);
-  let currentCount = 0;
-  try {
-    currentCount = Number.parseInt((await c.env.STATE.get(rateLimitKey)) ?? "0");
-  } catch (err) {
-    logger.warn("Failed to check rate limit, allowing request", { emailHash, error: err });
-  }
-
-  if (currentCount >= MAGIC_LINK_RATE_LIMIT) {
+  // Enforce per-email and per-IP magic-link caps.
+  const rateLimit = await checkMagicLinkRateLimits(c, email, logger);
+  if (rateLimit.blocked) {
     logger.warn("Magic link rate limit exceeded", { emailHash });
     return emailAuthRedirect(c, "error", "rate_limited", "/auth/signup");
   }
 
   try {
-    // Increment rate limit counter
-    await c.env.STATE.put(rateLimitKey, String(currentCount + 1), {
-      expirationTtl: MAGIC_LINK_RATE_WINDOW,
-    });
+    // Bump both rate-limit counters (per-email + per-IP) now that we are sending.
+    await rateLimit.commit();
 
     // Generate secure magic link token
     const token = generateSecureToken();
@@ -443,25 +480,16 @@ app.post("/send-login", async (c) => {
   // send-only-for-real-accounts branch isn't a cheap oracle.
   const existingUser = await getUserByEmail(c.env.DB, email, logger);
 
-  // Check rate limit (fail open if KV fails)
-  const rateLimitKey = getRateLimitKey(email);
-  let currentCount = 0;
-  try {
-    currentCount = Number.parseInt((await c.env.STATE.get(rateLimitKey)) ?? "0");
-  } catch (err) {
-    logger.warn("Failed to check rate limit, allowing request", { emailHash, error: err });
-  }
-
-  if (currentCount >= MAGIC_LINK_RATE_LIMIT) {
+  // Enforce per-email and per-IP magic-link caps.
+  const rateLimit = await checkMagicLinkRateLimits(c, email, logger);
+  if (rateLimit.blocked) {
     logger.warn("Magic link rate limit exceeded", { emailHash });
     return emailAuthRedirect(c, "error", "rate_limited", "/auth/login");
   }
 
   try {
-    // Increment rate limit counter
-    await c.env.STATE.put(rateLimitKey, String(currentCount + 1), {
-      expirationTtl: MAGIC_LINK_RATE_WINDOW,
-    });
+    // Bump both rate-limit counters (per-email + per-IP) now that we are sending.
+    await rateLimit.commit();
 
     if (existingUser.success) {
       // Generate secure magic link token
@@ -543,25 +571,16 @@ app.post("/send", async (c) => {
     return emailAuthRedirect(c, "error", "auth_config_incomplete");
   }
 
-  // Check rate limit (fail open if KV fails)
-  const rateLimitKey = getRateLimitKey(email);
-  let currentCount = 0;
-  try {
-    currentCount = Number.parseInt((await c.env.STATE.get(rateLimitKey)) ?? "0");
-  } catch (err) {
-    logger.warn("Failed to check rate limit, allowing request", { emailHash, error: err });
-  }
-
-  if (currentCount >= MAGIC_LINK_RATE_LIMIT) {
+  // Enforce per-email and per-IP magic-link caps.
+  const rateLimit = await checkMagicLinkRateLimits(c, email, logger);
+  if (rateLimit.blocked) {
     logger.warn("Magic link rate limit exceeded", { emailHash });
     return emailAuthRedirect(c, "error", "rate_limited");
   }
 
   try {
-    // Increment rate limit counter
-    await c.env.STATE.put(rateLimitKey, String(currentCount + 1), {
-      expirationTtl: MAGIC_LINK_RATE_WINDOW,
-    });
+    // Bump both rate-limit counters (per-email + per-IP) now that we are sending.
+    await rateLimit.commit();
 
     // Check if user exists to determine intent
     const existingUser = await getUserByEmail(c.env.DB, email, logger);

--- a/tests/auth-signup-login.test.ts
+++ b/tests/auth-signup-login.test.ts
@@ -668,6 +668,43 @@ describe("Auth Signup/Login Integration Tests", () => {
         expect(res.headers.get("location")).toContain("error=rate_limited");
       });
 
+      // The per-email bucket keys on a digest of the address. It has to be
+      // collision-resistant, not merely opaque: the old 32-bit string hash let
+      // an attacker construct a different address landing in a chosen victim's
+      // bucket ("cg1@acme.com" for "ceo@acme.com", found in a few thousand
+      // tries) and spend the victim's five sends from a distinct source IP, so
+      // neither cap noticed. No mail is sent for the collider, which need not
+      // even be a real account.
+      it("does not let a colliding address consume another address's budget", async () => {
+        const victim = "ceo@acme.com";
+        const collider = "cg1@acme.com";
+
+        // Burn the collider's five sends, each from its own IP so the per-IP
+        // cap plays no part in the outcome.
+        for (let i = 0; i < 5; i++) {
+          const res = await app.fetch(
+            request("/auth/email/send-login", {
+              method: "POST",
+              headers: { "CF-Connecting-IP": `203.0.113.${20 + i}` },
+              body: createFormData({ email: collider }),
+            }),
+            env,
+          );
+          expect(res.headers.get("location")).not.toContain("error=rate_limited");
+        }
+
+        // The victim's own bucket must be untouched.
+        const res = await app.fetch(
+          request("/auth/email/send-login", {
+            method: "POST",
+            headers: { "CF-Connecting-IP": "203.0.113.30" },
+            body: createFormData({ email: victim }),
+          }),
+          env,
+        );
+        expect(res.headers.get("location")).not.toContain("error=rate_limited");
+      });
+
       it("rate limits per source IP across many different emails (anti mail-bomb)", async () => {
         const ip = "203.0.113.7";
         // 20 distinct emails from one IP each pass the per-email limit but exhaust

--- a/tests/auth-signup-login.test.ts
+++ b/tests/auth-signup-login.test.ts
@@ -668,6 +668,46 @@ describe("Auth Signup/Login Integration Tests", () => {
         expect(res.headers.get("location")).toContain("error=rate_limited");
       });
 
+      /**
+       * The two reads are assigned in sequence, so a throw on the second one
+       * used to leave the first count standing. With the email bucket already
+       * exhausted that computed `blocked === true` — locking a user out of
+       * their own login on a transient KV blip, which is the exact failure the
+       * fail-open contract exists to prevent.
+       */
+      it("fails open when the per-IP read throws after the email bucket is full", async () => {
+        const email = "failopen@example.com";
+        const env = makeEnv();
+        const realGet = env.STATE.get.bind(env.STATE);
+        // Exhaust the per-email bucket through the real path first.
+        for (let i = 0; i < 5; i++) {
+          await app.fetch(
+            request("/auth/email/send-signup", {
+              method: "POST",
+              body: createFormData({ email, username: `failopen${i}` }),
+            }),
+            env,
+          );
+        }
+
+        // Now let the email read succeed and make only the per-IP read throw.
+        env.STATE.get = (async (key: string) => {
+          if (key.startsWith("magic_link_ip_rate:")) throw new Error("KV unavailable");
+          return realGet(key);
+        }) as typeof env.STATE.get;
+
+        const res = await app.fetch(
+          request("/auth/email/send-signup", {
+            method: "POST",
+            body: createFormData({ email, username: "failopen9" }),
+          }),
+          env,
+        );
+
+        expect(res.status).toBe(302);
+        expect(res.headers.get("location")).not.toContain("error=rate_limited");
+      });
+
       // The per-email bucket keys on a digest of the address. It has to be
       // collision-resistant, not merely opaque: the old 32-bit string hash let
       // an attacker construct a different address landing in a chosen victim's

--- a/tests/auth-signup-login.test.ts
+++ b/tests/auth-signup-login.test.ts
@@ -668,6 +668,45 @@ describe("Auth Signup/Login Integration Tests", () => {
         expect(res.headers.get("location")).toContain("error=rate_limited");
       });
 
+      it("rate limits per source IP across many different emails (anti mail-bomb)", async () => {
+        const ip = "203.0.113.7";
+        // 20 distinct emails from one IP each pass the per-email limit but exhaust
+        // the per-IP budget (MAGIC_LINK_IP_RATE_LIMIT = 20).
+        for (let i = 0; i < 20; i++) {
+          const res = await app.fetch(
+            request("/auth/email/send-signup", {
+              method: "POST",
+              headers: { "CF-Connecting-IP": ip },
+              body: createFormData({ email: `victim${i}@example.com`, username: `victim${i}` }),
+            }),
+            env,
+          );
+          expect(res.headers.get("location")).toContain("success=email_sent");
+        }
+
+        // The 21st send from the same IP — a brand-new email — is blocked.
+        const blocked = await app.fetch(
+          request("/auth/email/send-signup", {
+            method: "POST",
+            headers: { "CF-Connecting-IP": ip },
+            body: createFormData({ email: "victim20@example.com", username: "victim20" }),
+          }),
+          env,
+        );
+        expect(blocked.headers.get("location")).toContain("error=rate_limited");
+
+        // A different IP is unaffected.
+        const otherIp = await app.fetch(
+          request("/auth/email/send-signup", {
+            method: "POST",
+            headers: { "CF-Connecting-IP": "198.51.100.9" },
+            body: createFormData({ email: "victim21@example.com", username: "victim21" }),
+          }),
+          env,
+        );
+        expect(otherIp.headers.get("location")).toContain("success=email_sent");
+      });
+
       it("fails when email service not configured", async () => {
         const envWithoutEmail = makeEnv({ EMAIL: undefined });
 


### PR DESCRIPTION
## Summary

The magic-link rate limiter was keyed only per **email** (5/hour). One client could therefore mail links to unlimited addresses — one send per fresh email — turning the endpoint into a mail-bomb / email-cost amplification vector against arbitrary inboxes.

Change:
- Add a **per-IP cap** (`MAGIC_LINK_IP_RATE_LIMIT = 20` sends/hour/IP, keyed on `CF-Connecting-IP`) enforced alongside the per-email limit.
- Factor the duplicated inline check/increment (three copies across signup/login/send) into a shared `checkMagicLinkRateLimits()` helper that returns `blocked` plus a `commit()` bumping both counters together.
- Reads still **fail open** on a KV error — an auth path must not lock users out on a transient KV blip.

## Related issues

Addresses advisory **SA-7** (the per-IP mail-bomb vector). The other SA-7 items — non-atomic KV counters (bypassable under high concurrency) and the fail-open-on-error posture — need an atomic Durable Object counter and are called out as follow-up rather than half-implemented here, to avoid a risky fail-closed switch on the login path.

## Type of change

- [x] Bug fix (security)

## How was this verified?

- [x] `npm run typecheck` (clean)
- [x] `npm test` — `tests/auth-signup-login.test.ts` (73 passed) incl. a new case: 20 distinct emails from one IP succeed, the 21st is `rate_limited`, and a different IP is unaffected; `tests/magic-link.test.ts` still green
- [x] `npm run lint` (clean on touched files)

## Checklist

- [x] Tests added or updated for the change
- [x] Docs updated where the change makes them inaccurate (n/a)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015rgmQChstLxpyb4Kf9339J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hourly magic-link request limits based on both email address and source IP.
  * Applied consistent protection across signup, login, and legacy magic-link flows.
  * Strengthened safeguards against bypassing email-based limits by using protected email keys.

* **Bug Fixes**
  * Rate limiting now fails open during temporary storage read errors, preventing unnecessary request blocks.
  * Added coverage for cross-email IP limits and separate-IP exemptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->