### PR TITLE
Reclaim sha-keyed staged trees when changes are rejected

### DIFF
--- a/src/queue/event-consumer.ts
+++ b/src/queue/event-consumer.ts
@@ -1,4 +1,5 @@
 import { createPostHogClient } from "../analytics/posthog";
+import { getChange } from "../storage/changes";
 import {
   type EventRecord,
   getEvent,
@@ -8,6 +9,7 @@ import {
   markEventProcessed,
   setCompletedHandlers,
 } from "../storage/events";
+import { deletePinnedStagedTreeForChange } from "../storage/staged-tree-gc";
 import type { Env, Message, MessageBatch } from "../types";
 import type { Logger } from "../utils/logger";
 import { createLogger } from "../utils/logger";
@@ -54,11 +56,58 @@ const issueAutoCloseHandler: EventHandler = {
 };
 
 /**
+ * Reclaim the immutable R2 tree pinned by a terminal rejected change. This
+ * handler runs last: if R2 is transiently unavailable, event retry resumes at
+ * this handler without re-running analytics, issue auto-close, or webhooks.
+ */
+export const stagedTreeGcHandler: EventHandler = {
+  name: "staged-tree-gc",
+  async handle(env, event, logger) {
+    if (event.type !== "change.rejected" || !env.REPO_OBJECTS) return;
+
+    const changeId = event.payload.changeId;
+    if (typeof changeId !== "string" || changeId.length === 0) {
+      logger.warn("Rejected-change event missing changeId; staged-tree GC skipped", {
+        eventId: event.id,
+      });
+      return;
+    }
+
+    const changeResult = await getChange(env.DB, logger, changeId);
+    if (!changeResult.success) {
+      if (changeResult.error.code === "NOT_FOUND") {
+        logger.warn("Rejected change missing during staged-tree GC; skipping", {
+          eventId: event.id,
+          changeId,
+        });
+        return;
+      }
+      throw changeResult.error;
+    }
+
+    const key = await deletePinnedStagedTreeForChange(
+      env.REPO_OBJECTS,
+      changeResult.data,
+      event.projectId,
+    );
+    if (key !== null) {
+      logger.debug("Reclaimed rejected change staged tree", { changeId, key });
+    }
+  },
+};
+
+/**
  * Ordered handler registry. Every handler runs for every event and decides
  * internally whether the event type concerns it. Issue auto-close runs
- * before webhooks so receivers observe a consistent issue state.
+ * before webhooks so receivers observe a consistent issue state. GC runs last
+ * so a retry caused by R2 cleanup never replays externally-visible handlers.
  */
-const handlers: EventHandler[] = [analyticsHandler, issueAutoCloseHandler, webhookHandler];
+const handlers: EventHandler[] = [
+  analyticsHandler,
+  issueAutoCloseHandler,
+  webhookHandler,
+  stagedTreeGcHandler,
+];
 
 /** Exported for tests. Runs the ordered handlers, resuming past completed ones. */
 export async function processEvent(env: Env, event: EventRecord, logger: Logger): Promise<void> {

--- a/src/storage/staged-tree-gc.ts
+++ b/src/storage/staged-tree-gc.ts
@@ -1,0 +1,29 @@
+import type { Change } from "../types";
+import { stagedTreeShaKey } from "./git-ops";
+
+type StagedTreeChangeRef = Pick<
+  Change,
+  "projectId" | "workspace" | "workspaceHeadSha" | "evaluatedSha"
+>;
+
+/**
+ * Delete the immutable staged-tree copy for the commit a change was evaluated
+ * against. The latest-tip key is deliberately left alone: the workspace may
+ * already have advanced to a newer commit that another change still needs.
+ *
+ * Returns the deleted key, or null for legacy changes that do not carry enough
+ * identity to address a sha-keyed staged tree safely.
+ */
+export async function deletePinnedStagedTreeForChange(
+  bucket: R2Bucket,
+  change: StagedTreeChangeRef,
+  fallbackProjectId?: string,
+): Promise<string | null> {
+  const projectId = change.projectId ?? fallbackProjectId;
+  const pinnedSha = change.workspaceHeadSha ?? change.evaluatedSha;
+  if (projectId === undefined || pinnedSha === undefined) return null;
+
+  const key = stagedTreeShaKey(projectId, change.workspace, pinnedSha);
+  await bucket.delete(key);
+  return key;
+}

--- a/tests/staged-tree-gc.test.ts
+++ b/tests/staged-tree-gc.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import { stagedTreeGcHandler } from "../src/queue/event-consumer";
+import { deletePinnedStagedTreeForChange } from "../src/storage/staged-tree-gc";
+import type { Change, Env } from "../src/types";
+import type { Logger } from "../src/utils/logger";
+import { makeFakeR2 } from "./helpers/fake-r2";
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+};
+
+function change(overrides: Partial<Change> = {}): Change {
+  return {
+    id: "chg_1",
+    project: "demo",
+    projectId: "project-1",
+    workspace: "feature",
+    status: "rejected",
+    workspaceHeadSha: "evaluated-sha",
+    createdAt: "2026-08-24T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function changeDb(row: Record<string, unknown>): D1Database {
+  return {
+    prepare: vi.fn(() => ({
+      bind: vi.fn(() => ({
+        first: vi.fn(async () => row),
+      })),
+    })),
+  } as unknown as D1Database;
+}
+
+describe("staged-tree GC", () => {
+  it("deletes only the rejected change's pinned sha copy", async () => {
+    const bucket = makeFakeR2();
+    await bucket.put("repos/project-1/ws/feature", "latest");
+    await bucket.put("repos/project-1/ws/feature/sha/evaluated-sha", "pinned");
+    await bucket.put("repos/project-1/ws/feature/sha/newer-sha", "newer");
+
+    const key = await deletePinnedStagedTreeForChange(bucket, change());
+
+    expect(key).toBe("repos/project-1/ws/feature/sha/evaluated-sha");
+    expect(bucket.store.has("repos/project-1/ws/feature/sha/evaluated-sha")).toBe(false);
+    expect(bucket.store.has("repos/project-1/ws/feature")).toBe(true);
+    expect(bucket.store.has("repos/project-1/ws/feature/sha/newer-sha")).toBe(true);
+  });
+
+  it("falls back to evaluatedSha and the event project id for legacy rows", async () => {
+    const bucket = makeFakeR2();
+    await bucket.put("repos/project-legacy/ws/feature/sha/eval-only", "pinned");
+
+    const key = await deletePinnedStagedTreeForChange(
+      bucket,
+      change({ projectId: undefined, workspaceHeadSha: undefined, evaluatedSha: "eval-only" }),
+      "project-legacy",
+    );
+
+    expect(key).toBe("repos/project-legacy/ws/feature/sha/eval-only");
+    expect(bucket.store.size).toBe(0);
+  });
+
+  it("does nothing when a legacy change has no safe project id or pinned sha", async () => {
+    const bucket = makeFakeR2();
+    await bucket.put("repos/project-1/ws/feature/sha/some-sha", "keep");
+
+    const key = await deletePinnedStagedTreeForChange(
+      bucket,
+      change({ projectId: undefined, workspaceHeadSha: undefined, evaluatedSha: undefined }),
+    );
+
+    expect(key).toBeNull();
+    expect(bucket.store.has("repos/project-1/ws/feature/sha/some-sha")).toBe(true);
+  });
+
+  it("wires change.rejected events to exact pinned-tree reclamation", async () => {
+    const bucket = makeFakeR2();
+    await bucket.put("repos/project-1/ws/feature/sha/evaluated-sha", "pinned");
+    await bucket.put("repos/project-1/ws/feature/sha/newer-sha", "newer");
+
+    const db = changeDb({
+      id: "chg_1",
+      project: "demo",
+      project_id: "project-1",
+      workspace: "feature",
+      status: "rejected",
+      agent_id: null,
+      eval_score: null,
+      eval_passed: null,
+      eval_reason: null,
+      base_sha: null,
+      evaluated_sha: "evaluated-sha",
+      evaluated_tree_oid: null,
+      agent_model: null,
+      agent_prompt_hash: null,
+      workspace_head_sha: "evaluated-sha",
+      created_at: "2026-08-24T00:00:00.000Z",
+      merged_at: null,
+      github_owner: null,
+      github_repo: null,
+      github_branch: null,
+      github_pr_number: null,
+      github_pr_url: null,
+      github_pr_state: null,
+      github_head_sha: null,
+      github_comment_id: null,
+      promoted_at: null,
+      promoted_by: null,
+    });
+
+    await stagedTreeGcHandler.handle(
+      { DB: db, REPO_OBJECTS: bucket } as unknown as Env,
+      {
+        id: "evt_1",
+        type: "change.rejected",
+        project: "demo",
+        projectId: "project-1",
+        actorType: "user",
+        payload: { changeId: "chg_1" },
+        status: "pending",
+        attempts: 0,
+        createdAt: "2026-08-24T00:00:00.000Z",
+      },
+      logger,
+    );
+
+    expect(bucket.store.has("repos/project-1/ws/feature/sha/evaluated-sha")).toBe(false);
+    expect(bucket.store.has("repos/project-1/ws/feature/sha/newer-sha")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Reclaim the immutable SHA-keyed R2 staged-tree object when a change reaches the terminal `rejected` state.

The cleanup deliberately deletes only the object pinned to the rejected change's evaluated/workspace SHA. It leaves the latest workspace tree and any newer SHA-keyed copies intact, so evaluated-SHA pinning remains safe across re-pushes.

The GC handler runs last in the event pipeline so an R2 cleanup retry does not replay analytics, issue auto-close, or webhook handlers. Legacy changes without enough identity to address a staged tree safely are left untouched.

## Related issues

Addresses #262.

This is intentionally a focused slice of #262: rejected-change reclamation only. It does not claim to solve broader workspace or intermediate-commit lifecycle cleanup.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## Testing

- Added focused coverage for exact pinned-SHA reclamation.
- Verifies the latest workspace tree is preserved.
- Verifies newer SHA-keyed staged trees are preserved.
- Covers legacy project-ID / evaluated-SHA fallback.
- Covers `change.rejected` event wiring.
- Ran the implementation and invariant checks through TalkPipe in a container.