### PR TITLE
Backup: log dropped tags loudly when skipping a tag-only (unborn HEAD) repo

### DIFF
--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -81,7 +81,27 @@ export async function walkRepoObjects(
     log = await git.log({ fs, dir, depth: -1 });
   } catch (error) {
     if (error instanceof Error && error.name === "NotFoundError") {
-      logger.debug("Repo has no commits; skipping as empty", { dir });
+      // No HEAD history, but the repo can still have tag refs pointing at
+      // objects reached no other way (unborn HEAD, tag-only repo — #251).
+      // The full fix (a backup-format migration: optional tipSha, restore
+      // without refs/heads/main) is a product decision tracked separately;
+      // until then this loses those objects, so make the loss explicit and
+      // loud instead of a silent "empty" debug line.
+      let tagNames: string[] = [];
+      try {
+        tagNames = await git.listTags({ fs, dir });
+      } catch {
+        // Unreadable ref store on an already-unborn HEAD: nothing more to
+        // report than "no commits", so fall through to the debug case below.
+      }
+      if (tagNames.length > 0) {
+        logger.warn(
+          "Repo has no commits (unborn HEAD) but has tag refs; skipping as empty and DROPPING these tags — tag-only backup is not yet supported (#251)",
+          { dir, tags: [...tagNames].sort() },
+        );
+      } else {
+        logger.debug("Repo has no commits; skipping as empty", { dir });
+      }
       return ok({ empty: true });
     }
     logger.error("Failed to read repo log", error instanceof Error ? error : undefined, { dir });

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -8,6 +8,14 @@ import { type Result, err, ok } from "../utils/result";
 
 export const DEFAULT_MAX_BACKUP_BYTES = 128 * 1024 * 1024;
 
+/**
+ * How many dropped tag names the tag-only-repo warning will name inline.
+ * The count is always reported in full; only the sample is bounded, so a
+ * repo with a very large tag set cannot produce a log entry too big to be
+ * recorded at all.
+ */
+const MAX_LOGGED_TAG_NAMES = 50;
+
 /** A tag ref captured in a snapshot: refs/tags/<name> → oid (the annotated tag
  * object for annotated tags, the target itself for lightweight ones). */
 export interface TagRefRecord {
@@ -95,9 +103,20 @@ export async function walkRepoObjects(
         // report than "no commits", so fall through to the debug case below.
       }
       if (tagNames.length > 0) {
+        // Name the tags, but cap the list: this warning exists to make the
+        // loss visible, and a repo with thousands of tags would push the line
+        // past the log pipeline's per-entry limit and lose the whole thing --
+        // the failure mode the warning is here to prevent. `tagCount` is the
+        // number that always survives; `tags` is the sample.
+        const sorted = [...tagNames].sort();
         logger.warn(
           "Repo has no commits (unborn HEAD) but has tag refs; skipping as empty and DROPPING these tags — tag-only backup is not yet supported (#251)",
-          { dir, tags: [...tagNames].sort() },
+          {
+            dir,
+            tagCount: sorted.length,
+            tags: sorted.slice(0, MAX_LOGGED_TAG_NAMES),
+            ...(sorted.length > MAX_LOGGED_TAG_NAMES ? { tagsTruncated: true } : {}),
+          },
         );
       } else {
         logger.debug("Repo has no commits; skipping as empty", { dir });

--- a/tests/repo-snapshot.test.ts
+++ b/tests/repo-snapshot.test.ts
@@ -84,5 +84,36 @@ describe("repo snapshot capture", () => {
     expect(walk.success).toBe(true);
     if (!walk.success) return;
     expect("empty" in walk.data).toBe(true);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  // #251: a repo with no branch ref (unborn HEAD) but a tag pointing at a
+  // commit is reported empty and its tag-reachable objects are skipped. The
+  // full fix is a backup-format migration (tracked separately); this is the
+  // interim "loud, explicit skip" — the drop must be logged, not silent.
+  it("logs a loud warning naming the dropped tags for a tag-only repo (unborn HEAD)", async () => {
+    const { fs, tipSha } = await buildRepo([{ "a.txt": "one" }]);
+    // biome-ignore lint/suspicious/noExplicitAny: isomorphic-git fs shape
+    const gfs = fs as any;
+    await git.tag({ fs: gfs, dir: DIR, ref: "v1", object: tipSha });
+    // Remove the only branch ref directly (not via git.deleteBranch, which
+    // detaches HEAD onto the sha instead of leaving it unborn) so HEAD stays
+    // an unresolvable symref, mirroring a remote whose sole ref is a tag: the
+    // tagged commit stays reachable only via refs/tags/v1.
+    await gfs.promises.unlink(`${DIR}/.git/refs/heads/main`);
+
+    const walk = await walkRepoObjects(fs, DIR, 1_000_000, logger);
+    expect(walk.success).toBe(true);
+    if (!walk.success) return;
+    expect("empty" in walk.data).toBe(true);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [message, meta] = (logger.warn as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(message).toMatch(/dropping/i);
+    expect(message).toMatch(/tag/i);
+    expect(meta.tags).toEqual(["v1"]);
   });
 });

--- a/tests/repo-snapshot.test.ts
+++ b/tests/repo-snapshot.test.ts
@@ -1,5 +1,5 @@
 import git from "isomorphic-git";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildSnapshot, walkRepoObjects } from "../src/backup/repo-snapshot";
 import type { NodeFS } from "../src/storage/git-ops";
 import { MemoryFS } from "../src/storage/memory-fs";
@@ -49,6 +49,13 @@ const project: ProjectEntry = {
 };
 
 describe("repo snapshot capture", () => {
+  // The logger mock is module-scoped, so without this each test would see the
+  // previous test's calls and the call-count assertions below would pass or
+  // fail on declaration order rather than on behaviour.
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("walks the full reachable object set and preserves the tip sha", async () => {
     const { fs, tipSha } = await buildRepo([{ "a.txt": "one" }, { "b.txt": "two" }]);
     const walk = await walkRepoObjects(fs, DIR, 1_000_000, logger);
@@ -115,5 +122,37 @@ describe("repo snapshot capture", () => {
     expect(message).toMatch(/dropping/i);
     expect(message).toMatch(/tag/i);
     expect(meta.tags).toEqual(["v1"]);
+    expect(meta.tagCount).toBe(1);
+    expect(meta.tagsTruncated).toBeUndefined();
+  });
+
+  it("caps the named tags but still reports the true count", async () => {
+    // The warning's job is to make the loss visible. An unbounded name list
+    // on a repo with a large tag set would push the entry past the log
+    // pipeline's size limit and drop it entirely -- silence, which is exactly
+    // what this warning exists to prevent. The sample is bounded; the count
+    // is not.
+    const { fs, tipSha } = await buildRepo([{ "a.txt": "one" }]);
+    // biome-ignore lint/suspicious/noExplicitAny: isomorphic-git fs shape
+    const gfs = fs as any;
+    for (let i = 0; i < 60; i++) {
+      await git.tag({ fs: gfs, dir: DIR, ref: `v${String(i).padStart(3, "0")}`, object: tipSha });
+    }
+    await gfs.promises.unlink(`${DIR}/.git/refs/heads/main`);
+
+    const walk = await walkRepoObjects(fs, DIR, 1_000_000, logger);
+    expect(walk.success).toBe(true);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [, meta] = (logger.warn as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(meta.tagCount).toBe(60);
+    expect((meta.tags as string[]).length).toBe(50);
+    expect(meta.tagsTruncated).toBe(true);
+    // Sorted, so the sample is the first 50 by name rather than arbitrary.
+    expect((meta.tags as string[])[0]).toBe("v000");
+    expect((meta.tags as string[])[49]).toBe("v049");
   });
 });

--- a/tests/repo-snapshot.test.ts
+++ b/tests/repo-snapshot.test.ts
@@ -100,14 +100,12 @@ describe("repo snapshot capture", () => {
   // interim "loud, explicit skip" — the drop must be logged, not silent.
   it("logs a loud warning naming the dropped tags for a tag-only repo (unborn HEAD)", async () => {
     const { fs, tipSha } = await buildRepo([{ "a.txt": "one" }]);
-    // biome-ignore lint/suspicious/noExplicitAny: isomorphic-git fs shape
-    const gfs = fs as any;
-    await git.tag({ fs: gfs, dir: DIR, ref: "v1", object: tipSha });
+    await git.tag({ fs, dir: DIR, ref: "v1", object: tipSha });
     // Remove the only branch ref directly (not via git.deleteBranch, which
     // detaches HEAD onto the sha instead of leaving it unborn) so HEAD stays
     // an unresolvable symref, mirroring a remote whose sole ref is a tag: the
     // tagged commit stays reachable only via refs/tags/v1.
-    await gfs.promises.unlink(`${DIR}/.git/refs/heads/main`);
+    await fs.promises.unlink(`${DIR}/.git/refs/heads/main`);
 
     const walk = await walkRepoObjects(fs, DIR, 1_000_000, logger);
     expect(walk.success).toBe(true);
@@ -133,12 +131,10 @@ describe("repo snapshot capture", () => {
     // what this warning exists to prevent. The sample is bounded; the count
     // is not.
     const { fs, tipSha } = await buildRepo([{ "a.txt": "one" }]);
-    // biome-ignore lint/suspicious/noExplicitAny: isomorphic-git fs shape
-    const gfs = fs as any;
     for (let i = 0; i < 60; i++) {
-      await git.tag({ fs: gfs, dir: DIR, ref: `v${String(i).padStart(3, "0")}`, object: tipSha });
+      await git.tag({ fs, dir: DIR, ref: `v${String(i).padStart(3, "0")}`, object: tipSha });
     }
-    await gfs.promises.unlink(`${DIR}/.git/refs/heads/main`);
+    await fs.promises.unlink(`${DIR}/.git/refs/heads/main`);
 
     const walk = await walkRepoObjects(fs, DIR, 1_000_000, logger);
     expect(walk.success).toBe(true);


### PR DESCRIPTION
## Summary

Interim fix for the backup gap described in #251: `walkRepoObjects` resolves `HEAD` via `git.log` before enumerating `refs/tags/*`, so a repository whose only refs are tags (unborn HEAD) was reported `empty` and skipped with only a silent `logger.debug` — dropping its tag refs and every tag-reachable object from the backup with no trace.

This PR implements the explicitly-sanctioned cheap resolution from the issue's last paragraph: in the `NotFoundError` catch branch, enumerate `refs/tags/*` before returning. If any tags exist, log a `WARN` naming the dropped tags (sorted) and the repo dir; otherwise keep the original debug line. The function still returns `ok({ empty: true })` unconditionally — no manifest schema change, no restore-path change.

**What this deliberately does not do:** full tag-only backup/restore support requires a backup-format migration (optional `RepoManifest.tipSha`, `reconstructRepo` skipping `refs/heads/main`, `restoreProjectRepo` handling a tag-only push) plus a product decision on what a repo with no default branch means for the UI, git-http advertisement, and sync. That remains open in #251; this PR only makes the current loss explicit and loud instead of silent.

## Related issues

Refs #251 (interim loud-skip only — does not close it)

## Type of change

- [x] Bug fix

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` (full suite, 1724 passed)
- [x] `npm run lint`

New regression test in `tests/repo-snapshot.test.ts`: builds a repo with one commit, tags it `v1`, then removes `refs/heads/main` directly so HEAD stays an unborn symref — reproducing a real tag-only repo. Asserts the walk still reports `empty` and that `logger.warn` fires exactly once naming the dropped tag. The existing genuinely-empty-repo test now also asserts `logger.warn` is *not* called.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (none affected)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warnings for repositories without commit history when tag-reachable objects are skipped.
  * Warnings now include the total number of affected tags and a sample of tag names, with truncation clearly indicated for large tag sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->