### PR TITLE
Sandbox evaluator: require a pinned ref so the fail-closed read path is structural

### DIFF
--- a/src/evaluation/sandbox-evaluator.ts
+++ b/src/evaluation/sandbox-evaluator.ts
@@ -22,8 +22,16 @@ export interface SandboxRepoAccess {
   remote: string;
   /** A read-scoped token for that remote. */
   token: string;
-  /** The evaluated commit sha (pinned as evaluated_sha). HEAD when absent. */
-  ref?: string;
+  /**
+   * The evaluated commit sha (pinned as evaluated_sha). Required — not
+   * optional — so a `SandboxRepoAccess` can only be constructed with a commit
+   * pinned. `readRepoFiles` takes an unpinned, best-effort branch when `ref`
+   * is omitted (see its doc comment); that branch must never be reachable
+   * from the sandbox evaluator, which runs a merge gate and cannot let a
+   * silently partial tree produce a passing verdict. Requiring `ref` here
+   * makes that structural rather than a call-site convention.
+   */
+  ref: string;
 }
 
 /** Reads a repo tree into path → contents; injectable for tests. */
@@ -31,7 +39,7 @@ export type RepoFilesReader = (
   remote: string,
   token: string,
   logger: Logger,
-  ref?: string,
+  ref: string,
 ) => Promise<Result<Map<string, string>, AppError>>;
 
 /**

--- a/tests/sandbox-evaluator.test.ts
+++ b/tests/sandbox-evaluator.test.ts
@@ -1,11 +1,15 @@
+import git from "isomorphic-git";
 import { describe, expect, it, vi } from "vitest";
 import {
+  type RepoFilesReader,
   SandboxEvaluator,
   type SandboxRepoAccess,
   installCommandFor,
 } from "../src/evaluation/sandbox-evaluator";
 import type { EvalPolicy } from "../src/evaluation/types";
 import { buildEvaluators } from "../src/services/change-flow";
+import { type NodeFS, readTreeAtCommit } from "../src/storage/git-ops";
+import { MemoryFS } from "../src/storage/memory-fs";
 import type { Env, SandboxBinding, SandboxInstance } from "../src/types";
 import { AppError } from "../src/utils/errors";
 import type { Logger } from "../src/utils/logger";
@@ -140,15 +144,75 @@ describe("SandboxEvaluator — workspace tree materialization", () => {
     expect(result.success).toBe(false);
   });
 
-  it("passes ref: undefined through when no commit is pinned", async () => {
-    const { binding } = makeMockSandbox({ exitCode: 0 });
-    const readFiles = makeReadFiles();
+  it("requires `ref` at the type level — a SandboxRepoAccess cannot be built unpinned (#252)", () => {
+    // This is a compile-time guarantee, not a runtime assertion: `ref` on
+    // SandboxRepoAccess is a required `string`, so the object literal below
+    // is a type error and the whole file fails `tsc` if it ever stops being
+    // one. That makes the fail-closed pinned-commit read structural rather
+    // than resting on every construction site remembering to pass a ref.
+    // @ts-expect-error — ref is required; omitting it must not compile.
     const unpinned: SandboxRepoAccess = { remote: repo.remote, token: repo.token };
-    const evaluator = new SandboxEvaluator(binding, unpinned, readFiles);
+    expect(unpinned.remote).toBe(repo.remote);
+  });
 
-    await evaluator.evaluate("", makePolicy(), mockLogger);
+  it("an unreadable blob under the pinned ref produces an error verdict, never a pass (#252)", async () => {
+    // Wires the evaluator to the REAL readTreeAtCommit — the fail-closed path
+    // `SandboxRepoAccess.ref` being required now guarantees is the only one
+    // reachable — against a tree with one dangling blob oid. The regression
+    // this guards: a partial tree must never be handed to the sandbox as if
+    // it were complete, because that could let a broken/incomplete checkout
+    // score a false pass in a merge gate.
+    const fs = new MemoryFS().toNodeFS() as unknown as NodeFS;
+    const dir = "/";
+    await git.init({ fs, dir, defaultBranch: "main" });
+    const goodBlob = await git.writeBlob({
+      fs,
+      dir,
+      blob: new TextEncoder().encode("still readable"),
+    });
+    const treeOid = await git.writeTree({
+      fs,
+      dir,
+      tree: [
+        { mode: "100644", path: "good.txt", oid: goodBlob, type: "blob" },
+        // A dangling oid: listed in the tree but the object does not exist —
+        // simulates the unreadable-blob case the fail-closed path must catch.
+        {
+          mode: "100644",
+          path: "missing.txt",
+          oid: "0123456789abcdef0123456789abcdef01234567",
+          type: "blob",
+        },
+      ],
+    });
+    const author = { name: "Test", email: "test@example.com", timestamp: 0, timezoneOffset: 0 };
+    const commitSha = await git.writeCommit({
+      fs,
+      dir,
+      commit: { tree: treeOid, parent: [], author, committer: author, message: "broken tree" },
+    });
 
-    expect(readFiles).toHaveBeenCalledWith(repo.remote, repo.token, mockLogger, undefined);
+    const pinnedRepo: SandboxRepoAccess = {
+      remote: repo.remote,
+      token: repo.token,
+      ref: commitSha,
+    };
+    // Bypasses the network clone: reads straight from the local repo built
+    // above at the pinned commit, exactly as `readRepoFiles` would once
+    // cloned. Exercises the real fail-closed logic, not a mock of it.
+    const pinnedReader: RepoFilesReader = (_remote, _token, logger, ref) =>
+      readTreeAtCommit(fs, dir, ref, logger);
+    const { binding } = makeMockSandbox({ exitCode: 0 });
+    const evaluator = new SandboxEvaluator(binding, pinnedRepo, pinnedReader);
+
+    const result = await evaluator.evaluate("ignored diff", makePolicy(), mockLogger);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.message).toContain("Could not read workspace tree");
+    expect(result.error.message).toContain("missing.txt");
+    // No verdict was fabricated from the partial tree: no sandbox ever ran.
+    expect(binding.create).not.toHaveBeenCalled();
   });
 
   it("fails (err) with a clear reason when the tree cannot be read, without creating a sandbox", async () => {


### PR DESCRIPTION
## Summary

Implements option (1) from #252 — the smallest change that removes the fail-open trap. `SandboxRepoAccess.ref` and the `RepoFilesReader` `ref` parameter are now required `string`s, so the sandbox evaluator is structurally guaranteed to take the fail-closed pinned-commit read path (`readTreeAtCommit`, which errors on the first unreadable blob) instead of resting on call-site discipline.

Previously a future construction site that omitted `ref` would silently fall through to `readRepoFiles`'s lenient unpinned branch, which logs `"Skipping unreadable file in repo tree"` and returns a partial tree as `ok(...)` — letting a merge gate run tests against an incomplete checkout and potentially report **passed**, with only a warn line as evidence.

Scope notes:
- `readRepoFiles`'s own signature in `src/storage/git-ops.ts` is unchanged — `src/merge/post-merge.ts` still legitimately calls it without a ref for its non-gating post-merge path, and the optional-param function remains assignable to the stricter `RepoFilesReader` type.
- The two real construction sites (`src/services/change-flow.ts`, `src/routes/changes.ts`) already pass `ref: evaluatedSha` (non-optional), so no behavior change there.

## Related issues

Closes #252

## Type of change

- [x] Bug fix

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` (full suite: 1724 passed, 0 failures)
- [x] `npm run lint`

- A `@ts-expect-error`-backed test asserts constructing `SandboxRepoAccess` without `ref` is a compile error (replacing the prior test that exercised the now-impossible unpinned construction).
- New integration-style regression test wires `SandboxEvaluator` to the real `readTreeAtCommit` over a locally built git tree containing a dangling blob oid, asserting `evaluate()` returns `err` (never a fabricated pass), names the unreadable file, and never creates a sandbox.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (none affected)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository evaluations now use a required, pinned commit reference for consistent results.
  * Improved handling of unreadable files at the selected commit, returning an error without starting a sandbox.
* **Tests**
  * Expanded coverage for pinned repository access and unreadable file scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->