### PR TITLE
Auth middleware: fail closed on deleting-account lookups (align with #229's git-http fix)

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -95,9 +95,21 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
       }
       // An agent inherits its owner's access, so a deleting owner's agent must
       // stop working too — otherwise it's an authenticated write channel that
-      // re-creates rows the account cascade is erasing.
-      const ownerResult = await getUser(c.env.DB, agentResult.data.ownerId, logger);
-      if (ownerResult.success && ownerResult.data.deletingAt) {
+      // re-creates rows the account cascade is erasing. Fail CLOSED on the
+      // owner lookup: an unresolved lookup or a deleting owner rejects the
+      // agent token. getUser can reject on a D1 error, so catch it rather
+      // than letting it propagate past this middleware.
+      let ownerResult: Awaited<ReturnType<typeof getUser>>;
+      try {
+        ownerResult = await getUser(c.env.DB, agentResult.data.ownerId, logger);
+      } catch (error) {
+        logger.warn("Agent owner lookup threw during auth; failing closed", {
+          ownerId: agentResult.data.ownerId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return c.json({ error: "Invalid token" }, 401);
+      }
+      if (!ownerResult.success || ownerResult.data.deletingAt) {
         logger.warn("Auth failed - agent owner is deleting", { path: c.req.path });
         return c.json({ error: "Invalid token" }, 401);
       }
@@ -131,28 +143,33 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
         // Fetch the user row FIRST so a soft-`deleting` account is rejected
         // before any auth context is set (the deleting_at flag rides on the
         // same row, so this is not an extra round-trip beyond the username
-        // lookup this path already did).
-        const userResult = await getUser(c.env.DB, sessionResult.data.userId, logger);
-        if (userResult.success && userResult.data.deletingAt) {
-          logger.warn("Auth rejected - session user is deleting", { userId });
+        // lookup this path already did). Fail CLOSED: an unresolved lookup
+        // (missing row, or getUser rejecting on a D1 error) must not end up
+        // authenticated any more than a deleting account should.
+        let userResult: Awaited<ReturnType<typeof getUser>>;
+        try {
+          userResult = await getUser(c.env.DB, sessionResult.data.userId, logger);
+        } catch (error) {
+          logger.warn("Session user lookup threw during auth; failing closed", {
+            userId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return c.json({ error: "Unauthorized" }, 401);
+        }
+        if (!userResult.success || userResult.data.deletingAt) {
+          logger.warn("Auth rejected - session user missing or deleting", { userId });
           return c.json({ error: "Unauthorized" }, 401);
         }
 
         c.set("userId", sessionResult.data.userId);
         c.set("authVia", "session");
 
-        if (userResult.success) {
-          // Generate username from email if missing (backward compatibility)
-          const username =
-            userResult.data.username ||
-            (userResult.data.email.split("@")[0] ?? "").toLowerCase().replace(/[^a-z0-9]/g, "");
-          c.set("username", username);
-          logger.debug("Auth success - session", { userId: sessionResult.data.userId, username });
-        } else {
-          logger.debug("Auth success - session (username not found)", {
-            userId: sessionResult.data.userId,
-          });
-        }
+        // Generate username from email if missing (backward compatibility)
+        const username =
+          userResult.data.username ||
+          (userResult.data.email.split("@")[0] ?? "").toLowerCase().replace(/[^a-z0-9]/g, "");
+        c.set("username", username);
+        logger.debug("Auth success - session", { userId: sessionResult.data.userId, username });
       }
     } else {
       logger.debug("Session not found", { sessionId: sanitizeToken(sessionId) });

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -25,6 +25,16 @@ function sanitizeToken(token: string): string {
   return `${token.slice(0, 4)}...${token.slice(-4)}`;
 }
 
+/**
+ * Resolve the caller's identity from an agent token, a user token, or a session
+ * cookie, and populate the auth context the routes read.
+ *
+ * Every account lookup here fails CLOSED (#236, mirroring #229 in git-http):
+ * the caller is authenticated only when the lookup succeeds AND returns a live
+ * account. A lookup that errors, rejects, or finds no row is a 401, never a
+ * pass — otherwise a transient D1 failure would authenticate an account the
+ * deletion cascade is erasing.
+ */
 export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
   const requestId = crypto.randomUUID();
   const logger = createLogger({

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -6,7 +6,16 @@ import { NotFoundError } from "../src/utils/errors";
 
 vi.mock("../src/storage/users", () => ({
   getUserByToken: vi.fn(),
-  getUser: vi.fn(async () => ({ success: false, error: new Error("nf") })),
+  getUser: vi.fn(async () => ({
+    success: true,
+    data: {
+      id: "usr_abc",
+      email: "test@example.com",
+      username: "test",
+      tokenHash: "hash",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    },
+  })),
 }));
 
 vi.mock("../src/storage/agents", () => ({

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -143,7 +143,19 @@ vi.mock("../src/queue/events", () => ({
 
 vi.mock("../src/storage/users", () => ({
   getUserByToken: vi.fn(),
-  getUser: vi.fn(async () => ({ success: false, error: new Error("nf") })),
+  // Agent auth resolves the agent's owner via getUser (fail-closed on the
+  // owner lookup); default to a live owner so agent-token tests authenticate
+  // as before unless a test overrides this to exercise the deleting/failed path.
+  getUser: vi.fn(async () => ({
+    success: true,
+    data: {
+      id: "usr_owner",
+      email: "owner@example.com",
+      username: "owner",
+      tokenHash: "hash",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    },
+  })),
 }));
 
 // Need to setup mocks in beforeEach instead

--- a/tests/deletion-enforcement.test.ts
+++ b/tests/deletion-enforcement.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authMiddleware } from "../src/middleware/auth";
 import { isTargetDeleting } from "../src/storage/deletion";
 import type { Env, ProjectEntry } from "../src/types";
+import { NotFoundError } from "../src/utils/errors";
 import type { Logger } from "../src/utils/logger";
 
 vi.mock("../src/storage/users", () => ({
@@ -139,6 +140,64 @@ describe("deleting enforcement — auth middleware", () => {
       data: { ...liveUser, deletingAt: "2026-06-17T00:00:00.000Z" },
     });
     const res = await makeApp().fetch(request({ Authorization: "Bearer stratum_agent_x" }), env);
+    expect(res.status).toBe(401);
+  });
+
+  it("fails closed: rejects an agent whose owner lookup returns err (not found)", async () => {
+    vi.mocked(getAgentByToken).mockResolvedValue({
+      success: true,
+      data: {
+        id: "agt_1",
+        name: "a",
+        ownerId: "usr_ghost",
+        tokenHash: "h",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    vi.mocked(getUser).mockResolvedValue({
+      success: false,
+      error: new NotFoundError("User", "usr_ghost"),
+    });
+    const res = await makeApp().fetch(request({ Authorization: "Bearer stratum_agent_x" }), env);
+    expect(res.status).toBe(401);
+  });
+
+  it("fails closed: rejects an agent whose owner lookup throws (D1 rejection)", async () => {
+    vi.mocked(getAgentByToken).mockResolvedValue({
+      success: true,
+      data: {
+        id: "agt_1",
+        name: "a",
+        ownerId: "usr_1",
+        tokenHash: "h",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    vi.mocked(getUser).mockRejectedValue(new Error("D1 unavailable"));
+    const res = await makeApp().fetch(request({ Authorization: "Bearer stratum_agent_x" }), env);
+    expect(res.status).toBe(401);
+  });
+
+  it("fails closed: rejects a session whose user lookup returns err (not found)", async () => {
+    vi.mocked(getSession).mockResolvedValue({
+      success: true,
+      data: { id: "sess_1", userId: "usr_ghost", expiresAt: "2099-01-01T00:00:00.000Z" },
+    });
+    vi.mocked(getUser).mockResolvedValue({
+      success: false,
+      error: new NotFoundError("User", "usr_ghost"),
+    });
+    const res = await makeApp().fetch(request({ Cookie: "stratum_session=sess_1" }), env);
+    expect(res.status).toBe(401);
+  });
+
+  it("fails closed: rejects a session whose user lookup throws (D1 rejection)", async () => {
+    vi.mocked(getSession).mockResolvedValue({
+      success: true,
+      data: { id: "sess_1", userId: "usr_1", expiresAt: "2099-01-01T00:00:00.000Z" },
+    });
+    vi.mocked(getUser).mockRejectedValue(new Error("D1 unavailable"));
+    const res = await makeApp().fetch(request({ Cookie: "stratum_session=sess_1" }), env);
     expect(res.status).toBe(401);
   });
 });


### PR DESCRIPTION
## Summary

`src/middleware/auth.ts` had two fail-open sites mirroring the bug #229 fixed in `src/routes/git-http.ts` `authenticate()`: the agent-token owner lookup and the session user lookup both only rejected a deleting account when `result.success && result.data.deletingAt` held. When the lookup *failed* — the row missing, or `getUser` rejecting on a transient D1 error (it does an unwrapped `db.prepare().first()`) — the deleting check was skipped and the caller was authenticated anyway.

This mirrors #229's approach at both sites:

- Reject unless the lookup **succeeds** and `deletingAt` is unset: `!result.success || result.data.deletingAt` → 401.
- Wrap the `getUser` call in try/catch so a rejected promise is caught, logged, and fails closed with 401 instead of propagating past the middleware.

As part of this, the session path's prior fallback — authenticate with no username when the user row can't be found — is removed: a missing user row now rejects like a deleting account. The primary-credential lookups (`getUserByToken`, `getAgentByToken`) were already fail-closed and are untouched.

## Related issues

Closes #236

## Type of change

- [x] Bug fix

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` (full suite: 1727 passed, 0 failed)
- [x] `npm run lint`

- 4 new regression tests in `tests/deletion-enforcement.test.ts`: owner lookup returns `err` → 401; owner lookup throws → 401; session user lookup returns `err` → 401; session user lookup throws → 401.
- `tests/auth.test.ts` and `tests/changes.test.ts` had `getUser` mocks defaulting to `success: false`; their "agent auth succeeds" tests only passed because of the fail-open bug. Their defaults now resolve a live owner so those tests describe the legitimate scenario.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (none affected)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now rejects requests when owner or user lookups fail, return no record, or identify deleted accounts.
  * Successful session authentication consistently provides a username.
  * Prevents access when account verification cannot be completed.

* **Tests**
  * Added coverage for authentication failures caused by storage and lookup errors.
  * Updated test data to represent valid, active accounts by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->