### PR TITLE
Admin apply-endpoint to backfill webhooks.project_id from KV (steps 1–2 of #235)

### DIFF
--- a/src/routes/backfill.ts
+++ b/src/routes/backfill.ts
@@ -8,6 +8,11 @@ import { forbidden, internalError, ok } from "../utils/response";
 
 const app = new Hono<{ Bindings: Env }>();
 
+/**
+ * Gate an admin-only backfill route, returning a request-scoped logger on
+ * success. Accepts either the X-Admin-API-Key header or an authenticated
+ * admin user, matching the existing /plan endpoint's contract.
+ */
 async function requireAdmin(c: {
   env: Env;
   req: { header: (n: string) => string | undefined; path: string; method: string };
@@ -64,7 +69,7 @@ app.post("/webhooks/apply", async (c) => {
   const report = await backfillWebhookProjectIds(c.env, logger);
   if (!report.success) return internalError(report.error.message);
 
-  await recordAudit(c.env.DB, logger, {
+  const auditResult = await recordAudit(c.env.DB, logger, {
     action: "webhook.project_id_backfilled",
     actorType: c.get("userId") ? "user" : "system",
     ...(c.get("userId") !== undefined ? { actorId: c.get("userId") } : {}),
@@ -74,8 +79,25 @@ app.post("/webhooks/apply", async (c) => {
       remainingNullRows: report.data.remainingNullRows,
     },
   });
+  if (!auditResult.success) {
+    // The rows are already stamped by this point and nothing here can unwind
+    // them, so a failed audit write is a partial success, not a failure: the
+    // mutation landed, its provenance record did not. Deliberately NOT a 500
+    // — that would tell an operator the backfill did not happen when it did,
+    // and would throw away the `remainingNullRows` count this endpoint exists
+    // to report (the step-2 verification for #235), pushing them toward a
+    // re-run to recover numbers they already earned. Instead the gap is made
+    // explicit in the log and in `audited` below, so it can neither be missed
+    // nor mistaken for a clean run. (Auditing before the mutation, the
+    // deletion-runner's fail-hard order, isn't available here: the entry's
+    // detail is the run's own counts.)
+    logger.error("Backfill applied but its audit entry failed to persist", auditResult.error, {
+      updated: report.data.updated,
+      remainingNullRows: report.data.remainingNullRows,
+    });
+  }
 
-  return ok({ report: report.data });
+  return ok({ report: report.data, audited: auditResult.success });
 });
 
 export { app as backfillRouter };

--- a/src/routes/backfill.ts
+++ b/src/routes/backfill.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
-import { computeBackfillPlan } from "../storage/backfill-plan";
+import { recordAudit } from "../storage/audit";
+import { backfillWebhookProjectIds, computeBackfillPlan } from "../storage/backfill-plan";
 import type { Env } from "../types";
 import { isAdminRequest } from "../utils/admin";
 import { createLogger } from "../utils/logger";
@@ -41,6 +42,40 @@ app.get("/plan", async (c) => {
   const plan = await computeBackfillPlan(c.env, auth.logger);
   if (!plan.success) return internalError(plan.error.message);
   return ok({ plan: plan.data });
+});
+
+// POST /api/admin/backfill-project-id/webhooks/apply — APPLY: stamp
+// project_id on every legacy (NULL project_id) `webhooks` row whose `project`
+// name resolves to exactly one project across all namespaces. Ambiguous
+// (name shared by >1 project) and unresolved (no matching project) rows are
+// left NULL and reported — never guessed, since a bare name can collide
+// across tenants. Response reports rows updated, rows left NULL with why, and
+// the remaining NULL count (the step-2 verification for issue #235).
+//
+// This is step 1-2 of a 3-step coordinated fix (issue #235); the name-based
+// fallback in webhookBelongsToProject/listWebhooks intentionally stays in
+// place until this has actually run in production and the remaining NULL
+// count is verified at zero.
+app.post("/webhooks/apply", async (c) => {
+  const auth = await requireAdmin(c);
+  if (!auth.ok) return forbidden("Administrator access required");
+  const { logger } = auth;
+
+  const report = await backfillWebhookProjectIds(c.env, logger);
+  if (!report.success) return internalError(report.error.message);
+
+  await recordAudit(c.env.DB, logger, {
+    action: "webhook.project_id_backfilled",
+    actorType: c.get("userId") ? "user" : "system",
+    ...(c.get("userId") !== undefined ? { actorId: c.get("userId") } : {}),
+    detail: {
+      updated: report.data.updated,
+      skipped: report.data.skipped.length,
+      remainingNullRows: report.data.remainingNullRows,
+    },
+  });
+
+  return ok({ report: report.data });
 });
 
 export { app as backfillRouter };

--- a/src/routes/backfill.ts
+++ b/src/routes/backfill.ts
@@ -9,9 +9,9 @@ import { forbidden, internalError, ok } from "../utils/response";
 const app = new Hono<{ Bindings: Env }>();
 
 /**
- * Gate an admin-only backfill route, returning a request-scoped logger on
- * success. Accepts either the X-Admin-API-Key header or an authenticated
- * admin user, matching the existing /plan endpoint's contract.
+ * Accepts either the X-Admin-API-Key header or an authenticated admin user,
+ * deliberately matching /plan's contract: an operator running the dry-run and
+ * the apply back-to-back should not need two different credentials.
  */
 async function requireAdmin(c: {
   env: Env;
@@ -49,13 +49,12 @@ app.get("/plan", async (c) => {
   return ok({ plan: plan.data });
 });
 
-// POST /api/admin/backfill-project-id/webhooks/apply — APPLY: stamp
-// project_id on every legacy (NULL project_id) `webhooks` row whose `project`
-// name resolves to exactly one project across all namespaces. Ambiguous
-// (name shared by >1 project) and unresolved (no matching project) rows are
-// left NULL and reported — never guessed, since a bare name can collide
-// across tenants. Response reports rows updated, rows left NULL with why, and
-// the remaining NULL count (the step-2 verification for issue #235).
+// Only a name resolving to exactly one project across all namespaces is
+// stamped. Ambiguous and unresolved rows are left NULL and reported rather
+// than guessed: a bare project name can collide across tenants, so a guess
+// here would hand a legacy webhook (and its deliveries) to the wrong tenant.
+// `remainingNullRows` is reported because it is the step-2 verification for
+// issue #235 — it should read 0 after a clean run.
 //
 // This is step 1-2 of a 3-step coordinated fix (issue #235); the name-based
 // fallback in webhookBelongsToProject/listWebhooks intentionally stays in

--- a/src/storage/audit.ts
+++ b/src/storage/audit.ts
@@ -19,7 +19,8 @@ export type AuditAction =
   | "deletion.started"
   | "deletion.completed"
   | "deletion.incomplete"
-  | "deletion.redrive";
+  | "deletion.redrive"
+  | "webhook.project_id_backfilled";
 
 export interface AuditEntry {
   id: string;

--- a/src/storage/backfill-plan.ts
+++ b/src/storage/backfill-plan.ts
@@ -160,11 +160,16 @@ export async function backfillWebhookProjectIds(
       }
       // Re-assert `project_id IS NULL` at write time: cheap defense against a
       // concurrent backfill run (or a delivery/update in between) re-stamping
-      // an already-resolved row.
-      await env.DB.prepare("UPDATE webhooks SET project_id = ? WHERE id = ? AND project_id IS NULL")
+      // an already-resolved row. That guard means the UPDATE can legitimately
+      // match nothing, so count what it actually changed rather than how many
+      // times it ran -- `updated` is the step-2 verification number and must
+      // not report writes this run did not make.
+      const result = await env.DB.prepare(
+        "UPDATE webhooks SET project_id = ? WHERE id = ? AND project_id IS NULL",
+      )
         .bind(projectId, row.id)
         .run();
-      updated++;
+      updated += result.meta.changes;
     }
 
     const remaining = await env.DB.prepare(

--- a/src/storage/backfill-plan.ts
+++ b/src/storage/backfill-plan.ts
@@ -35,6 +35,20 @@ export interface BackfillPlan {
   };
 }
 
+export interface WebhookBackfillSkip {
+  webhookId: string;
+  project: string;
+  /** "ambiguous": name matches >1 project across namespaces. "unresolved": name matches none. */
+  reason: "ambiguous" | "unresolved";
+}
+
+export interface WebhookBackfillReport {
+  updated: number;
+  skipped: WebhookBackfillSkip[];
+  /** NULL project_id rows remaining in `webhooks` after this run — the step-2 verification. */
+  remainingNullRows: number;
+}
+
 /**
  * DRY-RUN diagnostic for the KV→D1 project_id backfill. Reads only: reports how
  * much legacy (NULL project_id) data exists per table and which project names
@@ -90,6 +104,91 @@ export async function computeBackfillPlan(
             { operation: "computeBackfillPlan" },
           );
     logger.error("Failed to compute backfill plan", appError);
+    return err(appError);
+  }
+}
+
+/**
+ * APPLY half of the KV→D1 project_id backfill, scoped to `webhooks` (see
+ * {@link computeBackfillPlan} for the read-only survey across all seven
+ * tables). For every `webhooks` row with a NULL `project_id`, resolves the
+ * row's free-form `project` name against the KV project directory and stamps
+ * `project_id` — but ONLY when the name resolves to exactly one project
+ * across ALL namespaces.
+ *
+ * A name shared by more than one project ("ambiguous") or matching none
+ * ("unresolved") is left NULL and reported rather than guessed: this is a
+ * tenant-isolation boundary, not a best-effort heuristic, since guessing here
+ * would silently attribute a legacy webhook (and its deliveries) to the wrong
+ * tenant's namespace-mate.
+ */
+export async function backfillWebhookProjectIds(
+  env: Pick<Env, "DB" | "STATE">,
+  logger: Logger,
+): Promise<Result<WebhookBackfillReport, AppError>> {
+  try {
+    const projectsResult = await listProjects(env.STATE, logger);
+    if (!projectsResult.success) return err(projectsResult.error);
+
+    // Single-pass name -> id resolution. A name is only ever backfillable while
+    // it maps to exactly one id; the moment a second project claims the same
+    // name it moves to `ambiguousNames` and is evicted from `nameToId` for good.
+    const nameToId = new Map<string, string>();
+    const ambiguousNames = new Set<string>();
+    for (const project of projectsResult.data) {
+      if (ambiguousNames.has(project.name)) continue;
+      if (nameToId.has(project.name)) {
+        nameToId.delete(project.name);
+        ambiguousNames.add(project.name);
+        continue;
+      }
+      nameToId.set(project.name, project.id);
+    }
+
+    const rows = await env.DB.prepare(
+      "SELECT id, project FROM webhooks WHERE project_id IS NULL",
+    ).all<{ id: string; project: string }>();
+
+    const skipped: WebhookBackfillSkip[] = [];
+    let updated = 0;
+    for (const row of rows.results) {
+      const projectId = nameToId.get(row.project);
+      if (projectId === undefined) {
+        const reason = ambiguousNames.has(row.project) ? "ambiguous" : "unresolved";
+        skipped.push({ webhookId: row.id, project: row.project, reason });
+        continue;
+      }
+      // Re-assert `project_id IS NULL` at write time: cheap defense against a
+      // concurrent backfill run (or a delivery/update in between) re-stamping
+      // an already-resolved row.
+      await env.DB.prepare("UPDATE webhooks SET project_id = ? WHERE id = ? AND project_id IS NULL")
+        .bind(projectId, row.id)
+        .run();
+      updated++;
+    }
+
+    const remaining = await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM webhooks WHERE project_id IS NULL",
+    ).first<{ n: number }>();
+
+    logger.info("Webhook project_id backfill applied", {
+      updated,
+      skipped: skipped.length,
+      remainingNullRows: remaining?.n ?? 0,
+    });
+
+    return ok({ updated, skipped, remainingNullRows: remaining?.n ?? 0 });
+  } catch (error) {
+    const appError =
+      error instanceof AppError
+        ? error
+        : new AppError(
+            error instanceof Error ? error.message : "Failed to backfill webhook project_id",
+            "DATABASE_ERROR",
+            500,
+            { operation: "backfillWebhookProjectIds" },
+          );
+    logger.error("Failed to backfill webhook project_id", appError);
     return err(appError);
   }
 }

--- a/tests/backfill-plan.test.ts
+++ b/tests/backfill-plan.test.ts
@@ -101,9 +101,16 @@ function makeWebhooksD1(rows: FakeWebhookRow[]): D1Database {
       if (sql.includes("UPDATE webhooks SET project_id")) {
         return {
           bind: (projectId: string, id: string) => ({
+            // Mirrors real D1: the statement's `AND project_id IS NULL` guard
+            // means a row another writer already stamped matches nothing, and
+            // `meta.changes` reports 0 for it.
             run: async () => {
               const row = rows.find((r) => r.id === id);
-              if (row && row.project_id === null) row.project_id = projectId;
+              if (row && row.project_id === null) {
+                row.project_id = projectId;
+                return { meta: { changes: 1 } };
+              }
+              return { meta: { changes: 0 } };
             },
           }),
         };
@@ -133,6 +140,42 @@ describe("backfillWebhookProjectIds (apply)", () => {
     expect(result.data.skipped).toEqual([]);
     expect(result.data.remainingNullRows).toBe(0);
     expect(rows[0]?.project_id).toBe("proj_a");
+  });
+
+  it("does not count a row another writer stamped between the read and the write", async () => {
+    // The UPDATE re-asserts `project_id IS NULL`, so a row resolved by a
+    // concurrent run (or an ordinary webhook update) in the gap after the
+    // SELECT matches nothing. `updated` is the number this backfill is
+    // verified against, so it has to be writes actually made, not attempts.
+    const rows: FakeWebhookRow[] = [
+      { id: "wh_race", project: "alpha", project_id: null },
+      { id: "wh_mine", project: "alpha", project_id: null },
+    ];
+    const db = makeWebhooksD1(rows);
+    const raced = { done: false };
+    const realPrepare = db.prepare.bind(db);
+    (db as unknown as { prepare: (sql: string) => unknown }).prepare = (sql: string) => {
+      // Simulate the other writer landing right after our SELECT returned
+      // both rows, and before our first UPDATE runs.
+      if (sql.includes("UPDATE webhooks SET project_id") && !raced.done) {
+        raced.done = true;
+        const row = rows.find((r) => r.id === "wh_race");
+        if (row) row.project_id = "proj_a";
+      }
+      return realPrepare(sql);
+    };
+    const env = {
+      DB: db,
+      STATE: makeKV([{ id: "proj_a", name: "alpha" }]),
+    } as unknown as Env;
+
+    const result = await backfillWebhookProjectIds(env, logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    // Two rows were attempted; only wh_mine was actually written by this run.
+    expect(result.data.updated).toBe(1);
+    expect(result.data.skipped).toEqual([]);
+    expect(result.data.remainingNullRows).toBe(0);
   });
 
   it("leaves an ambiguous name (same name in two namespaces) NULL and reports why", async () => {

--- a/tests/backfill-plan.test.ts
+++ b/tests/backfill-plan.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { computeBackfillPlan } from "../src/storage/backfill-plan";
+import { backfillWebhookProjectIds, computeBackfillPlan } from "../src/storage/backfill-plan";
 import type { Env } from "../src/types";
 import type { Logger } from "../src/utils/logger";
 
@@ -76,5 +76,121 @@ describe("computeBackfillPlan (read-only)", () => {
     expect(result.data.projects.collisions).toEqual([
       { name: "beta", projectIds: ["proj_b1", "proj_b2"] },
     ]);
+  });
+});
+
+interface FakeWebhookRow {
+  id: string;
+  project: string;
+  project_id: string | null;
+}
+
+/** Fake D1 backing just the three statements backfillWebhookProjectIds issues. */
+function makeWebhooksD1(rows: FakeWebhookRow[]): D1Database {
+  return {
+    prepare: (sql: string) => {
+      if (sql.includes("SELECT id, project FROM webhooks")) {
+        return {
+          all: async () => ({
+            results: rows
+              .filter((r) => r.project_id === null)
+              .map((r) => ({ id: r.id, project: r.project })),
+          }),
+        };
+      }
+      if (sql.includes("UPDATE webhooks SET project_id")) {
+        return {
+          bind: (projectId: string, id: string) => ({
+            run: async () => {
+              const row = rows.find((r) => r.id === id);
+              if (row && row.project_id === null) row.project_id = projectId;
+            },
+          }),
+        };
+      }
+      if (sql.includes("SELECT COUNT(*)")) {
+        return {
+          first: async () => ({ n: rows.filter((r) => r.project_id === null).length }),
+        };
+      }
+      throw new Error(`Unexpected SQL in fake D1: ${sql}`);
+    },
+  } as unknown as D1Database;
+}
+
+describe("backfillWebhookProjectIds (apply)", () => {
+  it("backfills a row whose project name resolves to exactly one project", async () => {
+    const rows: FakeWebhookRow[] = [{ id: "wh_1", project: "alpha", project_id: null }];
+    const env = {
+      DB: makeWebhooksD1(rows),
+      STATE: makeKV([{ id: "proj_a", name: "alpha" }]),
+    } as unknown as Env;
+
+    const result = await backfillWebhookProjectIds(env, logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.updated).toBe(1);
+    expect(result.data.skipped).toEqual([]);
+    expect(result.data.remainingNullRows).toBe(0);
+    expect(rows[0]?.project_id).toBe("proj_a");
+  });
+
+  it("leaves an ambiguous name (same name in two namespaces) NULL and reports why", async () => {
+    const rows: FakeWebhookRow[] = [{ id: "wh_2", project: "beta", project_id: null }];
+    const env = {
+      DB: makeWebhooksD1(rows),
+      STATE: makeKV([
+        { id: "proj_b1", name: "beta" },
+        { id: "proj_b2", name: "beta" },
+      ]),
+    } as unknown as Env;
+
+    const result = await backfillWebhookProjectIds(env, logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.updated).toBe(0);
+    expect(result.data.skipped).toEqual([
+      { webhookId: "wh_2", project: "beta", reason: "ambiguous" },
+    ]);
+    expect(result.data.remainingNullRows).toBe(1);
+    expect(rows[0]?.project_id).toBeNull();
+  });
+
+  it("leaves an unresolved name (no matching project) NULL and reports why", async () => {
+    const rows: FakeWebhookRow[] = [{ id: "wh_3", project: "ghost", project_id: null }];
+    const env = {
+      DB: makeWebhooksD1(rows),
+      STATE: makeKV([{ id: "proj_a", name: "alpha" }]),
+    } as unknown as Env;
+
+    const result = await backfillWebhookProjectIds(env, logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.updated).toBe(0);
+    expect(result.data.skipped).toEqual([
+      { webhookId: "wh_3", project: "ghost", reason: "unresolved" },
+    ]);
+    expect(result.data.remainingNullRows).toBe(1);
+  });
+
+  it("never touches rows that already carry a project_id", async () => {
+    const rows: FakeWebhookRow[] = [
+      { id: "wh_4", project: "alpha", project_id: "proj_a" },
+      { id: "wh_5", project: "alpha", project_id: null },
+    ];
+    const env = {
+      DB: makeWebhooksD1(rows),
+      STATE: makeKV([{ id: "proj_a", name: "alpha" }]),
+    } as unknown as Env;
+
+    const result = await backfillWebhookProjectIds(env, logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    // Only the NULL row is touched; the already-backfilled row is never
+    // selected and keeps its original project_id untouched.
+    expect(result.data.updated).toBe(1);
+    expect(result.data.remainingNullRows).toBe(0);
+    expect(rows[0]?.project_id).toBe("proj_a");
+    expect(rows[1]?.project_id).toBe("proj_a");
   });
 });

--- a/tests/backfill-route.test.ts
+++ b/tests/backfill-route.test.ts
@@ -2,10 +2,15 @@ import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../src/types";
 
-vi.mock("../src/storage/backfill-plan", () => ({ computeBackfillPlan: vi.fn() }));
+vi.mock("../src/storage/backfill-plan", () => ({
+  computeBackfillPlan: vi.fn(),
+  backfillWebhookProjectIds: vi.fn(),
+}));
+vi.mock("../src/storage/audit", () => ({ recordAudit: vi.fn() }));
 
 import { backfillRouter } from "../src/routes/backfill";
-import { computeBackfillPlan } from "../src/storage/backfill-plan";
+import { recordAudit } from "../src/storage/audit";
+import { backfillWebhookProjectIds, computeBackfillPlan } from "../src/storage/backfill-plan";
 
 const ADMIN_KEY = "admin-secret";
 
@@ -52,5 +57,48 @@ describe("GET /api/admin/backfill-project-id/plan", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { plan: { totalNullRows: number } };
     expect(body.plan.totalNullRows).toBe(3);
+  });
+});
+
+function applyReq(headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/admin/backfill-project-id/webhooks/apply", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("POST /api/admin/backfill-project-id/webhooks/apply", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("403 without admin credentials, and never runs the backfill", async () => {
+    const res = await makeApp().fetch(applyReq(), env, ctx);
+    expect(res.status).toBe(403);
+    expect(backfillWebhookProjectIds).not.toHaveBeenCalled();
+    expect(recordAudit).not.toHaveBeenCalled();
+  });
+
+  it("200 with the report for an admin, and records an audit entry", async () => {
+    vi.mocked(backfillWebhookProjectIds).mockResolvedValue({
+      success: true,
+      data: {
+        updated: 2,
+        skipped: [{ webhookId: "wh_2", project: "beta", reason: "ambiguous" }],
+        remainingNullRows: 1,
+      },
+    } as never);
+
+    const res = await makeApp().fetch(applyReq({ "X-Admin-API-Key": ADMIN_KEY }), env, ctx);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      report: { updated: number; remainingNullRows: number };
+    };
+    expect(body.report.updated).toBe(2);
+    expect(body.report.remainingNullRows).toBe(1);
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.anything(),
+      expect.objectContaining({ action: "webhook.project_id_backfilled" }),
+    );
   });
 });

--- a/tests/backfill-route.test.ts
+++ b/tests/backfill-route.test.ts
@@ -1,12 +1,15 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../src/types";
+import { AppError } from "../src/utils/errors";
 
 vi.mock("../src/storage/backfill-plan", () => ({
   computeBackfillPlan: vi.fn(),
   backfillWebhookProjectIds: vi.fn(),
 }));
-vi.mock("../src/storage/audit", () => ({ recordAudit: vi.fn() }));
+vi.mock("../src/storage/audit", () => ({
+  recordAudit: vi.fn(async () => ({ success: true, data: undefined })),
+}));
 
 import { backfillRouter } from "../src/routes/backfill";
 import { recordAudit } from "../src/storage/audit";
@@ -92,6 +95,7 @@ describe("POST /api/admin/backfill-project-id/webhooks/apply", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       report: { updated: number; remainingNullRows: number };
+      audited: boolean;
     };
     expect(body.report.updated).toBe(2);
     expect(body.report.remainingNullRows).toBe(1);
@@ -100,5 +104,34 @@ describe("POST /api/admin/backfill-project-id/webhooks/apply", () => {
       expect.anything(),
       expect.objectContaining({ action: "webhook.project_id_backfilled" }),
     );
+    expect(body.audited).toBe(true);
+  });
+
+  // A failed audit write is a partial success: the rows are already stamped
+  // and nothing here can unwind them, so the route must neither claim a clean
+  // run nor pretend the backfill did not happen. It reports the counts (the
+  // reason this endpoint exists) with `audited: false` alongside them.
+  it("still reports the counts when the audit write fails, flagged audited: false", async () => {
+    vi.mocked(backfillWebhookProjectIds).mockResolvedValue({
+      success: true,
+      data: { updated: 2, skipped: [], remainingNullRows: 0 },
+    } as never);
+    vi.mocked(recordAudit).mockResolvedValueOnce({
+      success: false,
+      error: new AppError("D1 write failed", "DATABASE_ERROR", 500),
+    } as never);
+
+    const res = await makeApp().fetch(applyReq({ "X-Admin-API-Key": ADMIN_KEY }), env, ctx);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      report: { updated: number; remainingNullRows: number };
+      audited: boolean;
+    };
+    expect(body.audited).toBe(false);
+    // The numbers survive the audit failure — losing them would push the
+    // operator into a re-run to recover counts they already earned.
+    expect(body.report.updated).toBe(2);
+    expect(body.report.remainingNullRows).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Implements the **backfill** and **verification** halves of #235's coordinated fix. `webhooks` rows written before migration 025 carry a NULL `project_id`; project identity lives in KV, so this is an app-level pass — exactly what `scripts/backfill-project-id.ts` documented as the intended shape but never implemented for lack of an admin write endpoint (the existing `/api/admin/backfill-project-id/plan` is read-only).

- **New:** `POST /api/admin/backfill-project-id/webhooks/apply` — admin-only, mirroring the existing plan endpoint's `requireAdmin` pattern. For every NULL-`project_id` row it resolves the row's `project` name against the KV project directory and stamps `project_id`, but **only when the name resolves to exactly one project across all namespaces**. Ambiguous or unresolved names are left NULL and reported — never guessed, since this is a tenant-isolation boundary and a bare name can collide across namespaces.
- The response reports `{ updated, skipped: [{ webhookId, project, reason }], remainingNullRows }` — `remainingNullRows` is the step-2 verification the issue calls for; it should read `0` after a clean run.
- Writes an audit entry (`webhook.project_id_backfilled`) per run. Updates re-assert `project_id IS NULL` at write time as defense against concurrent runs.

**Step 3 (removing the name-based fallback in `webhookBelongsToProject` / `listWebhooks`) is deliberately NOT in this PR.** It's only safe after this backfill has run against production and the report confirms zero remaining NULL rows; removing it earlier would orphan any legacy webhook whose name is ambiguous/unresolved. That removal should follow as its own PR once an operator has run the apply endpoint.

## Related issues

Refs #235 (steps 1–2; fallback removal deferred until production backfill is verified)

## Type of change

- [x] New feature

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` (full suite: 1729 passed, 0 failures)
- [x] `npm run lint`

- New unit tests (`tests/backfill-plan.test.ts`): unique-name row backfilled; ambiguous name (two namespaces, same project name) stays NULL and is reported; unresolved name stays NULL and is reported; already-backfilled rows untouched.
- New route tests (`tests/backfill-route.test.ts`): 403 without admin credentials (backfill/audit never invoked); 200 + audit entry for an admin.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (script stub already describes this shape)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a protected endpoint to apply webhook project associations.
  * Webhooks are updated only when their project name uniquely matches a project.
  * Results include updated, skipped, unresolved, and remaining-unmatched records.
  * Added audit logging with an indicator showing whether auditing succeeded.
  * Added documentation for the administrative operation.

* **Bug Fixes**
  * Prevented overwriting existing associations and handled concurrent updates safely.
  * Ambiguous or unresolved matches remain unchanged.
  * Audit failures no longer prevent successful webhook updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->