### PR TITLE
Make approval dismissal and evaluated-sha re-pin atomic in the re-evaluate route

### DIFF
--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -13,8 +13,8 @@ import {
   runEvaluation,
 } from "../services/change-flow";
 import { recordAudit } from "../storage/audit";
-import { dismissApprovals } from "../storage/change-reviews";
 import {
+  dismissApprovalsAndUpdateStatus,
   getChange,
   getChangesByIds,
   listChanges,
@@ -1342,20 +1342,49 @@ app.post("/changes/:id/evaluate", async (c) => {
     evaluateCostSamples,
   );
 
+  const newStatus = evalResult.passed ? "accepted" : "needs_changes";
+  const statusOpts = {
+    evalScore: evalResult.score,
+    evalPassed: evalResult.passed,
+    evalReason: evalResult.reason,
+    evaluatedSha,
+    evaluatedTreeOid,
+    // Re-pin to the commit this re-evaluation actually ran against (#115).
+    ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
+  };
+
   // Stale-approval dismissal (#193): a different evaluated sha means any prior
   // 'approve' verdicts were given for code the reviewer never saw — drop them
   // before re-pinning, so a re-push can't merge on approvals for the old
   // revision. request_changes verdicts survive, and a no-op re-evaluation of
   // the same sha (including legacy changes with no recorded sha) keeps
-  // approvals. Dismiss BEFORE the sha update: if the dismissal fails we bail
-  // with the old sha still pinned, never with stale approvals against a new one.
+  // approvals.
+  //
+  // The dismissal and the evaluatedSha/status re-pin run as ONE D1 batch
+  // (#238): dismissApprovals (DELETE on change_reviews) and updateChangeStatus
+  // (UPDATE on changes) used to be two separate writes, so a transient D1
+  // failure on the second one could land the dismissal without ever re-pinning
+  // the sha — losing the approvals for good while a retry against the old,
+  // still-pinned sha found none left to lose. Batching them makes the two
+  // writes all-or-nothing, and the review.approvals_dismissed audit entry is
+  // only recorded once the batch itself has actually succeeded.
   if (change.evaluatedSha !== undefined && change.evaluatedSha !== evaluatedSha) {
-    const dismissResult = await dismissApprovals(c.env.DB, logger, id);
-    if (!dismissResult.success) {
-      logger.error("Failed to dismiss stale approvals", dismissResult.error);
-      return internalError(dismissResult.error.message);
+    const batchResult = await dismissApprovalsAndUpdateStatus(
+      c.env.DB,
+      logger,
+      id,
+      newStatus,
+      statusOpts,
+    );
+    if (!batchResult.success) {
+      logger.error(
+        "Failed to atomically dismiss stale approvals and update change status",
+        batchResult.error,
+      );
+      return internalError(batchResult.error.message);
     }
-    if (dismissResult.data.length > 0) {
+    const { dismissedReviewerIds } = batchResult.data;
+    if (dismissedReviewerIds.length > 0) {
       const auditResult = await recordAudit(c.env.DB, logger, {
         action: "review.approvals_dismissed",
         actorType: "user",
@@ -1363,38 +1392,25 @@ app.post("/changes/:id/evaluate", async (c) => {
         subject: id,
         detail: {
           project: change.project,
-          dismissed: dismissResult.data.length,
-          dismissedReviewerIds: dismissResult.data,
+          dismissed: dismissedReviewerIds.length,
+          dismissedReviewerIds,
           previousEvaluatedSha: change.evaluatedSha,
           evaluatedSha,
         },
       });
       if (!auditResult.success) {
-        // The approvals are already dismissed; do not fail the request. Log
-        // the gap so a missing audit record for a real dismissal is detectable.
+        // The dismissal + re-pin already landed together; do not fail the
+        // request. Log the gap so a missing audit record for a real
+        // dismissal is detectable.
         logger.error("Failed to audit approval dismissal", auditResult.error, { changeId: id });
       }
     }
-  }
-
-  const updateResult = await updateChangeStatus(
-    c.env.DB,
-    logger,
-    id,
-    evalResult.passed ? "accepted" : "needs_changes",
-    {
-      evalScore: evalResult.score,
-      evalPassed: evalResult.passed,
-      evalReason: evalResult.reason,
-      evaluatedSha,
-      evaluatedTreeOid,
-      // Re-pin to the commit this re-evaluation actually ran against (#115).
-      ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
-    },
-  );
-  if (!updateResult.success) {
-    logger.error("Failed to update change status", updateResult.error);
-    return badRequest(updateResult.error.message);
+  } else {
+    const updateResult = await updateChangeStatus(c.env.DB, logger, id, newStatus, statusOpts);
+    if (!updateResult.success) {
+      logger.error("Failed to update change status", updateResult.error);
+      return badRequest(updateResult.error.message);
+    }
   }
 
   // Layer mode: report the verdict to the change's linked GitHub PR (comment

--- a/src/storage/change-reviews.ts
+++ b/src/storage/change-reviews.ts
@@ -184,11 +184,33 @@ export async function listReviews(
 }
 
 /**
+ * Build (without running) the statement that deletes every 'approve' verdict
+ * on a change. Shared by `dismissApprovals` and the atomic
+ * `dismissApprovalsAndUpdateStatus` batch in storage/changes.ts (#238) so both
+ * paths delete with the exact same SQL.
+ */
+export function buildDismissApprovalsStatement(
+  db: D1Database,
+  changeId: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      "DELETE FROM change_reviews WHERE change_id = ? AND verdict = 'approve' RETURNING reviewer_id",
+    )
+    .bind(changeId);
+}
+
+/**
  * Dismiss every 'approve' verdict on a change because its evaluated revision
  * changed (#193) — those approvals were given for different code and must not
  * count toward requiredApprovals. 'request_changes' verdicts are kept, matching
  * GitHub's dismiss-stale-approvals-on-push semantics. Returns the reviewer IDs
  * whose approvals were dismissed, so callers can record who was dismissed.
+ *
+ * This runs the DELETE on its own, with no accompanying write — for the
+ * re-evaluate route, which must also re-pin evaluatedSha/status atomically
+ * with this dismissal, use `dismissApprovalsAndUpdateStatus` in
+ * storage/changes.ts instead (#238).
  */
 export async function dismissApprovals(
   db: D1Database,
@@ -196,12 +218,9 @@ export async function dismissApprovals(
   changeId: string,
 ): Promise<Result<string[], AppError>> {
   try {
-    const result = await db
-      .prepare(
-        "DELETE FROM change_reviews WHERE change_id = ? AND verdict = 'approve' RETURNING reviewer_id",
-      )
-      .bind(changeId)
-      .all<{ reviewer_id: string }>();
+    const result = await buildDismissApprovalsStatement(db, changeId).all<{
+      reviewer_id: string;
+    }>();
     const dismissedReviewerIds = result.results.map((row) => row.reviewer_id);
     if (dismissedReviewerIds.length > 0) {
       logger.info("Stale approvals dismissed", {

--- a/src/storage/changes.ts
+++ b/src/storage/changes.ts
@@ -3,6 +3,7 @@ import { AppError, NotFoundError } from "../utils/errors";
 import { newId } from "../utils/ids";
 import type { Logger } from "../utils/logger";
 import { type Result, err, ok } from "../utils/result";
+import { buildDismissApprovalsStatement } from "./change-reviews";
 
 interface ChangeRow {
   id: string;
@@ -279,29 +280,77 @@ export async function getChangeByGitHubBranch(
   }
 }
 
+export interface UpdateChangeStatusOpts {
+  evalScore?: number;
+  evalPassed?: boolean;
+  evalReason?: string;
+  evaluatedSha?: string;
+  evaluatedTreeOid?: string;
+  workspaceHeadSha?: string;
+  mergedAt?: string;
+  githubOwner?: string;
+  githubRepo?: string;
+  githubBranch?: string;
+  githubPrNumber?: number;
+  githubPrUrl?: string;
+  githubPrState?: string;
+  githubHeadSha?: string;
+  promotedAt?: string;
+  promotedBy?: string;
+}
+
+/**
+ * Build (without running) the `UPDATE changes` statement for a status/opts
+ * transition. Shared by `updateChangeStatus` and the atomic
+ * `dismissApprovalsAndUpdateStatus` batch below (#238) so both paths update
+ * with the exact same column mapping.
+ */
+function buildUpdateChangeStatusStatement(
+  db: D1Database,
+  id: string,
+  status: Change["status"],
+  opts?: UpdateChangeStatusOpts,
+): D1PreparedStatement {
+  const assignments = ["status = ?"];
+  const bindings: unknown[] = [status];
+
+  const addOptional = (column: string, value: unknown) => {
+    if (value === undefined) return;
+    assignments.push(`${column} = ?`);
+    bindings.push(value);
+  };
+
+  addOptional("eval_score", opts?.evalScore);
+  addOptional(
+    "eval_passed",
+    opts?.evalPassed !== undefined ? (opts.evalPassed ? 1 : 0) : undefined,
+  );
+  addOptional("eval_reason", opts?.evalReason);
+  addOptional("evaluated_sha", opts?.evaluatedSha);
+  addOptional("evaluated_tree_oid", opts?.evaluatedTreeOid);
+  addOptional("workspace_head_sha", opts?.workspaceHeadSha);
+  addOptional("merged_at", opts?.mergedAt);
+  addOptional("github_owner", opts?.githubOwner);
+  addOptional("github_repo", opts?.githubRepo);
+  addOptional("github_branch", opts?.githubBranch);
+  addOptional("github_pr_number", opts?.githubPrNumber);
+  addOptional("github_pr_url", opts?.githubPrUrl);
+  addOptional("github_pr_state", opts?.githubPrState);
+  addOptional("github_head_sha", opts?.githubHeadSha);
+  addOptional("promoted_at", opts?.promotedAt);
+  addOptional("promoted_by", opts?.promotedBy);
+
+  bindings.push(id);
+
+  return db.prepare(`UPDATE changes SET ${assignments.join(", ")} WHERE id = ?`).bind(...bindings);
+}
+
 export async function updateChangeStatus(
   db: D1Database,
   logger: Logger,
   id: string,
   status: Change["status"],
-  opts?: {
-    evalScore?: number;
-    evalPassed?: boolean;
-    evalReason?: string;
-    evaluatedSha?: string;
-    evaluatedTreeOid?: string;
-    workspaceHeadSha?: string;
-    mergedAt?: string;
-    githubOwner?: string;
-    githubRepo?: string;
-    githubBranch?: string;
-    githubPrNumber?: number;
-    githubPrUrl?: string;
-    githubPrState?: string;
-    githubHeadSha?: string;
-    promotedAt?: string;
-    promotedBy?: string;
-  },
+  opts?: UpdateChangeStatusOpts,
 ): Promise<Result<void, NotFoundError | AppError>> {
   try {
     // First check if the change exists
@@ -315,41 +364,7 @@ export async function updateChangeStatus(
       return err(notFoundError);
     }
 
-    const assignments = ["status = ?"];
-    const bindings: unknown[] = [status];
-
-    const addOptional = (column: string, value: unknown) => {
-      if (value === undefined) return;
-      assignments.push(`${column} = ?`);
-      bindings.push(value);
-    };
-
-    addOptional("eval_score", opts?.evalScore);
-    addOptional(
-      "eval_passed",
-      opts?.evalPassed !== undefined ? (opts.evalPassed ? 1 : 0) : undefined,
-    );
-    addOptional("eval_reason", opts?.evalReason);
-    addOptional("evaluated_sha", opts?.evaluatedSha);
-    addOptional("evaluated_tree_oid", opts?.evaluatedTreeOid);
-    addOptional("workspace_head_sha", opts?.workspaceHeadSha);
-    addOptional("merged_at", opts?.mergedAt);
-    addOptional("github_owner", opts?.githubOwner);
-    addOptional("github_repo", opts?.githubRepo);
-    addOptional("github_branch", opts?.githubBranch);
-    addOptional("github_pr_number", opts?.githubPrNumber);
-    addOptional("github_pr_url", opts?.githubPrUrl);
-    addOptional("github_pr_state", opts?.githubPrState);
-    addOptional("github_head_sha", opts?.githubHeadSha);
-    addOptional("promoted_at", opts?.promotedAt);
-    addOptional("promoted_by", opts?.promotedBy);
-
-    bindings.push(id);
-
-    await db
-      .prepare(`UPDATE changes SET ${assignments.join(", ")} WHERE id = ?`)
-      .bind(...bindings)
-      .run();
+    await buildUpdateChangeStatusStatement(db, id, status, opts).run();
 
     logger.debug("Change status updated", { changeId: id, status, opts });
     return ok(undefined);
@@ -364,6 +379,85 @@ export async function updateChangeStatus(
             { operation: "updateChangeStatus", changeId: id, status },
           );
     logger.error("Failed to update change status", appError, { changeId: id, status });
+    return err(appError);
+  }
+}
+
+export interface DismissApprovalsAndUpdateStatusResult {
+  dismissedReviewerIds: string[];
+}
+
+/**
+ * Atomically dismiss any stale 'approve' verdicts on a change and re-pin its
+ * evaluated sha/status, as one D1 batch (#238).
+ *
+ * Before this, the re-evaluate route ran `dismissApprovals` (a DELETE on
+ * change_reviews) and `updateChangeStatus` (an UPDATE on changes) as two
+ * separate round trips. If the DELETE landed but the UPDATE then failed
+ * (e.g. a transient D1 error), the request errored out with approvals
+ * already gone while the OLD evaluatedSha stayed pinned — a retry against
+ * that same old sha would see zero approvals, permanently lost, even though
+ * the re-pin never actually happened.
+ *
+ * Both statements below run against the same D1 database (`changes` and
+ * `change_reviews` are both D1 tables — see rowToChange/ChangeRow above and
+ * the reviews rows in storage/change-reviews.ts), so `D1Database.batch()`
+ * gives real transactional atomicity here: per Cloudflare's D1 batch
+ * semantics, every statement in the list commits, or none of them do, if any
+ * statement throws. That makes the lost-approvals window above impossible —
+ * the delete and the re-pin now land, or fail, together.
+ */
+export async function dismissApprovalsAndUpdateStatus(
+  db: D1Database,
+  logger: Logger,
+  id: string,
+  status: Change["status"],
+  opts?: UpdateChangeStatusOpts,
+): Promise<Result<DismissApprovalsAndUpdateStatusResult, NotFoundError | AppError>> {
+  try {
+    // First check if the change exists (matches updateChangeStatus above).
+    const existingRow = await db
+      .prepare("SELECT id FROM changes WHERE id = ?")
+      .bind(id)
+      .first<{ id: string }>();
+    if (!existingRow) {
+      const notFoundError = new NotFoundError("Change", id);
+      logger.debug("Change not found for atomic dismiss+update", { changeId: id });
+      return err(notFoundError);
+    }
+
+    const dismissStmt = buildDismissApprovalsStatement(db, id);
+    const updateStmt = buildUpdateChangeStatusStatement(db, id, status, opts);
+
+    const [dismissResult] = await db.batch([dismissStmt, updateStmt]);
+    const dismissedReviewerIds = (
+      (dismissResult?.results ?? []) as Array<{ reviewer_id: string }>
+    ).map((row) => row.reviewer_id);
+
+    if (dismissedReviewerIds.length > 0) {
+      logger.info("Stale approvals dismissed", {
+        changeId: id,
+        dismissed: dismissedReviewerIds.length,
+      });
+    }
+    logger.debug("Change status updated", { changeId: id, status, opts });
+    return ok({ dismissedReviewerIds });
+  } catch (error) {
+    const appError =
+      error instanceof AppError
+        ? error
+        : new AppError(
+            error instanceof Error
+              ? error.message
+              : "Failed to dismiss approvals and update change status",
+            "DATABASE_ERROR",
+            500,
+            { operation: "dismissApprovalsAndUpdateStatus", changeId: id, status },
+          );
+    logger.error("Failed to atomically dismiss approvals and update change status", appError, {
+      changeId: id,
+      status,
+    });
     return err(appError);
   }
 }

--- a/src/storage/changes.ts
+++ b/src/storage/changes.ts
@@ -360,6 +360,11 @@ function buildUpdateChangeStatusStatement(
   return db.prepare(`UPDATE changes SET ${assignments.join(", ")} WHERE id = ?`).bind(...bindings);
 }
 
+/**
+ * Update a change's status (and any optional pinned fields) as a single,
+ * non-batched write. Callers that also need stale approvals dismissed in the
+ * same transaction should use dismissApprovalsAndUpdateStatus below instead.
+ */
 export async function updateChangeStatus(
   db: D1Database,
   logger: Logger,
@@ -444,10 +449,8 @@ export async function dismissApprovalsAndUpdateStatus(
     const dismissStmt = buildDismissApprovalsStatement(db, id);
     const updateStmt = buildUpdateChangeStatusStatement(db, id, status, opts);
 
-    const [dismissResult] = await db.batch([dismissStmt, updateStmt]);
-    const dismissedReviewerIds = (
-      (dismissResult?.results ?? []) as Array<{ reviewer_id: string }>
-    ).map((row) => row.reviewer_id);
+    const [dismissResult] = await db.batch<{ reviewer_id: string }>([dismissStmt, updateStmt]);
+    const dismissedReviewerIds = (dismissResult?.results ?? []).map((row) => row.reviewer_id);
 
     if (dismissedReviewerIds.length > 0) {
       logger.info("Stale approvals dismissed", {

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -10,6 +10,10 @@ vi.mock("../src/storage/changes", () => ({
   getChangesByIds: vi.fn(),
   listChanges: vi.fn(),
   updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
+  dismissApprovalsAndUpdateStatus: vi.fn(async () => ({
+    success: true,
+    data: { dismissedReviewerIds: [] },
+  })),
   // Default: this request won the transition, so the merge path emits + records.
   markChangeMerged: vi.fn(async () => ({ success: true, data: { transitioned: true } })),
   mergeTransitionOpts: (
@@ -129,7 +133,6 @@ vi.mock("../src/storage/provenance", () => ({
 }));
 
 vi.mock("../src/storage/change-reviews", () => ({
-  dismissApprovals: vi.fn(async () => ({ success: true, data: [] })),
   countApprovals: vi.fn(async () => ({ success: true, data: 0 })),
 }));
 
@@ -157,9 +160,9 @@ import { CompositeEvaluator, SecretScanEvaluator, loadPolicy } from "../src/eval
 import { emitEvent } from "../src/queue/events";
 import { getAgent, getAgentByToken } from "../src/storage/agents";
 import { recordAudit } from "../src/storage/audit";
-import { dismissApprovals } from "../src/storage/change-reviews";
 import {
   createChange,
+  dismissApprovalsAndUpdateStatus,
   getChange,
   getChangesByIds,
   listChanges,
@@ -2960,7 +2963,10 @@ describe("POST /api/changes/:id/evaluate — stale approval dismissal (#193)", (
     });
     vi.mocked(updateChangeStatus).mockResolvedValue({ success: true, data: undefined });
     vi.mocked(recordEvalRuns).mockResolvedValue({ success: true, data: [] });
-    vi.mocked(dismissApprovals).mockResolvedValue({ success: true, data: ["user_1"] });
+    vi.mocked(dismissApprovalsAndUpdateStatus).mockResolvedValue({
+      success: true,
+      data: { dismissedReviewerIds: ["user_1"] },
+    });
     vi.mocked(recordAudit).mockResolvedValue({ success: true, data: undefined });
     vi.mocked(CompositeEvaluator).mockImplementation(
       () =>
@@ -2970,31 +2976,31 @@ describe("POST /api/changes/:id/evaluate — stale approval dismissal (#193)", (
     );
   });
 
-  it("dismisses stale approvals when re-evaluation lands a new sha", async () => {
+  it("atomically dismisses stale approvals and re-pins the sha in one batch call (#238)", async () => {
     const res = await app.fetch(
       request("POST", "/api/changes/chg_abc123/evaluate", {}, USER_AUTH),
       env,
     );
     expect(res.status).toBe(200);
 
-    expect(dismissApprovals).toHaveBeenCalledWith(env.DB, expect.any(Object), "chg_abc123");
-    // Fail-closed ordering: approvals are dropped before the new sha is pinned.
-    const dismissOrder = vi.mocked(dismissApprovals).mock.invocationCallOrder[0] ?? 0;
-    const updateOrder = vi.mocked(updateChangeStatus).mock.invocationCallOrder[0] ?? 0;
-    expect(dismissOrder).toBeLessThan(updateOrder);
-    expect(updateChangeStatus).toHaveBeenCalledWith(
+    // The dismissal and the status/sha re-pin are ONE call now, not two
+    // separate writes — see storage/changes.ts dismissApprovalsAndUpdateStatus.
+    expect(dismissApprovalsAndUpdateStatus).toHaveBeenCalledWith(
       env.DB,
       expect.any(Object),
       "chg_abc123",
       "accepted",
       expect.objectContaining({ evaluatedSha: "new_sha" }),
     );
+    // The plain, non-atomic updateChangeStatus must not also run for this path
+    // — that would reintroduce the two-write race #238 removes.
+    expect(updateChangeStatus).not.toHaveBeenCalled();
   });
 
   it("records an audit entry for the dismissal", async () => {
-    vi.mocked(dismissApprovals).mockResolvedValue({
+    vi.mocked(dismissApprovalsAndUpdateStatus).mockResolvedValue({
       success: true,
-      data: ["user_1", "user_2"],
+      data: { dismissedReviewerIds: ["user_1", "user_2"] },
     });
     const res = await app.fetch(
       request("POST", "/api/changes/chg_abc123/evaluate", {}, USER_AUTH),
@@ -3015,10 +3021,17 @@ describe("POST /api/changes/:id/evaluate — stale approval dismissal (#193)", (
         evaluatedSha: "new_sha",
       },
     });
+    // The audit entry is only recorded once the batch itself has succeeded.
+    const batchOrder = vi.mocked(dismissApprovalsAndUpdateStatus).mock.invocationCallOrder[0] ?? 0;
+    const auditOrder = vi.mocked(recordAudit).mock.invocationCallOrder[0] ?? 0;
+    expect(batchOrder).toBeLessThan(auditOrder);
   });
 
   it("logs but does not fail the request when auditing the dismissal fails", async () => {
-    vi.mocked(dismissApprovals).mockResolvedValue({ success: true, data: ["user_1"] });
+    vi.mocked(dismissApprovalsAndUpdateStatus).mockResolvedValue({
+      success: true,
+      data: { dismissedReviewerIds: ["user_1"] },
+    });
     vi.mocked(recordAudit).mockResolvedValue({
       success: false,
       error: new AppError("D1 unavailable", "DATABASE_ERROR", 500),
@@ -3029,9 +3042,10 @@ describe("POST /api/changes/:id/evaluate — stale approval dismissal (#193)", (
       env,
     );
 
-    // The dismissal already happened; a failed audit write must not fail the request.
+    // The dismissal + re-pin batch already landed; a failed audit write must
+    // not fail the request.
     expect(res.status).toBe(200);
-    expect(updateChangeStatus).toHaveBeenCalled();
+    expect(dismissApprovalsAndUpdateStatus).toHaveBeenCalled();
   });
 
   it("keeps approvals when the re-evaluated sha is unchanged", async () => {
@@ -3050,8 +3064,10 @@ describe("POST /api/changes/:id/evaluate — stale approval dismissal (#193)", (
       env,
     );
     expect(res.status).toBe(200);
-    expect(dismissApprovals).not.toHaveBeenCalled();
+    expect(dismissApprovalsAndUpdateStatus).not.toHaveBeenCalled();
     expect(recordAudit).not.toHaveBeenCalled();
+    // No approvals at risk here, so the plain single-write path is used.
+    expect(updateChangeStatus).toHaveBeenCalled();
   });
 
   it("keeps approvals on a legacy change with no recorded evaluated sha", async () => {
@@ -3065,22 +3081,25 @@ describe("POST /api/changes/:id/evaluate — stale approval dismissal (#193)", (
       env,
     );
     expect(res.status).toBe(200);
-    expect(dismissApprovals).not.toHaveBeenCalled();
+    expect(dismissApprovalsAndUpdateStatus).not.toHaveBeenCalled();
   });
 
   it("skips the audit entry when there were no approvals to dismiss", async () => {
-    vi.mocked(dismissApprovals).mockResolvedValue({ success: true, data: [] });
+    vi.mocked(dismissApprovalsAndUpdateStatus).mockResolvedValue({
+      success: true,
+      data: { dismissedReviewerIds: [] },
+    });
     const res = await app.fetch(
       request("POST", "/api/changes/chg_abc123/evaluate", {}, USER_AUTH),
       env,
     );
     expect(res.status).toBe(200);
-    expect(dismissApprovals).toHaveBeenCalled();
+    expect(dismissApprovalsAndUpdateStatus).toHaveBeenCalled();
     expect(recordAudit).not.toHaveBeenCalled();
   });
 
-  it("fails closed without re-pinning the sha when dismissal fails", async () => {
-    vi.mocked(dismissApprovals).mockResolvedValue({
+  it("fails closed — without re-pinning the sha or losing approvals — when the atomic batch fails (#238)", async () => {
+    vi.mocked(dismissApprovalsAndUpdateStatus).mockResolvedValue({
       success: false,
       error: new AppError("D1 unavailable", "DATABASE_ERROR", 500),
     });
@@ -3090,7 +3109,10 @@ describe("POST /api/changes/:id/evaluate — stale approval dismissal (#193)", (
       env,
     );
     expect(res.status).toBe(500);
-    // The old evaluated sha stays pinned: stale approvals never coexist with a new sha.
+    // Neither write is applied outside the failed batch: no separate
+    // updateChangeStatus fallback, and no audit entry for a dismissal that
+    // never actually landed.
     expect(updateChangeStatus).not.toHaveBeenCalled();
+    expect(recordAudit).not.toHaveBeenCalled();
   });
 });

--- a/tests/dismiss-approvals-atomic.test.ts
+++ b/tests/dismiss-approvals-atomic.test.ts
@@ -109,6 +109,7 @@ function makeAtomicD1(seed: { changes: FakeChangeRow[]; reviews: FakeReviewRow[]
   };
   let failAtBatchIndex: number | null = null;
 
+  /** Fake D1PreparedStatement whose run/first/batch-execution routes through applyStatement. */
   function makeStmt(sql: string, bindings: unknown[]) {
     return {
       bind: (...args: unknown[]) => makeStmt(sql, args),
@@ -162,6 +163,7 @@ function makeAtomicD1(seed: { changes: FakeChangeRow[]; reviews: FakeReviewRow[]
   };
 }
 
+/** One approved change ("chg_1", old_sha) with an 'approve' and a 'request_changes' review — the #238 scenario. */
 function seedRows(): { change: FakeChangeRow; reviews: FakeReviewRow[] } {
   return {
     change: { id: "chg_1", status: "approved", evaluated_sha: "old_sha" },
@@ -277,12 +279,14 @@ describe("updateChangeStatus — unaffected by the #238 batch change", () => {
   it("still performs a single, non-batched write for callers with no approvals in play", async () => {
     const { change } = seedRows();
     const { db, state } = makeAtomicD1({ changes: [change], reviews: [] });
+    const batchSpy = vi.spyOn(db, "batch");
 
     const result = await updateChangeStatus(db, mockLogger, "chg_1", "accepted", {
       evaluatedSha: "new_sha",
     });
 
     expect(result.success).toBe(true);
+    expect(batchSpy).not.toHaveBeenCalled();
     expect(state.changes.get("chg_1")).toMatchObject({
       status: "accepted",
       evaluated_sha: "new_sha",

--- a/tests/dismiss-approvals-atomic.test.ts
+++ b/tests/dismiss-approvals-atomic.test.ts
@@ -109,7 +109,7 @@ function makeAtomicD1(seed: { changes: FakeChangeRow[]; reviews: FakeReviewRow[]
   };
   let failAtBatchIndex: number | null = null;
 
-  /** Fake D1PreparedStatement whose run/first/batch-execution routes through applyStatement. */
+  /** Keep all fake statement methods on one SQL simulation path so rollback tests exercise the same semantics. */
   function makeStmt(sql: string, bindings: unknown[]) {
     return {
       bind: (...args: unknown[]) => makeStmt(sql, args),

--- a/tests/dismiss-approvals-atomic.test.ts
+++ b/tests/dismiss-approvals-atomic.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it, vi } from "vitest";
+import { dismissApprovalsAndUpdateStatus, updateChangeStatus } from "../src/storage/changes";
+import { NotFoundError } from "../src/utils/errors";
+import type { Logger } from "../src/utils/logger";
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+interface FakeChangeRow {
+  id: string;
+  status: string;
+  evaluated_sha: string | null;
+  [column: string]: unknown;
+}
+
+interface FakeReviewRow {
+  id: string;
+  change_id: string;
+  reviewer_id: string;
+  verdict: string;
+  comment: string | null;
+  created_at: string;
+}
+
+interface FakeState {
+  changes: Map<string, FakeChangeRow>;
+  reviews: FakeReviewRow[];
+}
+
+/**
+ * Apply one statement's effect to a given state (either the real, committed
+ * state or a batch's in-flight snapshot). Understands exactly the three
+ * statement shapes `dismissApprovalsAndUpdateStatus` issues: the existence
+ * check, the change_reviews DELETE ... RETURNING, and the changes UPDATE.
+ */
+function applyStatement(
+  sql: string,
+  bindings: unknown[],
+  target: FakeState,
+): { results: unknown[]; success: boolean; meta: Record<string, unknown> } {
+  const upper = sql.trim().toUpperCase().replace(/\s+/g, " ");
+
+  if (upper.startsWith("SELECT ID FROM CHANGES")) {
+    const id = bindings[0] as string;
+    return { results: target.changes.has(id) ? [{ id }] : [], success: true, meta: {} };
+  }
+
+  if (upper.startsWith("DELETE FROM CHANGE_REVIEWS")) {
+    const changeId = bindings[0] as string;
+    const dismissed: FakeReviewRow[] = [];
+    target.reviews = target.reviews.filter((row) => {
+      if (row.change_id === changeId && row.verdict === "approve") {
+        dismissed.push(row);
+        return false;
+      }
+      return true;
+    });
+    return {
+      results: dismissed.map((row) => ({ reviewer_id: row.reviewer_id })),
+      success: true,
+      meta: {},
+    };
+  }
+
+  if (upper.startsWith("UPDATE CHANGES SET")) {
+    // Parse the dynamic `SET a = ?, b = ? WHERE id = ?` column list so this
+    // stays correct regardless of which optional fields the caller set.
+    const match = sql.match(/SET (.+) WHERE id = \?/i);
+    const columns = (match?.[1] ?? "")
+      .split(",")
+      .map((part) => part.trim().split("=")[0]?.trim() ?? "");
+    const id = bindings[bindings.length - 1] as string;
+    const row = target.changes.get(id);
+    if (row) {
+      columns.forEach((column, index) => {
+        row[column] = bindings[index];
+      });
+    }
+    return { results: [], success: true, meta: { changes: row ? 1 : 0 } };
+  }
+
+  throw new Error(`fake D1: unhandled SQL: ${sql}`);
+}
+
+/**
+ * Fake D1 that models Cloudflare's D1Database.batch() all-or-nothing
+ * guarantee: every statement passed to batch() applies to a snapshot first,
+ * and the snapshot only replaces the committed state once every statement in
+ * the batch has succeeded. If any statement throws, the committed state is
+ * left exactly as it was — the rollback semantics
+ * `dismissApprovalsAndUpdateStatus` relies on to close #238 (see
+ * https://developers.cloudflare.com/d1/worker-api/d1-database/#batch).
+ *
+ * Statements run individually via `.run()`/`.first()` (outside of `batch()`)
+ * apply straight to the committed state, with no such protection — matching
+ * real D1, where only `batch()` calls get transactional atomicity.
+ */
+function makeAtomicD1(seed: { changes: FakeChangeRow[]; reviews: FakeReviewRow[] }) {
+  const state: FakeState = {
+    changes: new Map(seed.changes.map((row) => [row.id, { ...row }])),
+    reviews: seed.reviews.map((row) => ({ ...row })),
+  };
+  let failAtBatchIndex: number | null = null;
+
+  function makeStmt(sql: string, bindings: unknown[]) {
+    return {
+      bind: (...args: unknown[]) => makeStmt(sql, args),
+      run: async () => applyStatement(sql, bindings, state),
+      all: async <T>() =>
+        applyStatement(sql, bindings, state) as unknown as {
+          results: T[];
+          success: boolean;
+          meta: Record<string, unknown>;
+        },
+      first: async <T>() => {
+        const result = applyStatement(sql, bindings, state);
+        return (result.results[0] ?? null) as T | null;
+      },
+      _sql: sql,
+      _bindings: bindings,
+    };
+  }
+
+  const db = {
+    prepare: (sql: string) => makeStmt(sql, []),
+    batch: async (statements: Array<{ _sql: string; _bindings: unknown[] }>) => {
+      // Apply every statement to a private snapshot first.
+      const snapshot: FakeState = {
+        changes: new Map(Array.from(state.changes.entries()).map(([id, row]) => [id, { ...row }])),
+        reviews: state.reviews.map((row) => ({ ...row })),
+      };
+      const results: unknown[] = [];
+      statements.forEach((stmt, index) => {
+        if (failAtBatchIndex !== null && index === failAtBatchIndex) {
+          throw new Error("simulated D1 batch failure");
+        }
+        results.push(applyStatement(stmt._sql, stmt._bindings, snapshot));
+      });
+      // Only now — every statement having succeeded — commit the snapshot.
+      // A thrown error above skips these lines entirely, so the committed
+      // `state` is untouched: this is the rollback the test below exercises.
+      state.changes = snapshot.changes;
+      state.reviews = snapshot.reviews;
+      return results;
+    },
+  } as unknown as D1Database;
+
+  return {
+    db,
+    state,
+    /** Make the statement at this index (0-based, in batch order) throw. */
+    failNextBatchAt: (index: number | null) => {
+      failAtBatchIndex = index;
+    },
+  };
+}
+
+function seedRows(): { change: FakeChangeRow; reviews: FakeReviewRow[] } {
+  return {
+    change: { id: "chg_1", status: "approved", evaluated_sha: "old_sha" },
+    reviews: [
+      {
+        id: "rev_1",
+        change_id: "chg_1",
+        reviewer_id: "user_1",
+        verdict: "approve",
+        comment: null,
+        created_at: "2026-08-01T00:00:00.000Z",
+      },
+      {
+        id: "rev_2",
+        change_id: "chg_1",
+        reviewer_id: "user_2",
+        verdict: "request_changes",
+        comment: null,
+        created_at: "2026-08-01T00:00:01.000Z",
+      },
+    ],
+  };
+}
+
+describe("dismissApprovalsAndUpdateStatus — atomic dismiss + re-pin (#238)", () => {
+  it("applies the approval dismissal and the status/sha update together on success", async () => {
+    const { change, reviews } = seedRows();
+    const { db, state } = makeAtomicD1({ changes: [change], reviews });
+
+    const result = await dismissApprovalsAndUpdateStatus(db, mockLogger, "chg_1", "accepted", {
+      evaluatedSha: "new_sha",
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.dismissedReviewerIds).toEqual(["user_1"]);
+
+    // Both writes landed: the approve verdict is gone, request_changes
+    // survives, and the sha/status are re-pinned.
+    expect(state.reviews.map((r) => r.reviewer_id)).toEqual(["user_2"]);
+    expect(state.changes.get("chg_1")).toMatchObject({
+      status: "accepted",
+      evaluated_sha: "new_sha",
+    });
+  });
+
+  it("returns NotFound and touches nothing for a missing change", async () => {
+    const { reviews } = seedRows();
+    const { db, state } = makeAtomicD1({ changes: [], reviews });
+
+    const result = await dismissApprovalsAndUpdateStatus(
+      db,
+      mockLogger,
+      "chg_missing",
+      "accepted",
+      {
+        evaluatedSha: "new_sha",
+      },
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toBeInstanceOf(NotFoundError);
+    expect(state.reviews).toHaveLength(2);
+  });
+
+  it("(failure injection) rolls back the dismissal when the paired status update fails mid-batch", async () => {
+    const { change, reviews } = seedRows();
+    const { db, state, failNextBatchAt } = makeAtomicD1({ changes: [change], reviews });
+    // Batch order is [DELETE change_reviews, UPDATE changes] — fail the 2nd
+    // write, exactly the "dismissal lands, re-pin doesn't" scenario #238
+    // reports.
+    failNextBatchAt(1);
+
+    const result = await dismissApprovalsAndUpdateStatus(db, mockLogger, "chg_1", "accepted", {
+      evaluatedSha: "new_sha",
+    });
+
+    expect(result.success).toBe(false);
+
+    // The regression this fixes: a failed status/sha update must not leave
+    // the approval dismissal applied on its own. Both verdicts are still
+    // present and the sha is still the OLD one — nothing was lost, and
+    // nothing was half-applied.
+    expect(state.reviews.map((r) => r.reviewer_id).sort()).toEqual(["user_1", "user_2"]);
+    expect(state.changes.get("chg_1")).toMatchObject({
+      status: "approved",
+      evaluated_sha: "old_sha",
+    });
+  });
+
+  it("(failure injection) rolls back the status update too when the dismissal statement fails mid-batch", async () => {
+    const { change, reviews } = seedRows();
+    const { db, state, failNextBatchAt } = makeAtomicD1({ changes: [change], reviews });
+    failNextBatchAt(0);
+
+    const result = await dismissApprovalsAndUpdateStatus(db, mockLogger, "chg_1", "accepted", {
+      evaluatedSha: "new_sha",
+    });
+
+    expect(result.success).toBe(false);
+    // The other direction of the same guarantee: the sha/status never moves
+    // ahead of a dismissal that didn't actually happen.
+    expect(state.changes.get("chg_1")).toMatchObject({
+      status: "approved",
+      evaluated_sha: "old_sha",
+    });
+    expect(state.reviews).toHaveLength(2);
+  });
+});
+
+describe("updateChangeStatus — unaffected by the #238 batch change", () => {
+  it("still performs a single, non-batched write for callers with no approvals in play", async () => {
+    const { change } = seedRows();
+    const { db, state } = makeAtomicD1({ changes: [change], reviews: [] });
+
+    const result = await updateChangeStatus(db, mockLogger, "chg_1", "accepted", {
+      evaluatedSha: "new_sha",
+    });
+
+    expect(result.success).toBe(true);
+    expect(state.changes.get("chg_1")).toMatchObject({
+      status: "accepted",
+      evaluated_sha: "new_sha",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`POST /api/changes/:id/evaluate` dismissed stale approvals (DELETE on `change_reviews`) and re-pinned `evaluatedSha`/status (UPDATE on `changes`) as two separate D1 writes. If the delete landed and the update then failed on a transient D1 error, the request bailed with approvals already gone while the old `evaluatedSha` stayed pinned — a retry against that same old sha then found zero approvals, permanently lost, even though the re-pin never landed.

Both tables live in the same D1 database, so the two writes are now composed into a single `D1Database.batch()` (all-or-nothing):

- `src/storage/change-reviews.ts`: extracted `buildDismissApprovalsStatement` so the DELETE SQL is shared rather than duplicated; standalone `dismissApprovals` unchanged for other callers.
- `src/storage/changes.ts`: extracted a `buildUpdateChangeStatusStatement` builder; new `dismissApprovalsAndUpdateStatus` composes both into one batch and returns the dismissed reviewer ids. `updateChangeStatus` keeps its existing signature/behavior for its other call sites.
- `src/routes/changes.ts`: the evaluate route uses the atomic path only in the stale-approval scenario, records the `review.approvals_dismissed` audit entry **only after the batch succeeds**, and falls back to plain `updateChangeStatus` when there is nothing to dismiss.

## Related issues

Closes #238

## Type of change

- [x] Bug fix

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` (full suite: 1728 passed, 0 failed)
- [x] `npm run lint`

- New `tests/dismiss-approvals-atomic.test.ts`: storage-layer tests against a fake D1 that models `batch()`'s all-or-nothing guarantee, with failure injection on each half — approvals survive a failed re-pin, and the sha never advances on a failed dismissal (the exact bug from the issue).
- Updated the route-level "#193 stale approval dismissal" suite in `tests/changes.test.ts` for the new call shape, including asserting the failure path records no audit entry and doesn't fall back to a lone status update.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (none affected)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Re-evaluating a change now atomically dismisses stale approvals and updates its status when the evaluated revision changes.
  * Prevented partial updates if approval dismissal or status changes fail.
  * Preserved existing approvals when the evaluated revision is unchanged.
  * Audit records are now created only after related updates succeed.

* **Tests**
  * Added coverage for atomic updates, rollback behavior, missing changes, and unchanged revisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->