### PR TITLE
Tags fetch: pull only tag-reachable objects, cap tag count with explicit truncation

### DIFF
--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -987,12 +987,14 @@ app.get("/:namespace/:slug/tags", async (c) => {
     return internalError(tagsResult.error.message);
   }
 
-  logger.info("Tags retrieved", { namespace, slug, tagCount: tagsResult.data.length });
+  logger.info("Tags retrieved", { namespace, slug, tagCount: tagsResult.data.tags.length });
   return ok({
     namespace,
     slug,
     path: `/${namespace}/${slug}`,
-    tags: tagsResult.data,
+    tags: tagsResult.data.tags,
+    truncated: tagsResult.data.truncated,
+    totalTagCount: tagsResult.data.totalTagCount,
   });
 });
 

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -881,7 +881,9 @@ app.get("/:namespace/:slug/tags", async (c) => {
   return c.html(
     <TagsPage
       project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
-      tags={tagsResult.data}
+      tags={tagsResult.data.tags}
+      truncated={tagsResult.data.truncated}
+      totalTagCount={tagsResult.data.totalTagCount}
       user={userResult}
     />,
   );

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -463,6 +463,15 @@ export async function initAndPush(
 }
 
 /**
+ * Hard cap on how many tags a single `includeTags` clone will fetch. Each tag
+ * costs its own fetch round trip (see below), so an unbounded remote tag count
+ * would turn one clone into an unbounded number of requests. Truncation is
+ * never silent: it is reported on the clone result (`tagsTruncated`,
+ * `totalTagCount`) so `listRepoTags` and its callers can surface it (#241).
+ */
+const MAX_TAGS = 500;
+
+/**
  * Clones the `main` branch of a repository into an in-memory filesystem.
  *
  * The whole tree lands in worker memory, which is what makes the depth choice
@@ -473,8 +482,8 @@ export async function initAndPush(
  * @param token - The authentication token for the repository
  * @param opts - Clone options
  * @param opts.fullHistory - Whether to clone the complete reachable history; otherwise, clone the most recent 50 commits
- * @param opts.includeTags - Whether to follow the clone with a fetch of `refs/tags/*`; a `singleBranch` clone never brings tags
- * @returns The cloned filesystem and its working directory, or an application error
+ * @param opts.includeTags - Whether to follow the clone with a per-tag fetch of `refs/tags/*`; a `singleBranch` clone never brings tags. Capped at {@link MAX_TAGS}; see the result's `tagsTruncated`/`totalTagCount`.
+ * @returns The cloned filesystem and its working directory (plus tag-fetch truncation info when `includeTags` was set), or an application error
  */
 export async function cloneRepo(
   remote: string,
@@ -482,7 +491,9 @@ export async function cloneRepo(
   logger: Logger,
   opts: { fullHistory?: boolean; includeTags?: boolean } = {},
   httpClient: HttpClient = http,
-): Promise<Result<{ fs: NodeFS; dir: string }, AppError>> {
+): Promise<
+  Result<{ fs: NodeFS; dir: string; tagsTruncated?: boolean; totalTagCount?: number }, AppError>
+> {
   logger.debug("Cloning repository", { remote, fullHistory: opts.fullHistory ?? false });
 
   const fs = new MemoryFS().toNodeFS();
@@ -510,30 +521,81 @@ export async function cloneRepo(
 
   // isomorphic-git's singleBranch clone requests ONLY the branch tip — tag refs
   // are neither advertised locally nor are their objects fetched. Callers that
-  // need tags (tags listing, backup) opt in to a follow-up fetch of every remote
-  // ref with `tags: true`, which writes refs/tags/* and pulls the tag objects
-  // plus their targets (depth-limited unless fullHistory).
+  // need tags (tags listing, backup) opt in to a follow-up tags-only fetch:
+  // `getRemoteInfo` enumerates `refs/tags/*` cheaply (a ref/oid handshake, no
+  // object data), then each tag is fetched INDIVIDUALLY with `singleBranch:
+  // true` — isomorphic-git's singleBranch fetch requests only the one resolved
+  // oid (`wants = [oid]`), so this pulls each tag's own object graph and
+  // nothing else. A combined `singleBranch: false, tags: true` fetch (the old
+  // approach) instead requests every branch tip the remote advertises, which
+  // for a project with large branches unrelated to any tag pulls substantially
+  // more than the feature needs (#241). depth/unresolvable degradation is
+  // unchanged: each per-tag fetch keeps the same shallow window, and a tag
+  // whose target lies outside it still degrades via `collectRepoTags` rather
+  // than failing the clone.
+  let tagsTruncated = false;
+  let totalTagCount = 0;
   if (opts.includeTags) {
-    const tagFetch = await fromPromise(
-      git.fetch({
-        fs,
-        http: httpClient,
-        dir: DIR,
-        url: remote,
-        singleBranch: false,
-        tags: true,
-        ...(opts.fullHistory ? {} : { depth: 50 }),
-        onAuth: makeAuth(token),
-      }),
+    const remoteInfoResult = await fromPromise(
+      git.getRemoteInfo({ http: httpClient, url: remote, onAuth: makeAuth(token) }),
     );
-    if (!tagFetch.success) {
-      logger.error("Failed to fetch tags after clone", tagFetch.error, { remote });
-      return err(new ExternalServiceError("Git", "Failed to fetch tags", tagFetch.error));
+    if (!remoteInfoResult.success) {
+      logger.error("Failed to enumerate remote tags", remoteInfoResult.error, { remote });
+      return err(
+        new ExternalServiceError("Git", "Failed to enumerate remote tags", remoteInfoResult.error),
+      );
+    }
+
+    // getRemoteInfo nests advertised refs into an object tree keyed by path
+    // segment (`refs.tags.<name>`); it also advertises each annotated tag's
+    // peeled commit under a `<name>^{}` key alongside the tag object itself —
+    // that suffix marks a peeled target, not a real tag name, so it's filtered
+    // out (we peel annotated tags ourselves in `collectRepoTags`).
+    const remoteTags = (remoteInfoResult.data.refs as { tags?: Record<string, string> } | undefined)
+      ?.tags;
+    const tagNames = Object.keys(remoteTags ?? {})
+      .filter((name) => !name.endsWith("^{}"))
+      .sort();
+
+    totalTagCount = tagNames.length;
+    tagsTruncated = totalTagCount > MAX_TAGS;
+    const tagNamesToFetch = tagsTruncated ? tagNames.slice(0, MAX_TAGS) : tagNames;
+    if (tagsTruncated) {
+      logger.warn("Remote tag count exceeds MAX_TAGS; truncating tags fetch", {
+        remote,
+        totalTagCount,
+        fetchedTagCount: tagNamesToFetch.length,
+        maxTags: MAX_TAGS,
+      });
+    }
+
+    for (const name of tagNamesToFetch) {
+      const tagFetch = await fromPromise(
+        git.fetch({
+          fs,
+          http: httpClient,
+          dir: DIR,
+          url: remote,
+          singleBranch: true,
+          remoteRef: `refs/tags/${name}`,
+          tags: true,
+          ...(opts.fullHistory ? {} : { depth: 50 }),
+          onAuth: makeAuth(token),
+        }),
+      );
+      if (!tagFetch.success) {
+        logger.error("Failed to fetch tag", tagFetch.error, { remote, tag: name });
+        return err(new ExternalServiceError("Git", `Failed to fetch tag: ${name}`, tagFetch.error));
+      }
     }
   }
 
   logger.info("Successfully cloned repository", { remote });
-  return ok({ fs: fs as unknown as NodeFS, dir: DIR });
+  return ok({
+    fs: fs as unknown as NodeFS,
+    dir: DIR,
+    ...(opts.includeTags ? { tagsTruncated, totalTagCount } : {}),
+  });
 }
 
 export async function commitAndPush(
@@ -2887,6 +2949,20 @@ export async function collectRepoTags(
   return entries;
 }
 
+/** Result of {@link listRepoTags}. */
+export interface ListRepoTagsResult {
+  /** The tags actually listed — capped at {@link MAX_TAGS} when the remote
+   * advertises more (see `truncated`). */
+  tags: RepoTagEntry[];
+  /** True when the remote advertised more than {@link MAX_TAGS} tags and the
+   * fetch was capped — reported explicitly, never silent, so callers/UI can
+   * show it rather than presenting a quietly-partial list as complete. */
+  truncated: boolean;
+  /** Total tags the remote advertised, independent of how many were fetched.
+   * Equal to `tags.length` unless `truncated` is true. */
+  totalTagCount: number;
+}
+
 /**
  * Lists the tags in a repository, including entries whose targets cannot be
  * resolved from the cloned history.
@@ -2897,16 +2973,21 @@ export async function collectRepoTags(
  * erroring would make the whole listing unavailable because of one old tag.
  * See `collectRepoTags`.
  *
+ * The underlying fetch is tags-only (per-tag `singleBranch` fetches, never a
+ * whole-branches pull) and capped at {@link MAX_TAGS}; a remote with more tags
+ * than that comes back with `truncated: true` rather than silently dropping
+ * the excess. See the `cloneRepo` `includeTags` option.
+ *
  * @param remote - The repository's remote URL
  * @param token - The authentication token for the remote
- * @returns The repository's tag entries
+ * @returns The repository's tag entries, plus truncation info
  */
 export async function listRepoTags(
   remote: string,
   token: string,
   logger: Logger,
   httpClient: HttpClient = http,
-): Promise<Result<RepoTagEntry[], AppError>> {
+): Promise<Result<ListRepoTagsResult, AppError>> {
   logger.debug("Listing repo tags", { remote });
 
   const cloneResult = await cloneRepo(remote, token, logger, { includeTags: true }, httpClient);
@@ -2920,6 +3001,20 @@ export async function listRepoTags(
     return err(new ExternalServiceError("Git", "Failed to list tags", collected.error));
   }
 
-  logger.info("Successfully listed repo tags", { remote, tagCount: collected.data.length });
-  return ok(collected.data);
+  const truncated = cloneResult.data.tagsTruncated ?? false;
+  const totalTagCount = cloneResult.data.totalTagCount ?? collected.data.length;
+  if (truncated) {
+    logger.warn("Tag listing truncated at MAX_TAGS", {
+      remote,
+      totalTagCount,
+      returnedTagCount: collected.data.length,
+    });
+  }
+
+  logger.info("Successfully listed repo tags", {
+    remote,
+    tagCount: collected.data.length,
+    truncated,
+  });
+  return ok({ tags: collected.data, truncated, totalTagCount });
 }

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -511,6 +511,36 @@ export const MAX_TAGS = 200;
  * @param opts.includeTags - Whether to follow the clone with a per-tag fetch of `refs/tags/*`; a `singleBranch` clone never brings tags. Capped at {@link MAX_TAGS}; see the result's `tagsTruncated`/`totalTagCount`.
  * @returns The cloned filesystem and its working directory (plus tag-fetch truncation info when `includeTags` was set), or an application error
  */
+
+/** The shape `getRemoteInfo` nests advertised refs into: each `/`-separated
+ * path segment of the ref becomes a nested key, with the oid (or symref
+ * target) only at the leaf. See {@link flattenRefTree}. */
+type RemoteRefTree = { [segment: string]: string | RemoteRefTree };
+
+/**
+ * `getRemoteInfo` builds an object TREE out of the flat ref list it gets from
+ * the remote, splitting every ref on "/" and nesting a level per segment (see
+ * isomorphic-git's `getRemoteInfo`) — so `refs/tags/release/1.0` lands at
+ * `refs.tags.release["1.0"]`, not `refs.tags["release/1.0"]`. A plain
+ * `Object.keys(refs.tags)` therefore only recovers the first path segment of
+ * any hierarchical tag name (yielding a nested object where an oid was
+ * expected). This walks the tree back down, rejoining segments with "/", to
+ * recover the true `name -> oid` pairs regardless of nesting depth.
+ */
+function flattenRefTree(node: RemoteRefTree | undefined, prefix = ""): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!node) return out;
+  for (const [segment, value] of Object.entries(node)) {
+    const name = prefix ? `${prefix}/${segment}` : segment;
+    if (typeof value === "string") {
+      out[name] = value;
+    } else {
+      Object.assign(out, flattenRefTree(value, name));
+    }
+  }
+  return out;
+}
+
 export async function cloneRepo(
   remote: string,
   token: string,
@@ -576,19 +606,28 @@ export async function cloneRepo(
     }
 
     // getRemoteInfo nests advertised refs into an object tree keyed by path
-    // segment (`refs.tags.<name>`); it also advertises each annotated tag's
-    // peeled commit under a `<name>^{}` key alongside the tag object itself —
-    // that suffix marks a peeled target, not a real tag name, so it's filtered
-    // out (we peel annotated tags ourselves in `collectRepoTags`).
-    const remoteTags = (remoteInfoResult.data.refs as { tags?: Record<string, string> } | undefined)
+    // segment (`refs.tags.<name>`, or several levels deep for a hierarchical
+    // tag name like `release/1.0` — see `flattenRefTree`); it also advertises
+    // each annotated tag's peeled commit under a `<name>^{}` key alongside the
+    // tag object itself — that suffix marks a peeled target, not a real tag
+    // name, so it's filtered out (we peel annotated tags ourselves in
+    // `collectRepoTags`).
+    const remoteTagsTree = (remoteInfoResult.data.refs as { tags?: RemoteRefTree } | undefined)
       ?.tags;
-    const tagNames = Object.keys(remoteTags ?? {})
-      .filter((name) => !name.endsWith("^{}"))
-      .sort();
+    const tagNames = Object.keys(flattenRefTree(remoteTagsTree)).filter(
+      (name) => !name.endsWith("^{}"),
+    );
 
     totalTagCount = tagNames.length;
     tagsTruncated = totalTagCount > MAX_TAGS;
-    const tagNamesToFetch = tagsTruncated ? tagNames.slice(0, MAX_TAGS) : tagNames;
+    // Sort ascending for stable, readable fetch order; when truncating, keep
+    // the highest-sorting names (tail of the ascending sort) rather than the
+    // lowest, since a release listing wants v9.x over v1.x when only one can
+    // fit. This is lexicographic, not chronological, ordering — "v10" sorts
+    // below "v9" — so it's a best-effort signal from names alone, not a
+    // guarantee of "newest".
+    const sortedTagNames = tagNames.sort();
+    const tagNamesToFetch = tagsTruncated ? sortedTagNames.slice(-MAX_TAGS) : sortedTagNames;
     if (tagsTruncated) {
       logger.warn("Remote tag count exceeds MAX_TAGS; truncating tags fetch", {
         remote,

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -469,8 +469,18 @@ export async function initAndPush(
  * would turn one clone into an unbounded number of requests. Truncation is
  * never silent: it is reported on the clone result (`tagsTruncated`,
  * `totalTagCount`) so `listRepoTags` and its callers can surface it (#241).
+ *
+ * Sized against the Workers subrequest budget, not picked round: one
+ * isomorphic-git fetch is TWO subrequests (a GET of
+ * `/info/refs?service=git-upload-pack`, then a POST to `/git-upload-pack`), so
+ * the loop below costs `2 * MAX_TAGS` on top of the clone's own pair and the
+ * `getRemoteInfo` handshake. At 500 that is ~1003 — on the nose of the
+ * ~1000-subrequest cap this codebase budgets against elsewhere (see the note in
+ * `src/storage/state.ts`), which would kill the request outright instead of
+ * degrading. 200 keeps the tag walk near 400 and leaves the rest of the request
+ * room to breathe; repos above it degrade visibly through `truncated`.
  */
-const MAX_TAGS = 500;
+export const MAX_TAGS = 200;
 
 /**
  * Clones the `main` branch of a repository into an in-memory filesystem.

--- a/src/ui/pages/tags.tsx
+++ b/src/ui/pages/tags.tsx
@@ -9,6 +9,12 @@ interface TagsProps {
     slug: string;
   };
   tags: RepoTagEntry[];
+  /** True when the remote had more tags than the fetch cap and the listing
+   * was truncated — surfaced explicitly rather than silently showing a
+   * partial list as complete (#241). */
+  truncated?: boolean;
+  /** Total tags the remote advertised; only meaningful alongside `truncated`. */
+  totalTagCount?: number;
   user?: { id: string; email: string; username: string } | null;
 }
 
@@ -25,7 +31,7 @@ export function formatTagDate(timestamp: number | undefined): string {
   return date.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
 }
 
-export const TagsPage: FC<TagsProps> = ({ project, tags, user }) => {
+export const TagsPage: FC<TagsProps> = ({ project, tags, truncated, totalTagCount, user }) => {
   return (
     <Layout title={`Tags — ${project.name}`} user={user}>
       <div class="page-header">
@@ -34,6 +40,13 @@ export const TagsPage: FC<TagsProps> = ({ project, tags, user }) => {
           Back to repo
         </a>
       </div>
+
+      {truncated && (
+        <div class="empty-state-hint" style="margin-bottom: 1rem;">
+          Showing the first {tags.length} of {totalTagCount ?? tags.length} tags. The rest were not
+          fetched.
+        </div>
+      )}
 
       {tags.length === 0 ? (
         <div class="empty-state">

--- a/src/ui/pages/tags.tsx
+++ b/src/ui/pages/tags.tsx
@@ -31,6 +31,15 @@ export function formatTagDate(timestamp: number | undefined): string {
   return date.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
 }
 
+/**
+ * Renders a project's git tags, annotated and lightweight alike.
+ *
+ * When `truncated` is set the page says so in place, showing how many of the
+ * remote's `totalTagCount` tags are actually listed. That notice is the whole
+ * point of the prop pair: the fetch caps tag count at `MAX_TAGS` to stay
+ * inside the Workers subrequest budget, and a capped listing that rendered
+ * like a complete one would quietly read as "this repo has 200 tags" (#241).
+ */
 export const TagsPage: FC<TagsProps> = ({ project, tags, truncated, totalTagCount, user }) => {
   return (
     <Layout title={`Tags — ${project.name}`} user={user}>

--- a/src/ui/pages/tags.tsx
+++ b/src/ui/pages/tags.tsx
@@ -12,9 +12,17 @@ interface TagsProps {
   /** True when the remote had more tags than the fetch cap and the listing
    * was truncated — surfaced explicitly rather than silently showing a
    * partial list as complete (#241). */
-  truncated?: boolean;
-  /** Total tags the remote advertised; only meaningful alongside `truncated`. */
-  totalTagCount?: number;
+  truncated: boolean;
+  /** Total tags the remote advertised, independent of how many were fetched.
+   *
+   * Required, not optional, because `ListRepoTagsResult` always carries it and
+   * the route passes it straight through. Optional here would admit
+   * `truncated` without a total, and the only way to render that is to fall
+   * back to `tags.length` — which reads "the first 200 of 200 tags. The rest
+   * were not fetched", a sentence that contradicts itself and looks like a
+   * complete listing. That is the exact failure this notice exists to
+   * prevent, so the state is made unrepresentable rather than handled. */
+  totalTagCount: number;
   user?: { id: string; email: string; username: string } | null;
 }
 
@@ -32,8 +40,6 @@ export function formatTagDate(timestamp: number | undefined): string {
 }
 
 /**
- * Renders a project's git tags, annotated and lightweight alike.
- *
  * When `truncated` is set the page says so in place, showing how many of the
  * remote's `totalTagCount` tags are actually listed. That notice is the whole
  * point of the prop pair: the fetch caps tag count at `MAX_TAGS` to stay
@@ -52,8 +58,7 @@ export const TagsPage: FC<TagsProps> = ({ project, tags, truncated, totalTagCoun
 
       {truncated && (
         <div class="empty-state-hint" style="margin-bottom: 1rem;">
-          Showing the first {tags.length} of {totalTagCount ?? tags.length} tags. The rest were not
-          fetched.
+          Showing the first {tags.length} of {totalTagCount} tags. The rest were not fetched.
         </div>
       )}
 

--- a/tests/git-tags-ops.test.ts
+++ b/tests/git-tags-ops.test.ts
@@ -2,6 +2,7 @@ import git from "isomorphic-git";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { snapshotRepo, walkRepoObjects } from "../src/backup/repo-snapshot";
 import {
+  MAX_TAGS,
   type NodeFS,
   cloneRepo,
   collectRepoTags,
@@ -418,7 +419,6 @@ describe("cloneRepo includeTags", () => {
     mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
       await buildRepo(dir, [{ "a.txt": "one" }], fs);
     });
-    const MAX_TAGS = 500; // matches the private constant in git-ops.ts
     const manyTags: Record<string, string> = {};
     for (let i = 0; i < MAX_TAGS + 37; i++) {
       manyTags[`t${String(i).padStart(5, "0")}`] = i.toString(16).padStart(40, "0");
@@ -566,7 +566,6 @@ describe("listRepoTags", () => {
     mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
       await buildRepo(dir, [{ "a.txt": "one" }], fs);
     });
-    const MAX_TAGS = 500; // matches the private constant in git-ops.ts
     const manyTags: Record<string, string> = {};
     for (let i = 0; i < MAX_TAGS + 10; i++) {
       manyTags[`t${String(i).padStart(5, "0")}`] = i.toString(16).padStart(40, "0");

--- a/tests/git-tags-ops.test.ts
+++ b/tests/git-tags-ops.test.ts
@@ -45,10 +45,24 @@ vi.mock("isomorphic-git", async (importActual) => {
   };
 });
 
-/** Shape a `getRemoteInfo` mock resolution for a set of tag names, matching
- * the real nested `{ refs: { tags: { <name>: oid } } }` shape (see git-ops.ts). */
+/** Shape a `getRemoteInfo` mock resolution for a set of tag names, mirroring
+ * the real nesting getRemoteInfo builds: each ref is split on "/" and nested
+ * a level per segment, so a hierarchical tag name (e.g. "release/1.0") lands
+ * at `refs.tags.release["1.0"]`, not `refs.tags["release/1.0"]` — a flat mock
+ * shape would hide exactly the bug this nesting causes (see git-ops.ts). */
 function remoteInfoWithTags(tags: Record<string, string>) {
-  return { capabilities: [], refs: { tags } };
+  const tree: Record<string, unknown> = {};
+  for (const [name, oid] of Object.entries(tags)) {
+    const parts = name.split("/");
+    const last = parts.pop() as string;
+    let node = tree;
+    for (const part of parts) {
+      node[part] = node[part] ?? {};
+      node = node[part] as Record<string, unknown>;
+    }
+    node[last] = oid;
+  }
+  return { capabilities: [], refs: { tags: tree } };
 }
 
 /**
@@ -372,6 +386,32 @@ describe("cloneRepo includeTags", () => {
     );
   });
 
+  it("fetches a hierarchical tag name, which getRemoteInfo nests several levels deep", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      await buildRepo(dir, [{ "a.txt": "one" }], fs);
+    });
+    // "release/1.0" advertises as refs/tags/release/1.0, which getRemoteInfo
+    // nests as refs.tags.release["1.0"] — a plain Object.keys(refs.tags)
+    // would yield "release" (a nested object, not an oid) instead of the
+    // real tag name.
+    mockGetRemoteInfo.mockResolvedValue(
+      remoteInfoWithTags({ "release/1.0": "a".repeat(40), "v1/rc1": "b".repeat(40) }),
+    );
+    mockFetch.mockResolvedValue({});
+
+    const result = await cloneRepo("https://r.example/repo.git", "tok", logger, {
+      includeTags: true,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.totalTagCount).toBe(2);
+
+    const remoteRefs = mockFetch.mock.calls
+      .map((c) => (c[0] as Record<string, unknown>).remoteRef)
+      .sort();
+    expect(remoteRefs).toEqual(["refs/tags/release/1.0", "refs/tags/v1/rc1"]);
+  });
+
   it("does not enumerate or fetch tags unless asked", async () => {
     mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
       await buildRepo(dir, [{ "a.txt": "one" }], fs);
@@ -436,6 +476,38 @@ describe("cloneRepo includeTags", () => {
     // Only the cap's worth of tags were actually fetched — not silently more
     // or fewer.
     expect(mockFetch).toHaveBeenCalledTimes(MAX_TAGS);
+  });
+
+  it("keeps the highest-sorting tags, not the lowest, when truncating", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      await buildRepo(dir, [{ "a.txt": "one" }], fs);
+    });
+    // v0..v(MAX_TAGS+9): a plain lexicographic sort keeps the "v0*" tags and
+    // drops "v1*" — the opposite of what a release listing wants.
+    const manyTags: Record<string, string> = {};
+    const total = MAX_TAGS + 10;
+    for (let i = 0; i < total; i++) {
+      manyTags[`v${String(i).padStart(5, "0")}`] = i.toString(16).padStart(40, "0");
+    }
+    mockGetRemoteInfo.mockResolvedValue(remoteInfoWithTags(manyTags));
+    mockFetch.mockResolvedValue({});
+
+    const result = await cloneRepo("https://r.example/repo.git", "tok", logger, {
+      includeTags: true,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.tagsTruncated).toBe(true);
+
+    const fetchedNames = mockFetch.mock.calls
+      .map((c) => (c[0] as Record<string, unknown>).remoteRef as string)
+      .map((ref) => ref.replace("refs/tags/", ""))
+      .sort();
+    const expectedKept = Object.keys(manyTags).sort().slice(-MAX_TAGS);
+    expect(fetchedNames).toEqual(expectedKept);
+    // The lowest-sorting names were the ones dropped.
+    expect(fetchedNames).not.toContain("v00000");
+    expect(fetchedNames).toContain(`v${String(total - 1).padStart(5, "0")}`);
   });
 
   it("does not materialize a large branch's objects that no tag references", async () => {

--- a/tests/git-tags-ops.test.ts
+++ b/tests/git-tags-ops.test.ts
@@ -13,13 +13,14 @@ import { placeLooseObject } from "../src/storage/object-loader";
 import type { Env, ProjectEntry } from "../src/types";
 import type { Logger } from "../src/utils/logger";
 
-// Partial isomorphic-git mock: `clone`, `fetch`, and `push` are the only
-// network-coupled calls the code under test makes; everything else (init,
-// commit, tag, readObject, …) stays real so the tests exercise genuine git
-// object stores in MemoryFS.
-const { mockClone, mockFetch, mockPush, listTagsOverride } = vi.hoisted(() => ({
+// Partial isomorphic-git mock: `clone`, `fetch`, `getRemoteInfo`, and `push`
+// are the only network-coupled calls the code under test makes; everything
+// else (init, commit, tag, readObject, …) stays real so the tests exercise
+// genuine git object stores in MemoryFS.
+const { mockClone, mockFetch, mockGetRemoteInfo, mockPush, listTagsOverride } = vi.hoisted(() => ({
   mockClone: vi.fn(),
   mockFetch: vi.fn(),
+  mockGetRemoteInfo: vi.fn(),
   mockPush: vi.fn(),
   // When set, replaces git.listTags for a single test (reset in beforeEach).
   listTagsOverride: { fn: null as null | ((args: unknown) => Promise<string[]>) },
@@ -33,6 +34,7 @@ vi.mock("isomorphic-git", async (importActual) => {
       ...actual.default,
       clone: (args: unknown) => mockClone(args),
       fetch: (args: unknown) => mockFetch(args),
+      getRemoteInfo: (args: unknown) => mockGetRemoteInfo(args),
       push: (args: unknown) => mockPush(args),
       listTags: (args: unknown) =>
         listTagsOverride.fn
@@ -41,6 +43,55 @@ vi.mock("isomorphic-git", async (importActual) => {
     },
   };
 });
+
+/** Shape a `getRemoteInfo` mock resolution for a set of tag names, matching
+ * the real nested `{ refs: { tags: { <name>: oid } } }` shape (see git-ops.ts). */
+function remoteInfoWithTags(tags: Record<string, string>) {
+  return { capabilities: [], refs: { tags } };
+}
+
+/**
+ * Recursively copies a git object and everything it reaches (commit parents,
+ * trees, blobs, peeled tags) from one MemoryFS-backed repo into another,
+ * using isomorphic-git's real object store — no synthetic data. Used to give
+ * `mockFetch` genuine "only what was asked for" semantics in tests, so a
+ * fetch that (incorrectly) asked for an unrelated branch's oid would actually
+ * pull that branch's objects, and a correct per-tag fetch provably would not.
+ */
+async function copyReachableObjects(
+  srcFs: NodeFS,
+  srcDir: string,
+  destFs: NodeFS,
+  destDir: string,
+  oid: string,
+  visited: Set<string> = new Set(),
+): Promise<void> {
+  if (visited.has(oid)) return;
+  visited.add(oid);
+  const { type, object } = await git.readObject({ fs: srcFs, dir: srcDir, oid, format: "wrapped" });
+  const gitdir = destDir.endsWith("/") ? `${destDir}.git` : `${destDir}/.git`;
+  await placeLooseObject(
+    destFs as unknown as Parameters<typeof placeLooseObject>[0],
+    gitdir,
+    oid,
+    object as Uint8Array,
+  );
+  if (type === "commit") {
+    const { commit } = await git.readCommit({ fs: srcFs, dir: srcDir, oid });
+    await copyReachableObjects(srcFs, srcDir, destFs, destDir, commit.tree, visited);
+    for (const parent of commit.parent) {
+      await copyReachableObjects(srcFs, srcDir, destFs, destDir, parent, visited);
+    }
+  } else if (type === "tree") {
+    const { tree } = await git.readTree({ fs: srcFs, dir: srcDir, oid });
+    for (const entry of tree) {
+      await copyReachableObjects(srcFs, srcDir, destFs, destDir, entry.oid, visited);
+    }
+  } else if (type === "tag") {
+    const { tag } = await git.readTag({ fs: srcFs, dir: srcDir, oid });
+    await copyReachableObjects(srcFs, srcDir, destFs, destDir, tag.object, visited);
+  }
+}
 
 const logger = {
   trace: vi.fn(),
@@ -77,6 +128,9 @@ async function buildRepo(
 beforeEach(() => {
   vi.clearAllMocks();
   listTagsOverride.fn = null;
+  // Default: no tags advertised. Individual tests override with the tag set
+  // they need before calling cloneRepo/listRepoTags.
+  mockGetRemoteInfo.mockResolvedValue(remoteInfoWithTags({}));
 });
 
 describe("collectRepoTags", () => {
@@ -245,28 +299,45 @@ describe("collectRepoTags", () => {
 });
 
 describe("cloneRepo includeTags", () => {
-  it("follows the singleBranch clone with a tags fetch (shallow by default)", async () => {
+  it("enumerates tags via getRemoteInfo, then fetches each individually (shallow by default)", async () => {
     mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
       await buildRepo(dir, [{ "a.txt": "one" }], fs);
     });
+    mockGetRemoteInfo.mockResolvedValue(
+      remoteInfoWithTags({ "v1.0.0": "a".repeat(40), "v2.0.0": "b".repeat(40) }),
+    );
     mockFetch.mockResolvedValue({});
 
     const result = await cloneRepo("https://r.example/repo.git", "tok", logger, {
       includeTags: true,
     });
     expect(result.success).toBe(true);
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const args = mockFetch.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(args.tags).toBe(true);
-    expect(args.singleBranch).toBe(false);
-    expect(args.depth).toBe(50);
-    expect(args.url).toBe("https://r.example/repo.git");
+    if (!result.success) return;
+    expect(result.data.tagsTruncated).toBe(false);
+    expect(result.data.totalTagCount).toBe(2);
+
+    expect(mockGetRemoteInfo).toHaveBeenCalledTimes(1);
+    const infoArgs = mockGetRemoteInfo.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(infoArgs.url).toBe("https://r.example/repo.git");
+
+    // One fetch per tag — never a combined all-refs fetch.
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    for (const call of mockFetch.mock.calls) {
+      const args = call[0] as Record<string, unknown>;
+      expect(args.tags).toBe(true);
+      expect(args.singleBranch).toBe(true);
+      expect(args.depth).toBe(50);
+      expect(args.url).toBe("https://r.example/repo.git");
+    }
+    const remoteRefs = mockFetch.mock.calls.map((c) => (c[0] as Record<string, unknown>).remoteRef);
+    expect(remoteRefs).toEqual(["refs/tags/v1.0.0", "refs/tags/v2.0.0"]);
   });
 
   it("fetches tags with full history when fullHistory is set (no depth)", async () => {
     mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
       await buildRepo(dir, [{ "a.txt": "one" }], fs);
     });
+    mockGetRemoteInfo.mockResolvedValue(remoteInfoWithTags({ "v1.0.0": "a".repeat(40) }));
     mockFetch.mockResolvedValue({});
 
     await cloneRepo("https://r.example/repo.git", "tok", logger, {
@@ -276,28 +347,170 @@ describe("cloneRepo includeTags", () => {
     const args = mockFetch.mock.calls[0]?.[0] as Record<string, unknown>;
     expect("depth" in args).toBe(false);
     expect(args.tags).toBe(true);
+    expect(args.singleBranch).toBe(true);
   });
 
-  it("does not fetch tags unless asked", async () => {
+  it("filters out peeled-tag `^{}` advertisement keys — they aren't tag names", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      await buildRepo(dir, [{ "a.txt": "one" }], fs);
+    });
+    mockGetRemoteInfo.mockResolvedValue(
+      remoteInfoWithTags({ "v1.0.0": "a".repeat(40), "v1.0.0^{}": "b".repeat(40) }),
+    );
+    mockFetch.mockResolvedValue({});
+
+    const result = await cloneRepo("https://r.example/repo.git", "tok", logger, {
+      includeTags: true,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.totalTagCount).toBe(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect((mockFetch.mock.calls[0]?.[0] as Record<string, unknown>).remoteRef).toBe(
+      "refs/tags/v1.0.0",
+    );
+  });
+
+  it("does not enumerate or fetch tags unless asked", async () => {
     mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
       await buildRepo(dir, [{ "a.txt": "one" }], fs);
     });
     const result = await cloneRepo("https://r.example/repo.git", "tok", logger);
     expect(result.success).toBe(true);
+    expect(mockGetRemoteInfo).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("fails the clone when the tags fetch fails", async () => {
+  it("fails the clone when remote tag enumeration fails", async () => {
     mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
       await buildRepo(dir, [{ "a.txt": "one" }], fs);
     });
-    mockFetch.mockRejectedValue(new Error("network down"));
+    mockGetRemoteInfo.mockRejectedValue(new Error("network down"));
 
     const result = await cloneRepo("https://r.example/repo.git", "tok", logger, {
       includeTags: true,
     });
     expect(result.success).toBe(false);
-    if (!result.success) expect(result.error.message).toContain("Failed to fetch tags");
+    if (!result.success) expect(result.error.message).toContain("Failed to enumerate remote tags");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("fails the clone when an individual tag fetch fails, naming the tag", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      await buildRepo(dir, [{ "a.txt": "one" }], fs);
+    });
+    mockGetRemoteInfo.mockResolvedValue(
+      remoteInfoWithTags({ "v1.0.0": "a".repeat(40), "v2.0.0": "b".repeat(40) }),
+    );
+    mockFetch.mockResolvedValueOnce({}).mockRejectedValueOnce(new Error("network down"));
+
+    const result = await cloneRepo("https://r.example/repo.git", "tok", logger, {
+      includeTags: true,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("Failed to fetch tag");
+      expect(result.error.message).toContain("v2.0.0");
+    }
+  });
+
+  it("caps the number of tags fetched at MAX_TAGS and reports truncation", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      await buildRepo(dir, [{ "a.txt": "one" }], fs);
+    });
+    const MAX_TAGS = 500; // matches the private constant in git-ops.ts
+    const manyTags: Record<string, string> = {};
+    for (let i = 0; i < MAX_TAGS + 37; i++) {
+      manyTags[`t${String(i).padStart(5, "0")}`] = i.toString(16).padStart(40, "0");
+    }
+    mockGetRemoteInfo.mockResolvedValue(remoteInfoWithTags(manyTags));
+    mockFetch.mockResolvedValue({});
+
+    const result = await cloneRepo("https://r.example/repo.git", "tok", logger, {
+      includeTags: true,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.tagsTruncated).toBe(true);
+    expect(result.data.totalTagCount).toBe(MAX_TAGS + 37);
+    // Only the cap's worth of tags were actually fetched — not silently more
+    // or fewer.
+    expect(mockFetch).toHaveBeenCalledTimes(MAX_TAGS);
+  });
+
+  it("does not materialize a large branch's objects that no tag references", async () => {
+    // A "remote" repo, separate from the destination fs, with:
+    //  - main: one commit
+    //  - a tag pointing at that same commit
+    //  - a "big" branch with its own commits/blobs, reachable from no tag
+    const remoteDir = "/remote";
+    const { fs: remoteFs, shas } = await buildRepo(remoteDir, [{ "a.txt": "one" }]);
+    const c1 = shas[0] as string;
+
+    await (
+      remoteFs as unknown as { promises: { writeFile: (p: string, c: string) => Promise<void> } }
+    ).promises.writeFile(`${remoteDir}/big1.txt`, "x".repeat(500));
+    await git.add({ fs: remoteFs, dir: remoteDir, filepath: "big1.txt" });
+    const big1 = await git.commit({
+      fs: remoteFs,
+      dir: remoteDir,
+      message: "big1",
+      author,
+      ref: "refs/heads/big",
+      parent: [c1],
+    });
+
+    await git.tag({ fs: remoteFs, dir: remoteDir, ref: "v1.0.0", object: c1 });
+
+    // The main clone mirrors what a real singleBranch clone would produce:
+    // only main's own object graph.
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      await git.init({ fs, dir, defaultBranch: "main" });
+      await copyReachableObjects(remoteFs, remoteDir, fs, dir, c1);
+      await git.writeRef({ fs, dir, ref: "refs/heads/main", value: c1, force: true });
+    });
+
+    mockGetRemoteInfo.mockResolvedValue(remoteInfoWithTags({ "v1.0.0": c1 }));
+
+    // A faithful per-tag fetch: copy only the requested ref's own object
+    // graph from the "remote" — exactly what a real singleBranch fetch does.
+    mockFetch.mockImplementation(
+      async ({ fs, dir, remoteRef }: { fs: NodeFS; dir: string; remoteRef: string }) => {
+        const name = remoteRef.replace("refs/tags/", "");
+        const oid = await git.resolveRef({
+          fs: remoteFs,
+          dir: remoteDir,
+          ref: `refs/tags/${name}`,
+        });
+        await copyReachableObjects(remoteFs, remoteDir, fs, dir, oid);
+        await git.writeRef({ fs, dir, ref: `refs/tags/${name}`, value: oid, force: true });
+        return {};
+      },
+    );
+
+    const result = await cloneRepo("https://r.example/repo.git", "tok", logger, {
+      includeTags: true,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    // The tag's target is present.
+    await expect(
+      git.readObject({ fs: result.data.fs, dir: result.data.dir, oid: c1 }),
+    ).resolves.toBeDefined();
+    // The untagged branch's own commit was never fetched.
+    await expect(
+      git.readObject({ fs: result.data.fs, dir: result.data.dir, oid: big1 }),
+    ).rejects.toThrow();
+
+    // Every tags-fetch call asked for exactly one tag ref — never a
+    // whole-repo (`singleBranch: false`) fetch, and never the branch ref.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    for (const call of mockFetch.mock.calls) {
+      const args = call[0] as Record<string, unknown>;
+      expect(args.singleBranch).toBe(true);
+      expect(args.remoteRef).toBe("refs/tags/v1.0.0");
+    }
   });
 });
 
@@ -315,14 +528,19 @@ describe("listRepoTags", () => {
         tagger,
       });
     });
+    mockGetRemoteInfo.mockResolvedValue(
+      remoteInfoWithTags({ "v1.0.0": "a".repeat(40), "v2.0.0": "b".repeat(40) }),
+    );
     mockFetch.mockResolvedValue({});
 
     const result = await listRepoTags("https://r.example/repo.git", "tok", logger);
     expect(result.success).toBe(true);
     if (!result.success) return;
-    expect(result.data.map((t) => t.name)).toEqual(["v1.0.0", "v2.0.0"]);
-    expect(result.data[1]?.annotated).toBe(true);
-    expect(result.data[1]?.message).toBe("second");
+    expect(result.data.tags.map((t) => t.name)).toEqual(["v1.0.0", "v2.0.0"]);
+    expect(result.data.tags[1]?.annotated).toBe(true);
+    expect(result.data.tags[1]?.message).toBe("second");
+    expect(result.data.truncated).toBe(false);
+    expect(result.data.totalTagCount).toBe(2);
   });
 
   it("propagates a clone failure", async () => {
@@ -342,6 +560,40 @@ describe("listRepoTags", () => {
     const result = await listRepoTags("https://r.example/repo.git", "tok", logger);
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error.message).toContain("Failed to list tags");
+  });
+
+  it("reports truncation and the true remote total when the tag count exceeds MAX_TAGS", async () => {
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      await buildRepo(dir, [{ "a.txt": "one" }], fs);
+    });
+    const MAX_TAGS = 500; // matches the private constant in git-ops.ts
+    const manyTags: Record<string, string> = {};
+    for (let i = 0; i < MAX_TAGS + 10; i++) {
+      manyTags[`t${String(i).padStart(5, "0")}`] = i.toString(16).padStart(40, "0");
+    }
+    mockGetRemoteInfo.mockResolvedValue(remoteInfoWithTags(manyTags));
+    // Each per-tag fetch actually writes the local ref so collectRepoTags has
+    // something to find (pointed at an already-present commit).
+    let mainSha = "";
+    mockClone.mockImplementation(async ({ fs, dir }: { fs: NodeFS; dir: string }) => {
+      const { shas } = await buildRepo(dir, [{ "a.txt": "one" }], fs);
+      mainSha = shas[0] as string;
+    });
+    mockFetch.mockImplementation(
+      async ({ fs, dir, remoteRef }: { fs: NodeFS; dir: string; remoteRef: string }) => {
+        await git.writeRef({ fs, dir, ref: remoteRef, value: mainSha, force: true });
+        return {};
+      },
+    );
+
+    const result = await listRepoTags("https://r.example/repo.git", "tok", logger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.truncated).toBe(true);
+    expect(result.data.totalTagCount).toBe(MAX_TAGS + 10);
+    // Exactly MAX_TAGS tags were fetched and are therefore listed — the
+    // truncation is real, not just reported while everything still lists.
+    expect(result.data.tags).toHaveLength(MAX_TAGS);
   });
 });
 
@@ -406,6 +658,7 @@ describe("snapshotRepo clones with tags", () => {
         tagger,
       });
     });
+    mockGetRemoteInfo.mockResolvedValue(remoteInfoWithTags({ "v1.0.0": "a".repeat(40) }));
     mockFetch.mockResolvedValue({});
 
     const result = await snapshotRepo(makeEnv(), project, "2026-08-18T00:00:00Z", logger);
@@ -415,11 +668,13 @@ describe("snapshotRepo clones with tags", () => {
     if (result.data.status !== "ok") return;
     expect(result.data.snapshot.manifest.tags?.map((t) => t.name)).toEqual(["v1.0.0"]);
 
-    // The backup clone is full-history AND tag-fetching.
+    // The backup clone is full-history AND tag-fetching, one tag ref at a time.
     const cloneArgs = mockClone.mock.calls[0]?.[0] as Record<string, unknown>;
     expect("depth" in cloneArgs).toBe(false);
     const fetchArgs = mockFetch.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(fetchArgs.tags).toBe(true);
+    expect(fetchArgs.singleBranch).toBe(true);
+    expect(fetchArgs.remoteRef).toBe("refs/tags/v1.0.0");
     expect("depth" in fetchArgs).toBe(false);
   });
 

--- a/tests/tags-routes.test.ts
+++ b/tests/tags-routes.test.ts
@@ -16,42 +16,46 @@ vi.mock("../src/storage/git-ops", async (importActual) => {
     freshRepoToken: vi.fn(async () => ({ success: true, data: "mock-token" })),
     listRepoTags: vi.fn(async () => ({
       success: true,
-      data: [
-        {
-          name: "v1.0.0",
-          oid: "c".repeat(40),
-          targetSha: "b".repeat(40),
-          annotated: true,
-          message: "First stable release",
-          tagger: "tagger <tag@x.com>",
-          timestamp: 1_700_000_100,
-          unresolvable: false,
-        },
-        {
-          name: "v0.9.0",
-          oid: "b".repeat(40),
-          targetSha: "b".repeat(40),
-          annotated: false,
-          unresolvable: false,
-        },
-        {
-          name: "ancient",
-          oid: "d".repeat(40),
-          targetSha: null,
-          annotated: false,
-          unresolvable: true,
-        },
-        {
-          // Annotated tag whose TARGET is outside the shallow window: the
-          // intended target sha is known, but the commit itself is missing.
-          name: "deep",
-          oid: "e".repeat(40),
-          targetSha: "a".repeat(40),
-          annotated: true,
-          message: "too deep",
-          unresolvable: true,
-        },
-      ],
+      data: {
+        tags: [
+          {
+            name: "v1.0.0",
+            oid: "c".repeat(40),
+            targetSha: "b".repeat(40),
+            annotated: true,
+            message: "First stable release",
+            tagger: "tagger <tag@x.com>",
+            timestamp: 1_700_000_100,
+            unresolvable: false,
+          },
+          {
+            name: "v0.9.0",
+            oid: "b".repeat(40),
+            targetSha: "b".repeat(40),
+            annotated: false,
+            unresolvable: false,
+          },
+          {
+            name: "ancient",
+            oid: "d".repeat(40),
+            targetSha: null,
+            annotated: false,
+            unresolvable: true,
+          },
+          {
+            // Annotated tag whose TARGET is outside the shallow window: the
+            // intended target sha is known, but the commit itself is missing.
+            name: "deep",
+            oid: "e".repeat(40),
+            targetSha: "a".repeat(40),
+            annotated: true,
+            message: "too deep",
+            unresolvable: true,
+          },
+        ],
+        truncated: false,
+        totalTagCount: 4,
+      },
     })),
   };
 });
@@ -130,10 +134,14 @@ describe("REST GET /api/projects/:namespace/:slug/tags", () => {
       namespace: string;
       slug: string;
       tags: Array<Record<string, unknown>>;
+      truncated: boolean;
+      totalTagCount: number;
     };
     expect(body.namespace).toBe("@owner");
     expect(body.slug).toBe("repo");
     expect(body.tags).toHaveLength(4);
+    expect(body.truncated).toBe(false);
+    expect(body.totalTagCount).toBe(4);
 
     const annotated = body.tags.find((t) => t.name === "v1.0.0");
     expect(annotated?.annotated).toBe(true);
@@ -217,10 +225,39 @@ describe("UI GET /:namespace/:slug/tags", () => {
   it("renders an empty state when the repo has no tags", async () => {
     const env = makeEnv();
     await seedProject(env);
-    vi.mocked(listRepoTags).mockResolvedValueOnce({ success: true, data: [] });
+    vi.mocked(listRepoTags).mockResolvedValueOnce({
+      success: true,
+      data: { tags: [], truncated: false, totalTagCount: 0 },
+    });
     const res = await app.fetch(req("/@owner/repo/tags"), env);
     expect(res.status).toBe(200);
     expect(await res.text()).toContain("No tags yet");
+  });
+
+  it("surfaces truncation when the remote has more tags than the fetch cap", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    vi.mocked(listRepoTags).mockResolvedValueOnce({
+      success: true,
+      data: {
+        tags: [
+          {
+            name: "v1.0.0",
+            oid: "c".repeat(40),
+            targetSha: "b".repeat(40),
+            annotated: false,
+            unresolvable: false,
+          },
+        ],
+        truncated: true,
+        totalTagCount: 600,
+      },
+    });
+    const res = await app.fetch(req("/@owner/repo/tags"), env);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("600");
+    expect(html.toLowerCase()).toContain("not fetched");
   });
 
   it("404s a missing or unreadable project", async () => {


### PR DESCRIPTION
## Summary

`cloneRepo`&#39;s `includeTags` fetch used `singleBranch: false, tags: true`, which requests every advertised branch tip *and* every tag tip — so a project with large branches unrelated to any tag pulled far more data than tag listing/backup needs. `listRepoTags` also had no bound on tag count.

Following the approach sketched in #241:

- Enumerate `refs/tags/*` cheaply via `git.getRemoteInfo` (ref/oid handshake, no object data), filtering out peeled `^{}` advertisement keys, then fetch each tag individually with `singleBranch: true, remoteRef: refs/tags/<name>, tags: true` — pulling only the objects reachable from tags, never unrelated branches. The existing shallow-depth window and the `unresolvable: true` degradation for out-of-window tag targets are unchanged.
- New `MAX_TAGS = 200` cap with explicit (never silent) truncation: a `logger.warn`, plus `tagsTruncated`/`totalTagCount` on the clone result and `truncated`/`totalTagCount` on `listRepoTags`&#39; result — plumbed through the REST route and rendered in the tags UI as a &#34;showing the first N of M tags&#34; notice.
- `collectRepoTags` is unchanged: message/tagger/timestamp for annotated tags still come from the fetched tag objects (which is why a `listServerRefs`-only swap was rejected in the issue).

### Why the cap is 200 and not 500

An earlier revision of this branch used 500; it was lowered deliberately, and the rationale is in the `MAX_TAGS` docstring. One isomorphic-git fetch is **two** Workers subrequests (a `GET /info/refs?service=git-upload-pack`, then a `POST /git-upload-pack`), and the per-tag loop pays that per tag. At 500 the tag walk alone is ~1000 subrequests — plus the clone&#39;s own pair and the `getRemoteInfo` handshake, ~1003 total — right on the ~1000-subrequest cap this codebase budgets against elsewhere (see the note in `src/storage/state.ts:10`). Exceeding it kills the request outright, which is precisely the silent-cliff failure the explicit-truncation design exists to avoid. 200 keeps the tag walk near 400 with room left for the rest of the request, and repos above it degrade *visibly* through `truncated`/`totalTagCount` rather than erroring.

Issue #241 asks for &#34;a `MAX_TAGS` cap on tag *count* with explicit (not silent) truncation reporting&#34; and does not name a number; 200 satisfies it within the platform&#39;s actual budget.

## Related issues

Closes #241

## Type of change

- [x] Bug fix

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` (full suite: 1729 passed, 0 failed)
- [x] `npm run lint`

- New test proves a large untagged branch&#39;s objects are never fetched: a real second in-memory repo plus a real object-graph copy in the `git.fetch` mock, asserting `git.readObject` on the branch&#39;s commit oid fails post-clone while the tag&#39;s target is present (not just call-arg assertions).
- New truncation tests on both `cloneRepo` and `listRepoTags`, plus REST/UI tests for the truncation notice.
- All existing tag behavior (annotated/lightweight, unresolvable degradation, tag-of-tag peeling, backup manifest tags) still covered and passing.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (none affected)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (truncation notice is server-rendered JSX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof)_


## Summary by CodeRabbit

* **New Features**
  * Tag listings now indicate when results are truncated, showing the number displayed and the total available.
  * Repository tag retrieval supports large tag sets while limiting the number fetched for improved reliability.
* **Bug Fixes**
  * Improved tag fetching reliability with clearer handling of individual tag retrieval failures.
* **Tests**
  * Expanded coverage for tag limits, truncation details, empty results, and targeted tag retrieval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tag listings now report when results are limited to 200 tags.
  - The tags page displays the number of loaded tags and the total number detected.
  - Repository tag handling supports hierarchical names and selectively retrieves available tags.

- **Bug Fixes**
  - Improved reliability when retrieving individual tags.
  - Excluded internal peeled references from displayed tag results.

- **Tests**
  - Expanded coverage for tag limits, truncation messaging, hierarchical names, empty results, and retrieval errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->