### PR TITLE
Cap JSON request bodies before parsing (readJsonWithLimit across all JSON routes)

### DIFF
--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -3,9 +3,13 @@ import { createAgent, deleteAgent, getAgent, listAgents } from "../storage/agent
 import { recordAudit } from "../storage/audit";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
 import { badRequest, created, ok } from "../utils/response";
 
 const app = new Hono<{ Bindings: Env }>();
+
+// Agent registration body is a handful of short strings.
+const MAX_AGENT_BODY_BYTES = 1024 * 1024;
 
 app.post("/", async (c) => {
   const logger = createLogger({
@@ -20,12 +24,13 @@ app.post("/", async (c) => {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  const body = await c.req.json<{
+  const body = await readJsonWithLimit<{
     name?: unknown;
     model?: unknown;
     description?: unknown;
     promptHash?: unknown;
-  }>();
+  }>(c, MAX_AGENT_BODY_BYTES, logger);
+  if (body instanceof Response) return body;
   if (typeof body.name !== "string" || !body.name.trim()) {
     logger.warn("Missing or invalid agent name");
     return badRequest("name is required");

--- a/src/routes/bulk-import.ts
+++ b/src/routes/bulk-import.ts
@@ -10,10 +10,14 @@ import { getProjectByPath, setProject } from "../storage/state";
 import type { ArtifactsCreateResult, BulkImportJob, Env, ProjectEntry } from "../types";
 import { getArtifactsRepoName } from "../types";
 import { createLogger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
 import { badRequest, created, forbidden, notFound, ok, unauthorized } from "../utils/response";
 import { isValidNamespace, isValidSlug } from "../utils/validation";
 
 const app = new Hono<{ Bindings: Env }>();
+
+// At most 50 repo entries (enforced below), each a handful of short strings.
+const MAX_BULK_IMPORT_BODY_BYTES = 1024 * 1024;
 
 // In-memory storage for bulk import jobs (should be moved to D1 in production)
 // Key: jobId, Value: BulkImportJob
@@ -252,7 +256,12 @@ app.post("/", async (c) => {
   const username = c.get("username");
   if (!userId || !username) return unauthorized("Authentication required");
 
-  const body = await c.req.json<{ repos?: RepoImportRequest[] }>();
+  const body = await readJsonWithLimit<{ repos?: RepoImportRequest[] }>(
+    c,
+    MAX_BULK_IMPORT_BODY_BYTES,
+    logger,
+  );
+  if (body instanceof Response) return body;
 
   if (!body.repos || !Array.isArray(body.repos)) {
     return badRequest("repos must be an array");

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -50,6 +50,7 @@ import { getWaitUntil } from "../utils/execution-ctx";
 import { newId } from "../utils/ids";
 import { createLogger } from "../utils/logger";
 import type { Logger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
 import {
   appError,
   badRequest,
@@ -62,6 +63,13 @@ import {
 } from "../utils/response";
 
 const app = new Hono<{ Bindings: Env }>();
+
+// Change-creation body is just a workspace name.
+const MAX_CHANGE_CREATE_BODY_BYTES = 1024 * 1024;
+// changeIds is a list of ids, capped post-parse by MAX_MERGE_BATCH.
+const MAX_MERGE_BATCH_BODY_BYTES = 1024 * 1024;
+// GitHub PR promotion body is a handful of short strings.
+const MAX_GITHUB_PR_BODY_BYTES = 1024 * 1024;
 
 // Merge-policy cache (ADR 004). Reading the policy clones the repo; under a swarm
 // of concurrent merges that per-request clone both throttles and de-coalesces the
@@ -240,7 +248,12 @@ app.post("/projects/:name/changes", async (c) => {
     return c.json({ error: "Project is being deleted", code: "TARGET_DELETING" }, 409);
   }
 
-  const body = await c.req.json<{ workspace?: unknown }>().catch(() => ({ workspace: undefined }));
+  const body = await readJsonWithLimit<{ workspace?: unknown }>(
+    c,
+    MAX_CHANGE_CREATE_BODY_BYTES,
+    logger,
+  ).catch(() => ({ workspace: undefined }));
+  if (body instanceof Response) return body;
   if (typeof body.workspace !== "string" || !body.workspace.trim()) {
     return badRequest("workspace is required");
   }
@@ -842,9 +855,12 @@ app.post("/projects/:name/changes/merge-batch", async (c) => {
   if (!(await canWriteProject(c.env.DB, project, userId)))
     return forbidden("Project access denied");
 
-  const body = await c.req
-    .json<{ changeIds?: unknown; force?: unknown }>()
-    .catch(() => ({ changeIds: undefined, force: undefined }));
+  const body = await readJsonWithLimit<{ changeIds?: unknown; force?: unknown }>(
+    c,
+    MAX_MERGE_BATCH_BODY_BYTES,
+    logger,
+  ).catch(() => ({ changeIds: undefined, force: undefined }));
+  if (body instanceof Response) return body;
   if (!Array.isArray(body.changeIds) || body.changeIds.length === 0) {
     return badRequest("changeIds (non-empty array) is required");
   }
@@ -1623,9 +1639,15 @@ app.post("/changes/:id/github-pr", async (c) => {
   }
   const repo = { owner: parsedRepo.info.owner, repo: parsedRepo.info.repo };
 
-  const body = await c.req
-    .json<{ title?: string; body?: string; base?: string; draft?: boolean }>()
-    .catch(() => ({}) as { title?: string; body?: string; base?: string; draft?: boolean });
+  const body = await readJsonWithLimit<{
+    title?: string;
+    body?: string;
+    base?: string;
+    draft?: boolean;
+  }>(c, MAX_GITHUB_PR_BODY_BYTES, logger).catch(
+    () => ({}) as { title?: string; body?: string; base?: string; draft?: boolean },
+  );
+  if (body instanceof Response) return body;
 
   // `base` comes straight from the request body — only a sane branch name may
   // reach the GitHub API. Absent, fall back to the project's known default.

--- a/src/routes/issues.ts
+++ b/src/routes/issues.ts
@@ -36,6 +36,10 @@ const MAX_BODY_LENGTH = 20_000;
 const MAX_ISSUE_BODY_BYTES = 1024 * 1024;
 const MAX_ISSUE_UPDATE_BODY_BYTES = 1024 * 1024;
 const MAX_COMMENT_LENGTH = 20_000;
+// Same reasoning as MAX_ISSUE_BODY_BYTES: MAX_COMMENT_LENGTH truncates only
+// after the parse, so without a cap on the raw read a caller could still make
+// the isolate buffer an arbitrarily large body just to have it thrown away.
+const MAX_COMMENT_BODY_BYTES = 1024 * 1024;
 const MAX_LABEL_LENGTH = 50;
 const MAX_LABELS_PER_ISSUE = 20;
 /** Longest ?q= text the search filter accepts (bounds the LIKE pattern). */
@@ -505,7 +509,11 @@ app.post("/:namespace/:slug/issues/:number/comments", async (c) => {
   let body: { body?: unknown };
   const contentType = c.req.header("content-type") ?? "";
   if (contentType.includes("application/json")) {
-    body = await c.req.json<typeof body>().catch(() => ({}));
+    const parsed = await readJsonWithLimit<typeof body>(c, MAX_COMMENT_BODY_BYTES, logger).catch(
+      () => ({}),
+    );
+    if (parsed instanceof Response) return parsed;
+    body = parsed;
   } else {
     const form = await c.req.parseBody();
     body = { body: form.body };

--- a/src/routes/issues.ts
+++ b/src/routes/issues.ts
@@ -14,6 +14,7 @@ import type { Env, ProjectEntry } from "../types";
 import { canReadProject, canWriteProject } from "../utils/authz";
 import { createLogger } from "../utils/logger";
 import type { Logger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
 import {
   badRequest,
   created,
@@ -28,6 +29,10 @@ const app = new Hono<{ Bindings: Env }>();
 
 const MAX_TITLE_LENGTH = 200;
 const MAX_BODY_LENGTH = 20_000;
+// Issue title/body are short text; cap the raw read well above MAX_BODY_LENGTH
+// (which truncates post-parse) but far under the isolate budget.
+const MAX_ISSUE_BODY_BYTES = 1024 * 1024;
+const MAX_ISSUE_UPDATE_BODY_BYTES = 1024 * 1024;
 
 /** Default + hard cap for the paginated issues listing (bounds the response). */
 const DEFAULT_ISSUES_PAGE = 100;
@@ -94,7 +99,11 @@ app.post("/:namespace/:slug/issues", async (c) => {
   let body: { title?: unknown; body?: unknown; linkedChangeId?: unknown };
   const contentType = c.req.header("content-type") ?? "";
   if (contentType.includes("application/json")) {
-    body = await c.req.json<typeof body>().catch(() => ({}));
+    const parsed = await readJsonWithLimit<typeof body>(c, MAX_ISSUE_BODY_BYTES, logger).catch(
+      () => ({}),
+    );
+    if (parsed instanceof Response) return parsed;
+    body = parsed;
   } else {
     const form = await c.req.parseBody();
     body = { title: form.title, body: form.body, linkedChangeId: form.linkedChangeId };
@@ -250,9 +259,13 @@ app.patch("/:namespace/:slug/issues/:number", async (c) => {
   const number = parseIssueNumber(c.req.param("number"));
   if (number === null) return badRequest("Invalid issue number");
 
-  const body = await c.req
-    .json<{ title?: unknown; body?: unknown; status?: unknown; linkedChangeId?: unknown }>()
-    .catch(() => ({}) as Record<string, unknown>);
+  const body = await readJsonWithLimit<{
+    title?: unknown;
+    body?: unknown;
+    status?: unknown;
+    linkedChangeId?: unknown;
+  }>(c, MAX_ISSUE_UPDATE_BODY_BYTES, logger).catch(() => ({}) as Record<string, unknown>);
+  if (body instanceof Response) return body;
 
   const updates: {
     title?: string;

--- a/src/routes/orgs.ts
+++ b/src/routes/orgs.ts
@@ -19,10 +19,17 @@ import {
 import { getUserByUsername } from "../storage/users";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
 import { badRequest, created, notFound, ok } from "../utils/response";
 import { isValidSlug } from "../utils/validation";
 
 const app = new Hono<{ Bindings: Env }>();
+
+// Org/team management bodies are a handful of short strings.
+const MAX_ORG_BODY_BYTES = 1024 * 1024;
+const MAX_ORG_MEMBER_BODY_BYTES = 1024 * 1024;
+const MAX_TEAM_BODY_BYTES = 1024 * 1024;
+const MAX_TEAM_MEMBER_BODY_BYTES = 1024 * 1024;
 
 app.post("/", async (c) => {
   const userId = c.get("userId");
@@ -33,7 +40,12 @@ app.post("/", async (c) => {
     userId,
   });
 
-  const body = await c.req.json<{ name?: unknown; slug?: unknown }>();
+  const body = await readJsonWithLimit<{ name?: unknown; slug?: unknown }>(
+    c,
+    MAX_ORG_BODY_BYTES,
+    logger,
+  );
+  if (body instanceof Response) return body;
   if (typeof body.name !== "string" || !body.name.trim()) {
     return badRequest("name is required");
   }
@@ -140,7 +152,12 @@ app.post("/:slug/members", async (c) => {
     return c.json({ error: "Forbidden" }, 403);
   }
 
-  const body = await c.req.json<{ userId?: unknown; role?: unknown }>();
+  const body = await readJsonWithLimit<{ userId?: unknown; role?: unknown }>(
+    c,
+    MAX_ORG_MEMBER_BODY_BYTES,
+    logger,
+  );
+  if (body instanceof Response) return body;
   if (typeof body.userId !== "string" || !body.userId.trim()) {
     return badRequest("userId is required");
   }
@@ -219,7 +236,12 @@ app.post("/:slug/teams", async (c) => {
     return c.json({ error: "Forbidden" }, 403);
   }
 
-  const body = await c.req.json<{ name?: unknown; slug?: unknown; permissions?: unknown }>();
+  const body = await readJsonWithLimit<{
+    name?: unknown;
+    slug?: unknown;
+    permissions?: unknown;
+  }>(c, MAX_TEAM_BODY_BYTES, logger);
+  if (body instanceof Response) return body;
   if (typeof body.name !== "string" || !body.name.trim()) {
     return badRequest("name is required");
   }
@@ -363,7 +385,8 @@ app.post("/:slug/teams/:id/members", async (c) => {
     return notFound("Team", id);
   }
 
-  const body = await c.req.json<{ userId?: unknown }>();
+  const body = await readJsonWithLimit<{ userId?: unknown }>(c, MAX_TEAM_MEMBER_BODY_BYTES, logger);
+  if (body instanceof Response) return body;
   if (typeof body.userId !== "string" || !body.userId.trim()) {
     return badRequest("userId is required");
   }

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -78,7 +78,9 @@ const app = new Hono<{ Bindings: Env }>();
 const MAX_PROJECT_CREATE_BODY_BYTES = 1024 * 1024;
 // Import body is a repo URL + a few short fields.
 const MAX_PROJECT_IMPORT_BODY_BYTES = 1024 * 1024;
-// Delete-confirmation body is a single confirm string.
+// Same backstop rationale as MAX_ACCOUNT_DELETE_BODY_BYTES in routes/users.ts:
+// only a short confirmation value is ever read back, so 1 MiB is headroom no
+// legitimate request can reach rather than a limit anyone will meet.
 const MAX_PROJECT_DELETE_BODY_BYTES = 1024 * 1024;
 
 function parseGitHubRepo(url: string): { owner: string; repo: string } | null {

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -44,6 +44,7 @@ import { getFileContent, isValidFilePath } from "../ui/file-content";
 import { canReadProject, filterReadableProjects, isDirectOwner } from "../utils/authz";
 import { createLogger } from "../utils/logger";
 import type { Logger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
 import {
   badRequest,
   created,
@@ -68,6 +69,14 @@ const DEFAULT_FILES: Record<string, string> = {
 };
 
 const app = new Hono<{ Bindings: Env }>();
+
+// Project-create body carries an optional seed file set — no post-parse cap
+// exists today, so this pre-parse ceiling is the only bound on it.
+const MAX_PROJECT_CREATE_BODY_BYTES = 1024 * 1024;
+// Import body is a repo URL + a few short fields.
+const MAX_PROJECT_IMPORT_BODY_BYTES = 1024 * 1024;
+// Delete-confirmation body is a single confirm string.
+const MAX_PROJECT_DELETE_BODY_BYTES = 1024 * 1024;
 
 function parseGitHubRepo(url: string): { owner: string; repo: string } | null {
   const match = url.match(/^https?:\/\/github\.com\/([^/]+)\/([^/\s]+?)(?:\.git|\/)?$/i);
@@ -108,7 +117,9 @@ app.post("/", async (c) => {
   };
   const contentType = c.req.header("content-type") ?? "";
   if (contentType.includes("application/json")) {
-    body = await c.req.json<typeof body>();
+    const parsed = await readJsonWithLimit<typeof body>(c, MAX_PROJECT_CREATE_BODY_BYTES, logger);
+    if (parsed instanceof Response) return parsed;
+    body = parsed;
   } else {
     const form = await c.req.parseBody();
     body = { name: form.name, visibility: form.visibility, seed: form.seed, org: form.org };
@@ -484,7 +495,13 @@ app.post(
       const contentType = c.req.header("content-type") || "";
 
       if (contentType.includes("application/json")) {
-        body = await c.req.json();
+        const parsed = await readJsonWithLimit<typeof body>(
+          c,
+          MAX_PROJECT_IMPORT_BODY_BYTES,
+          logger,
+        );
+        if (parsed instanceof Response) return parsed;
+        body = parsed;
       } else {
         // Form data
         const formData = await c.req.parseBody();
@@ -1901,9 +1918,12 @@ async function handleProjectDelete(c: Context<{ Bindings: Env }>) {
   // Confirm token must EXACTLY equal "@namespace/slug".
   let confirm: unknown;
   if (isJson) {
-    const body = await c.req
-      .json<{ confirm?: unknown }>()
-      .catch(() => ({}) as { confirm?: unknown });
+    const body = await readJsonWithLimit<{ confirm?: unknown }>(
+      c,
+      MAX_PROJECT_DELETE_BODY_BYTES,
+      logger,
+    ).catch(() => ({}) as { confirm?: unknown });
+    if (body instanceof Response) return body;
     confirm = body.confirm;
   } else {
     const form = await c.req.parseBody();

--- a/src/routes/reviews.ts
+++ b/src/routes/reviews.ts
@@ -14,6 +14,7 @@ import type { Change, Env, ProjectEntry } from "../types";
 import { canReadProject, canWriteProject } from "../utils/authz";
 import { createLogger } from "../utils/logger";
 import type { Logger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
 import {
   badRequest,
   created,
@@ -27,6 +28,10 @@ import {
 const app = new Hono<{ Bindings: Env }>();
 
 const MAX_COMMENT_LENGTH = 20_000;
+// Comment/review bodies are short text; cap the raw read well above
+// MAX_COMMENT_LENGTH (which truncates post-parse) but far under the isolate budget.
+const MAX_COMMENT_BODY_BYTES = 1024 * 1024;
+const MAX_REVIEW_BODY_BYTES = 1024 * 1024;
 
 /** Statuses on which a human verdict can still move the change. */
 const REVIEWABLE_STATUSES: Change["status"][] = ["open", "needs_changes", "accepted", "approved"];
@@ -84,7 +89,11 @@ app.post("/changes/:id/comments", async (c) => {
   let body: { body?: unknown };
   const contentType = c.req.header("content-type") ?? "";
   if (contentType.includes("application/json")) {
-    body = await c.req.json<typeof body>().catch(() => ({}));
+    const parsed = await readJsonWithLimit<typeof body>(c, MAX_COMMENT_BODY_BYTES, logger).catch(
+      () => ({}),
+    );
+    if (parsed instanceof Response) return parsed;
+    body = parsed;
   } else {
     const form = await c.req.parseBody();
     body = { body: form.body };
@@ -182,7 +191,11 @@ app.post("/changes/:id/reviews", async (c) => {
   let body: { verdict?: unknown; comment?: unknown };
   const contentType = c.req.header("content-type") ?? "";
   if (contentType.includes("application/json")) {
-    body = await c.req.json<typeof body>().catch(() => ({}));
+    const parsed = await readJsonWithLimit<typeof body>(c, MAX_REVIEW_BODY_BYTES, logger).catch(
+      () => ({}),
+    );
+    if (parsed instanceof Response) return parsed;
+    body = parsed;
   } else {
     const form = await c.req.parseBody();
     body = { verdict: form.verdict, comment: form.comment };

--- a/src/routes/sync-management.ts
+++ b/src/routes/sync-management.ts
@@ -13,9 +13,13 @@ import {
 import type { Env } from "../types";
 import { canWriteProject } from "../utils/authz";
 import { createLogger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
 import { notFound, ok } from "../utils/response";
 
 const app = new Hono<{ Bindings: Env }>();
+
+const MAX_SYNC_SETTINGS_BODY_BYTES = 1024 * 1024;
+const MAX_CONFLICT_RESOLVE_BODY_BYTES = 1024 * 1024;
 
 // Apply auth middleware
 app.use("*", authMiddleware);
@@ -180,10 +184,6 @@ app.post("/projects/:namespace/:slug/sync/settings", async (c) => {
   }
 
   const { namespace, slug } = c.req.param();
-  const body = await c.req.json<{
-    autoSyncEnabled?: boolean;
-    syncFrequency?: number;
-  }>();
 
   const logger = createLogger({
     requestId: crypto.randomUUID(),
@@ -191,6 +191,12 @@ app.post("/projects/:namespace/:slug/sync/settings", async (c) => {
     method: c.req.method,
     userId,
   });
+
+  const body = await readJsonWithLimit<{
+    autoSyncEnabled?: boolean;
+    syncFrequency?: number;
+  }>(c, MAX_SYNC_SETTINGS_BODY_BYTES, logger);
+  if (body instanceof Response) return body;
 
   logger.info("Updating sync settings", {
     namespace,
@@ -457,9 +463,12 @@ app.post("/projects/conflicts/:id/resolve", async (c) => {
     return c.json({ error: "Corrupt conflict context" }, 500);
   }
 
-  const body: { strategy?: unknown; resolutions?: unknown } = await c.req
-    .json<{ strategy?: unknown; resolutions?: unknown }>()
-    .catch(() => ({ strategy: undefined, resolutions: undefined }));
+  const body = await readJsonWithLimit<{ strategy?: unknown; resolutions?: unknown }>(
+    c,
+    MAX_CONFLICT_RESOLVE_BODY_BYTES,
+    logger,
+  ).catch(() => ({ strategy: undefined, resolutions: undefined }));
+  if (body instanceof Response) return body;
 
   const VALID_STRATEGIES = ["accept-project", "accept-workspace", "manual"] as const;
   type Strategy = (typeof VALID_STRATEGIES)[number];

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -11,7 +11,9 @@ import { validateUsername } from "../utils/username-validation";
 
 const app = new Hono<{ Bindings: Env }>();
 
-// Delete-confirmation body is a single confirm string.
+// A backstop against an unbounded read, not a real limit: this route reads back
+// only a short confirmation value, so 1 MiB is already far more headroom than
+// any request matching the route's contract could use.
 const MAX_ACCOUNT_DELETE_BODY_BYTES = 1024 * 1024;
 
 // NOTE: user creation has no API route. Accounts are bootstrapped only through

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -5,10 +5,14 @@ import { createDeletionJob } from "../storage/deletion-jobs";
 import { getUser, getUserByUsername, markUserDeleting, rotateUserToken } from "../storage/users";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
 import { badRequest, internalError, ok } from "../utils/response";
 import { validateUsername } from "../utils/username-validation";
 
 const app = new Hono<{ Bindings: Env }>();
+
+// Delete-confirmation body is a single confirm string.
+const MAX_ACCOUNT_DELETE_BODY_BYTES = 1024 * 1024;
 
 // NOTE: user creation has no API route. Accounts are bootstrapped only through
 // verified flows (`/auth/github`, `/auth/google`, `/auth/email` magic link, and
@@ -102,9 +106,12 @@ async function handleAccountDelete(c: Context<{ Bindings: Env }>): Promise<Respo
   const isJson = c.req.header("content-type")?.includes("application/json") ?? false;
   let confirm: unknown;
   if (isJson) {
-    const body = await c.req
-      .json<{ confirm?: unknown }>()
-      .catch(() => ({}) as { confirm?: unknown });
+    const body = await readJsonWithLimit<{ confirm?: unknown }>(
+      c,
+      MAX_ACCOUNT_DELETE_BODY_BYTES,
+      logger,
+    ).catch(() => ({}) as { confirm?: unknown });
+    if (body instanceof Response) return body;
     confirm = body.confirm;
   } else {
     const form = await c.req.parseBody();

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -15,8 +15,12 @@ import { canWriteProject } from "../utils/authz";
 import { escapeHtml } from "../utils/html";
 import { createLogger } from "../utils/logger";
 import type { Logger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
 import { badRequest, created, forbidden, internalError, notFound, ok } from "../utils/response";
 import { validateWebhookUrl } from "../utils/validation";
+
+// Webhook config body is small (a URL string + an events list).
+const MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -104,7 +108,11 @@ app.post("/:namespace/:slug/webhooks", async (c) => {
   let body: { url?: unknown; events?: unknown };
   const contentType = c.req.header("content-type") ?? "";
   if (contentType.includes("application/json")) {
-    body = await c.req.json<typeof body>().catch(() => ({}));
+    const parsed = await readJsonWithLimit<typeof body>(c, MAX_WEBHOOK_BODY_BYTES, logger).catch(
+      () => ({}),
+    );
+    if (parsed instanceof Response) return parsed;
+    body = parsed;
   } else {
     const form = await c.req.parseBody();
     body = { url: form.url, events: form.events };

--- a/src/routes/workspaces.ts
+++ b/src/routes/workspaces.ts
@@ -22,6 +22,7 @@ import type { Env } from "../types";
 import { getArtifactsRepoName } from "../types";
 import { canReadProject, canWriteProject, canWriteWorkspace } from "../utils/authz";
 import { createLogger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
 import {
   badRequest,
   created,
@@ -38,6 +39,13 @@ const app = new Hono<{ Bindings: Env }>();
 // Commit payload bounds — the commit clones into an in-isolate MemoryFS.
 const MAX_COMMIT_FILES = 2000;
 const MAX_COMMIT_BYTES = 25 * 1024 * 1024;
+// Pre-parse read ceiling: comfortably above the 25 MiB post-parse aggregate
+// (JSON framing — quoting, escaping, keys — inflates the wire size above the
+// raw file bytes) while still well short of the ~128 MB isolate budget once
+// the parsed object graph is accounted for.
+const MAX_COMMIT_BODY_BYTES = 32 * 1024 * 1024;
+// The create-workspace body is just an optional name string.
+const MAX_CREATE_WORKSPACE_BODY_BYTES = 1024 * 1024;
 
 // POST /projects/:namespace/:slug/workspaces - Create a workspace
 app.post("/:namespace/:slug/workspaces", async (c) => {
@@ -74,7 +82,12 @@ app.post("/:namespace/:slug/workspaces", async (c) => {
     return c.json({ error: "Project is being deleted", code: "TARGET_DELETING" }, 409);
   }
 
-  const body = await c.req.json<{ name?: unknown }>().catch(() => ({ name: undefined }));
+  const body = await readJsonWithLimit<{ name?: unknown }>(
+    c,
+    MAX_CREATE_WORKSPACE_BODY_BYTES,
+    logger,
+  ).catch(() => ({ name: undefined }));
+  if (body instanceof Response) return body;
   const workspaceName = isValidSlug(body.name) ? body.name : `ws-${Date.now()}`;
 
   // Get the Artifacts repo using the namespaced name
@@ -197,7 +210,12 @@ app.post("/:name/commit", async (c) => {
 
   const { name: workspaceName } = c.req.param();
 
-  const body = await c.req.json<{ files?: unknown; message?: unknown; projectId?: unknown }>();
+  const body = await readJsonWithLimit<{
+    files?: unknown;
+    message?: unknown;
+    projectId?: unknown;
+  }>(c, MAX_COMMIT_BODY_BYTES, logger);
+  if (body instanceof Response) return body;
   if (!isStringRecord(body.files))
     return badRequest("files must be an object of string paths to string contents");
   if (typeof body.message !== "string" || !body.message.trim())

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -45,6 +45,13 @@ export class ConflictError extends AppError {
   }
 }
 
+export class PayloadTooLargeError extends AppError {
+  constructor(message = "Request body too large") {
+    super(message, "PAYLOAD_TOO_LARGE", 413);
+    this.name = "PayloadTooLargeError";
+  }
+}
+
 export class ExternalServiceError extends AppError {
   constructor(
     service: string,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -45,6 +45,13 @@ export class ConflictError extends AppError {
   }
 }
 
+/**
+ * Exists so an over-cap body can be *thrown* from deep inside a util or storage
+ * layer and still surface as a 413 with its code intact: `handleError` maps any
+ * `AppError` to a coded response, whereas a plain `Error` collapses into a 500
+ * that tells the caller nothing actionable. Routes that already have the
+ * response in hand should prefer `payloadTooLarge()` in `./response`.
+ */
 export class PayloadTooLargeError extends AppError {
   constructor(message = "Request body too large") {
     super(message, "PAYLOAD_TOO_LARGE", 413);

--- a/src/utils/request-body.ts
+++ b/src/utils/request-body.ts
@@ -1,0 +1,84 @@
+import { type Logger, defaultLogger } from "./logger";
+import { payloadTooLarge } from "./response";
+
+/** Minimal shape needed from a Hono context to read + cap a request body. */
+interface BodyLimitedContext {
+  req: {
+    raw: Request;
+    header(name: string): string | undefined;
+  };
+}
+
+/**
+ * Reads a JSON request body while enforcing a byte ceiling *during* the read
+ * (mirrors `readCappedBody` in `src/routes/git-http.ts`), so an oversized
+ * payload is aborted before it is ever fully buffered — a `Content-Length`
+ * that lies (or is simply absent, e.g. chunked transfer-encoding) cannot get
+ * past the cap. A declared `Content-Length` over the ceiling is still used as
+ * a cheap early reject before touching the stream at all.
+ *
+ * Returns the parsed body on success, or a `413` Response (the repo's
+ * standard `{ error, code }` shape) ready to return directly from the route
+ * handler:
+ *
+ * ```ts
+ * const body = await readJsonWithLimit<{ files?: unknown }>(c, MAX_BYTES);
+ * if (body instanceof Response) return body;
+ * ```
+ *
+ * Malformed JSON within the cap still throws, exactly like `c.req.json()`
+ * would — callers that already wrap the call in `.catch(() => ({}))` keep
+ * that fallback behavior unchanged.
+ */
+export async function readJsonWithLimit<T>(
+  c: BodyLimitedContext,
+  maxBytes: number,
+  logger?: Logger,
+): Promise<T | Response> {
+  const log = logger ?? defaultLogger;
+
+  // Cheap early reject when the client declares a length outright — saves
+  // spinning up the reader for an obviously oversized request. This is a
+  // fast path only: an absent or understated Content-Length falls through to
+  // the streaming cap below, which is the actual enforcement.
+  const declaredLength = c.req.header("content-length");
+  if (declaredLength !== undefined) {
+    const declared = Number(declaredLength);
+    if (Number.isFinite(declared) && declared > maxBytes) {
+      log.warn("request body exceeds cap (Content-Length)", { cap: maxBytes, declared });
+      return payloadTooLarge(`request body too large (max ${maxBytes} bytes)`);
+    }
+  }
+
+  const stream = c.req.raw.body;
+  if (!stream) {
+    // No body at all — let JSON.parse raise the same "Unexpected end of JSON
+    // input" that `c.req.json()` would on an empty body.
+    return JSON.parse("") as T;
+  }
+
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      log.warn("request body exceeds cap", { cap: maxBytes });
+      return payloadTooLarge(`request body too large (max ${maxBytes} bytes)`);
+    }
+    chunks.push(value);
+  }
+
+  const buffer = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  const text = new TextDecoder().decode(buffer);
+  return JSON.parse(text) as T;
+}

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -37,6 +37,15 @@ export function internalError(message: string): Response {
   return error(message, 500);
 }
 
+/**
+ * Unlike its sibling helpers above, this one routes through `appError` so the
+ * response carries a machine-readable `code` alongside the message. That
+ * matters more here than for the others: a 413 from `readJsonWithLimit` is
+ * emitted mid-read, before any route handler has run, so the client gets no
+ * route-specific context to interpret it by. The code is the only stable signal
+ * telling a caller to retry with a smaller payload rather than treat the
+ * failure as a generic 4xx and give up (or worse, retry unchanged).
+ */
 export function payloadTooLarge(message: string): Response {
   return appError(new PayloadTooLargeError(message));
 }

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,5 +1,12 @@
 import type { ApiError } from "../types";
-import { AppError, AuthError, ForbiddenError, NotFoundError, ValidationError } from "./errors";
+import {
+  AppError,
+  AuthError,
+  ForbiddenError,
+  NotFoundError,
+  PayloadTooLargeError,
+  ValidationError,
+} from "./errors";
 import type { Logger } from "./logger";
 
 export function ok<T>(data: T, status = 200): Response {
@@ -28,6 +35,10 @@ export function forbidden(message: string): Response {
 
 export function internalError(message: string): Response {
   return error(message, 500);
+}
+
+export function payloadTooLarge(message: string): Response {
+  return appError(new PayloadTooLargeError(message));
 }
 
 /**

--- a/tests/issues-comment-body-limit.test.ts
+++ b/tests/issues-comment-body-limit.test.ts
@@ -29,6 +29,12 @@ const ISSUES_API = "/api/projects/testns/my-project/issues";
 /** Route-level cap in src/routes/issues.ts (MAX_COMMENT_BODY_BYTES). */
 const COMMENT_CAP_BYTES = 1024 * 1024;
 
+/**
+ * Builds the app over a real SQLite D1 with a real user, project and issue, so
+ * the request reaches the body-parse step through the genuine auth and lookup
+ * path. Stubbing those out would let a 401 or 404 masquerade as the 413 this
+ * file is meant to pin down.
+ */
 async function makeApp() {
   const { db, raw } = makeSqliteD1();
   const now = "2026-01-01T00:00:00.000Z";

--- a/tests/issues-comment-body-limit.test.ts
+++ b/tests/issues-comment-body-limit.test.ts
@@ -1,0 +1,171 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authMiddleware } from "../src/middleware/auth";
+import { issuesRouter } from "../src/routes/issues";
+import type { Env, ProjectEntry } from "../src/types";
+import { hashToken } from "../src/utils/crypto";
+import { makeFakeKV } from "./helpers/fake-kv";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
+
+// Same stubbing approach as workspaces-commit-body-limit.test.ts: everything up
+// to the body read is exercised for real (auth, project load, issue lookup) and
+// only the write is stubbed, so `addIssueComment` not being called is proof the
+// request died at the cap rather than somewhere downstream.
+vi.mock("../src/storage/issue-comments", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/issue-comments")>();
+  return {
+    ...actual,
+    addIssueComment: vi.fn(actual.addIssueComment),
+  };
+});
+
+import { addIssueComment } from "../src/storage/issue-comments";
+
+const OWNER_TOKEN = "stratum_user_ownertoken0000000000000000";
+const OWNER_AUTH = { Authorization: `Bearer ${OWNER_TOKEN}` };
+const PROJECT_ID = "proj_body_limit";
+const ISSUES_API = "/api/projects/testns/my-project/issues";
+
+/** Route-level cap in src/routes/issues.ts (MAX_COMMENT_BODY_BYTES). */
+const COMMENT_CAP_BYTES = 1024 * 1024;
+
+async function makeApp() {
+  const { db, raw } = makeSqliteD1();
+  const now = "2026-01-01T00:00:00.000Z";
+  raw
+    .prepare(
+      "INSERT INTO users (id, email, username, token_hash, created_at) VALUES (?, ?, ?, ?, ?)",
+    )
+    .run("user_owner", "owner@example.com", "owner", await hashToken(OWNER_TOKEN), now);
+
+  const project = {
+    id: PROJECT_ID,
+    name: "my-project",
+    slug: "my-project",
+    namespace: "testns",
+    ownerId: "user_owner",
+    ownerType: "user",
+    remote: "https://artifacts.example.com/repos/my-project",
+    createdAt: now,
+    visibility: "private",
+  } as ProjectEntry;
+  const kv = makeFakeKV();
+  await kv.put("project:testns:my-project", JSON.stringify(project));
+
+  const env = { DB: db, STATE: kv } as unknown as Env;
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", authMiddleware);
+  app.route("/api/projects", issuesRouter);
+
+  const openIssue = async () => {
+    const res = await app.fetch(
+      new Request(`http://localhost${ISSUES_API}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...OWNER_AUTH },
+        body: JSON.stringify({ title: "Something is broken" }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(201);
+    const parsed = (await res.json()) as { issue: { number: number } };
+    return parsed.issue.number;
+  };
+
+  return { app, env, openIssue };
+}
+
+/**
+ * Streams `totalBytes` of filler in 64 KiB chunks, deliberately WITHOUT a
+ * Content-Length header — the "chunked / unknown length" case that only the
+ * streaming cap can catch, since the cheap declared-length pre-check has
+ * nothing to look at.
+ */
+function streamingCommentRequest(issueNumber: number, totalBytes: number): Request {
+  const chunkSize = 64 * 1024;
+  let sent = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent >= totalBytes) {
+        controller.close();
+        return;
+      }
+      const n = Math.min(chunkSize, totalBytes - sent);
+      controller.enqueue(new Uint8Array(n).fill(120)); // 'x' filler, deliberately not valid JSON
+      sent += n;
+    },
+  });
+  return new Request(`http://localhost${ISSUES_API}/${issueNumber}/comments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...OWNER_AUTH },
+    body,
+    duplex: "half",
+  } as RequestInit);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/projects/:ns/:slug/issues/:number/comments — pre-parse body-size cap (issue #264)", () => {
+  it("rejects a body over the 1 MiB pre-parse cap with 413 before parsing — even with no Content-Length header", async () => {
+    const { app, env, openIssue } = await makeApp();
+    const number = await openIssue();
+    vi.mocked(addIssueComment).mockClear();
+
+    const req = streamingCommentRequest(number, COMMENT_CAP_BYTES + 64 * 1024);
+    expect(req.headers.get("content-length")).toBeNull();
+
+    const res = await app.fetch(req, env);
+
+    expect(res.status).toBe(413);
+    expect(await res.json()).toMatchObject({ code: "PAYLOAD_TOO_LARGE" });
+    // The filler is not valid JSON, so an uncapped read would fall into the
+    // route's `.catch(() => ({}))` and answer 400 "body is required" — a 400
+    // here means the body was fully buffered and parsed after all.
+    expect(vi.mocked(addIssueComment)).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it("rejects an oversized body on the declared-Content-Length fast path with 413", async () => {
+    const { app, env, openIssue } = await makeApp();
+    const number = await openIssue();
+    vi.mocked(addIssueComment).mockClear();
+
+    // `new Request(...)` does not populate Content-Length itself, so set it
+    // explicitly — otherwise this would silently retest the streaming path.
+    const payload = JSON.stringify({ body: "x".repeat(COMMENT_CAP_BYTES + 1024) });
+    const req = new Request(`http://localhost${ISSUES_API}/${number}/comments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": String(new TextEncoder().encode(payload).byteLength),
+        ...OWNER_AUTH,
+      },
+      body: payload,
+    });
+    expect(req.headers.get("content-length")).not.toBeNull();
+
+    const res = await app.fetch(req, env);
+
+    expect(res.status).toBe(413);
+    expect(await res.json()).toMatchObject({ code: "PAYLOAD_TOO_LARGE" });
+    expect(vi.mocked(addIssueComment)).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it("a normal comment body well under the cap still succeeds", async () => {
+    const { app, env, openIssue } = await makeApp();
+    const number = await openIssue();
+    vi.mocked(addIssueComment).mockClear();
+
+    const res = await app.fetch(
+      new Request(`http://localhost${ISSUES_API}/${number}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...OWNER_AUTH },
+        body: JSON.stringify({ body: "looks fine to me" }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(201);
+    expect(vi.mocked(addIssueComment)).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/request-body.test.ts
+++ b/tests/request-body.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { readJsonWithLimit } from "../src/utils/request-body";
+
+function ctxFor(request: Request) {
+  return {
+    req: {
+      raw: request,
+      header: (name: string) => request.headers.get(name) ?? undefined,
+    },
+  };
+}
+
+/** A stream that yields the given chunks one at a time via `pull`. */
+function streamFromChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(chunks[i]);
+        i++;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function requestWithStream(chunks: Uint8Array[], opts: { contentLength?: number } = {}): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (opts.contentLength !== undefined) {
+    headers.set("content-length", String(opts.contentLength));
+  }
+  return new Request("http://localhost/test", {
+    method: "POST",
+    headers,
+    body: streamFromChunks(chunks),
+    // Node's fetch requires this for a streaming request body.
+    duplex: "half",
+  } as RequestInit);
+}
+
+const enc = (s: string) => new TextEncoder().encode(s);
+
+describe("readJsonWithLimit", () => {
+  it("rejects a declared Content-Length over the cap with 413, without ever reading the stream", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(enc('{"a":1}'));
+        controller.close();
+      },
+    });
+    const req = new Request("http://localhost/test", {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": "1000" },
+      body: stream,
+      duplex: "half",
+    } as RequestInit);
+
+    const result = await readJsonWithLimit(ctxFor(req), 100);
+
+    expect(result).toBeInstanceOf(Response);
+    const res = result as Response;
+    expect(res.status).toBe(413);
+    // getReader() locks the stream — the fast Content-Length path must never
+    // acquire a reader at all, so the underlying stream stays unlocked.
+    expect(req.body?.locked).toBe(false);
+  });
+
+  it("caps a body with NO Content-Length while streaming, and never parses it", async () => {
+    // Well over the 10-byte cap, and not valid JSON — if the parse ran anyway
+    // it would throw a SyntaxError instead of resolving to a 413 Response.
+    const chunks = [enc("x".repeat(30)), enc("NOT VALID JSON")];
+    const req = requestWithStream(chunks);
+    expect(req.headers.get("content-length")).toBeNull();
+
+    const result = await readJsonWithLimit(ctxFor(req), 10);
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(413);
+  });
+
+  it("does not trust an understated Content-Length — the streaming cap still catches an actually-oversized body", async () => {
+    const chunks = [enc("x".repeat(1000))];
+    const req = requestWithStream(chunks, { contentLength: 5 }); // lies small
+    const result = await readJsonWithLimit(ctxFor(req), 10);
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(413);
+  });
+
+  it("the 413 response uses the repo's standard error shape and a PAYLOAD_TOO_LARGE code", async () => {
+    const chunks = [enc("x".repeat(50))];
+    const req = requestWithStream(chunks, { contentLength: 50 });
+    const result = await readJsonWithLimit(ctxFor(req), 10);
+
+    expect(result).toBeInstanceOf(Response);
+    const res = result as Response;
+    expect(res.status).toBe(413);
+    const json = await res.json();
+    expect(json).toEqual({ error: expect.any(String), code: "PAYLOAD_TOO_LARGE" });
+  });
+
+  it("parses a body right at the cap", async () => {
+    const payload = JSON.stringify({ ok: true, pad: "y".repeat(50) });
+    const bytes = enc(payload);
+    const req = requestWithStream([bytes], { contentLength: bytes.byteLength });
+
+    const result = await readJsonWithLimit<{ ok: boolean }>(ctxFor(req), bytes.byteLength);
+
+    expect(result).not.toBeInstanceOf(Response);
+    expect((result as { ok: boolean }).ok).toBe(true);
+  });
+
+  it("rejects a body one byte over a tight cap", async () => {
+    const bytes = enc(JSON.stringify({ ok: true }));
+    const req = requestWithStream([bytes], { contentLength: bytes.byteLength });
+
+    const result = await readJsonWithLimit(ctxFor(req), bytes.byteLength - 1);
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(413);
+  });
+
+  it("still throws on malformed JSON within the cap, matching plain c.req.json() — callers that .catch() it keep that fallback", async () => {
+    const bytes = enc("{not valid json");
+    const req = requestWithStream([bytes], { contentLength: bytes.byteLength });
+
+    await expect(readJsonWithLimit(ctxFor(req), 1024)).rejects.toThrow();
+  });
+
+  it("parses normally when there is no body-size concern at all", async () => {
+    const bytes = enc(JSON.stringify({ hello: "world" }));
+    const req = requestWithStream([bytes], { contentLength: bytes.byteLength });
+
+    const result = await readJsonWithLimit<{ hello: string }>(ctxFor(req), 1024 * 1024);
+
+    expect(result).toEqual({ hello: "world" });
+  });
+});

--- a/tests/request-body.test.ts
+++ b/tests/request-body.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { readJsonWithLimit } from "../src/utils/request-body";
 
+/**
+ * `readJsonWithLimit` takes a structural `BodyLimitedContext` rather than a real
+ * Hono `Context` specifically so it can be driven from a bare Request; this is
+ * the seam that buys us. Testing through a live Hono app instead would put
+ * routing and middleware between the assertion and the cap, and could not
+ * produce the malformed headers several cases below depend on.
+ */
 function ctxFor(request: Request) {
   return {
     req: {
@@ -10,7 +17,13 @@ function ctxFor(request: Request) {
   };
 }
 
-/** A stream that yields the given chunks one at a time via `pull`. */
+/**
+ * Hands the body over one chunk per `pull` rather than as a single buffer, so
+ * the reader has to accumulate across iterations. That incremental delivery is
+ * what puts the *streaming* cap under test: a body handed over whole would be
+ * caught (or missed) by the declared-Content-Length pre-check instead, and the
+ * mid-read abort these tests exist to pin down would never run.
+ */
 function streamFromChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
   let i = 0;
   return new ReadableStream({
@@ -25,6 +38,14 @@ function streamFromChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
   });
 }
 
+/**
+ * Takes `contentLength` independently of the bytes actually enqueued, on
+ * purpose: the cap has two enforcement paths that disagree exactly when the
+ * header lies, so the tests need to set the declared length to something other
+ * than the truth — understated, overstated, or absent — to pin down which path
+ * fired. Deriving the header from the chunks would make those cases impossible
+ * to express.
+ */
 function requestWithStream(chunks: Uint8Array[], opts: { contentLength?: number } = {}): Request {
   const headers = new Headers({ "content-type": "application/json" });
   if (opts.contentLength !== undefined) {

--- a/tests/workspaces-commit-body-limit.test.ts
+++ b/tests/workspaces-commit-body-limit.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../src/index";
+import type { Env, ProjectEntry } from "../src/types";
+
+// Same stubbing approach as workspaces-authz.test.ts: the commit path clones +
+// pushes via git-ops, which we don't want to exercise here — we only need to
+// prove the pre-parse body cap rejects an oversized commit BEFORE any of that
+// runs (and before the body is ever fully parsed).
+vi.mock("../src/storage/git-ops", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/git-ops")>();
+  return {
+    ...actual,
+    freshRepoToken: vi.fn(async () => ({ success: true, data: "secret?expires=9999999999" })),
+    cloneRepo: vi.fn(async () => ({ success: true, data: { fs: {}, dir: "/tmp/x" } })),
+    commitAndPush: vi.fn(async () => ({ success: true, data: "abc123" })),
+    stageWorkspaceTree: vi.fn(async () => ({ success: false, error: { message: "skip" } })),
+  };
+});
+
+const OWNER_TOKEN = "stratum_user_owner000000000000000000";
+
+vi.mock("../src/storage/users", () => ({
+  getUserByToken: vi.fn(async (_db: unknown, token: string) => {
+    if (token === OWNER_TOKEN)
+      return { success: true, data: { id: "user_owner", email: "o@x.io", username: "owner" } };
+    return { success: false, error: { message: "not found" } };
+  }),
+  getUser: vi.fn(async () => ({ success: false, error: { message: "not found" } })),
+}));
+
+import { commitAndPush } from "../src/storage/git-ops";
+
+const ARTIFACTS_REMOTE = "https://acct.artifacts.cloudflare.net/git/@owner/repo.git";
+const WS_REMOTE = "https://acct.artifacts.cloudflare.net/git/@owner/myws.git";
+
+function makeKV(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    list: async ({ prefix }: { prefix?: string } = {}) => ({
+      keys: [...store.keys()]
+        .filter((k) => (prefix ? k.startsWith(prefix) : true))
+        .map((name) => ({ name })),
+      list_complete: true,
+      cacheStatus: null,
+    }),
+  } as unknown as KVNamespace;
+}
+
+function makeEnv(): Env {
+  return {
+    ARTIFACTS: {} as Env["ARTIFACTS"],
+    STATE: makeKV(),
+    DB: {} as D1Database,
+  } as Env;
+}
+
+async function seed(env: Env): Promise<void> {
+  const project: ProjectEntry = {
+    id: "proj_1",
+    name: "repo",
+    slug: "repo",
+    namespace: "@owner",
+    ownerId: "user_owner",
+    ownerType: "user",
+    remote: ARTIFACTS_REMOTE,
+    createdAt: new Date().toISOString(),
+    visibility: "private",
+  };
+  await env.STATE.put(`project:${project.namespace}:${project.slug}`, JSON.stringify(project));
+  await env.STATE.put(
+    "workspace:proj_1:myws",
+    JSON.stringify({
+      name: "myws",
+      remote: WS_REMOTE,
+      parent: "proj_1",
+      createdAt: new Date().toISOString(),
+      createdByUserId: "user_owner",
+    }),
+  );
+}
+
+/**
+ * Streams `totalBytes` of filler in 1 MiB chunks, deliberately WITHOUT a
+ * Content-Length header — this is the "chunked / unknown length" case the
+ * streaming cap exists for, as opposed to the cheap declared-length pre-check.
+ */
+function streamingCommitRequest(totalBytes: number): Request {
+  const chunkSize = 1024 * 1024;
+  let sent = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent >= totalBytes) {
+        controller.close();
+        return;
+      }
+      const n = Math.min(chunkSize, totalBytes - sent);
+      controller.enqueue(new Uint8Array(n).fill(120)); // 'x' filler, deliberately not valid JSON
+      sent += n;
+    },
+  });
+  return new Request("http://localhost/api/workspaces/myws/commit", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${OWNER_TOKEN}`, "Content-Type": "application/json" },
+    body,
+    duplex: "half",
+  } as RequestInit);
+}
+
+function smallCommitRequest(): Request {
+  return new Request("http://localhost/api/workspaces/myws/commit", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${OWNER_TOKEN}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ projectId: "proj_1", message: "m", files: { "a.txt": "hi" } }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/workspaces/:name/commit — pre-parse body-size cap (issue #264)", () => {
+  it("rejects a body over the 32 MiB pre-parse cap with 413 before any git work — even with no Content-Length header", async () => {
+    const env = makeEnv();
+    await seed(env);
+    const req = streamingCommitRequest(33 * 1024 * 1024);
+    expect(req.headers.get("content-length")).toBeNull();
+
+    const res = await app.fetch(req, env);
+
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body).toMatchObject({ code: "PAYLOAD_TOO_LARGE" });
+    // The body is neither valid JSON (parse would throw) nor a real commit
+    // payload — reaching commitAndPush would mean the cap didn't fire.
+    expect(vi.mocked(commitAndPush)).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it("a normal commit body well under the cap still succeeds", async () => {
+    const env = makeEnv();
+    await seed(env);
+    const res = await app.fetch(smallCommitRequest(), env);
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(commitAndPush)).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/workspaces-commit-body-limit.test.ts
+++ b/tests/workspaces-commit-body-limit.test.ts
@@ -33,6 +33,11 @@ import { commitAndPush } from "../src/storage/git-ops";
 const ARTIFACTS_REMOTE = "https://acct.artifacts.cloudflare.net/git/@owner/repo.git";
 const WS_REMOTE = "https://acct.artifacts.cloudflare.net/git/@owner/myws.git";
 
+/**
+ * The commit route resolves the project and workspace through KV before it
+ * ever looks at the body, so the test needs that lookup to succeed — otherwise
+ * a 404 would pass for a "rejection" and the cap would go untested.
+ */
 function makeKV(): KVNamespace {
   const store = new Map<string, string>();
   return {
@@ -53,6 +58,12 @@ function makeKV(): KVNamespace {
   } as unknown as KVNamespace;
 }
 
+/**
+ * Supplies only the binding the pre-parse path actually reads. `ARTIFACTS` and
+ * `DB` are left as bare objects on purpose: the cap must reject before either
+ * is touched, so a test that somehow reached them would throw rather than
+ * quietly pass.
+ */
 function makeEnv(): Env {
   return {
     ARTIFACTS: {} as Env["ARTIFACTS"],
@@ -61,6 +72,11 @@ function makeEnv(): Env {
   } as Env;
 }
 
+/**
+ * Puts the route one step away from parsing: a real project and workspace the
+ * owner can reach, so the only thing left to fail is the body size. Without
+ * this the request dies at lookup and proves nothing about the limit.
+ */
 async function seed(env: Env): Promise<void> {
   const project: ProjectEntry = {
     id: "00000000-0000-4000-8000-000000000001",
@@ -113,6 +129,8 @@ function streamingCommitRequest(totalBytes: number): Request {
   } as RequestInit);
 }
 
+/** The control case: proves the cap rejects oversized bodies without also
+ * breaking an ordinary commit, which a too-eager guard easily would. */
 function smallCommitRequest(): Request {
   return new Request("http://localhost/api/workspaces/myws/commit", {
     method: "POST",

--- a/tests/workspaces-commit-body-limit.test.ts
+++ b/tests/workspaces-commit-body-limit.test.ts
@@ -34,9 +34,11 @@ const ARTIFACTS_REMOTE = "https://acct.artifacts.cloudflare.net/git/@owner/repo.
 const WS_REMOTE = "https://acct.artifacts.cloudflare.net/git/@owner/myws.git";
 
 /**
- * The commit route resolves the project and workspace through KV before it
- * ever looks at the body, so the test needs that lookup to succeed — otherwise
- * a 404 would pass for a "rejection" and the cap would go untested.
+ * Backs the workspace/project lookups the commit route performs *after* the
+ * body cap (`readJsonWithLimit` runs first, at workspaces.ts:229; `getWorkspace`
+ * and `getProjectById` follow at 283 and 305). The oversized cases never reach
+ * KV at all — this exists so the under-cap control case can get past lookup and
+ * prove the guard does not break an ordinary commit.
  */
 function makeKV(): KVNamespace {
   const store = new Map<string, string>();
@@ -73,9 +75,9 @@ function makeEnv(): Env {
 }
 
 /**
- * Puts the route one step away from parsing: a real project and workspace the
- * owner can reach, so the only thing left to fail is the body size. Without
- * this the request dies at lookup and proves nothing about the limit.
+ * Seeds the project and workspace the under-cap control case needs to succeed.
+ * The oversized cases do not depend on it: the cap rejects before the route
+ * ever looks either up, which is the ordering that makes the guard cheap.
  */
 async function seed(env: Env): Promise<void> {
   const project: ProjectEntry = {


### PR DESCRIPTION
## Summary

Every JSON route parsed the full request body before any size limit applied — the workspace-commit route's post-parse caps (2000 files, 10 MiB/file, 25 MiB aggregate) only ran after a potentially 400 MB body was already fully materialized in the isolate.

This adds a shared `readJsonWithLimit(c, maxBytes)` helper (`src/utils/request-body.ts`) that streams the body and aborts once bytes read exceed the cap, mirroring the bounded-read pattern the git-receive-pack path already uses in `src/routes/git-http.ts`. A declared `Content-Length` over the cap is a cheap early reject, but enforcement never trusts it — absent or understated lengths are caught mid-stream.

- Workspace commit route: 32 MiB ceiling (`MAX_COMMIT_BODY_BYTES`, above its 25 MiB post-parse aggregate).
- Every other `c.req.json()` call site (22 across 10 route files): 1 MiB default, each as its own named constant.
- New `PayloadTooLargeError` (413, `PAYLOAD_TOO_LARGE`) in the existing `AppError` taxonomy, with a `payloadTooLarge()` response helper producing the standard `{ error, code }` shape.
- No post-parse validation logic changed. Malformed JSON within the cap still throws exactly like `c.req.json()`, so existing `.catch(() => ({}))` call sites behave identically.

Note: this sweeps many route files, so it will conflict textually (small, mechanical) with in-flight PRs touching the same routes (e.g. #216).

## Related issues

Closes #264

## Type of change

- [x] Bug fix

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` (full suite: 1733 passed, no regressions)
- [x] `npm run lint`

- New `tests/request-body.test.ts` (8 tests): declared Content-Length over cap rejects before the stream is read (asserted via `stream.locked`); no-Content-Length body still capped mid-stream and never parsed; understated Content-Length doesn't bypass the cap; 413 body shape; exact-boundary cases; malformed-JSON-within-cap still throws.
- New `tests/workspaces-commit-body-limit.test.ts`: a 33 MiB streamed body with no Content-Length hits the real 32 MiB route ceiling → 413 and `commitAndPush` never runs; a normal small commit still succeeds.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (none affected)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added request-body size limits across API operations to prevent oversized requests from being processed.
  * Oversized payloads now receive consistent HTTP 413 responses with a machine-readable error code.
  * Supports payloads up to 32 MiB for workspace commits and conflict resolution while maintaining smaller limits elsewhere.

* **Tests**
  * Added coverage for streaming requests, size boundaries, malformed JSON, and normal parsing.
  * Added integration tests confirming oversized requests are rejected before processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->