### PR TITLE
Promotion: pin the published sha to change.evaluatedSha and migrate PR creation onto GitHubClient

### DIFF
--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -14,6 +14,20 @@ const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
 const MAX_DELAY_MS = 32000;
 
+/**
+ * Bound on a single GitHub subrequest so one slow response can't hold a
+ * Worker invocation open until the platform's own subrequest limit kills it.
+ * Callers that also retry (the private `request()` method's `maxRetries`)
+ * get a FRESH timeout per attempt, not one deadline shared across the whole
+ * call — the
+ * worst case wall time for a retried request is therefore roughly
+ * `attempts × timeoutMs` plus backoff sleeps between attempts, not
+ * `timeoutMs` total. A caller that needs a hard ceiling on total latency
+ * (e.g. a request lifecycle bound) should pass `maxRetries: 0` alongside the
+ * timeout rather than relying on the timeout alone to cap retries.
+ */
+const DEFAULT_TIMEOUT_MS = 15_000;
+
 export interface GitHubToken {
   accessToken: string;
   refreshToken?: string;
@@ -37,6 +51,61 @@ export interface CreatePROpts {
   body: string;
   head: string;
   base: string;
+  /** Opens the PR as a draft. Defaults to GitHub's own default (false) when omitted. */
+  draft?: boolean;
+}
+
+/** Result of {@link GitHubClient.createOrReusePR}. */
+export type CreateOrReusePRResult =
+  | { success: true; pr: unknown; reused: boolean; status: number }
+  | {
+      success: false;
+      /** `true` when the request itself failed (network error/timeout) — no
+       * GitHub response was received, so `status`/`githubMessage`/`errors`
+       * describe nothing GitHub actually said. */
+      networkError: boolean;
+      status: number;
+      githubMessage?: string;
+      errors: GithubErrorDetail[];
+    };
+
+/** One entry of GitHub's `errors` array, as far as this client relies on it. */
+export interface GithubErrorDetail {
+  message?: string;
+  code?: string;
+  field?: string;
+}
+
+/** Narrows one element of an untrusted `errors` array before it is read. */
+function isGithubErrorDetail(value: unknown): value is GithubErrorDetail {
+  if (typeof value !== "object" || value === null) return false;
+  const detail = value as Record<string, unknown>;
+  return (["message", "code", "field"] as const).every(
+    (key) => detail[key] === undefined || typeof detail[key] === "string",
+  );
+}
+
+/**
+ * Parses a GitHub error response body into its documented `message` +
+ * `errors[]` shape, tolerating anything else GitHub might actually send.
+ * GitHub is not guaranteed to send the documented shape on every failure —
+ * `{"errors":{}}`, `{"errors":"invalid"}`, `{"errors":[null]}`, and a
+ * non-JSON body all reach naive `.map()`/property access otherwise.
+ */
+function parseGithubErrorBody(text: string): { message?: string; errors: GithubErrorDetail[] } {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    const body = (typeof parsed === "object" && parsed !== null ? parsed : {}) as {
+      message?: unknown;
+      errors?: unknown;
+    };
+    return {
+      message: typeof body.message === "string" ? body.message : undefined,
+      errors: Array.isArray(body.errors) ? body.errors.filter(isGithubErrorDetail) : [],
+    };
+  } catch {
+    return { errors: [] };
+  }
 }
 
 export interface UpdatePROpts {
@@ -75,6 +144,17 @@ interface CircuitBreakerState {
 const circuitBreakers = new Map<string, CircuitBreakerState>();
 const CIRCUIT_BREAKER_THRESHOLD = 5;
 const CIRCUIT_BREAKER_TIMEOUT_MS = 60000;
+
+/**
+ * Test-only escape hatch: this module-level state is shared by every
+ * `GitHubClient` instance (and persists for the lifetime of the module), so a
+ * test file that exercises several failing calls against the same
+ * owner/repo can otherwise trip the breaker and starve later, unrelated
+ * assertions in the same run. Not for production use.
+ */
+export function resetCircuitBreakersForTests(): void {
+  circuitBreakers.clear();
+}
 
 function isCircuitOpen(endpoint: string): boolean {
   const key = endpoint.split("/").slice(0, 3).join("/");
@@ -209,14 +289,40 @@ export class GitHubClient {
     this.logger = logger;
   }
 
+  /**
+   * Issues one GitHub API call, with retry/backoff, rate-limit handling, and
+   * the circuit breaker applying by default.
+   *
+   * `maxRetries` and `timeoutMs` are opt-in per call (existing callers that
+   * don't pass them keep exactly the prior behavior: `MAX_RETRIES` retries,
+   * no deadline). Passing `timeoutMs` bounds a single attempt, not the whole
+   * call — see the {@link DEFAULT_TIMEOUT_MS} doc comment for how that
+   * combines with retries. A caller that wants a single bounded attempt
+   * (no automatic retry) should pass `maxRetries: 0` explicitly — e.g. PR
+   * creation is not safe to blindly retry on a network-level failure, since
+   * the client can't tell whether GitHub received the request before the
+   * connection dropped (see `createOrReusePR`, which relies on the
+   * duplicate-head 422 to detect that case instead).
+   */
   private async request<T>(
     endpoint: string,
     options: RequestInit = {},
-    retryCount = 0,
+    requestOpts: { maxRetries?: number; timeoutMs?: number; retryCount?: number } = {},
   ): Promise<
-    | { success: true; data: T }
-    | { success: false; error: string; status: number; rateLimited?: boolean }
+    | { success: true; data: T; status: number }
+    | {
+        success: false;
+        error: string;
+        status: number;
+        rateLimited?: boolean;
+        networkError?: boolean;
+        githubMessage?: string;
+        errors?: GithubErrorDetail[];
+      }
   > {
+    const maxRetries = requestOpts.maxRetries ?? MAX_RETRIES;
+    const retryCount = requestOpts.retryCount ?? 0;
+
     if (isCircuitOpen(endpoint)) {
       return {
         success: false,
@@ -226,9 +332,19 @@ export class GitHubClient {
     }
 
     const url = `${GITHUB_API_BASE}${endpoint}`;
+    // A fresh timeout signal per attempt: a retried call gets the full
+    // `timeoutMs` again on each try, not a shrinking remainder of one shared
+    // deadline (see the doc comment above).
+    const timeoutSignal =
+      requestOpts.timeoutMs !== undefined ? AbortSignal.timeout(requestOpts.timeoutMs) : undefined;
+    const signal =
+      options.signal && timeoutSignal
+        ? AbortSignal.any([options.signal, timeoutSignal])
+        : (options.signal ?? timeoutSignal);
     try {
       const response = await fetch(url, {
         ...options,
+        signal,
         headers: {
           Authorization: `Bearer ${this.token}`,
           Accept: "application/vnd.github+json",
@@ -245,14 +361,14 @@ export class GitHubClient {
         if (rateLimitRemaining === "0" && rateLimitReset) {
           const resetTime = Number.parseInt(rateLimitReset) * 1000;
           const waitTime = resetTime - Date.now();
-          if (retryCount < MAX_RETRIES && waitTime < MAX_DELAY_MS) {
+          if (retryCount < maxRetries && waitTime < MAX_DELAY_MS) {
             this.logger.warn("Rate limited, waiting and retrying", {
               endpoint,
               waitTime,
               retryCount,
             });
             await new Promise((resolve) => setTimeout(resolve, Math.max(waitTime, 1000)));
-            return this.request(endpoint, options, retryCount + 1);
+            return this.request(endpoint, options, { ...requestOpts, retryCount: retryCount + 1 });
           }
           recordCircuitResult(endpoint, false);
           return {
@@ -265,7 +381,7 @@ export class GitHubClient {
       }
 
       // Handle other retryable errors (5xx)
-      if (response.status >= 500 && retryCount < MAX_RETRIES) {
+      if (response.status >= 500 && retryCount < maxRetries) {
         const delay = getBackoffDelay(retryCount);
         this.logger.warn("Retryable error, backing off", {
           endpoint,
@@ -274,11 +390,12 @@ export class GitHubClient {
           delay,
         });
         await new Promise((resolve) => setTimeout(resolve, delay));
-        return this.request(endpoint, options, retryCount + 1);
+        return this.request(endpoint, options, { ...requestOpts, retryCount: retryCount + 1 });
       }
 
       if (!response.ok) {
         const errorText = await response.text();
+        const { message: githubMessage, errors } = parseGithubErrorBody(errorText);
         this.logger.error("GitHub API error", undefined, {
           endpoint,
           status: response.status,
@@ -289,12 +406,34 @@ export class GitHubClient {
           success: false,
           error: `GitHub API error: ${response.status} - ${errorText}`,
           status: response.status,
+          githubMessage,
+          errors,
         };
       }
 
       recordCircuitResult(endpoint, true);
-      const data = await response.json();
-      return { success: true, data: data as T };
+      // A 2xx response with a body that isn't valid JSON is a malformed
+      // response, not a network failure — GitHub was reached and answered.
+      // Parsed separately from the fetch itself so the outer catch (network
+      // errors/timeouts) doesn't swallow this into the same bucket: a caller
+      // that persists side effects before this point (the promotion route
+      // has already force-pushed the branch) needs to tell "GitHub never
+      // responded" apart from "GitHub responded with garbage".
+      try {
+        const data = await response.json();
+        return { success: true, data: data as T, status: response.status };
+      } catch (parseError) {
+        this.logger.error(
+          "GitHub API response was not valid JSON",
+          parseError instanceof Error ? parseError : undefined,
+          { endpoint, status: response.status },
+        );
+        return {
+          success: false,
+          error: `GitHub API returned a response that could not be parsed as JSON (status ${response.status})`,
+          status: response.status,
+        };
+      }
     } catch (error) {
       this.logger.error("GitHub API request failed", error instanceof Error ? error : undefined, {
         endpoint,
@@ -303,7 +442,8 @@ export class GitHubClient {
       return {
         success: false,
         error: `Request failed: ${error instanceof Error ? error.message : "Unknown error"}`,
-        status: 500,
+        status: 0,
+        networkError: true,
       };
     }
   }
@@ -329,11 +469,99 @@ export class GitHubClient {
           body: opts.body,
           head: opts.head,
           base: opts.base,
+          draft: opts.draft,
         }),
       },
     );
     if (!result.success) return { success: false, error: result.error };
     return { success: true, pr: result.data };
+  }
+
+  /**
+   * Creates a PR from `opts.head`, or reuses the open PR GitHub already has
+   * for that head if one exists.
+   *
+   * GitHub 422s PR creation with "a pull request already exists" when the
+   * head ref already has one open — either a concurrent promotion, or a
+   * retry after the caller failed to persist the result of a prior create.
+   * Looking that PR up and reusing it turns what would otherwise be a dead
+   * end into a successful, idempotent call.
+   *
+   * The raw, `unknown` GitHub response is returned on success rather than a
+   * type asserted from it — callers that persist the result (as the
+   * promotion route does) are expected to validate its shape themselves
+   * against whatever they trust enough to store, since a JSON parse alone
+   * doesn't guarantee GitHub's documented fields are actually present.
+   *
+   * `isReusablePr` gates the lookup hit before it's treated as a successful
+   * reuse: this client has no opinion on what a caller trusts enough to
+   * accept as "the PR" (the promotion route, for one, only accepts an open
+   * PR whose `html_url` is exactly this repo's canonical page for the
+   * matched number — see `isUsableGithubPr`). A lookup hit the predicate
+   * rejects behaves exactly like a lookup that failed or found nothing open:
+   * the ORIGINAL create error is what gets reported, not a new failure about
+   * the lookup response, since that's the one call the caller actually asked
+   * for. Defaults to accepting anything the lookup returns.
+   *
+   * Both requests this makes use `maxRetries: 0`: a create call is not safe
+   * to retry blindly on a network-level failure (this client can't tell
+   * whether GitHub received it before the connection dropped — a retry could
+   * either double-create or land on the duplicate-head path above, which is
+   * exactly why that path exists), and the lookup is a best-effort read
+   * whose failure already falls back to the original create error below.
+   */
+  async createOrReusePR(
+    opts: CreatePROpts,
+    isReusablePr: (pr: unknown) => boolean = () => true,
+  ): Promise<CreateOrReusePRResult> {
+    const result = await this.request<unknown>(
+      `/repos/${opts.owner}/${opts.repo}/pulls`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: opts.title,
+          body: opts.body,
+          head: opts.head,
+          base: opts.base,
+          draft: opts.draft,
+        }),
+      },
+      { maxRetries: 0, timeoutMs: DEFAULT_TIMEOUT_MS },
+    );
+
+    if (result.success) {
+      return { success: true, pr: result.data, reused: false, status: result.status };
+    }
+
+    const duplicateHead =
+      result.status === 422 &&
+      (result.errors ?? []).some((e) =>
+        e.message?.toLowerCase().includes("pull request already exists"),
+      );
+
+    if (duplicateHead) {
+      const lookup = await this.request<unknown>(
+        `/repos/${opts.owner}/${opts.repo}/pulls?head=${opts.owner}:${opts.head}&state=open`,
+        {},
+        { maxRetries: 0, timeoutMs: DEFAULT_TIMEOUT_MS },
+      );
+      const candidate = lookup.success && Array.isArray(lookup.data) ? lookup.data[0] : undefined;
+      if (candidate !== undefined && isReusablePr(candidate)) {
+        return { success: true, pr: candidate, reused: true, status: lookup.status };
+      }
+      // Lookup failed, found nothing open, or found something the caller
+      // won't accept — fall through to the original create error below;
+      // that's still the most useful thing to report.
+    }
+
+    return {
+      success: false,
+      networkError: result.networkError ?? false,
+      status: result.status,
+      githubMessage: result.githubMessage,
+      errors: result.errors ?? [],
+    };
   }
 
   async updatePR(

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -501,7 +501,13 @@ export class GitHubClient {
    * rejects behaves exactly like a lookup that failed or found nothing open:
    * the ORIGINAL create error is what gets reported, not a new failure about
    * the lookup response, since that's the one call the caller actually asked
-   * for. Defaults to accepting anything the lookup returns.
+   * for.
+   *
+   * Required, deliberately not defaulted. The code this replaced always ran
+   * an owner/repo check on the lookup hit, and a parameter defaulting to
+   * "accept anything" would turn that into something a caller drops by
+   * saying nothing. Reuse means persisting a PR this client did not create
+   * and did not choose; the caller has to name what it will accept.
    *
    * Both requests this makes use `maxRetries: 0`: a create call is not safe
    * to retry blindly on a network-level failure (this client can't tell
@@ -512,7 +518,7 @@ export class GitHubClient {
    */
   async createOrReusePR(
     opts: CreatePROpts,
-    isReusablePr: (pr: unknown) => boolean = () => true,
+    isReusablePr: (pr: unknown) => boolean,
   ): Promise<CreateOrReusePRResult> {
     const result = await this.request<unknown>(
       `/repos/${opts.owner}/${opts.repo}/pulls`,

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -156,6 +156,23 @@ export function resetCircuitBreakersForTests(): void {
   circuitBreakers.clear();
 }
 
+/**
+ * Whether calls to `endpoint`'s repository are currently being short-circuited.
+ *
+ * Keyed by the first three path segments (`/repos/<owner>/<repo>`), so the
+ * breaker is per-repository rather than per-endpoint: a repo that is gone,
+ * renamed, or whose token lost access fails every call against it, and there
+ * is nothing to gain by discovering that once per endpoint. The flip side is
+ * blast radius — every caller reaching that repo through this client shares
+ * one breaker, so a burst of failures from one route (promotion, say) can
+ * short-circuit an unrelated one (evaluation reporting) for
+ * {@link CIRCUIT_BREAKER_TIMEOUT_MS}.
+ *
+ * The open→half-open transition happens on read rather than on a timer: there
+ * is no scheduler here, and the next caller after the cooldown is the one that
+ * gets to probe. It is allowed through, and {@link recordCircuitResult} decides
+ * from its outcome whether the breaker closes or re-opens.
+ */
 function isCircuitOpen(endpoint: string): boolean {
   const key = endpoint.split("/").slice(0, 3).join("/");
   const cb = circuitBreakers.get(key);
@@ -170,6 +187,15 @@ function isCircuitOpen(endpoint: string): boolean {
   return false;
 }
 
+/**
+ * Feeds one call's outcome back into its repository's breaker.
+ *
+ * Any success closes the breaker and zeroes the failure count, not just a
+ * success while half-open: the count is meant to measure a *consecutive* run
+ * of failures, so an intervening success means whatever was wrong is no longer
+ * reproducing and the tally should not carry forward into an unrelated later
+ * incident.
+ */
 function recordCircuitResult(endpoint: string, success: boolean): void {
   const key = endpoint.split("/").slice(0, 3).join("/");
   const cb = circuitBreakers.get(key) || { failures: 0, lastFailure: 0, state: "closed" };

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1675,7 +1675,15 @@ app.post("/changes/:id/github-pr", async (c) => {
   // matching the merge path's behavior.
   let publishedSha: string | undefined;
   if (change.evaluatedSha !== undefined) {
-    const tipResult = await resolveLocalTip(cloneResult.data.fs, cloneResult.data.dir);
+    // Resolved against `defaultBranch`, matching the clone above: that clone is
+    // singleBranch, so on a project whose default branch is not `main` it holds
+    // that branch and nothing else. Asking for any other ref here throws inside
+    // isomorphic-git and turns a valid promotion into a 502.
+    const tipResult = await resolveLocalTip(
+      cloneResult.data.fs,
+      cloneResult.data.dir,
+      defaultBranch,
+    );
     if (!tipResult.success) return appError(tipResult.error);
     publishedSha = tipResult.data;
     if (publishedSha !== change.evaluatedSha) {

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -37,6 +37,7 @@ import {
   mergeWorkspaceIntoProject,
   parseStagedTree,
   pushBranchToRemote,
+  resolveLocalTip,
   stagedTreeKey,
   stagedTreeShaKey,
 } from "../storage/git-ops";
@@ -1663,6 +1664,40 @@ app.post("/changes/:id/github-pr", async (c) => {
   });
   if (!cloneResult.success) return appError(cloneResult.error);
 
+  // The evaluation gate is only meaningful if the code published to GitHub is
+  // the code that was evaluated. The clone above is a live read of the
+  // workspace right now, which can have advanced past `change.evaluatedSha`
+  // between evaluation and this request — same TOCTOU the merge path guards
+  // against a few hundred lines up (SEC-2) and #223 pinned on the R2/DO fast
+  // paths. Reject rather than push+promote against unevaluated content:
+  // fails closed, and is the smaller change than re-targeting the push at the
+  // pinned sha (that needs its own answer for what re-promotion then means).
+  // Legacy changes with no evaluatedSha (pre migration 024) skip the check,
+  // matching the merge path's behavior.
+  let publishedSha: string | undefined;
+  if (change.evaluatedSha !== undefined) {
+    const tipResult = await resolveLocalTip(cloneResult.data.fs, cloneResult.data.dir);
+    if (!tipResult.success) return appError(tipResult.error);
+    publishedSha = tipResult.data;
+    if (publishedSha !== change.evaluatedSha) {
+      logger.warn("Workspace advanced past the evaluated revision; rejecting promotion", {
+        changeId: id,
+        evaluatedSha: change.evaluatedSha,
+        currentTip: publishedSha,
+      });
+      return c.json(
+        {
+          error:
+            "Workspace is stale: it advanced since this change was evaluated. Re-evaluate before promoting.",
+          code: "STALE_WORKSPACE",
+          evaluatedSha: change.evaluatedSha,
+          currentTip: publishedSha,
+        },
+        409,
+      );
+    }
+  }
+
   const pushResult = await pushBranchToRemote(
     cloneResult.data.fs,
     cloneResult.data.dir,
@@ -1867,6 +1902,10 @@ app.post("/changes/:id/github-pr", async (c) => {
     githubPrNumber: pr.number,
     githubPrUrl: pr.html_url,
     githubPrState: pr.state,
+    // The revision actually force-pushed as this PR's head — only known
+    // precisely when the evaluatedSha gate above ran (legacy changes with no
+    // evaluatedSha have no pinned revision to record here).
+    ...(publishedSha !== undefined ? { githubHeadSha: publishedSha } : {}),
     promotedAt,
     promotedBy: userId,
   });

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1,6 +1,7 @@
 import { type Context, Hono } from "hono";
 import { loadPolicy } from "../evaluation";
 import type { EvalPolicy } from "../evaluation/types";
+import { GitHubClient } from "../github/client";
 import { buildEvaluationReport, reportEvaluationToGitHub } from "../github/sync";
 import { runPostMergeCheck } from "../merge/post-merge";
 import { checkMergeProtection } from "../merge/protection";
@@ -1425,13 +1426,6 @@ app.post("/changes/:id/evaluate", async (c) => {
   return okOrFormRedirect(c, id, { changeId: id, eval: evalResult, evalRuns: recordResult.data });
 });
 
-/**
- * Bound on every direct GitHub API call in the promotion flow below, so one
- * slow GitHub subrequest cannot consume the whole request lifetime and get the
- * worker killed by the platform's own limit instead of failing cleanly.
- */
-const GITHUB_API_TIMEOUT_MS = 15_000;
-
 /** The repository a promotion is targeting, as resolved from the project source. */
 type GithubRepoTarget = { owner: string; repo: string };
 
@@ -1439,22 +1433,6 @@ interface GithubPr {
   number: number;
   html_url: string;
   state: string;
-}
-
-/** One entry of GitHub's `errors` array, as far as this route relies on it. */
-interface GithubErrorDetail {
-  message?: string;
-  code?: string;
-  field?: string;
-}
-
-/** Narrows one element of an untrusted `errors` array before it is read. */
-function isGithubErrorDetail(value: unknown): value is GithubErrorDetail {
-  if (typeof value !== "object" || value === null) return false;
-  const detail = value as Record<string, unknown>;
-  return (["message", "code", "field"] as const).every(
-    (key) => detail[key] === undefined || typeof detail[key] === "string",
-  );
 }
 
 /**
@@ -1529,45 +1507,6 @@ function isUsableGithubUrl(raw: string, target: GithubRepoTarget, prNumber: numb
   return (
     url.pathname.toLowerCase() === `/${target.owner}/${target.repo}/pull/${prNumber}`.toLowerCase()
   );
-}
-
-/**
- * Finds an open GitHub pull request associated with a branch.
- *
- * GitHub 422s PR creation with "a pull request already exists" when the head
- * ref already has one open — either a concurrent promotion, or a retry after
- * `updateChangeStatus` failed post-creation. Looking the PR up and reusing it
- * turns that dead end into a successful, idempotent promotion.
- *
- * @param repo - The GitHub repository to search
- * @param branch - The head branch associated with the pull request
- * @returns The matching pull request, or `undefined` if none is found or the lookup fails.
- */
-async function findOpenPrForHead(
-  repo: GithubRepoTarget,
-  branch: string,
-  headers: Record<string, string>,
-  logger: Logger,
-): Promise<GithubPr | undefined> {
-  const url = `https://api.github.com/repos/${repo.owner}/${repo.repo}/pulls?head=${repo.owner}:${branch}&state=open`;
-  let res: Response;
-  try {
-    res = await fetch(url, { headers, signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) });
-  } catch (error) {
-    logger.error(
-      "Lookup of existing PR for duplicate head failed",
-      error instanceof Error ? error : undefined,
-      {
-        branch,
-      },
-    );
-    return undefined;
-  }
-  if (!res.ok) return undefined;
-  const body: unknown = await res.json().catch(() => undefined);
-  if (!Array.isArray(body)) return undefined;
-  const pr = body[0];
-  return isUsableGithubPr(pr, repo) ? pr : undefined;
 }
 
 app.post("/changes/:id/github-pr", async (c) => {
@@ -1775,120 +1714,99 @@ app.post("/changes/:id/github-pr", async (c) => {
   const prBody =
     `## Stratum review\n\n- Change: \`${change.id}\`\n- Workspace: \`${change.workspace}\`\n- Evaluation: ${change.evalPassed ? "passed" : "failed"}, score ${change.evalScore ?? "n/a"}\n\n${body.body ?? ""}`.trim();
 
-  const githubHeaders = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${githubToken}`,
-    "User-Agent": "stratum",
-  };
+  // Duplicate-head 422 → look up + reuse the open PR GitHub already has for
+  // this head lives in the client (createOrReusePR): a re-promotion race, or
+  // a retry after `updateChangeStatus` failed post-creation, both 422 here,
+  // and the PR the caller wanted already exists either way.
+  const client = new GitHubClient(githubToken, logger);
+  const result = await client.createOrReusePR(
+    {
+      owner: repo.owner,
+      repo: repo.repo,
+      title: body.title ?? `Stratum: ${change.id}`,
+      body: prBody,
+      head: branch,
+      base,
+      draft: body.draft ?? true,
+    },
+    // A duplicate-head lookup hit is only worth reusing if it's a PR this
+    // route would be willing to persist — otherwise the original create
+    // error is the more useful thing to report (see isUsableGithubPr above).
+    (candidate) => isUsableGithubPr(candidate, repo),
+  );
 
-  let ghRes: Response;
-  try {
-    ghRes = await fetch(`https://api.github.com/repos/${repo.owner}/${repo.repo}/pulls`, {
-      method: "POST",
-      headers: githubHeaders,
-      body: JSON.stringify({
-        title: body.title ?? `Stratum: ${change.id}`,
-        body: prBody,
-        head: branch,
-        base,
-        draft: body.draft ?? true,
-      }),
-      // A slow GitHub response must not hold the request open until the
-      // platform's own subrequest limit kills it.
-      signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
-    });
-  } catch (error) {
-    logger.error("GitHub PR creation request failed", error instanceof Error ? error : undefined, {
-      changeId: id,
-    });
-    return c.json(
-      {
-        error: "GitHub PR creation failed: request timed out or network error",
-        code: "GITHUB_ERROR",
-      },
-      502,
-    );
-  }
-
-  let pr: GithubPr;
-
-  if (!ghRes.ok) {
-    // Surface GitHub's own status + message (never the token) instead of a
-    // generic 400 — a 422 "head invalid" vs. a 404 repo tells the caller
-    // exactly what to fix.
-    const detail = await ghRes.text().catch(() => "");
-    let githubMessage: string | undefined;
-    let errors: GithubErrorDetail[] = [];
-    try {
-      // The branch is already pushed by this point, so anything thrown while
-      // parsing an error body escapes as a bare 500 and loses the structured
-      // GITHUB_ERROR/502 the caller needs. GitHub is not guaranteed to send the
-      // documented shape on every failure, so validate rather than cast:
-      // `{"errors":{}}`, `{"errors":"invalid"}` and `{"errors":[null]}` all
-      // reach `.map()` otherwise.
-      const parsed: unknown = JSON.parse(detail);
-      const body = (typeof parsed === "object" && parsed !== null ? parsed : {}) as {
-        message?: unknown;
-        errors?: unknown;
-      };
-      errors = Array.isArray(body.errors) ? body.errors.filter(isGithubErrorDetail) : [];
-      githubMessage = [
-        typeof body.message === "string" ? body.message : undefined,
-        ...errors.map((e) => e.message ?? (e.field ? `${e.field} ${e.code}` : e.code)),
-      ]
-        .filter(Boolean)
-        .join("; ");
-    } catch {
-      githubMessage = undefined;
-    }
-
-    // GitHub's duplicate-head 422 ("A pull request already exists for
-    // owner:branch") means the PR the caller wanted already exists — reuse it
-    // rather than failing (see findOpenPrForHead above).
-    const duplicateHead =
-      ghRes.status === 422 &&
-      errors.some((e) => e.message?.toLowerCase().includes("pull request already exists"));
-    const existingPr = duplicateHead
-      ? await findOpenPrForHead(repo, branch, githubHeaders, logger)
-      : undefined;
-
-    if (!existingPr) {
-      logger.error("GitHub PR creation failed", undefined, {
-        status: ghRes.status,
-        changeId: id,
-        githubMessage,
-      });
+  if (!result.success) {
+    if (result.networkError) {
+      logger.error("GitHub PR creation request failed", undefined, { changeId: id });
       return c.json(
         {
-          error: `GitHub PR creation failed (${ghRes.status})${githubMessage ? `: ${githubMessage}` : ""}`,
+          error: "GitHub PR creation failed: request timed out or network error",
           code: "GITHUB_ERROR",
-          githubStatus: ghRes.status,
         },
         502,
       );
     }
-    pr = existingPr;
-  } else {
-    // The branch is already pushed by this point, so a malformed success body
-    // must not escape as an unhandled rejection (a bare 500): map it to the
-    // same structured 502 every other GitHub failure uses.
-    const parsed: unknown = await ghRes.json().catch(() => undefined);
-    if (!isUsableGithubPr(parsed, repo)) {
-      logger.error("GitHub PR creation returned an unusable response body", undefined, {
-        status: ghRes.status,
+    // The branch is already pushed by this point. A 2xx status with a body
+    // the client couldn't parse as JSON is GitHub responding, just not
+    // usefully — the same "unreadable response" the shape-validation failure
+    // below reports for a 2xx body missing the expected fields, not a
+    // GitHub-reported error to relay.
+    if (result.status >= 200 && result.status < 300) {
+      logger.error("GitHub PR creation returned an unparseable response body", undefined, {
+        status: result.status,
         changeId: id,
       });
       return c.json(
         {
           error: "GitHub PR creation failed: unreadable response from GitHub",
           code: "GITHUB_ERROR",
-          githubStatus: ghRes.status,
+          githubStatus: result.status,
         },
         502,
       );
     }
-    pr = parsed;
+    // Surface GitHub's own status + message (never the token) instead of a
+    // generic 400 — a 422 "head invalid" vs. a 404 repo tells the caller
+    // exactly what to fix.
+    const githubMessage = [
+      result.githubMessage,
+      ...result.errors.map((e) => e.message ?? (e.field ? `${e.field} ${e.code}` : e.code)),
+    ]
+      .filter(Boolean)
+      .join("; ");
+    logger.error("GitHub PR creation failed", undefined, {
+      status: result.status,
+      changeId: id,
+      githubMessage,
+    });
+    return c.json(
+      {
+        error: `GitHub PR creation failed (${result.status})${githubMessage ? `: ${githubMessage}` : ""}`,
+        code: "GITHUB_ERROR",
+        githubStatus: result.status,
+      },
+      502,
+    );
   }
+
+  // The branch is already pushed by this point, so a malformed response body
+  // (created or reused) must not escape as an unhandled rejection (a bare
+  // 500): map it to the same structured 502 every other GitHub failure uses.
+  if (!isUsableGithubPr(result.pr, repo)) {
+    logger.error("GitHub PR creation returned an unusable response body", undefined, {
+      status: result.status,
+      changeId: id,
+    });
+    return c.json(
+      {
+        error: "GitHub PR creation failed: unreadable response from GitHub",
+        code: "GITHUB_ERROR",
+        githubStatus: result.status,
+      },
+      502,
+    );
+  }
+  const pr: GithubPr = result.pr;
 
   const promotedAt = new Date().toISOString();
 

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -387,6 +387,24 @@ export async function pushBranchToRemote(
 }
 
 /**
+ * Resolves the tip commit of an already-cloned repository's default branch.
+ *
+ * Distinct from {@link getCommitLog}, which clones fresh: this reads the `fs`/`dir`
+ * of a clone the caller already has open, so it costs no extra network round trip.
+ * Promotion (#243) uses this to confirm the workspace clone it is about to
+ * force-push to GitHub is still the revision recorded as `change.evaluatedSha` —
+ * the clone is a live read of the workspace, which can have advanced since
+ * evaluation ran.
+ */
+export async function resolveLocalTip(fs: NodeFS, dir: string): Promise<Result<string, AppError>> {
+  const tipResult = await fromPromise(git.resolveRef({ fs, dir, ref: "main" }));
+  if (!tipResult.success) {
+    return err(new ExternalServiceError("Git", "Failed to resolve local tip", tipResult.error));
+  }
+  return ok(tipResult.data);
+}
+
+/**
  * Initializes a repository with the supplied files, commits them, and pushes the commit to `main`.
  *
  * Only valid against a remote with no history: this builds the root commit, so

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -402,7 +402,7 @@ export async function pushBranchToRemote(
 }
 
 /**
- * Resolves the tip commit of an already-cloned repository's default branch.
+ * Resolves the tip commit of `ref` in an already-cloned repository.
  *
  * Distinct from {@link getCommitLog}, which clones fresh: this reads the `fs`/`dir`
  * of a clone the caller already has open, so it costs no extra network round trip.
@@ -410,9 +410,24 @@ export async function pushBranchToRemote(
  * force-push to GitHub is still the revision recorded as `change.evaluatedSha` —
  * the clone is a live read of the workspace, which can have advanced since
  * evaluation ran.
+ *
+ * `ref` is required and deliberately not defaulted to `"main"`. Callers hand
+ * this a clone they made themselves, and those clones are routinely
+ * `singleBranch` on a project-configured default branch — a `main` default
+ * would resolve a ref that does not exist in such a clone and fail a valid
+ * promotion, which is exactly the bug a silent default hid here before. The
+ * caller already knows which ref it cloned; making it say so keeps the two
+ * from drifting apart again.
+ *
+ * @param ref - The ref to resolve, which must exist in this clone — normally
+ * the same ref the caller passed to {@link cloneRepo}.
  */
-export async function resolveLocalTip(fs: NodeFS, dir: string): Promise<Result<string, AppError>> {
-  const tipResult = await fromPromise(git.resolveRef({ fs, dir, ref: "main" }));
+export async function resolveLocalTip(
+  fs: NodeFS,
+  dir: string,
+  ref: string,
+): Promise<Result<string, AppError>> {
+  const tipResult = await fromPromise(git.resolveRef({ fs, dir, ref }));
   if (!tipResult.success) {
     return err(new ExternalServiceError("Git", "Failed to resolve local tip", tipResult.error));
   }

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -34,6 +34,7 @@ vi.mock("../src/storage/git-ops", async (importActual) => {
     cloneRepo: vi.fn(async () => ({ success: true, data: { fs: {}, dir: "/" } })),
     batchMergeStagedTrees: vi.fn(),
     pushBranchToRemote: vi.fn(async () => ({ success: true, data: undefined })),
+    resolveLocalTip: vi.fn(),
   };
 });
 
@@ -178,6 +179,7 @@ import {
   getDiffBetweenRepos,
   mergeWorkspaceIntoProject,
   pushBranchToRemote,
+  resolveLocalTip,
 } from "../src/storage/git-ops";
 import { packObjects } from "../src/storage/object-loader";
 import { recordProvenance } from "../src/storage/provenance";
@@ -2204,6 +2206,96 @@ describe("POST /api/changes/:id/github-pr", () => {
         promotedBy: "user_test",
       }),
     );
+  });
+
+  // #243: the evaluation gate is only meaningful if the code published to
+  // GitHub is the code that was evaluated. change.evaluatedSha is the pinned
+  // revision; the clone above is a live read of the workspace, which can have
+  // advanced since evaluation ran.
+  describe("evaluatedSha gate (#243)", () => {
+    it("pushes and promotes, recording the published sha, when the workspace tip matches evaluatedSha", async () => {
+      vi.mocked(getChange).mockResolvedValue({
+        success: true,
+        data: { ...acceptedChange, evaluatedSha: "sha-evaluated" },
+      });
+      vi.mocked(resolveLocalTip).mockResolvedValue({ success: true, data: "sha-evaluated" });
+
+      const res = await promote();
+      expect(res.status).toBe(200);
+      expect(resolveLocalTip).toHaveBeenCalledWith({}, "/");
+
+      // The gate runs strictly before the push (before anything is published).
+      const tipOrder = vi.mocked(resolveLocalTip).mock.invocationCallOrder[0] ?? -1;
+      const pushOrder = vi.mocked(pushBranchToRemote).mock.invocationCallOrder[0] ?? -1;
+      expect(tipOrder).toBeGreaterThan(0);
+      expect(tipOrder).toBeLessThan(pushOrder);
+
+      expect(updateChangeStatus).toHaveBeenCalledWith(
+        env.DB,
+        expect.anything(),
+        "chg_abc123",
+        "promoted",
+        expect.objectContaining({ githubHeadSha: "sha-evaluated" }),
+      );
+    });
+
+    it("rejects the promotion with a structured error when the workspace tip has moved past evaluatedSha", async () => {
+      vi.mocked(getChange).mockResolvedValue({
+        success: true,
+        data: { ...acceptedChange, evaluatedSha: "sha-evaluated" },
+      });
+      vi.mocked(resolveLocalTip).mockResolvedValue({ success: true, data: "sha-advanced" });
+
+      const res = await promote();
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as {
+        error: string;
+        code: string;
+        evaluatedSha: string;
+        currentTip: string;
+      };
+      expect(body.code).toBe("STALE_WORKSPACE");
+      expect(body.evaluatedSha).toBe("sha-evaluated");
+      expect(body.currentTip).toBe("sha-advanced");
+      // Fails closed BEFORE anything is published or persisted.
+      expect(pushBranchToRemote).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(updateChangeStatus).not.toHaveBeenCalled();
+    });
+
+    it("502s without pushing when the local tip can't be resolved", async () => {
+      vi.mocked(getChange).mockResolvedValue({
+        success: true,
+        data: { ...acceptedChange, evaluatedSha: "sha-evaluated" },
+      });
+      vi.mocked(resolveLocalTip).mockResolvedValue({
+        success: false,
+        error: new AppError(
+          "Git error: Failed to resolve local tip",
+          "EXTERNAL_SERVICE_ERROR",
+          502,
+        ),
+      });
+
+      const res = await promote();
+      expect(res.status).toBe(502);
+      expect(pushBranchToRemote).not.toHaveBeenCalled();
+      expect(updateChangeStatus).not.toHaveBeenCalled();
+    });
+
+    it("skips the gate (legacy live-tip behavior) when the change has no evaluatedSha", async () => {
+      // acceptedChange has no evaluatedSha.
+      const res = await promote();
+      expect(res.status).toBe(200);
+      expect(resolveLocalTip).not.toHaveBeenCalled();
+      expect(updateChangeStatus).toHaveBeenCalledWith(
+        env.DB,
+        expect.anything(),
+        "chg_abc123",
+        "promoted",
+        expect.not.objectContaining({ githubHeadSha: expect.anything() }),
+      );
+    });
   });
 
   it("promotes a bulk-imported project that only has sourceUrl", async () => {

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -155,6 +155,7 @@ vi.mock("../src/storage/agents", () => ({
 }));
 
 import { CompositeEvaluator, SecretScanEvaluator, loadPolicy } from "../src/evaluation";
+import { resetCircuitBreakersForTests } from "../src/github/client";
 import { emitEvent } from "../src/queue/events";
 import { getAgent, getAgentByToken } from "../src/storage/agents";
 import { recordAudit } from "../src/storage/audit";
@@ -2099,6 +2100,12 @@ describe("POST /api/changes/:id/github-pr", () => {
     env = makeEnv();
     env.GITHUB_TOKEN = "ghp_secret_token";
     vi.clearAllMocks();
+    // GitHubClient's circuit breaker is module-level state shared by every
+    // instance — this suite deliberately drives many consecutive GitHub
+    // failures against the same acme/widgets repo across test cases, which
+    // would otherwise trip the breaker and starve later, unrelated
+    // assertions with a spurious 503.
+    resetCircuitBreakersForTests();
     vi.mocked(getUserByToken).mockImplementation(async (_db, token) => {
       if (token === "stratum_user_testtoken00000000000000000") {
         return {

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -2258,7 +2258,9 @@ describe("POST /api/changes/:id/github-pr", () => {
 
       const res = await promote();
       expect(res.status).toBe(200);
-      expect(resolveLocalTip).toHaveBeenCalledWith({}, "/");
+      // The ref is the project's default branch (this suite's project defaults
+      // to `develop`), not a hard-coded `main` — see the dedicated case below.
+      expect(resolveLocalTip).toHaveBeenCalledWith({}, "/", "develop");
 
       // The gate runs strictly before the push (before anything is published).
       const tipOrder = vi.mocked(resolveLocalTip).mock.invocationCallOrder[0] ?? -1;
@@ -2317,6 +2319,36 @@ describe("POST /api/changes/:id/github-pr", () => {
       expect(res.status).toBe(502);
       expect(pushBranchToRemote).not.toHaveBeenCalled();
       expect(updateChangeStatus).not.toHaveBeenCalled();
+    });
+
+    // The gate resolves the tip of the branch that was actually cloned. The
+    // clone is singleBranch on the project's default branch, so a project whose
+    // default is not `main` has no `main` for isomorphic-git to resolve: a
+    // hard-coded ref here throws and 502s a promotion that should have passed
+    // the gate. Asserted through the ref the resolver is handed rather than the
+    // status alone, because the resolver is mocked in this suite and would
+    // happily answer for any ref.
+    it("resolves the tip of the project's default branch, not `main`", async () => {
+      vi.mocked(getProject).mockResolvedValue({
+        success: true,
+        data: { ...githubProject, githubDefaultBranch: "release-2026" },
+      });
+      vi.mocked(getChange).mockResolvedValue({
+        success: true,
+        data: { ...acceptedChange, evaluatedSha: "sha-evaluated" },
+      });
+      vi.mocked(resolveLocalTip).mockResolvedValue({ success: true, data: "sha-evaluated" });
+
+      const res = await promote();
+      expect(res.status).toBe(200);
+      // Same ref the clone asked for — the two must not drift apart.
+      expect(cloneRepo).toHaveBeenCalledWith(
+        mockWorkspace.remote,
+        "artifacts-token",
+        expect.anything(),
+        { ref: "release-2026", fullHistory: true },
+      );
+      expect(resolveLocalTip).toHaveBeenCalledWith({}, "/", "release-2026");
     });
 
     it("skips the gate (legacy live-tip behavior) when the change has no evaluatedSha", async () => {

--- a/tests/github-client-create-or-reuse-pr.test.ts
+++ b/tests/github-client-create-or-reuse-pr.test.ts
@@ -54,6 +54,13 @@ describe("GitHubClient.createPR", () => {
 });
 
 describe("GitHubClient.createOrReusePR", () => {
+  // These cases are about the create/lookup/error plumbing, not about what a
+  // caller trusts, so they accept whatever the lookup returns. The predicate
+  // is a required argument precisely so that choice is visible here rather
+  // than inherited from a default (the promotion route passes
+  // isUsableGithubPr instead).
+  const acceptAny = () => true;
+
   const opts = {
     owner: "acme",
     repo: "widgets",
@@ -76,7 +83,7 @@ describe("GitHubClient.createOrReusePR", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const client = new GitHubClient("tok", logger);
-    const result = await client.createOrReusePR(opts);
+    const result = await client.createOrReusePR(opts, acceptAny);
 
     expect(result).toEqual({
       success: true,
@@ -110,7 +117,7 @@ describe("GitHubClient.createOrReusePR", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const client = new GitHubClient("tok", logger);
-    const result = await client.createOrReusePR(opts);
+    const result = await client.createOrReusePR(opts, acceptAny);
 
     expect(result).toEqual({
       success: true,
@@ -171,7 +178,7 @@ describe("GitHubClient.createOrReusePR", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const client = new GitHubClient("tok", logger);
-    const result = await client.createOrReusePR(opts);
+    const result = await client.createOrReusePR(opts, acceptAny);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(result.success).toBe(false);
@@ -186,7 +193,7 @@ describe("GitHubClient.createOrReusePR", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const client = new GitHubClient("tok", logger);
-    const result = await client.createOrReusePR(opts);
+    const result = await client.createOrReusePR(opts, acceptAny);
 
     expect(fetchMock).toHaveBeenCalledTimes(1); // maxRetries: 0 — no automatic retry
     expect(result.success).toBe(false);
@@ -203,7 +210,7 @@ describe("GitHubClient.createOrReusePR", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const client = new GitHubClient("tok", logger);
-    const result = await client.createOrReusePR(opts);
+    const result = await client.createOrReusePR(opts, acceptAny);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(result.success).toBe(false);
@@ -215,7 +222,7 @@ describe("GitHubClient.createOrReusePR", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const client = new GitHubClient("tok", logger);
-    const result = await client.createOrReusePR(opts);
+    const result = await client.createOrReusePR(opts, acceptAny);
 
     expect(result.success).toBe(false);
     if (!result.success) {

--- a/tests/github-client-create-or-reuse-pr.test.ts
+++ b/tests/github-client-create-or-reuse-pr.test.ts
@@ -12,6 +12,15 @@ const logger: Logger = {
   child: vi.fn(() => logger),
 };
 
+/**
+ * Builds a real `Response` for a stubbed `fetch`.
+ *
+ * The client consumes the response object itself — `response.status`, its
+ * headers, and `response.json()`/`response.text()` — so these tests have to
+ * hand it the genuine article rather than a plain object shaped like one.
+ * Cases that exercise the malformed-body path deliberately bypass this helper
+ * and construct their own non-JSON `Response`.
+ */
 function jsonResponse(body: unknown, status: number): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -54,11 +63,15 @@ describe("GitHubClient.createPR", () => {
 });
 
 describe("GitHubClient.createOrReusePR", () => {
-  // These cases are about the create/lookup/error plumbing, not about what a
-  // caller trusts, so they accept whatever the lookup returns. The predicate
-  // is a required argument precisely so that choice is visible here rather
-  // than inherited from a default (the promotion route passes
-  // isUsableGithubPr instead).
+  /**
+   * A predicate that accepts any lookup hit.
+   *
+   * These cases are about the create/lookup/error plumbing, not about what a
+   * caller trusts, so they accept whatever the lookup returns. The predicate
+   * is a required argument precisely so that choice is visible here rather
+   * than inherited from a default (the promotion route passes
+   * isUsableGithubPr instead).
+   */
   const acceptAny = () => true;
 
   const opts = {
@@ -166,7 +179,7 @@ describe("GitHubClient.createOrReusePR", () => {
     }
   });
 
-  it("does not look up a duplicate head when the caller accepts nothing (default predicate) but the failure isn't a duplicate-head 422", async () => {
+  it("does not look up a duplicate head when the 422 is not a duplicate-head failure", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValue(

--- a/tests/github-client-create-or-reuse-pr.test.ts
+++ b/tests/github-client-create-or-reuse-pr.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GitHubClient, resetCircuitBreakersForTests } from "../src/github/client";
+import type { Logger } from "../src/utils/logger";
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+};
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  resetCircuitBreakersForTests();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("GitHubClient.createPR", () => {
+  it("forwards draft through to the request body", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ number: 1, title: "t", body: "b", state: "open", html_url: "u" }, 201),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.createPR({
+      owner: "acme",
+      repo: "widgets",
+      title: "t",
+      body: "b",
+      head: "feature",
+      base: "main",
+      draft: true,
+    });
+
+    expect(result.success).toBe(true);
+    const payload = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(payload.draft).toBe(true);
+  });
+});
+
+describe("GitHubClient.createOrReusePR", () => {
+  const opts = {
+    owner: "acme",
+    repo: "widgets",
+    title: "Stratum: chg_1",
+    body: "body",
+    head: "stratum/chg_1",
+    base: "main",
+    draft: true,
+  };
+
+  it("creates the PR and reports reused: false on a clean 201", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(
+          { number: 7, html_url: "https://github.com/acme/widgets/pull/7", state: "open" },
+          201,
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.createOrReusePR(opts);
+
+    expect(result).toEqual({
+      success: true,
+      reused: false,
+      status: 201,
+      pr: { number: 7, html_url: "https://github.com/acme/widgets/pull/7", state: "open" },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(payload.draft).toBe(true);
+  });
+
+  it("reuses the open PR GitHub already has for the head on a duplicate-head 422", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            message: "Validation Failed",
+            errors: [{ message: "A pull request already exists for acme:stratum/chg_1." }],
+          },
+          422,
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          [{ number: 9, html_url: "https://github.com/acme/widgets/pull/9", state: "open" }],
+          200,
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.createOrReusePR(opts);
+
+    expect(result).toEqual({
+      success: true,
+      reused: true,
+      status: 200,
+      pr: { number: 9, html_url: "https://github.com/acme/widgets/pull/9", state: "open" },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/repos/acme/widgets/pulls?head=acme:stratum/chg_1&state=open",
+      expect.anything(),
+    );
+  });
+
+  it("falls back to the original create error when the lookup hit is rejected by the caller's predicate", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            message: "Validation Failed",
+            errors: [{ message: "A pull request already exists for acme:stratum/chg_1." }],
+          },
+          422,
+        ),
+      )
+      // The lookup finds something, but the caller won't accept it (e.g. it's closed).
+      .mockResolvedValueOnce(
+        jsonResponse(
+          [{ number: 9, html_url: "https://github.com/acme/widgets/pull/9", state: "closed" }],
+          200,
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.createOrReusePR(opts, () => false);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.status).toBe(422);
+      expect(result.networkError).toBe(false);
+      expect(result.githubMessage).toBe("Validation Failed");
+      expect(result.errors[0]?.message).toContain("pull request already exists");
+    }
+  });
+
+  it("does not look up a duplicate head when the caller accepts nothing (default predicate) but the failure isn't a duplicate-head 422", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(
+          { message: "Validation Failed", errors: [{ field: "base", code: "invalid" }] },
+          422,
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.createOrReusePR(opts);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.status).toBe(422);
+      expect(result.errors).toEqual([{ field: "base", code: "invalid" }]);
+    }
+  });
+
+  it("reports a network error distinctly, without retrying, on a request-level failure", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new DOMException("aborted", "TimeoutError"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.createOrReusePR(opts);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // maxRetries: 0 — no automatic retry
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.networkError).toBe(true);
+    }
+  });
+
+  // createOrReusePR passes maxRetries: 0 deliberately — a create call isn't
+  // safe to retry blindly (see the method's doc comment) — unlike the
+  // client's other methods, which retry 5xx by default.
+  it("does not retry a 5xx from PR creation (unlike the client's default retry behavior)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("upstream down", { status: 502 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.createOrReusePR(opts);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.status).toBe(502);
+  });
+
+  it("treats a 2xx response with an unparseable body as a failure carrying the 2xx status, not a network error", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("not json", { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.createOrReusePR(opts);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.networkError).toBe(false);
+      expect(result.status).toBe(201);
+    }
+  });
+});
+
+describe("GitHubClient default retry behavior (unaffected by createOrReusePR's opt-out)", () => {
+  it("retries a 5xx up to the default budget for a call that doesn't override maxRetries", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("down", { status: 502 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ default_branch: "main" }), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.getRepo("acme", "widgets");
+
+    expect(result).toEqual({ success: true, default_branch: "main" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  }, 10000);
+});
+
+describe("resetCircuitBreakersForTests", () => {
+  it("clears a tripped breaker so the next call reaches fetch again", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("nope", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    // Trip the breaker: 5 consecutive failures against the same owner/repo key.
+    for (let i = 0; i < 5; i++) {
+      await client.getRepo("acme", "widgets");
+    }
+    fetchMock.mockClear();
+
+    const openResult = await client.getRepo("acme", "widgets");
+    expect(openResult).toEqual({
+      success: false,
+      error: "Service temporarily unavailable (circuit open)",
+    });
+    expect(fetchMock).not.toHaveBeenCalled(); // short-circuited before reaching fetch
+
+    resetCircuitBreakersForTests();
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ default_branch: "main" }), { status: 200 }),
+    );
+    const afterReset = await client.getRepo("acme", "widgets");
+    expect(afterReset).toEqual({ success: true, default_branch: "main" });
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Two commits, same route (`POST /changes/:id/github-pr`):

**#243 — promotion could publish an unevaluated revision.** The route force-pushed the cloned workspace's *current* tip to GitHub, then recorded the promotion as carrying the verdict for `change.evaluatedSha` — never comparing the two. A workspace write between evaluation and promotion silently published unevaluated commits under a verdict for a different revision. The route now resolves the clone's local tip (new `resolveLocalTip` in `src/storage/git-ops.ts` — no extra network round trip) and compares it to `change.evaluatedSha` before pushing; a mismatch rejects with a structured `409 STALE_WORKSPACE` (the same code the merge path uses for the identical TOCTOU), telling the caller to re-evaluate — fail closed, the smaller option per the issue. Legacy changes with no `evaluatedSha` keep prior live-tip behavior. On a match, the confirmed sha is recorded as `githubHeadSha` in `updateChangeStatus`.

**#244 — promotion bypassed GitHubClient.** The route hand-rolled fetch/headers/timeout/error-parsing/duplicate-head-422 reconciliation — a second GitHub call path with none of the client's retry/backoff, circuit breaker, or rate-limit handling. `GitHubClient` was extended so the route could adopt it without regressing what #189/#210 added, then migrated:

- `CreatePROpts.draft` (promotion opens draft PRs).
- `request()` returns status + GitHub's parsed `message`/`errors[]` so the route keeps its tested `{ code: "GITHUB_ERROR", githubStatus, error }` contract; a 2xx with an unparseable body is reported distinctly from a network failure.
- Optional per-call `maxRetries`/`timeoutMs` with a fresh timeout per attempt (documented retry/timeout budget); existing callers keep the same defaults.
- New `createOrReusePR`: creates with `maxRetries: 0` (a create isn't blindly retryable), detects the duplicate-head 422, and looks up + reuses the open PR — with an `isReusablePr` predicate so the route's persistence-trust validation still gates reuse.
- `resetCircuitBreakersForTests()` since the breaker is module-level state and the route's suite deliberately drives consecutive failures.

**Not touched:** base-branch selection, which #233 is reworking — left exactly where it was to minimize conflicts with that PR.

## Related issues

Closes #243, closes #244

## Type of change

- [x] Bug fix
- [x] Refactor / cleanup

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` (full suite: 1737 passed, 0 failed)
- [x] `npm run lint`

- 4 new route tests for the evaluatedSha gate in `tests/changes.test.ts`; the 175 existing assertions in that suite pass unmodified.
- New `tests/github-client-create-or-reuse-pr.test.ts` (10 tests): draft flag, create/reuse, predicate-rejected fallback, non-duplicate 422, network error, no-retry-on-5xx for creates, malformed 2xx body, default retry budget unchanged, breaker reset.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (none affected)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supports creating draft pull requests.
  * Reuses eligible existing pull requests instead of creating duplicates.
* **Bug Fixes**
  * Prevents publishing when the workspace is out of sync with the evaluated revision.
  * Improves handling of network failures, timeouts, malformed responses, and service-reported errors.
  * Provides clearer failure details when pull request promotion cannot be completed.
* **Reliability**
  * Adds configurable retry behavior and avoids unnecessary repeated requests after known failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->