### PR TITLE
Fail closed on git submodules at import and push instead of silently corrupting them

### DIFF
--- a/docs/CURRENT_CAPABILITIES.md
+++ b/docs/CURRENT_CAPABILITIES.md
@@ -80,3 +80,11 @@ Last updated: 2026-06-11 — reflects completion of the master-plan feature road
   along with the reachable history of a rotating slice of repos (coverage rotates
   across runs under a per-run cap), with a tested restore path
   (`docs/runbooks/backup-restore.md`).
+- Git submodules are not supported (#258). A gitlink tree entry (mode 160000)
+  or a `.gitmodules` file is detected and rejected at the two points repo
+  content enters Stratum — GitHub import and a gated push — with a structured
+  `SUBMODULES_UNSUPPORTED` (422) error, so a repo using submodules fails
+  closed instead of importing partially and being corrupted by a later
+  server-side merge (isomorphic-git's checkout silently drops a gitlink from
+  the materialized working tree). Recursive submodule clone/browse is future
+  work; see `docs/user-guide/importing.md#unsupported-content`.

--- a/docs/CURRENT_CAPABILITIES.md
+++ b/docs/CURRENT_CAPABILITIES.md
@@ -82,13 +82,21 @@ limitation recorded below.
   across runs under a per-run cap), with a tested restore path
   (`docs/runbooks/backup-restore.md`).
 - Git submodules are not supported (#258). A gitlink tree entry (mode 160000)
-  or a `.gitmodules` file is detected and rejected at the two points repo
-  content enters Stratum — GitHub import and a gated push — with a structured
-  `SUBMODULES_UNSUPPORTED` (422) error, so a repo using submodules fails
-  closed instead of importing partially and being corrupted by a later
-  server-side merge (isomorphic-git's checkout silently drops a gitlink from
-  the materialized working tree). Recursive submodule clone/browse is future
-  work; see `docs/user-guide/importing.md#unsupported-content`.
+  or a `.gitmodules` file is detected and rejected with a structured
+  `SUBMODULES_UNSUPPORTED` (422) error at the three points repo content enters
+  Stratum — GitHub import, a gated push, and REST change creation (the last two
+  share one scan, in the diff the change gate computes). Change creation fails
+  closed unconditionally: submodule content is refused, and so is a change
+  whose scan could not run — that is the gate that keeps submodule content out
+  of a server-side merge, which would otherwise corrupt it silently
+  (isomorphic-git's checkout drops a gitlink from the materialized working
+  tree). The import guard is deliberately best-effort: if the imported tree
+  cannot be read at all — the read token cannot be minted, the clone fails, or
+  the scan itself errors — the import proceeds with a warning and is left
+  unscanned rather than failing a healthy repo on an infrastructure hiccup, so
+  a completed import is not on its own proof the repo is submodule-free.
+  Recursive submodule clone/browse is future work; see
+  `user-guide/importing.md#unsupported-content`.
 
 ## Git LFS: not supported
 

--- a/docs/CURRENT_CAPABILITIES.md
+++ b/docs/CURRENT_CAPABILITIES.md
@@ -82,10 +82,15 @@ limitation recorded below.
   across runs under a per-run cap), with a tested restore path
   (`docs/runbooks/backup-restore.md`).
 - Git submodules are not supported (#258). A gitlink tree entry (mode 160000)
-  or a `.gitmodules` file is detected and rejected with a structured
-  `SUBMODULES_UNSUPPORTED` (422) error at the three points repo content enters
-  Stratum — GitHub import, a gated push, and REST change creation (the last two
-  share one scan, in the diff the change gate computes). Change creation fails
+  at any depth, or a root-level `.gitmodules` file, is detected and rejected at
+  the three points repo content enters Stratum — GitHub import, a gated push,
+  and REST change creation (the last two share one scan, in the diff the change
+  gate computes). The rejection carries the `SUBMODULES_UNSUPPORTED` code
+  internally, but each entry point reports it in its own transport's terms: a
+  gated push answers 200 with a per-ref `ng` reason and a permanent
+  `push rejected` message, `POST /api/projects/{name}/changes` answers 400 with
+  the explanatory message, and an import records the queue job as `failed`
+  rather than answering any request at all. Change creation fails
   closed unconditionally: submodule content is refused, and so is a change
   whose scan could not run — that is the gate that keeps submodule content out
   of a server-side merge, which would otherwise corrupt it silently

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -44,3 +44,6 @@ codes are in the [OpenAPI specification](openapi.yml).
 - `NOT_REDRIVABLE` — the deletion job is not in an incomplete state
 - `GONE` — the resource was deleted
 - `INVALID_PATH` — the requested path is invalid
+- `SUBMODULES_UNSUPPORTED` — a gitlink entry and/or `.gitmodules` file was
+  found on import or in a pushed workspace; git submodules are not supported
+  (see [Importing from GitHub](../user-guide/importing.md#unsupported-content))

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -45,5 +45,7 @@ codes are in the [OpenAPI specification](openapi.yml).
 - `GONE` — the resource was deleted
 - `INVALID_PATH` — the requested path is invalid
 - `SUBMODULES_UNSUPPORTED` — a gitlink entry and/or `.gitmodules` file was
-  found on import or in a pushed workspace; git submodules are not supported
+  found on import, or in the workspace a change is being created from — a
+  gated push and `POST /api/projects/{name}/changes` alike, since both run the
+  same scan; git submodules are not supported
   (see [Importing from GitHub](../user-guide/importing.md#unsupported-content))

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -44,8 +44,13 @@ codes are in the [OpenAPI specification](openapi.yml).
 - `NOT_REDRIVABLE` — the deletion job is not in an incomplete state
 - `GONE` — the resource was deleted
 - `INVALID_PATH` — the requested path is invalid
-- `SUBMODULES_UNSUPPORTED` — a gitlink entry and/or `.gitmodules` file was
-  found on import, or in the workspace a change is being created from — a
-  gated push and `POST /api/projects/{name}/changes` alike, since both run the
-  same scan; git submodules are not supported
-  (see [Importing from GitHub](../user-guide/importing.md#unsupported-content))
+- `SUBMODULES_UNSUPPORTED` — a gitlink entry (any depth) and/or a root-level
+  `.gitmodules` file was found on import, or in the workspace a change is being
+  created from — a gated push and `POST /api/projects/{name}/changes` alike,
+  since both run the same scan; git submodules are not supported
+  (see [Importing from GitHub](../user-guide/importing.md#unsupported-content)).
+  This code is internal and is **not** returned to API clients as a code:
+  `POST /api/projects/{name}/changes` reports it as a plain 400 carrying the
+  explanatory message, a gated push reports it over the git protocol as a
+  per-ref `ng` reason, and an import records a `failed` queue job. Match on the
+  message, not on this identifier.

--- a/docs/user-guide/importing.md
+++ b/docs/user-guide/importing.md
@@ -154,8 +154,11 @@ Bidirectional GitHub sync — inbound webhooks and outbound PR promotion, i.e.
 ## Unsupported content
 
 **Git submodules are not supported.** A repository containing a gitlink tree
-entry (the `160000` mode git uses for a submodule reference) or a
-`.gitmodules` file is rejected with a `SUBMODULES_UNSUPPORTED` error.
+entry (the `160000` mode git uses for a submodule reference) at any depth, or a
+root-level `.gitmodules` file, is rejected. A gated push is refused over the
+git protocol, `POST /api/projects/{name}/changes` answers 400, and an import
+ends as `failed` — each carrying an explanatory message rather than a
+machine-readable submodule code.
 
 On import the check is best-effort. When the just-imported tree can be read,
 submodule content fails the import with `status: "failed"` — before the

--- a/docs/user-guide/importing.md
+++ b/docs/user-guide/importing.md
@@ -92,3 +92,21 @@ curl -X POST "$STRATUM_HOST/api/projects/@username/repo/sync/settings" \
 
 Bidirectional GitHub sync — inbound webhooks and outbound PR promotion, i.e.
 **layer mode** — is covered in [Getting started](getting-started.md).
+
+## Unsupported content
+
+**Git submodules are not supported.** A repository containing a gitlink tree
+entry (the `160000` mode git uses for a submodule reference) or a
+`.gitmodules` file is detected up front and the import fails with
+`status: "failed"` and a `SUBMODULES_UNSUPPORTED` error — before the project
+is ever marked imported. The same check runs on a gated push to a project's
+default branch, so a workspace containing a submodule can't be merged either.
+
+This is deliberate: git's checkout silently drops a gitlink entry when
+Stratum's server-side git layer materializes a working tree, so partially
+importing a repo with submodules would let a later merge quietly corrupt it
+rather than fail loudly. Remove submodules (or flatten them into the repo)
+before importing, or push to a workspace remote for content that never
+touches the default branch. Full submodule support (recursive clone and
+browsing) is tracked for later; see
+[`CURRENT_CAPABILITIES.md`](https://github.com/stratum-eng/stratum/blob/main/docs/CURRENT_CAPABILITIES.md).

--- a/docs/user-guide/importing.md
+++ b/docs/user-guide/importing.md
@@ -155,10 +155,21 @@ Bidirectional GitHub sync — inbound webhooks and outbound PR promotion, i.e.
 
 **Git submodules are not supported.** A repository containing a gitlink tree
 entry (the `160000` mode git uses for a submodule reference) or a
-`.gitmodules` file is detected up front and the import fails with
-`status: "failed"` and a `SUBMODULES_UNSUPPORTED` error — before the project
-is ever marked imported. The same check runs on a gated push to a project's
-default branch, so a workspace containing a submodule can't be merged either.
+`.gitmodules` file is rejected with a `SUBMODULES_UNSUPPORTED` error.
+
+On import the check is best-effort. When the just-imported tree can be read,
+submodule content fails the import with `status: "failed"` — before the
+project is ever marked imported. When the tree cannot be read at all (the read
+token cannot be minted, the clone fails, or the scan itself errors) the import
+proceeds with a warning and is left unscanned, rather than failing a healthy
+repository because of an infrastructure hiccup. So a completed import is not
+on its own proof that a repository is submodule-free.
+
+The same scan runs whenever a change is created — on a gated push to a
+project's default branch and on `POST /api/projects/{name}/changes` alike —
+and there it is unconditional: a change carrying submodule content is refused,
+and so is one whose scan could not run. That is the gate that keeps submodule
+content out of a merge.
 
 This is deliberate: git's checkout silently drops a gitlink entry when
 Stratum's server-side git layer materializes a working tree, so partially

--- a/src/queue/import-queue.ts
+++ b/src/queue/import-queue.ts
@@ -192,10 +192,17 @@ async function checkAndHandleCancellation(
  * Each underlying failure is already logged where it happens; what none of
  * those sites can say, and the caller does, is that the submodule guard was
  * therefore skipped for this import.
+ *
+ * `branch` is the branch that was actually imported, and both the clone and
+ * the scan must use it: an imported repo keeps its source branch name
+ * (master/trunk/...), so hard-coding `main` here would make the scan fail to
+ * find its ref on exactly those projects and silently downgrade the guard to
+ * "skipped" for every one of them.
  */
 async function readSubmoduleReport(
   env: Env,
   remote: string,
+  branch: string,
   logger: Logger,
 ): Promise<SubmoduleContentReport | null> {
   // Every failure mode collapses to null, including a thrown one. The caller
@@ -207,9 +214,9 @@ async function readSubmoduleReport(
   try {
     const tokenResult = await freshRepoToken(env.ARTIFACTS, remote, "read", logger);
     if (!tokenResult.success) return null;
-    const cloneResult = await cloneRepo(remote, tokenResult.data, logger);
+    const cloneResult = await cloneRepo(remote, tokenResult.data, logger, { ref: branch });
     if (!cloneResult.success) return null;
-    const scanResult = await scanForSubmoduleContent(cloneResult.data.fs, "main", logger);
+    const scanResult = await scanForSubmoduleContent(cloneResult.data.fs, branch, logger);
     return scanResult.success ? scanResult.data : null;
   } catch (error) {
     logger.warn("Submodule scan threw while reading the imported tree", {
@@ -357,7 +364,12 @@ async function processImportJob(
     // should not be indistinguishable from a real rejection -- but it is said
     // out loud, because "did not scan" and "scanned, found nothing" are not
     // the same state and only one of them leaves the guard unenforced.
-    const submoduleReport = await readSubmoduleReport(env, importResult.data.remote, logger);
+    const submoduleReport = await readSubmoduleReport(
+      env,
+      importResult.data.remote,
+      branch,
+      logger,
+    );
     if (submoduleReport === null) {
       logger.warn(
         "Submodule guard skipped: could not read the imported tree; import proceeds unscanned",
@@ -379,6 +391,9 @@ async function processImportJob(
         branch,
         error,
         startedAt,
+        // Same as every other failure path: without the initiator the user who
+        // started this import is never told why it stopped.
+        ...(initiatedBy !== undefined ? { initiatedBy } : {}),
       });
       await updateImportStatus(env.DB, namespace, slug, "failed", logger, error.message);
       msg.ack();
@@ -1038,7 +1053,13 @@ async function sendFailureNotification(
   }
 }
 /**
- * Classify error type from error message
+ * Reduce an import failure to a stable, coarse error type.
+ *
+ * The failures arrive as free-form messages from GitHub, Artifacts and git, so
+ * the raw text is useless for grouping. This tag is what the stored import
+ * record and the failure notification key off, which is why every new terminal
+ * failure mode (submodule rejection included) needs a branch here rather than
+ * falling into `UNKNOWN_ERROR` and becoming invisible in aggregate.
  */
 function classifyError(error: Error): string {
   const message = error.message.toLowerCase();
@@ -1079,7 +1100,14 @@ function classifyError(error: Error): string {
 }
 
 /**
- * Handle import failure with logging, storage, and alerting
+ * The single place a terminal import failure is turned into everything the
+ * outside world sees: the log line, the metric, the stored failure record, and
+ * the email to the person who started it.
+ *
+ * Every failing path funnels through here so a new failure mode cannot ship
+ * with only some of those effects — most easily by forgetting `initiatedBy`,
+ * which leaves the user who triggered the import waiting on a notification
+ * that only ever reached the instance admin.
  */
 async function handleImportFailure(
   env: Env,

--- a/src/queue/import-queue.ts
+++ b/src/queue/import-queue.ts
@@ -6,6 +6,7 @@
 import { syncOrImportProject } from "../services/project-sync";
 import { isTargetDeleting } from "../storage/deletion";
 import {
+  type SubmoduleContentReport,
   cloneRepo,
   freshRepoToken,
   importFromGitHub,
@@ -174,6 +175,28 @@ async function checkAndHandleCancellation(
 }
 
 /**
+ * Best-effort read of a just-imported repo's tree for submodule content
+ * (#258). Returns `null` when the guard could not run at all -- the read
+ * token could not be minted, the clone failed, or the tree walk failed -- so
+ * the caller can distinguish "did not scan" from "scanned, found nothing".
+ * Each underlying failure is already logged where it happens; what none of
+ * those sites can say, and the caller does, is that the submodule guard was
+ * therefore skipped for this import.
+ */
+async function readSubmoduleReport(
+  env: Env,
+  remote: string,
+  logger: Logger,
+): Promise<SubmoduleContentReport | null> {
+  const tokenResult = await freshRepoToken(env.ARTIFACTS, remote, "read", logger);
+  if (!tokenResult.success) return null;
+  const cloneResult = await cloneRepo(remote, tokenResult.data, logger);
+  if (!cloneResult.success) return null;
+  const scanResult = await scanForSubmoduleContent(cloneResult.data.fs, "main", logger);
+  return scanResult.success ? scanResult.data : null;
+}
+
+/**
  * Process a GitHub import job
  * This is the core import logic that runs within the queue consumer
  */
@@ -292,49 +315,38 @@ async function processImportJob(
     // which silently drops a gitlink on checkout (see scanForSubmoduleContent's
     // doc comment). This is the last point the imported repo is still
     // disposable, so reject here rather than completing an import a later merge
-    // could then silently corrupt. A failure to even run the scan (token mint or
-    // clone) is logged and does not block the import -- it is the same
-    // best-effort clone `writeSnapshotFromRepo` performs moments later, and an
-    // infra hiccup here should not be indistinguishable from a real rejection.
-    const scanTokenResult = await freshRepoToken(
-      env.ARTIFACTS,
-      importResult.data.remote,
-      "read",
-      logger,
-    );
-    if (scanTokenResult.success) {
-      const scanCloneResult = await cloneRepo(
-        importResult.data.remote,
-        scanTokenResult.data,
-        logger,
+    // could then silently corrupt. A failure to even run the scan does not
+    // block the import -- it is the same best-effort clone
+    // `writeSnapshotFromRepo` performs moments later, and an infra hiccup here
+    // should not be indistinguishable from a real rejection -- but it is said
+    // out loud, because "did not scan" and "scanned, found nothing" are not
+    // the same state and only one of them leaves the guard unenforced.
+    const submoduleReport = await readSubmoduleReport(env, importResult.data.remote, logger);
+    if (submoduleReport === null) {
+      logger.warn(
+        "Submodule guard skipped: could not read the imported tree; import proceeds unscanned",
+        { namespace, slug, remote: importResult.data.remote },
       );
-      if (scanCloneResult.success) {
-        const scanResult = await scanForSubmoduleContent(scanCloneResult.data.fs, "main", logger);
-        if (
-          scanResult.success &&
-          (scanResult.data.gitlinkPaths.length > 0 || scanResult.data.hasGitmodules)
-        ) {
-          const error = submoduleUnsupportedError(scanResult.data);
-          logger.warn("Rejecting import: repository contains unsupported submodule content", {
-            namespace,
-            slug,
-            gitlinkPaths: scanResult.data.gitlinkPaths,
-            hasGitmodules: scanResult.data.hasGitmodules,
-          });
-          await handleImportFailure(env, {
-            importId,
-            namespace,
-            slug,
-            githubUrl,
-            branch,
-            error,
-            startedAt,
-          });
-          await updateImportStatus(env.DB, namespace, slug, "failed", logger, error.message);
-          msg.ack();
-          return;
-        }
-      }
+    } else if (submoduleReport.gitlinkPaths.length > 0 || submoduleReport.hasGitmodules) {
+      const error = submoduleUnsupportedError(submoduleReport);
+      logger.warn("Rejecting import: repository contains unsupported submodule content", {
+        namespace,
+        slug,
+        gitlinkPaths: submoduleReport.gitlinkPaths,
+        hasGitmodules: submoduleReport.hasGitmodules,
+      });
+      await handleImportFailure(env, {
+        importId,
+        namespace,
+        slug,
+        githubUrl,
+        branch,
+        error,
+        startedAt,
+      });
+      await updateImportStatus(env.DB, namespace, slug, "failed", logger, error.message);
+      msg.ack();
+      return;
     }
 
     // Update project with actual repo info and mark import as complete

--- a/src/queue/import-queue.ts
+++ b/src/queue/import-queue.ts
@@ -370,6 +370,18 @@ async function processImportJob(
       branch,
       logger,
     );
+    // The scan is a full clone plus a tree walk, so it is a phase long enough
+    // for a cancellation to land inside it -- and the rejection branch below
+    // returns before the next checkpoint, so without this the user who hit
+    // cancel gets told their repo was refused for submodules instead of that
+    // it was cancelled. Every other phase boundary in this job checks here for
+    // the same reason.
+    if (await checkAndHandleCancellation(env, namespace, slug)) {
+      await recordImportCancelled(env.DB, namespace, slug, logger);
+      msg.ack();
+      return;
+    }
+
     if (submoduleReport === null) {
       logger.warn(
         "Submodule guard skipped: could not read the imported tree; import proceeds unscanned",

--- a/src/queue/import-queue.ts
+++ b/src/queue/import-queue.ts
@@ -5,7 +5,13 @@
 
 import { syncOrImportProject } from "../services/project-sync";
 import { isTargetDeleting } from "../storage/deletion";
-import { importFromGitHub } from "../storage/git-ops";
+import {
+  cloneRepo,
+  freshRepoToken,
+  importFromGitHub,
+  scanForSubmoduleContent,
+  submoduleUnsupportedError,
+} from "../storage/git-ops";
 import { getProviderFromUrl } from "../storage/git-providers";
 import { deleteImportJob, isImportCancelled, updateImportStatus } from "../storage/imports";
 import {
@@ -277,6 +283,58 @@ async function processImportJob(
       await recordImportCancelled(env.DB, namespace, slug, logger);
       msg.ack();
       return;
+    }
+
+    // Fail closed on git submodules (#258). The raw import above (Artifacts
+    // cloning the source directly) preserves a gitlink entry byte-for-byte, but
+    // every later consumer of this repo's tree -- squash merges, the repo
+    // browser, the sandbox evaluator -- goes through isomorphic-git/MemoryFS,
+    // which silently drops a gitlink on checkout (see scanForSubmoduleContent's
+    // doc comment). This is the last point the imported repo is still
+    // disposable, so reject here rather than completing an import a later merge
+    // could then silently corrupt. A failure to even run the scan (token mint or
+    // clone) is logged and does not block the import -- it is the same
+    // best-effort clone `writeSnapshotFromRepo` performs moments later, and an
+    // infra hiccup here should not be indistinguishable from a real rejection.
+    const scanTokenResult = await freshRepoToken(
+      env.ARTIFACTS,
+      importResult.data.remote,
+      "read",
+      logger,
+    );
+    if (scanTokenResult.success) {
+      const scanCloneResult = await cloneRepo(
+        importResult.data.remote,
+        scanTokenResult.data,
+        logger,
+      );
+      if (scanCloneResult.success) {
+        const scanResult = await scanForSubmoduleContent(scanCloneResult.data.fs, "main", logger);
+        if (
+          scanResult.success &&
+          (scanResult.data.gitlinkPaths.length > 0 || scanResult.data.hasGitmodules)
+        ) {
+          const error = submoduleUnsupportedError(scanResult.data);
+          logger.warn("Rejecting import: repository contains unsupported submodule content", {
+            namespace,
+            slug,
+            gitlinkPaths: scanResult.data.gitlinkPaths,
+            hasGitmodules: scanResult.data.hasGitmodules,
+          });
+          await handleImportFailure(env, {
+            importId,
+            namespace,
+            slug,
+            githubUrl,
+            branch,
+            error,
+            startedAt,
+          });
+          await updateImportStatus(env.DB, namespace, slug, "failed", logger, error.message);
+          msg.ack();
+          return;
+        }
+      }
     }
 
     // Update project with actual repo info and mark import as complete
@@ -906,6 +964,9 @@ function classifyError(error: Error): string {
   }
   if (message.includes("rate limit") || message.includes("429")) {
     return "RATE_LIMITED";
+  }
+  if (message.includes("submodule")) {
+    return "UNSUPPORTED_CONTENT";
   }
   if (message.includes("disk") || message.includes("quota") || message.includes("space")) {
     return "STORAGE_ERROR";

--- a/src/routes/git-http.ts
+++ b/src/routes/git-http.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
+import { type EventActor, emitEvent } from "../queue/events";
 import { createChangeWithEvaluation, createWorkspaceFork } from "../services/change-flow";
 import { getAgentByToken } from "../storage/agents";
+import { updateChangeStatus } from "../storage/changes";
 import { isTargetDeleting } from "../storage/deletion";
 import {
   artifactsRepoNameFromRemote,
@@ -657,10 +659,12 @@ async function forwardPackToWorkspace(
 }
 
 /**
- * Best-effort teardown of the server-managed fork when a gated push dies
- * before its change exists: nothing references the workspace yet, so leaving
- * it would leak an Artifacts repo + KV entry per failed push. Failures are
- * logged with enough coordinates to find the orphan by hand.
+ * Best-effort teardown of the server-managed fork when a gated push ends
+ * without a change anyone can act on -- it died before the change existed, or
+ * the change gate rejected it permanently. Nothing owner-visible depends on
+ * the workspace in either case, so leaving it would leak an Artifacts repo +
+ * KV entry per failed push, once per retry. Failures are logged with enough
+ * coordinates to find the orphan by hand.
  */
 async function cleanupPushWorkspace(
   env: Env,
@@ -689,6 +693,55 @@ async function cleanupPushWorkspace(
       error: deleteResult.error.message,
     });
   }
+}
+
+/**
+ * Close the change a gated push created after the change gate has rejected it
+ * for good.
+ *
+ * A deterministic rejection (submodule content, #258) is decided AFTER the
+ * change row exists, and no retry can make that change pass -- so leaving it
+ * `open` would put a change in the owner's queue that only ever wastes their
+ * time, and every retried push would add another. It is closed as `rejected`
+ * rather than deleted because the storage layer has no change-delete path and
+ * because the refusal is worth keeping in the audit trail; the accompanying
+ * `change.rejected` event keeps consumers that saw `change.created` from
+ * tracking it as open forever.
+ *
+ * Every failure here is logged and swallowed: the pusher must still get the
+ * protocol-level rejection, which is the part that actually protects them.
+ */
+async function closeRejectedChange(
+  env: Env,
+  logger: ReturnType<typeof createLogger>,
+  args: {
+    changeId: string;
+    projectId: string;
+    projectName: string;
+    reason: string;
+    actor: EventActor;
+  },
+): Promise<void> {
+  const updateResult = await updateChangeStatus(env.DB, logger, args.changeId, "rejected", {
+    evalPassed: false,
+    evalReason: args.reason,
+  });
+  if (!updateResult.success) {
+    logger.warn("Gated push cleanup: could not close the rejected change", {
+      changeId: args.changeId,
+      projectId: args.projectId,
+      error: updateResult.error.message,
+    });
+    return;
+  }
+  await emitEvent(
+    env.DB,
+    env.EVENTS_QUEUE,
+    { type: "change.rejected", project: args.projectName, changeId: args.changeId },
+    args.actor,
+    logger,
+    args.projectId,
+  );
 }
 
 // POST /@:namespace/:slug.git/git-receive-pack — push to the project ref.
@@ -858,6 +911,22 @@ gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
     // permanent-rejection message instead of the generic "re-evaluate it"
     // guidance below.
     if (outcome.error.code === "SUBMODULES_UNSUPPORTED") {
+      // The change already exists by the time the scan runs (it is created
+      // before the diff), so refusing without releasing it would leave an open
+      // change, a workspace entry and an Artifacts fork behind on every retry.
+      const rejectedChangeId = outcome.error.context?.changeId;
+      if (typeof rejectedChangeId === "string") {
+        await closeRejectedChange(c.env, logger, {
+          changeId: rejectedChangeId,
+          projectId: project.id,
+          projectName: `${namespace}/${slug}`,
+          reason: outcome.error.message,
+          actor: identity?.agentId
+            ? { type: "agent", id: identity.agentId }
+            : { type: "user", ...(identity?.userId !== undefined ? { id: identity.userId } : {}) },
+        });
+      }
+      await cleanupPushWorkspace(c.env, project.id, forkedName, forkResult.data.remote, logger);
       return refuseAll(`push rejected: ${outcome.error.message}`, [
         "Git submodules are not supported. Remove submodules (or flatten them into the repo) and push again.",
       ]);

--- a/src/routes/git-http.ts
+++ b/src/routes/git-http.ts
@@ -737,6 +737,15 @@ gitHttpRouter.post("/:namespace/:slug/git-receive-pack", async (c) => {
   });
   if (!outcome.success) {
     logger.error("Gated push change creation failed", outcome.error);
+    // Submodules (#258) fail closed deterministically -- re-evaluating never
+    // helps, unlike a transient diff/eval hiccup, so this gets its own
+    // permanent-rejection message instead of the generic "re-evaluate it"
+    // guidance below.
+    if (outcome.error.code === "SUBMODULES_UNSUPPORTED") {
+      return refuseAll(`push rejected: ${outcome.error.message}`, [
+        "Git submodules are not supported. Remove submodules (or flatten them into the repo) and push again.",
+      ]);
+    }
     // Post-creation failures carry the open change's id in the error context;
     // naming it steers the user to re-evaluate rather than open a duplicate.
     const stuckChangeId = outcome.error.context?.changeId;

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -2023,8 +2023,9 @@ export interface SubmoduleContentReport {
  * missing -- exactly the silent corruption #258 forbids. Reading the tree
  * object directly is the only way to reliably detect a gitlink.
  *
- * Called at the two points repo content enters Stratum -- GitHub import and a
- * gated push's change creation -- so an unsupported repo is rejected up front
+ * Called at every point repo content enters Stratum -- GitHub import, and
+ * change creation for both a gated push and the REST API (both go through
+ * {@link getDiffBetweenRepos}) -- so an unsupported repo is rejected up front
  * with a clear, structured error instead of partially importing or reaching a
  * server-side merge.
  */
@@ -2841,6 +2842,22 @@ function deletedFileDiff(path: string, content: string): string {
   return `diff --git a/${path} b/${path}\ndeleted file mode 100644\n--- a/${path}\n+++ /dev/null\n@@ -1,${lineCount} +0,0 @@\n${body}\n`;
 }
 
+/**
+ * Produce the change-gate's view of a workspace fork: the unified diff against
+ * its base project plus the exact workspace revision that diff was computed
+ * from.
+ *
+ * Both sides are cloned at the SAME `branch` -- an imported project keeps its
+ * source branch name (master/trunk/...), and its fork inherits it -- so a caller
+ * that passes the project's real default branch gets a diff of like against
+ * like. Every ref this function reads (the submodule scan, the tip resolution,
+ * the file listing) must use that same `branch`, or the work silently happens
+ * against a ref that does not exist on a non-`main` project.
+ *
+ * The returned tip and tree oids come from this one clone so a caller can pin
+ * evaluation to precisely the revision that was diffed, instead of re-resolving
+ * later and racing a concurrent push.
+ */
 export async function getDiffBetweenRepos(
   baseRemote: string,
   baseToken: string,
@@ -2874,7 +2891,7 @@ export async function getDiffBetweenRepos(
   // here -- ahead of the full file listing/content read below -- rejects with a
   // clear, structured error instead of leaving a change record stuck on an
   // opaque diff failure.
-  const submoduleScan = await scanForSubmoduleContent(workspaceFs, "main", logger);
+  const submoduleScan = await scanForSubmoduleContent(workspaceFs, branch, logger);
   if (!submoduleScan.success) return err(submoduleScan.error);
   if (submoduleScan.data.gitlinkPaths.length > 0 || submoduleScan.data.hasGitmodules) {
     logger.warn("Rejecting change: workspace contains unsupported submodule content", {

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -1933,6 +1933,87 @@ function mapPushError(error: AppError): Result<never, AppError> {
   return err(error);
 }
 
+export interface SubmoduleContentReport {
+  /** Paths of gitlink (mode 160000 / walk type "commit") tree entries found. */
+  gitlinkPaths: string[];
+  /** Whether a `.gitmodules` file exists at the repo root. */
+  hasGitmodules: boolean;
+}
+
+/**
+ * Scans commit `ref`'s full tree for submodule-related content Stratum does
+ * not support (#258): gitlink entries (the tree-level marker for a submodule
+ * pointer) and a `.gitmodules` file (the config git uses to declare them).
+ *
+ * This walks the TREE OBJECT, not a checked-out working copy. That matters:
+ * isomorphic-git's checkout silently ignores a gitlink entry -- it writes
+ * nothing to the working tree and raises nothing (see the `mkdir-index`/
+ * `commit-tree` cases in its checkout implementation, and MemoryFS's
+ * `MODE_GITLINK` override, which only fires for an index write that never
+ * happens on checkout). A consumer that walked the checked-out filesystem
+ * instead would see an ordinary-looking tree with the submodule quietly
+ * missing -- exactly the silent corruption #258 forbids. Reading the tree
+ * object directly is the only way to reliably detect a gitlink.
+ *
+ * Called at the two points repo content enters Stratum -- GitHub import and a
+ * gated push's change creation -- so an unsupported repo is rejected up front
+ * with a clear, structured error instead of partially importing or reaching a
+ * server-side merge.
+ */
+export async function scanForSubmoduleContent(
+  fs: NodeFS,
+  ref: string,
+  logger: Logger,
+): Promise<Result<SubmoduleContentReport, AppError>> {
+  const gitlinkPaths: string[] = [];
+  let hasGitmodules = false;
+  const walkResult = await fromPromise(
+    git.walk({
+      fs,
+      dir: DIR,
+      trees: [git.TREE({ ref })],
+      map: async (filepath, [entry]) => {
+        if (!entry) return;
+        const type = await entry.type();
+        if (type === "commit") {
+          gitlinkPaths.push(filepath);
+        } else if (type === "blob" && filepath === ".gitmodules") {
+          hasGitmodules = true;
+        }
+      },
+    }),
+  );
+  if (!walkResult.success) {
+    logger.error("Failed to scan tree for submodule content", walkResult.error, { ref });
+    return err(
+      new ExternalServiceError("Git", `Failed to scan tree at commit: ${ref}`, walkResult.error),
+    );
+  }
+  return ok({ gitlinkPaths, hasGitmodules });
+}
+
+/** Builds the standard fail-closed error for submodule content found by
+ * {@link scanForSubmoduleContent} (#258). */
+export function submoduleUnsupportedError(report: SubmoduleContentReport): AppError {
+  const found: string[] = [];
+  if (report.gitlinkPaths.length > 0) {
+    const shown = report.gitlinkPaths.slice(0, 5);
+    const rest = report.gitlinkPaths.length - shown.length;
+    found.push(
+      `gitlink entr${report.gitlinkPaths.length === 1 ? "y" : "ies"} at ${shown.join(", ")}${
+        rest > 0 ? `, and ${rest} more` : ""
+      }`,
+    );
+  }
+  if (report.hasGitmodules) found.push(".gitmodules");
+  return new AppError(
+    `Repository uses git submodules (found ${found.join(" and ")}), which Stratum does not support yet. Remove submodules and retry.`,
+    "SUBMODULES_UNSUPPORTED",
+    422,
+    { gitlinkPaths: report.gitlinkPaths, hasGitmodules: report.hasGitmodules },
+  );
+}
+
 async function listFilesAtCommit(
   fs: NodeFS,
   ref: string,
@@ -2693,6 +2774,23 @@ export async function getDiffBetweenRepos(
 
   const { fs: workspaceFs, dir: workspaceDir } = workspaceCloneResult.data;
   const { fs: baseFs } = baseCloneResult.data;
+
+  // Fail closed on submodule content (#258) before doing any further work: the
+  // base project is already vetted (import and every prior push go through this
+  // same gate), so only the incoming workspace tree needs the check. Scanning
+  // here -- ahead of the full file listing/content read below -- rejects with a
+  // clear, structured error instead of leaving a change record stuck on an
+  // opaque diff failure.
+  const submoduleScan = await scanForSubmoduleContent(workspaceFs, "main", logger);
+  if (!submoduleScan.success) return err(submoduleScan.error);
+  if (submoduleScan.data.gitlinkPaths.length > 0 || submoduleScan.data.hasGitmodules) {
+    logger.warn("Rejecting change: workspace contains unsupported submodule content", {
+      workspaceRemote,
+      gitlinkPaths: submoduleScan.data.gitlinkPaths,
+      hasGitmodules: submoduleScan.data.hasGitmodules,
+    });
+    return err(submoduleUnsupportedError(submoduleScan.data));
+  }
 
   // Resolve the workspace tip + its tree from the SAME clone the diff is computed
   // against, so callers can pin evaluation to this exact revision (#115 selects

--- a/tests/git-http.test.ts
+++ b/tests/git-http.test.ts
@@ -1179,6 +1179,36 @@ describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
     expect(vi.mocked(env.ARTIFACTS.delete)).not.toHaveBeenCalled();
   });
 
+  it("rejects a push with a permanent, non-re-evaluate message for unsupported submodule content (#258)", async () => {
+    const env = gatedEnv();
+    await seedProject(env);
+    stubFetch(() => upstreamPushOk());
+    vi.mocked(createChangeWithEvaluation).mockResolvedValueOnce(
+      err(
+        new AppError(
+          "Repository uses git submodules (found gitlink entry at vendor/lib), which Stratum does not support yet. Remove submodules and retry.",
+          "SUBMODULES_UNSUPPORTED",
+          400,
+          { changeId: "chg_stuck_submodule" },
+        ),
+      ),
+    );
+    const res = await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+    const text = await res.text();
+    expect(text).toContain("push rejected");
+    expect(text).toContain("git submodules");
+    // Unlike a transient processing failure, this is permanent -- the pusher
+    // must not be told to re-evaluate a change that can never pass.
+    expect(text).not.toContain("re-evaluate");
+  });
+
   it("cleans up the fork when the upstream transport fails", async () => {
     const env = gatedEnv();
     await seedProject(env);

--- a/tests/git-http.test.ts
+++ b/tests/git-http.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import app from "../src/index";
 import { isGitHttpPath } from "../src/routes/git-http";
+import { updateChangeStatus } from "../src/storage/changes";
 import { freshRepoToken } from "../src/storage/git-ops";
 import type { Env, ProjectEntry } from "../src/types";
 import { AppError } from "../src/utils/errors";
@@ -49,6 +50,17 @@ vi.mock("../src/services/change-flow", async (importActual) => {
         evalRuns: [],
       },
     })),
+  };
+});
+
+// The gated-push submodule path closes the change it created (#258); the
+// storage call is stubbed so the assertion is about WHAT the route does with
+// the rejected change, not about D1.
+vi.mock("../src/storage/changes", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/changes")>();
+  return {
+    ...actual,
+    updateChangeStatus: vi.fn(async () => ({ success: true, data: undefined })),
   };
 });
 
@@ -1502,6 +1514,51 @@ describe("git smart-HTTP proxy — gated push (slice 2b)", () => {
     // Unlike a transient processing failure, this is permanent -- the pusher
     // must not be told to re-evaluate a change that can never pass.
     expect(text).not.toContain("re-evaluate");
+  });
+
+  it("leaves no orphaned change or workspace behind when submodules are rejected (#258)", async () => {
+    // The change row already exists when the submodule scan rejects, so a bare
+    // refusal would strand an open change, a workspace entry and an Artifacts
+    // fork -- one full set per retried push.
+    const env = gatedEnv();
+    await seedProject(env);
+    await seedWorkspace(
+      env,
+      "push-abcd1234",
+      "https://acct.artifacts.cloudflare.net/git/@owner/push-abcd1234.git",
+    );
+    stubFetch(() => upstreamPushOk());
+    vi.mocked(createChangeWithEvaluation).mockResolvedValueOnce(
+      err(
+        new AppError(
+          "Repository uses git submodules (found gitlink entry at vendor/lib), which Stratum does not support yet. Remove submodules and retry.",
+          "SUBMODULES_UNSUPPORTED",
+          400,
+          { changeId: "chg_stuck_submodule" },
+        ),
+      ),
+    );
+
+    await app.fetch(
+      req("/@owner/repo.git/git-receive-pack", {
+        method: "POST",
+        headers: basic(OWNER_TOKEN),
+        body: MAIN_PUSH,
+      }),
+      env,
+    );
+
+    // The change is closed rather than left open in the owner's queue.
+    expect(vi.mocked(updateChangeStatus)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "chg_stuck_submodule",
+      "rejected",
+      expect.objectContaining({ evalPassed: false }),
+    );
+    // …and the fork + workspace entry it was created from are released.
+    expect(vi.mocked(env.ARTIFACTS.delete)).toHaveBeenCalledWith("push-abcd1234");
+    expect(await env.STATE.get("workspace:proj_1:push-abcd1234")).toBeNull();
   });
 
   it("cleans up the fork when the upstream transport fails", async () => {

--- a/tests/git-ops.test.ts
+++ b/tests/git-ops.test.ts
@@ -7,9 +7,12 @@ import {
   buildUnifiedDiff,
   extractTokenSecret,
   freshRepoToken,
+  getDiffBetweenRepos,
   mergeWorkspaceIntoProject,
   readRepoFiles,
   readTreeAtCommit,
+  scanForSubmoduleContent,
+  submoduleUnsupportedError,
   walkDir,
 } from "../src/storage/git-ops";
 import { MemoryFS } from "../src/storage/memory-fs";
@@ -535,5 +538,202 @@ describe("mergeWorkspaceIntoProject merge-failure classification (#185)", () => 
     expect(result.success).toBe(true);
     if (result.success) expect(result.data).toBe("merged-sha");
     expect(git.push).toHaveBeenCalled();
+  });
+});
+
+/** Builds a one-commit local repo (real git objects, no network) on `main`,
+ * optionally with a nested gitlink entry and/or a root `.gitmodules` file. A
+ * gitlink lives inside a real `vendor` subtree because a tree entry name
+ * cannot contain a slash — a flat "vendor/lib" entry is a tree git cannot
+ * produce, so the walker in `scanForSubmoduleContent` would not be exercised
+ * the way it is in practice. */
+async function seedSubmoduleRepo(
+  fs: NodeFS,
+  dir: string,
+  opts: { gitlink?: boolean; gitmodules?: boolean } = {},
+): Promise<string> {
+  const gitfs = fs as unknown as Parameters<typeof git.init>[0]["fs"];
+  await git.init({ fs: gitfs, dir, defaultBranch: "main" });
+
+  const rootEntries: {
+    mode: string;
+    path: string;
+    oid: string;
+    type: "blob" | "tree" | "commit";
+  }[] = [];
+  const readmeOid = await git.writeBlob({
+    fs: gitfs,
+    dir,
+    blob: new TextEncoder().encode("hi\n"),
+  });
+  rootEntries.push({ mode: "100644", path: "README.md", oid: readmeOid, type: "blob" });
+
+  if (opts.gitlink) {
+    // The gitlink's oid is the submodule's commit -- never read as a blob, so
+    // it doesn't need to exist as an object (mirrors squash-merge-modes.test.ts).
+    const vendorTreeOid = await git.writeTree({
+      fs: gitfs,
+      dir,
+      tree: [{ mode: "160000", path: "lib", oid: "a".repeat(40), type: "commit" }],
+    });
+    rootEntries.push({ mode: "040000", path: "vendor", oid: vendorTreeOid, type: "tree" });
+  }
+  if (opts.gitmodules) {
+    const gitmodulesOid = await git.writeBlob({
+      fs: gitfs,
+      dir,
+      blob: new TextEncoder().encode(
+        '[submodule "lib"]\n\tpath = vendor/lib\n\turl = https://example.test/lib.git\n',
+      ),
+    });
+    rootEntries.push({ mode: "100644", path: ".gitmodules", oid: gitmodulesOid, type: "blob" });
+  }
+
+  const treeOid = await git.writeTree({ fs: gitfs, dir, tree: rootEntries });
+  const author = { name: "Test", email: "test@example.com", timestamp: 0, timezoneOffset: 0 };
+  const commit = await git.writeCommit({
+    fs: gitfs,
+    dir,
+    commit: { tree: treeOid, parent: [], author, committer: author, message: "seed" },
+  });
+  await git.writeRef({ fs: gitfs, dir, ref: "refs/heads/main", value: commit, force: true });
+  return commit;
+}
+
+describe("scanForSubmoduleContent (#258)", () => {
+  it("reports nothing unsupported for an ordinary tree", async () => {
+    const fs = new MemoryFS().toNodeFS() as unknown as NodeFS;
+    const commit = await seedSubmoduleRepo(fs, "/", {});
+
+    const result = await scanForSubmoduleContent(fs, commit, noopLogger);
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual({ gitlinkPaths: [], hasGitmodules: false });
+  });
+
+  it("detects a gitlink entry nested in a subtree", async () => {
+    const fs = new MemoryFS().toNodeFS() as unknown as NodeFS;
+    const commit = await seedSubmoduleRepo(fs, "/", { gitlink: true });
+
+    const result = await scanForSubmoduleContent(fs, commit, noopLogger);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.gitlinkPaths).toEqual(["vendor/lib"]);
+      expect(result.data.hasGitmodules).toBe(false);
+    }
+  });
+
+  it("detects a root .gitmodules file even without a gitlink entry", async () => {
+    const fs = new MemoryFS().toNodeFS() as unknown as NodeFS;
+    const commit = await seedSubmoduleRepo(fs, "/", { gitmodules: true });
+
+    const result = await scanForSubmoduleContent(fs, commit, noopLogger);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.gitlinkPaths).toEqual([]);
+      expect(result.data.hasGitmodules).toBe(true);
+    }
+  });
+});
+
+describe("submoduleUnsupportedError (#258)", () => {
+  it("names the gitlink path(s) with a 422 SUBMODULES_UNSUPPORTED error", () => {
+    const error = submoduleUnsupportedError({ gitlinkPaths: ["vendor/lib"], hasGitmodules: false });
+
+    expect(error.code).toBe("SUBMODULES_UNSUPPORTED");
+    expect(error.statusCode).toBe(422);
+    expect(error.message).toContain("vendor/lib");
+  });
+
+  it("names .gitmodules when only the config file is present", () => {
+    const error = submoduleUnsupportedError({ gitlinkPaths: [], hasGitmodules: true });
+
+    expect(error.code).toBe("SUBMODULES_UNSUPPORTED");
+    expect(error.message).toContain(".gitmodules");
+  });
+});
+
+describe("getDiffBetweenRepos rejects submodule content (#258)", () => {
+  const workspaceUrl = "https://artifacts.example.test/git/ns/ws.git";
+  const baseUrl = "https://artifacts.example.test/git/ns/project.git";
+
+  beforeEach(() => {
+    vi.mocked(git.clone).mockReset();
+    vi.mocked(git.resolveRef).mockReset();
+  });
+
+  /** Wires `git.clone` (mocked at the module level) to build a tiny local
+   * repo directly into the fs/dir it's handed, keyed by which url is being
+   * "cloned" -- exactly what a real clone of that remote would leave behind,
+   * without any network layer. */
+  function stubClones(build: (url: string, fs: NodeFS, dir: string) => Promise<void> | void): void {
+    vi.mocked(git.clone).mockImplementation(async (opts: unknown) => {
+      const { fs, dir, url } = opts as { fs: NodeFS; dir: string; url: string };
+      await build(url, fs, dir);
+    });
+  }
+
+  it("rejects when the workspace tree contains a gitlink entry", async () => {
+    stubClones(async (url, fs, dir) => {
+      await seedSubmoduleRepo(fs, dir, url === workspaceUrl ? { gitlink: true } : {});
+    });
+
+    const result = await getDiffBetweenRepos(
+      baseUrl,
+      "base-token",
+      workspaceUrl,
+      "ws-token",
+      noopLogger,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("SUBMODULES_UNSUPPORTED");
+      expect(result.error.message).toContain("vendor/lib");
+    }
+    // Rejected before ever resolving the workspace tip -- no partial change
+    // record's worth of extra work happens past the scan.
+    expect(git.resolveRef).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the workspace tree contains only .gitmodules", async () => {
+    stubClones(async (url, fs, dir) => {
+      await seedSubmoduleRepo(fs, dir, url === workspaceUrl ? { gitmodules: true } : {});
+    });
+
+    const result = await getDiffBetweenRepos(
+      baseUrl,
+      "base-token",
+      workspaceUrl,
+      "ws-token",
+      noopLogger,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("SUBMODULES_UNSUPPORTED");
+      expect(result.error.message).toContain(".gitmodules");
+    }
+  });
+
+  it("does not reject an ordinary workspace diff", async () => {
+    let workspaceCommit = "";
+    stubClones(async (url, fs, dir) => {
+      const commit = await seedSubmoduleRepo(fs, dir, {});
+      if (url === workspaceUrl) workspaceCommit = commit;
+    });
+    vi.mocked(git.resolveRef).mockImplementation(async () => workspaceCommit);
+
+    const result = await getDiffBetweenRepos(
+      baseUrl,
+      "base-token",
+      workspaceUrl,
+      "ws-token",
+      noopLogger,
+    );
+
+    expect(result.success).toBe(true);
   });
 });

--- a/tests/git-ops.test.ts
+++ b/tests/git-ops.test.ts
@@ -574,8 +574,10 @@ describe("mergeWorkspaceIntoProject merge-failure classification (#185)", () => 
   });
 });
 
-/** Builds a one-commit local repo (real git objects, no network) on `main`,
- * optionally with a nested gitlink entry and/or a root `.gitmodules` file. A
+/** Builds a one-commit local repo (real git objects, no network) on `main` —
+ * or on `opts.branch`, and ONLY on it, so a test can prove a caller reads the
+ * branch it was handed rather than a hard-coded `main` — optionally with a
+ * nested gitlink entry and/or a root `.gitmodules` file. A
  * gitlink lives inside a real `vendor` subtree because a tree entry name
  * cannot contain a slash — a flat "vendor/lib" entry is a tree git cannot
  * produce, so the walker in `scanForSubmoduleContent` would not be exercised
@@ -583,7 +585,7 @@ describe("mergeWorkspaceIntoProject merge-failure classification (#185)", () => 
 async function seedSubmoduleRepo(
   fs: NodeFS,
   dir: string,
-  opts: { gitlink?: boolean; gitmodules?: boolean } = {},
+  opts: { gitlink?: boolean; gitmodules?: boolean; branch?: string } = {},
 ): Promise<string> {
   const gitfs = fs as unknown as Parameters<typeof git.init>[0]["fs"];
   await git.init({ fs: gitfs, dir, defaultBranch: "main" });
@@ -629,7 +631,13 @@ async function seedSubmoduleRepo(
     dir,
     commit: { tree: treeOid, parent: [], author, committer: author, message: "seed" },
   });
-  await git.writeRef({ fs: gitfs, dir, ref: "refs/heads/main", value: commit, force: true });
+  await git.writeRef({
+    fs: gitfs,
+    dir,
+    ref: `refs/heads/${opts.branch ?? "main"}`,
+    value: commit,
+    force: true,
+  });
   return commit;
 }
 
@@ -748,6 +756,37 @@ describe("getDiffBetweenRepos rejects submodule content (#258)", () => {
     if (!result.success) {
       expect(result.error.code).toBe("SUBMODULES_UNSUPPORTED");
       expect(result.error.message).toContain(".gitmodules");
+    }
+  });
+
+  it("scans the branch it was asked for, not a hard-coded main (#258)", async () => {
+    // A project imported from a repo whose default branch is `trunk` has no
+    // `main` anywhere: base repo, workspace fork and both clones are on
+    // `trunk`. Scanning `main` regardless would fail to resolve the ref and
+    // surface an opaque git error, so a submodule push would get past the
+    // guard on exactly the projects it was not hard-coded for.
+    stubClones(async (url, fs, dir) => {
+      await seedSubmoduleRepo(fs, dir, {
+        branch: "trunk",
+        ...(url === workspaceUrl ? { gitlink: true } : {}),
+      });
+    });
+
+    const result = await getDiffBetweenRepos(
+      baseUrl,
+      "base-token",
+      workspaceUrl,
+      "ws-token",
+      noopLogger,
+      "trunk",
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // The structured rejection specifically — not a generic git failure
+      // from scanning a ref this project does not have.
+      expect(result.error.code).toBe("SUBMODULES_UNSUPPORTED");
+      expect(result.error.message).toContain("vendor/lib");
     }
   });
 

--- a/tests/import-fidelity.test.ts
+++ b/tests/import-fidelity.test.ts
@@ -183,6 +183,18 @@ vi.mock("../src/storage/git-ops", () => ({
   getCommitLog: vi.fn(),
   readFileFromRepo: vi.fn(),
   freshRepoToken: vi.fn(),
+  // The post-import submodule guard (#258). Left unconfigured it rejects the
+  // token mint the way every other mock in this suite does nothing, so the
+  // guard skips itself and the pre-existing tests below are unaffected; the
+  // rejection test drives it explicitly. The real scan is covered against
+  // genuine tree objects in tests/integration/import-flow.test.ts.
+  scanForSubmoduleContent: vi.fn(),
+  submoduleUnsupportedError: vi.fn(
+    () =>
+      new Error(
+        "Repository uses git submodules (found gitlink entry at vendor/lib), which Stratum does not support yet. Remove submodules and retry.",
+      ),
+  ),
 }));
 
 vi.mock("../src/storage/repo-snapshot", () => ({
@@ -1070,6 +1082,53 @@ describe("import queue consumer", () => {
 
     expect(mockImportJobs.get("@usera:repo")?.status).toBe("failed");
     expect(emailSend).toHaveBeenCalledTimes(2);
+    const recipients = emailSend.mock.calls.map(
+      (call) => (call as unknown as [{ to: string }])[0].to,
+    );
+    expect(recipients).toContain("userA@example.com");
+    expect(recipients).toContain("admin@example.com");
+  });
+
+  it("emails the triggering user when the import is rejected for submodules (#258)", async () => {
+    // The submodule rejection is a terminal import failure like any other, and
+    // the person who started the import is the only one who can act on it —
+    // dropping the initiator here would leave them staring at a stalled import
+    // while only the instance admin learns why.
+    const { handleImportQueue } = await import("../src/queue/import-queue");
+    const { importFromGitHub, freshRepoToken, cloneRepo, scanForSubmoduleContent } = await import(
+      "../src/storage/git-ops"
+    );
+    vi.mocked(importFromGitHub).mockResolvedValue({
+      success: true,
+      data: {
+        name: "usera__repo",
+        remote: "https://artifacts.example.com/repos/usera__repo",
+        token: "tok_x",
+      },
+    });
+    vi.mocked(freshRepoToken).mockResolvedValue({ success: true, data: "scan-token" });
+    vi.mocked(cloneRepo).mockResolvedValue({
+      success: true,
+      data: { fs: {} as never, dir: "/" },
+    });
+    vi.mocked(scanForSubmoduleContent).mockResolvedValue({
+      success: true,
+      data: { gitlinkPaths: ["vendor/lib"], hasGitmodules: false },
+    });
+
+    const emailSend = vi.fn(async () => ({ messageId: "m1" }));
+    const env = makeEnv({
+      EMAIL: { send: emailSend },
+      ADMIN_EMAIL: "admin@example.com",
+      EMAIL_FROM_ADDRESS: "alerts@stratum.dev",
+    });
+    await seedProject(env, { namespace: "@usera", slug: "repo", projectId: "proj_1" });
+    await seedImportJob({ namespace: "@usera", slug: "repo", projectId: "proj_1" });
+
+    const message = createMockMessage(importMessage({ initiatedBy: "user_A" }));
+    await handleImportQueue(createMockBatch([message]), env);
+
+    expect(mockImportJobs.get("@usera:repo")?.status).toBe("failed");
     const recipients = emailSend.mock.calls.map(
       (call) => (call as unknown as [{ to: string }])[0].to,
     );

--- a/tests/integration/import-flow.test.ts
+++ b/tests/integration/import-flow.test.ts
@@ -817,7 +817,14 @@ describe("End-to-End Import Flow", () => {
       return { fs, dir };
     }
 
-    async function runImport(slug: string) {
+    /**
+     * Drives one whole import job through the queue consumer and hands back
+     * the stored progress record — the only externally visible verdict on
+     * whether the submodule guard rejected, skipped, or passed the repo.
+     * `branch` is the branch the user selected for the import, which the
+     * guard is required to scan (a repo imported from `trunk` has no `main`).
+     */
+    async function runImport(slug: string, branch = "main") {
       const { importFromGitHub } = await import("../../src/storage/git-ops");
       vi.mocked(importFromGitHub).mockResolvedValue({
         success: true,
@@ -837,7 +844,7 @@ describe("End-to-End Import Flow", () => {
         namespace: "@userA",
         slug,
         githubUrl: "https://github.com/test/repo",
-        branch: "main",
+        branch,
         depth: 10,
         timestamp: new Date().toISOString(),
       });
@@ -906,11 +913,11 @@ describe("End-to-End Import Flow", () => {
           },
         },
         {
-          // The scan reads the tree at `main`. A repo whose default branch is
-          // `master` has no such ref, so the walk itself fails and the guard
-          // never runs -- the concrete shape the skip takes for any imported
-          // repo that keeps a non-`main` source branch name.
-          name: "tree walk fails (repo's branch is not `main`)",
+          // The scan reads the tree at the imported branch. A clone that comes
+          // back without that ref at all (a half-written fork, a fetch that
+          // dropped the branch) makes the walk itself fail, so the guard never
+          // produces a report.
+          name: "tree walk fails (cloned tree has no such ref)",
           arrange: async () => {
             vi.mocked(freshRepoToken).mockResolvedValue({ success: true, data: "scan-token" });
             vi.mocked(cloneRepo).mockResolvedValue({
@@ -926,6 +933,36 @@ describe("End-to-End Import Flow", () => {
         const progress = await runImport(`scan-unavailable-${index}`);
         expect(progress.data?.status, testCase.name).toBe("completed");
       }
+    });
+
+    it("scans the imported branch, so a non-`main` repo is still rejected (#258)", async () => {
+      // An imported repo keeps its source branch name, and nothing in it is
+      // called `main`. Scanning `main` regardless would fail to resolve the
+      // ref, collapse to "could not scan", and wave the repo through — the
+      // guard silently unenforced for every project not on `main`.
+      const { freshRepoToken, cloneRepo } = await import("../../src/storage/git-ops");
+      vi.mocked(freshRepoToken).mockResolvedValue({ success: true, data: "scan-token" });
+      vi.mocked(cloneRepo).mockResolvedValue({
+        success: true,
+        data: await buildScannedRepo({ gitlink: true, branch: "trunk" }),
+      });
+
+      const progress = await runImport("trunk-gitlink-project", "trunk");
+
+      expect(progress.data?.status).toBe("failed");
+      expect(
+        progress.data?.logs.some(
+          (log) => log.message.includes("submodule") || log.message.includes("gitlink"),
+        ),
+      ).toBe(true);
+      // The clone has to be pinned to that branch too — a clone of `main`
+      // would leave the scan nothing correct to read.
+      expect(vi.mocked(cloneRepo)).toHaveBeenCalledWith(
+        expect.any(String),
+        "scan-token",
+        expect.anything(),
+        { ref: "trunk" },
+      );
     });
 
     it("completes normally when the tree has neither a gitlink nor .gitmodules", async () => {

--- a/tests/integration/import-flow.test.ts
+++ b/tests/integration/import-flow.test.ts
@@ -9,8 +9,12 @@
  * lifecycle through the queue system.
  */
 
+import git from "isomorphic-git";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleImportQueue, queueImportJob, queueSyncJob } from "../../src/queue/import-queue";
+import { blobObject, commitObject, treeObject } from "../../src/storage/git-objects";
+import { MemoryFS } from "../../src/storage/memory-fs";
+import { placeLooseObject } from "../../src/storage/object-loader";
 import type {
   Env,
   ImportJobMessage,
@@ -194,6 +198,12 @@ vi.mock("../../src/storage/git-ops", async (importActual) => {
     ...actual,
     importFromGitHub: vi.fn(),
     syncFromGitHub: vi.fn(),
+    // Real network cloning has no place in this suite; the submodule-rejection
+    // tests below drive this mock to hand back a fully local MemoryFS clone
+    // (real git objects, no HTTP) so the REAL `scanForSubmoduleContent` runs
+    // against it exactly as it would against a genuine clone.
+    freshRepoToken: vi.fn(),
+    cloneRepo: vi.fn(),
   };
 });
 
@@ -329,12 +339,22 @@ async function createTestImportJob(
 describe("End-to-End Import Flow", () => {
   let env: Env;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     env = makeEnv();
     vi.clearAllMocks();
     mockImportJobs.clear();
     mockProjects.clear();
     mockJobIdCounter = 0;
+
+    // Default the post-import submodule scan's token mint to "fails" so
+    // existing tests that never touch it keep exercising the pre-#258
+    // behavior (the scan is best-effort and skips itself on a mint failure —
+    // see processImportJob). Tests below override this per-case.
+    const { freshRepoToken } = await import("../../src/storage/git-ops");
+    vi.mocked(freshRepoToken).mockResolvedValue({
+      success: false,
+      error: new AppError("no token in this suite", "EXTERNAL_SERVICE_ERROR", 502),
+    });
   });
 
   describe("Happy Path - Successful Import", () => {
@@ -726,6 +746,144 @@ describe("End-to-End Import Flow", () => {
         const progress = await getImportProgress(env.DB, "@userA", slug, logger);
         expect(progress.data?.status).toBe("completed");
       }
+    });
+  });
+
+  describe("Submodule rejection (#258)", () => {
+    const enc = (s: string) => new TextEncoder().encode(s);
+
+    /**
+     * Builds a fully local "clone" (real git objects in a fresh MemoryFS, no
+     * network) with `main` at a single commit, optionally containing a gitlink
+     * tree entry and/or a `.gitmodules` file. Wired in as `cloneRepo`'s mock
+     * implementation so `processImportJob`'s real `scanForSubmoduleContent`
+     * runs against genuine tree objects exactly as it would against a real
+     * clone of the just-imported repo.
+     */
+    async function buildScannedRepo(opts: { gitlink?: boolean; gitmodules?: boolean }) {
+      const raw = new MemoryFS();
+      const fs = raw.toNodeFS();
+      const gitfs = fs;
+      const dir = "/";
+      const gitdir = "/.git";
+      await git.init({ fs: gitfs, dir, defaultBranch: "main" });
+
+      const entries: { mode: string; name: string; oid: string }[] = [];
+      const objects: { oid: string; bytes: Uint8Array }[] = [];
+
+      const readme = await blobObject(enc("hello\n"));
+      objects.push(readme);
+      entries.push({ mode: "100644", name: "README.md", oid: readme.oid });
+
+      if (opts.gitlink) {
+        // A gitlink lives inside a real subtree because a tree entry name
+        // cannot contain a slash (mirrors tests/squash-merge-modes.test.ts).
+        const vendorTree = await treeObject([{ mode: "160000", name: "lib", oid: "a".repeat(40) }]);
+        objects.push(vendorTree);
+        entries.push({ mode: "40000", name: "vendor", oid: vendorTree.oid });
+      }
+      if (opts.gitmodules) {
+        const gitmodules = await blobObject(
+          enc('[submodule "lib"]\n\tpath = vendor/lib\n\turl = https://example.test/lib.git\n'),
+        );
+        objects.push(gitmodules);
+        entries.push({ mode: "100644", name: ".gitmodules", oid: gitmodules.oid });
+      }
+
+      const tree = await treeObject(entries);
+      objects.push(tree);
+      const commit = await commitObject({
+        tree: tree.oid,
+        parents: [],
+        message: "seed",
+        timestamp: 1700000000,
+      });
+      objects.push(commit);
+
+      for (const o of objects) await placeLooseObject(fs, gitdir, o.oid, o.bytes);
+      await git.writeRef({
+        fs: gitfs,
+        dir,
+        ref: "refs/heads/main",
+        value: commit.oid,
+        force: true,
+      });
+
+      return { fs, dir };
+    }
+
+    async function runImport(slug: string) {
+      const { importFromGitHub } = await import("../../src/storage/git-ops");
+      vi.mocked(importFromGitHub).mockResolvedValue({
+        success: true,
+        data: {
+          remote: `https://artifacts.example.com/repos/test__${slug}`,
+          token: "tok_abc123",
+        },
+      });
+
+      const projectId = "proj_submodule";
+      await createTestImportJob(env, { namespace: "@userA", slug, status: "queued", projectId });
+
+      const message = createMockMessage<ImportJobMessage>({
+        type: "github.import",
+        importId: "import_1",
+        projectId,
+        namespace: "@userA",
+        slug,
+        githubUrl: "https://github.com/test/repo",
+        branch: "main",
+        depth: 10,
+        timestamp: new Date().toISOString(),
+      });
+      await handleImportQueue(createMockBatch([message], "stratum-imports"), env);
+
+      const { getImportProgress } = await import("../../src/storage/imports");
+      const { createLogger } = await import("../../src/utils/logger");
+      const logger = createLogger({ component: "Test" });
+      return getImportProgress(env.DB, "@userA", slug, logger);
+    }
+
+    it("rejects an import whose tree contains a gitlink entry", async () => {
+      const { freshRepoToken, cloneRepo } = await import("../../src/storage/git-ops");
+      vi.mocked(freshRepoToken).mockResolvedValue({ success: true, data: "scan-token" });
+      vi.mocked(cloneRepo).mockResolvedValue({
+        success: true,
+        data: await buildScannedRepo({ gitlink: true }),
+      });
+
+      const progress = await runImport("gitlink-project");
+
+      expect(progress.data?.status).toBe("failed");
+      expect(
+        progress.data?.logs.some(
+          (log) => log.message.includes("submodule") || log.message.includes("gitlink"),
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects an import whose tree contains only a .gitmodules file", async () => {
+      const { freshRepoToken, cloneRepo } = await import("../../src/storage/git-ops");
+      vi.mocked(freshRepoToken).mockResolvedValue({ success: true, data: "scan-token" });
+      vi.mocked(cloneRepo).mockResolvedValue({
+        success: true,
+        data: await buildScannedRepo({ gitmodules: true }),
+      });
+
+      const progress = await runImport("gitmodules-only-project");
+
+      expect(progress.data?.status).toBe("failed");
+      expect(progress.data?.logs.some((log) => log.message.includes("submodule"))).toBe(true);
+    });
+
+    it("completes normally when the tree has neither a gitlink nor .gitmodules", async () => {
+      const { freshRepoToken, cloneRepo } = await import("../../src/storage/git-ops");
+      vi.mocked(freshRepoToken).mockResolvedValue({ success: true, data: "scan-token" });
+      vi.mocked(cloneRepo).mockResolvedValue({ success: true, data: await buildScannedRepo({}) });
+
+      const progress = await runImport("clean-project");
+
+      expect(progress.data?.status).toBe("completed");
     });
   });
 });

--- a/tests/integration/import-flow.test.ts
+++ b/tests/integration/import-flow.test.ts
@@ -965,6 +965,37 @@ describe("End-to-End Import Flow", () => {
       );
     });
 
+    it("reports a cancellation that lands during the scan as cancelled, not as a submodule failure", async () => {
+      // The scan clones and walks a tree, so it is wide enough for a user's
+      // cancel to arrive mid-flight. Reporting that as "failed: submodules"
+      // would blame the repo for something the user chose, and would fire a
+      // failure notification for an import nobody was still waiting on.
+      const { freshRepoToken, cloneRepo } = await import("../../src/storage/git-ops");
+      const { cancelImportJob } = await import("../../src/storage/imports");
+      const { createLogger } = await import("../../src/utils/logger");
+      const cancelLogger = createLogger({ component: "Test" });
+      vi.mocked(freshRepoToken).mockResolvedValue({ success: true, data: "scan-token" });
+      vi.mocked(cloneRepo).mockImplementation(async () => {
+        // Cancel while the scan is in flight — the window this guards.
+        await cancelImportJob(env.DB, "@userA", "cancelled-mid-scan", cancelLogger);
+        return { success: true, data: await buildScannedRepo({ gitlink: true }) };
+      });
+
+      const { updateImportStatus } = await import("../../src/storage/imports");
+      await runImport("cancelled-mid-scan");
+
+      // A cancelled import is marked "cancelled" and then deleted, so assert
+      // on the status transition rather than on the (now absent) job.
+      const statuses = vi
+        .mocked(updateImportStatus)
+        .mock.calls.filter((call) => call[2] === "cancelled-mid-scan")
+        .map((call) => call[3]);
+      expect(statuses).toContain("cancelled");
+      // The point of the guard: the gitlink in the tree must NOT turn the
+      // user's cancellation into a submodule rejection.
+      expect(statuses).not.toContain("failed");
+    });
+
     it("completes normally when the tree has neither a gitlink nor .gitmodules", async () => {
       const { freshRepoToken, cloneRepo } = await import("../../src/storage/git-ops");
       vi.mocked(freshRepoToken).mockResolvedValue({ success: true, data: "scan-token" });

--- a/tests/integration/import-flow.test.ts
+++ b/tests/integration/import-flow.test.ts
@@ -760,7 +760,12 @@ describe("End-to-End Import Flow", () => {
      * runs against genuine tree objects exactly as it would against a real
      * clone of the just-imported repo.
      */
-    async function buildScannedRepo(opts: { gitlink?: boolean; gitmodules?: boolean }) {
+    async function buildScannedRepo(opts: {
+      gitlink?: boolean;
+      gitmodules?: boolean;
+      branch?: string;
+    }) {
+      const branch = opts.branch ?? "main";
       const raw = new MemoryFS();
       const fs = raw.toNodeFS();
       const gitfs = fs;
@@ -804,7 +809,7 @@ describe("End-to-End Import Flow", () => {
       await git.writeRef({
         fs: gitfs,
         dir,
-        ref: "refs/heads/main",
+        ref: `refs/heads/${branch}`,
         value: commit.oid,
         force: true,
       });
@@ -874,6 +879,53 @@ describe("End-to-End Import Flow", () => {
 
       expect(progress.data?.status).toBe("failed");
       expect(progress.data?.logs.some((log) => log.message.includes("submodule"))).toBe(true);
+    });
+
+    it("skips the guard without blocking the import when the scan cannot run", async () => {
+      // The guard is best-effort: an infra failure must not turn a healthy
+      // repo into a failed import. Each of the three ways the scan can fail
+      // to produce a report takes that path. processImportJob also warns that
+      // the guard was skipped, so "did not scan" is not silently
+      // indistinguishable from "scanned, found nothing" -- that line goes to
+      // the pino logger, which this suite has no seam to capture, so only the
+      // skip-does-not-block contract is asserted here.
+      const { freshRepoToken, cloneRepo } = await import("../../src/storage/git-ops");
+      const failure = new AppError("scan unavailable", "EXTERNAL_SERVICE_ERROR", 502);
+      const cases = [
+        {
+          name: "token mint fails",
+          arrange: async () => {
+            vi.mocked(freshRepoToken).mockResolvedValue({ success: false, error: failure });
+          },
+        },
+        {
+          name: "clone fails",
+          arrange: async () => {
+            vi.mocked(freshRepoToken).mockResolvedValue({ success: true, data: "scan-token" });
+            vi.mocked(cloneRepo).mockResolvedValue({ success: false, error: failure });
+          },
+        },
+        {
+          // The scan reads the tree at `main`. A repo whose default branch is
+          // `master` has no such ref, so the walk itself fails and the guard
+          // never runs -- the concrete shape the skip takes for any imported
+          // repo that keeps a non-`main` source branch name.
+          name: "tree walk fails (repo's branch is not `main`)",
+          arrange: async () => {
+            vi.mocked(freshRepoToken).mockResolvedValue({ success: true, data: "scan-token" });
+            vi.mocked(cloneRepo).mockResolvedValue({
+              success: true,
+              data: await buildScannedRepo({ branch: "master", gitlink: true }),
+            });
+          },
+        },
+      ];
+
+      for (const [index, testCase] of cases.entries()) {
+        await testCase.arrange();
+        const progress = await runImport(`scan-unavailable-${index}`);
+        expect(progress.data?.status, testCase.name).toBe("completed");
+      }
     });
 
     it("completes normally when the tree has neither a gitlink nor .gitmodules", async () => {

--- a/website/src/content/docs/guides/faq.md
+++ b/website/src/content/docs/guides/faq.md
@@ -113,8 +113,11 @@ Honestly, several:
 - **Evaluation runs synchronously** at change creation — there's no async
   evaluation queue yet, so very slow evaluators stretch the request.
 - **Git submodules are not supported.** A gitlink entry or `.gitmodules` file
-  is detected and rejected — with a clear error — at import and at a gated
-  push, rather than risk a server-side merge silently corrupting it. See
+  is rejected — with a clear error — whenever a change is created, on a gated
+  push and through the REST API alike, rather than risk a server-side merge
+  silently corrupting it. The same check runs on import, but there it is
+  best-effort: an import whose tree can't be read proceeds unscanned with a
+  warning. See
   [Importing from GitHub](/guides/importing/#unsupported-content).
 
 See

--- a/website/src/content/docs/guides/faq.md
+++ b/website/src/content/docs/guides/faq.md
@@ -112,9 +112,9 @@ Honestly, several:
   access.
 - **Evaluation runs synchronously** at change creation — there's no async
   evaluation queue yet, so very slow evaluators stretch the request.
-- **Git submodules are not supported.** A gitlink entry or `.gitmodules` file
-  is rejected — with a clear error — whenever a change is created, on a gated
-  push and through the REST API alike, rather than risk a server-side merge
+- **Git submodules are not supported.** A gitlink entry at any depth, or a
+  root-level `.gitmodules` file, is rejected — with a clear error — whenever a
+  change is created, on a gated push and through the REST API alike, rather than risk a server-side merge
   silently corrupting it. The same check runs on import, but there it is
   best-effort: an import whose tree can't be read proceeds unscanned with a
   warning. See

--- a/website/src/content/docs/guides/faq.md
+++ b/website/src/content/docs/guides/faq.md
@@ -112,6 +112,10 @@ Honestly, several:
   access.
 - **Evaluation runs synchronously** at change creation — there's no async
   evaluation queue yet, so very slow evaluators stretch the request.
+- **Git submodules are not supported.** A gitlink entry or `.gitmodules` file
+  is detected and rejected — with a clear error — at import and at a gated
+  push, rather than risk a server-side merge silently corrupting it. See
+  [Importing from GitHub](/guides/importing/#unsupported-content).
 
 See
 [`docs/CURRENT_CAPABILITIES.md`](https://github.com/stratum-eng/stratum/blob/main/docs/CURRENT_CAPABILITIES.md)

--- a/website/src/content/docs/guides/importing.md
+++ b/website/src/content/docs/guides/importing.md
@@ -100,8 +100,11 @@ Bidirectional GitHub sync — inbound webhooks and outbound PR promotion, i.e.
 ## Unsupported content
 
 **Git submodules are not supported.** A repository containing a gitlink tree
-entry (the `160000` mode git uses for a submodule reference) or a
-`.gitmodules` file is rejected with a `SUBMODULES_UNSUPPORTED` error.
+entry (the `160000` mode git uses for a submodule reference) at any depth, or a
+root-level `.gitmodules` file, is rejected. A gated push is refused over the
+git protocol, `POST /api/projects/{name}/changes` answers 400, and an import
+ends as `failed` — each carrying an explanatory message rather than a
+machine-readable submodule code.
 
 On import the check is best-effort. When the just-imported tree can be read,
 submodule content fails the import with `status: "failed"` — before the

--- a/website/src/content/docs/guides/importing.md
+++ b/website/src/content/docs/guides/importing.md
@@ -96,3 +96,20 @@ curl -X POST "$STRATUM_HOST/api/projects/@username/repo/sync/settings" \
 Bidirectional GitHub sync — inbound webhooks and outbound PR promotion, i.e.
 **layer mode** — is covered in
 [Getting started](/guides/getting-started/#choose-your-level-of-buy-in-layer-mode-vs-alternative-mode).
+
+## Unsupported content
+
+**Git submodules are not supported.** A repository containing a gitlink tree
+entry (the `160000` mode git uses for a submodule reference) or a
+`.gitmodules` file is detected up front and the import fails with
+`status: "failed"` and a `SUBMODULES_UNSUPPORTED` error — before the project
+is ever marked imported. The same check runs on a gated push to a project's
+default branch, so a workspace containing a submodule can't be merged either.
+
+This is deliberate: git's checkout silently drops a gitlink entry when
+Stratum's server-side git layer materializes a working tree, so partially
+importing a repo with submodules would let a later merge quietly corrupt it
+rather than fail loudly. Remove submodules (or flatten them into the repo)
+before importing, or push to a workspace remote for content that never
+touches the default branch. Full submodule support (recursive clone and
+browsing) is tracked for later.

--- a/website/src/content/docs/guides/importing.md
+++ b/website/src/content/docs/guides/importing.md
@@ -101,10 +101,21 @@ Bidirectional GitHub sync — inbound webhooks and outbound PR promotion, i.e.
 
 **Git submodules are not supported.** A repository containing a gitlink tree
 entry (the `160000` mode git uses for a submodule reference) or a
-`.gitmodules` file is detected up front and the import fails with
-`status: "failed"` and a `SUBMODULES_UNSUPPORTED` error — before the project
-is ever marked imported. The same check runs on a gated push to a project's
-default branch, so a workspace containing a submodule can't be merged either.
+`.gitmodules` file is rejected with a `SUBMODULES_UNSUPPORTED` error.
+
+On import the check is best-effort. When the just-imported tree can be read,
+submodule content fails the import with `status: "failed"` — before the
+project is ever marked imported. When the tree cannot be read at all (the read
+token cannot be minted, the clone fails, or the scan itself errors) the import
+proceeds with a warning and is left unscanned, rather than failing a healthy
+repository because of an infrastructure hiccup. So a completed import is not
+on its own proof that a repository is submodule-free.
+
+The same scan runs whenever a change is created — on a gated push to a
+project's default branch and on `POST /api/projects/{name}/changes` alike —
+and there it is unconditional: a change carrying submodule content is refused,
+and so is one whose scan could not run. That is the gate that keeps submodule
+content out of a merge.
 
 This is deliberate: git's checkout silently drops a gitlink entry when
 Stratum's server-side git layer materializes a working tree, so partially

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -48,5 +48,7 @@ codes are in the [OpenAPI specification](/reference/openapi/).
 - `GONE` — the resource was deleted
 - `INVALID_PATH` — the requested path is invalid
 - `SUBMODULES_UNSUPPORTED` — a gitlink entry and/or `.gitmodules` file was
-  found on import or in a pushed workspace; git submodules are not supported
+  found on import, or in the workspace a change is being created from — a
+  gated push and `POST /api/projects/{name}/changes` alike, since both run the
+  same scan; git submodules are not supported
   (see [Importing from GitHub](/guides/importing/#unsupported-content))

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -47,8 +47,13 @@ codes are in the [OpenAPI specification](/reference/openapi/).
 - `NOT_REDRIVABLE` — the deletion job is not in an incomplete state
 - `GONE` — the resource was deleted
 - `INVALID_PATH` — the requested path is invalid
-- `SUBMODULES_UNSUPPORTED` — a gitlink entry and/or `.gitmodules` file was
-  found on import, or in the workspace a change is being created from — a
-  gated push and `POST /api/projects/{name}/changes` alike, since both run the
-  same scan; git submodules are not supported
-  (see [Importing from GitHub](/guides/importing/#unsupported-content))
+- `SUBMODULES_UNSUPPORTED` — a gitlink entry (any depth) and/or a root-level
+  `.gitmodules` file was found on import, or in the workspace a change is being
+  created from — a gated push and `POST /api/projects/{name}/changes` alike,
+  since both run the same scan; git submodules are not supported
+  (see [Importing from GitHub](/guides/importing/#unsupported-content)).
+  This code is internal and is **not** returned to API clients as a code:
+  `POST /api/projects/{name}/changes` reports it as a plain 400 carrying the
+  explanatory message, a gated push reports it over the git protocol as a
+  per-ref `ng` reason, and an import records a `failed` queue job. Match on the
+  message, not on this identifier.

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -47,3 +47,6 @@ codes are in the [OpenAPI specification](/reference/openapi/).
 - `NOT_REDRIVABLE` — the deletion job is not in an incomplete state
 - `GONE` — the resource was deleted
 - `INVALID_PATH` — the requested path is invalid
+- `SUBMODULES_UNSUPPORTED` — a gitlink entry and/or `.gitmodules` file was
+  found on import or in a pushed workspace; git submodules are not supported
+  (see [Importing from GitHub](/guides/importing/#unsupported-content))


### PR DESCRIPTION
## Summary

Implements the scoped first step of #258 — non-corruption, not full submodule support. Submodule content (a gitlink tree entry, mode 160000, at any depth, and/or a root-level `.gitmodules` file) is now detected at the three points repo content enters Stratum — GitHub import, a gated push, and REST change creation — and rejected with a message naming the offending paths, instead of letting a repo partially import and later be corrupted by a server-side merge.

Preservation was investigated first and found **not provable**: isomorphic-git&#39;s checkout has a deliberate no-op for gitlink entries (writes nothing, raises nothing), so any consumer reading the checked-out MemoryFS tree sees a submodule silently disappear. #213 already fails closed on gitlinks inside `squashMerge`&#39;s tree walk; this extends the same tree-object-walk technique to the entry points:

- **Import:** `processImportJob` clones the freshly-imported branch and runs `scanForSubmoduleContent` before marking the import complete; `classifyError` gains a `submodule` → `UNSUPPORTED_CONTENT` classification. This guard is **best-effort**: if the tree cannot be read at all (token minting, clone, or scan failure) the import proceeds with a warning and is left unscanned, rather than failing a healthy repo over an infrastructure hiccup. A completed import is therefore not on its own proof that a repo is submodule-free.
- **Push / change creation:** `getDiffBetweenRepos` (the shared diff step behind both gated `git push` and `POST /api/projects/{name}/changes`) scans the workspace tree before any further work, and there the check is unconditional — a scan that cannot run fails the change. The gated-push in-protocol response gets a dedicated &#34;push rejected&#34; message rather than the generic &#34;re-evaluate it&#34; guidance, since a submodule change can never pass re-evaluation; the change it created is closed as `rejected` (with a `change.rejected` event) and its workspace and Artifacts fork are released, so a retried push does not accumulate orphans.

### How the rejection reaches each caller

The `SUBMODULES_UNSUPPORTED` code is internal — it is **not** returned to API clients as a machine-readable code, and there is no shared 422. Each entry point reports in its own transport&#39;s terms:

| Entry point | What the caller sees |
| --- | --- |
| Gated `git push` | HTTP 200 with a per-ref `ng` reason and the permanent `push rejected` message |
| `POST /api/projects/{name}/changes` | HTTP 400 carrying the explanatory message (`changes.ts` funnels every non-5xx through `badRequest`) |
| GitHub import | No HTTP response at all — the queue job is recorded `failed` |

Callers should match on the message, not on the identifier.

Limitation documented in `docs/CURRENT_CAPABILITIES.md`, `docs/user-guide/importing.md`, `docs/api/errors.md`, and their website mirrors. **Full submodule support (recursive clone/browse) remains out of scope.**

## Related issues

Refs #258 (non-corruption first step only — does not close it)

## Type of change

- [x] Bug fix
- [x] Documentation

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Full suite: 2109 passed, 27 env-gated skips unchanged from main, 0 failures

- Unit tests for `scanForSubmoduleContent` / `submoduleUnsupportedError` (gitlink, `.gitmodules`-only, clean tree).
- `getDiffBetweenRepos` rejection tests using a locally built repo through the mocked clone.
- Import-flow integration tests: gitlink rejection, `.gitmodules`-only rejection, clean-repo regression.
- `git-http.ts` test asserting the permanent push-rejection message, and that no orphaned change or workspace survives a rejected push.
- Regression tests added from review, each verified to **fail when its fix is reverted**: a non-`main` repo is still rejected (both the import and diff paths previously scanned a hard-coded `main`); the initiating user is notified when their import is rejected; and a cancellation arriving during the scan is recorded `cancelled`, not as a submodule `failed`.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof)_


## Summary by CodeRabbit

* **New Features**
  * Repository imports, gated pushes, change creation, and REST requests now detect Git submodules and reject unsupported content with clear, actionable guidance.
  * Imports proceed with a warning when submodule scanning cannot be completed, while pushes and change creation remain blocked when scanning fails.
  * Rejected changes are closed automatically, and associated temporary resources are cleaned up.

* **Documentation**
  * Added guidance covering submodule limitations, detection behavior, workarounds, and error reporting.
