### PR TITLE
Route manual conflict resolutions through the full merge gate (SA-5 follow-up)

### DIFF
--- a/src/merge/protection.ts
+++ b/src/merge/protection.ts
@@ -109,7 +109,11 @@ export function requiredEvaluatorReasons(
 
   const passedByType = new Map<string, boolean>();
   for (const { evaluatorType, result } of evalRuns) {
-    passedByType.set(evaluatorType, result.passed);
+    // A policy may list the same evaluator type more than once (e.g. two diff
+    // evaluators with different forbiddenPatterns). Fold duplicates with AND:
+    // a required type passes only when every run of it passed, so a passing
+    // duplicate can never mask a failure.
+    passedByType.set(evaluatorType, (passedByType.get(evaluatorType) ?? true) && result.passed);
   }
 
   const reasons: string[] = [];

--- a/src/merge/protection.ts
+++ b/src/merge/protection.ts
@@ -1,3 +1,4 @@
+import { diffTouchesProtectedConfig } from "../evaluation/policy-loader";
 import type { EvalPolicy } from "../evaluation/types";
 import { countApprovals } from "../storage/change-reviews";
 import { listEvalRuns } from "../storage/eval-runs";
@@ -89,6 +90,113 @@ export async function checkMergeProtection(
 
   if (reasons.length > 0) {
     logger.info("Merge blocked by branch protection", { changeId: change.id, reasons });
+  }
+  return ok({ allowed: reasons.length === 0, reasons });
+}
+
+/**
+ * Same reason strings `checkMergeProtection` produces for `requiredEvaluators`,
+ * but sourced from an in-memory list of evaluation runs instead of a change's
+ * persisted `eval_runs` history. Exported separately so it's independently
+ * testable — see `checkResolutionMergeProtection` for why a manual conflict
+ * resolution needs this instead of the DB-backed check.
+ */
+export function requiredEvaluatorReasons(
+  evalRuns: Array<{ evaluatorType: string; result: { passed: boolean } }>,
+  requiredEvaluators: string[] | undefined,
+): string[] {
+  if (!requiredEvaluators || requiredEvaluators.length === 0) return [];
+
+  const passedByType = new Map<string, boolean>();
+  for (const { evaluatorType, result } of evalRuns) {
+    passedByType.set(evaluatorType, result.passed);
+  }
+
+  const reasons: string[] = [];
+  for (const required of requiredEvaluators) {
+    const passed = passedByType.get(required);
+    if (passed === undefined) {
+      reasons.push(`Required evaluator '${required}' has not run`);
+    } else if (!passed) {
+      reasons.push(`Required evaluator '${required}' failed`);
+    }
+  }
+  return reasons;
+}
+
+/**
+ * Merge-protection check for a manual conflict resolution (issue #260,
+ * SA-5 follow-up).
+ *
+ * A manual resolution has no Change row of its own — its content exists only
+ * as the caller-supplied {file, content} pairs, evaluated once, inline, right
+ * before resolveConflict pushes. That shapes two deliberate differences from
+ * `checkMergeProtection`:
+ *
+ * - `requiredEvaluators` is checked against the `evalRuns` this exact
+ *   resolution diff just produced (passed in), not a DB history keyed by some
+ *   change id — there is no earlier row for THIS content, and the whole point
+ *   of this gate is judging it, not whatever an earlier, different diff
+ *   scored.
+ * - `requiredApprovals` is checked against the approvals already recorded on
+ *   `originatingChange`, the Change whose merge attempt produced this
+ *   conflict. Resolving a conflict is part of landing that already-reviewed
+ *   change, not a new change of its own — there is no UI to grant a fresh
+ *   approval against the exact resolved bytes — so it reuses that change's
+ *   review trail (still excluding the change author's own approval, same as
+ *   `checkMergeProtection`). When no originating change is known (only
+ *   possible for a conflict recorded before this check existed), any
+ *   required approval fails closed rather than being silently skipped.
+ *
+ * `touchesProtectedConfig` is computed fresh from the resolution's own diff
+ * rather than copied from the originating change: the resolution can add,
+ * remove, or leave alone a `.stratum/policy.yaml` edit independently of what
+ * the original change's diff did (SA-3).
+ */
+export async function checkResolutionMergeProtection(
+  db: D1Database,
+  logger: Logger,
+  args: {
+    diff: string;
+    evalRuns: Array<{ evaluatorType: string; result: { passed: boolean } }>;
+    originatingChange?: { id: string; createdByUserId?: string };
+  },
+  policy: EvalPolicy,
+): Promise<Result<ProtectionVerdict, AppError>> {
+  if (policy.configError) {
+    return ok({ allowed: false, reasons: [policy.configError] });
+  }
+
+  const merge = policy.merge;
+  const touchesProtectedConfig = diffTouchesProtectedConfig(args.diff);
+  if (!merge && !touchesProtectedConfig) return ok({ allowed: true, reasons: [] });
+
+  const reasons: string[] = requiredEvaluatorReasons(args.evalRuns, merge?.requiredEvaluators);
+
+  const requiredApprovals = Math.max(merge?.requiredApprovals ?? 0, touchesProtectedConfig ? 1 : 0);
+  if (requiredApprovals > 0) {
+    if (!args.originatingChange) {
+      reasons.push(
+        `Requires ${requiredApprovals} approval${requiredApprovals === 1 ? "" : "s"}, but this resolution has no linked change to verify approvals against`,
+      );
+    } else {
+      const approvalsResult = await countApprovals(
+        db,
+        logger,
+        args.originatingChange.id,
+        args.originatingChange.createdByUserId,
+      );
+      if (!approvalsResult.success) return err(approvalsResult.error);
+      if (approvalsResult.data < requiredApprovals) {
+        reasons.push(
+          `Requires ${requiredApprovals} approval${requiredApprovals === 1 ? "" : "s"}, has ${approvalsResult.data}`,
+        );
+      }
+    }
+  }
+
+  if (reasons.length > 0) {
+    logger.info("Manual conflict resolution blocked by branch protection", { reasons });
   }
   return ok({ allowed: reasons.length === 0, reasons });
 }

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -713,6 +713,12 @@ app.post("/changes/:id/merge", async (c) => {
           workspaceName: change.workspace,
           conflictingFiles: mergeResult.error.conflictingFiles,
           detectedAt: new Date().toISOString(),
+          // The Change whose merge attempt hit this conflict. A manual resolution
+          // is part of landing THIS change, not a change of its own — the
+          // resolve route uses it to check the review trail this change already
+          // has (SA-5 follow-up, #260) rather than demanding fresh approvals
+          // with no UI to grant them against resolved bytes.
+          changeId: id,
         }),
         { expirationTtl: 7 * 24 * 60 * 60 },
       );

--- a/src/routes/sync-management.ts
+++ b/src/routes/sync-management.ts
@@ -1,7 +1,17 @@
 import { Hono } from "hono";
+import { loadPolicy } from "../evaluation/policy-loader";
 import { scanContentForSecrets } from "../evaluation/secret-scanner";
+import { checkResolutionMergeProtection } from "../merge/protection";
 import { authMiddleware } from "../middleware/auth";
-import { MAX_FILE_BYTES, freshRepoToken, resolveConflict } from "../storage/git-ops";
+import { buildEvaluators, runEvaluation } from "../services/change-flow";
+import { recordAudit } from "../storage/audit";
+import { getChange } from "../storage/changes";
+import {
+  MAX_FILE_BYTES,
+  buildManualResolutionDiff,
+  freshRepoToken,
+  resolveConflict,
+} from "../storage/git-ops";
 import { getProject, getProjectByPath, getWorkspace, setProject } from "../storage/state";
 import {
   checkForSyncUpdates,
@@ -451,6 +461,10 @@ app.post("/projects/conflicts/:id/resolve", async (c) => {
     workspaceName: string;
     conflictingFiles: string[];
     detectedAt: string;
+    // The Change whose merge attempt produced this conflict. Absent on entries
+    // written before this field existed (KV entries expire after 7 days, so
+    // this is a short-lived compatibility window, not a permanent case).
+    changeId?: string;
   };
   try {
     conflictCtx = JSON.parse(conflictRaw);
@@ -529,10 +543,14 @@ app.post("/projects/conflicts/:id/resolve", async (c) => {
   const workspace = workspaceResult.data;
 
   // The `manual` strategy commits caller-supplied file contents straight to the
-  // project's default branch, which otherwise bypasses the always-on secret
-  // scan that every change is subject to. Run that mandatory, blocking scan here
-  // so a resolution cannot smuggle a credential onto main. (accept-project /
-  // accept-workspace reuse already-committed trees and need no re-scan.)
+  // project's default branch, which otherwise bypasses everything a normal
+  // Change goes through. Run the mandatory, blocking secret scan first — it's
+  // cheap relative to a full evaluator pass and the size guard ahead of it is
+  // cheaper still — then (below, once tokens are minted) the project's full
+  // evaluator suite and merge protection, so a resolution can't land content
+  // no evaluator saw and no approver reviewed (#260, SA-5 follow-up).
+  // accept-project / accept-workspace reuse already-committed, already-evaluated
+  // trees (see the full-gate block below for why) and need none of this.
   if (strategy === "manual") {
     const resolutions = body.resolutions as Array<{ file: string; content: string }>;
 
@@ -587,6 +605,124 @@ app.post("/projects/conflicts/:id/resolve", async (c) => {
   if (!projectToken.success) return c.json({ error: projectToken.error.message }, 502);
   if (!workspaceToken.success) return c.json({ error: workspaceToken.error.message }, 502);
 
+  // Route a manual resolution through the same merge gate a normal Change goes
+  // through: the project's configured evaluator suite, then merge protection
+  // (required evaluators + required approvals), both run against the exact
+  // content about to be committed — BEFORE resolveConflict pushes it.
+  //
+  // accept-project / accept-workspace are exempt: they re-stage content that
+  // already exists, committed, on one side of the conflict (the project's own
+  // HEAD, or the workspace fork) — content a Change already evaluated (or that
+  // is already live on the default branch) on its way into this merge. `manual`
+  // is the one strategy that introduces content no evaluator or approver has
+  // ever seen, which is exactly what this gate exists to close.
+  let manualResolutionAudit:
+    | { conflictId: string; resolvedByUserId: string; evaluatedBaseSha: string; evalScore: number }
+    | undefined;
+  if (strategy === "manual") {
+    const resolutions = body.resolutions as Array<{ file: string; content: string }>;
+    const branch = projectDefaultBranch(project);
+
+    const diffResult = await buildManualResolutionDiff(
+      project.remote,
+      projectToken.data,
+      resolutions,
+      branch,
+      logger,
+    );
+    if (!diffResult.success) {
+      logger.error("Failed to prepare manual resolution for evaluation", diffResult.error, {
+        conflictId,
+      });
+      return c.json(
+        { error: "Failed to prepare resolution for evaluation", code: "EVAL_PREP_FAILED" },
+        502,
+      );
+    }
+    const { diff, baseSha } = diffResult.data;
+
+    const policy = await loadPolicy(project.remote, projectToken.data, logger, branch);
+    const projectName = `${conflictCtx.namespace}/${conflictCtx.slug}`;
+    // No workspace repo access is passed for the sandbox evaluator: the content
+    // being judged here has no commit of its own yet — that's the point, it must
+    // pass BEFORE resolveConflict creates one — so there is no ref a sandbox
+    // could check out. A policy naming `sandbox` fails closed via
+    // UnavailableEvaluator, same as any other missing prerequisite.
+    const evaluators = buildEvaluators(c.env, policy, projectName, logger);
+    const { evalRuns, evalResult } = await runEvaluation(evaluators, diff, policy, logger);
+
+    if (!evalResult.passed) {
+      logger.warn("Manual conflict resolution blocked by evaluator suite", {
+        conflictId,
+        evalScore: evalResult.score,
+        evalReason: evalResult.reason,
+      });
+      return c.json(
+        {
+          error: `Resolution rejected: ${evalResult.reason}`,
+          code: "EVALUATION_FAILED",
+          issues: evalResult.issues ?? [],
+        },
+        422,
+      );
+    }
+
+    // Approvals are checked against the Change whose merge attempt produced
+    // this conflict, not a fresh review round on the resolution itself — see
+    // checkResolutionMergeProtection's doc comment for why.
+    let originatingChange: { id: string; createdByUserId?: string } | undefined;
+    if (conflictCtx.changeId) {
+      const changeResult = await getChange(c.env.DB, logger, conflictCtx.changeId);
+      if (changeResult.success) {
+        originatingChange = {
+          id: changeResult.data.id,
+          ...(changeResult.data.createdByUserId !== undefined
+            ? { createdByUserId: changeResult.data.createdByUserId }
+            : {}),
+        };
+      } else {
+        // Best effort: a missing originating change (e.g. deleted) must not
+        // crash the resolution — it falls through to checkResolutionMergeProtection
+        // failing closed on any required approval, same as no changeId at all.
+        logger.warn("Could not load originating change for resolution approvals", {
+          conflictId,
+          changeId: conflictCtx.changeId,
+          error: changeResult.error.message,
+        });
+      }
+    }
+
+    const protectionResult = await checkResolutionMergeProtection(
+      c.env.DB,
+      logger,
+      { diff, evalRuns, originatingChange },
+      policy,
+    );
+    if (!protectionResult.success) {
+      logger.error("Failed to evaluate merge protection for resolution", protectionResult.error, {
+        conflictId,
+      });
+      return c.json({ error: protectionResult.error.message }, 500);
+    }
+    if (!protectionResult.data.allowed) {
+      return c.json(
+        {
+          error: "Resolution blocked by branch protection",
+          code: "PROTECTION_BLOCKED",
+          reasons: protectionResult.data.reasons,
+        },
+        403,
+      );
+    }
+
+    manualResolutionAudit = {
+      conflictId,
+      resolvedByUserId: userId,
+      evaluatedBaseSha: baseSha,
+      evalScore: evalResult.score,
+    };
+  }
+
   const startedAt = Date.now();
   const resolveResult = await resolveConflict(
     {
@@ -629,6 +765,27 @@ app.post("/projects/conflicts/:id/resolve", async (c) => {
   );
 
   await c.env.STATE.delete(`conflict:${conflictId}`);
+
+  // Provenance for a manual resolution commit: who resolved it, from which
+  // conflict, and against which sha the evaluator suite ran (#260). Best-effort
+  // by contract, same as recordSyncHistory above — an audit-log failure must
+  // not undo an already-pushed, already-gated resolution.
+  if (manualResolutionAudit) {
+    await recordAudit(c.env.DB, logger, {
+      action: "conflict.resolved_manually",
+      actorType: "user",
+      actorId: manualResolutionAudit.resolvedByUserId,
+      subject: commitSha,
+      detail: {
+        conflictId: manualResolutionAudit.conflictId,
+        project: `${conflictCtx.namespace}/${conflictCtx.slug}`,
+        workspace: conflictCtx.workspaceName,
+        evaluatedBaseSha: manualResolutionAudit.evaluatedBaseSha,
+        evalScore: manualResolutionAudit.evalScore,
+        commitSha,
+      },
+    });
+  }
 
   logger.info("Conflict resolved", { conflictId, commitSha });
   return c.json({ status: "resolved", commitSha });

--- a/src/storage/audit.ts
+++ b/src/storage/audit.ts
@@ -13,6 +13,7 @@ export type AuditAction =
   | "webhook.toggled"
   | "webhook.deleted"
   | "merge.forced"
+  | "conflict.resolved_manually"
   | "review.approvals_dismissed"
   | "backup.run"
   | "deletion.requested"

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -2879,6 +2879,55 @@ export function buildUnifiedDiff(
   return diffParts.join("\n");
 }
 
+/**
+ * Build a unified diff of what a manual conflict resolution would change
+ * relative to the project's current default-branch tip, without pushing
+ * anything. This lets the resolution's content be run through the same
+ * evaluator pipeline a normal Change goes through (buildEvaluators +
+ * runEvaluation in ../services/change-flow) BEFORE resolveConflict commits it.
+ *
+ * Only reads the resolution's own file paths from project HEAD, not the whole
+ * tree — every other path is untouched by a manual resolution and would
+ * appear nowhere in the diff, so there is nothing worth spending a full-repo
+ * read on. A resolution path absent from HEAD reads as a new-file addition.
+ *
+ * Returns the resolved base commit sha alongside the diff so callers can
+ * record what revision the evaluation ran against (provenance) — the same
+ * role `evaluatedSha` plays for a Change.
+ */
+export async function buildManualResolutionDiff(
+  projectRemote: string,
+  projectToken: string,
+  resolutions: Array<{ file: string; content: string }>,
+  branch: string,
+  logger: Logger,
+): Promise<Result<{ diff: string; baseSha: string }, AppError>> {
+  const cloneResult = await cloneRepo(projectRemote, projectToken, logger, { ref: branch });
+  if (!cloneResult.success) return err(cloneResult.error);
+  const { fs, dir } = cloneResult.data;
+
+  const baseOidResult = await fromPromise(git.resolveRef({ fs, dir, ref: branch }));
+  if (!baseOidResult.success) {
+    return err(
+      new AppError("Failed to resolve project HEAD for resolution diff", "GIT_ERROR", 500),
+    );
+  }
+  const baseOid = baseOidResult.data;
+
+  const baseContent = new Map<string, string>();
+  const resolvedContent = new Map<string, string>();
+  for (const { file, content } of resolutions) {
+    const readResult = await readFileAtCommit(fs, baseOid, file, logger);
+    // A read failure (most commonly: the file doesn't exist on HEAD yet) is
+    // treated as "no base content" so buildUnifiedDiff renders it as an
+    // addition, matching getDiffBetweenRepos' handling of the same case.
+    if (readResult.success) baseContent.set(file, readResult.data);
+    resolvedContent.set(file, content);
+  }
+
+  return ok({ diff: buildUnifiedDiff(baseContent, resolvedContent), baseSha: baseOid });
+}
+
 /** A tag as listed from a cloned repo (see `collectRepoTags`). */
 export interface RepoTagEntry {
   /** Tag name without the refs/tags/ prefix. */

--- a/tests/conflict-resolution.test.ts
+++ b/tests/conflict-resolution.test.ts
@@ -123,9 +123,16 @@ vi.mock("../src/evaluation/policy-loader", async (importActual) => {
   };
 });
 
-vi.mock("../src/storage/changes", () => ({
-  getChange: vi.fn(),
-}));
+vi.mock("../src/storage/changes", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/changes")>();
+  return {
+    // Keep every real export: routes/changes.ts (loaded by src/index.ts)
+    // statically imports several named exports from this module, and a
+    // factory that defines only getChange would break module loading.
+    ...actual,
+    getChange: vi.fn(),
+  };
+});
 
 vi.mock("../src/storage/users", () => ({
   getUserByToken: vi.fn(async (_: unknown, token: string) => {
@@ -587,6 +594,45 @@ describe("POST /api/projects/conflicts/:id/resolve (route)", () => {
     const body = await res.json<{ code: string; reasons: string[] }>();
     expect(body.code).toBe("PROTECTION_BLOCKED");
     expect(body.reasons[0]).toContain("Requires 1 approval");
+    expect(vi.mocked(resolveConflict)).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when approvals are required but the conflict has no linked change (never pushes)", async () => {
+    // Default CONFLICT_CTX carries no changeId — the shape of a conflict
+    // recorded before the changeId field existed. With approvals required
+    // there is nothing to verify them against, so the gate must block.
+    const kv = makeKv();
+    vi.mocked(resolveConflict).mockClear();
+    vi.mocked(getProjectByPath).mockResolvedValue({
+      success: true,
+      data: { ...PROJECT, ownerId: "user_test" },
+    } as Awaited<ReturnType<typeof getProjectByPath>>);
+    vi.mocked(getWorkspace).mockResolvedValue({
+      success: true,
+      data: WORKSPACE,
+    } as Awaited<ReturnType<typeof getWorkspace>>);
+    vi.mocked(loadPolicy).mockResolvedValueOnce({
+      evaluators: [],
+      requireAll: true,
+      minScore: 0.7,
+      merge: { requiredApprovals: 1 },
+    });
+
+    const res = await app.fetch(
+      new Request("http://localhost/api/projects/conflicts/conflict-abc/resolve", {
+        method: "POST",
+        headers: { ...AUTH_HEADER, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          strategy: "manual",
+          resolutions: [{ file: "src/foo.ts", content: "export const x = 1;" }],
+        }),
+      }),
+      { STATE: kv, DB: makeDb() },
+    );
+
+    expect(res.status).toBe(403);
+    const body = await res.json<{ code: string; reasons: string[] }>();
+    expect(body.code).toBe("PROTECTION_BLOCKED");
     expect(vi.mocked(resolveConflict)).not.toHaveBeenCalled();
   });
 

--- a/tests/conflict-resolution.test.ts
+++ b/tests/conflict-resolution.test.ts
@@ -100,8 +100,32 @@ vi.mock("../src/storage/git-ops", async (importActual) => {
     ...actual,
     resolveConflict: vi.fn(),
     freshRepoToken: vi.fn(async () => ({ success: true, data: "test-token" })),
+    // The merge-gate diff builder clones the project repo for real; stub it so
+    // manual-resolution route tests don't need network access. Individual tests
+    // override this to feed a specific diff into the evaluator suite.
+    buildManualResolutionDiff: vi.fn(async () => ({
+      success: true,
+      data: { diff: "", baseSha: "base-sha-default" },
+    })),
   };
 });
+
+vi.mock("../src/evaluation/policy-loader", async (importActual) => {
+  const actual = await importActual<typeof import("../src/evaluation/policy-loader")>();
+  return {
+    ...actual,
+    // Real loadPolicy clones the repo to read .stratum/policy.yaml; stub it so
+    // tests control the policy directly instead of needing network access.
+    // Defaults to the same permissive shape loadPolicy returns when no policy
+    // file is present, so strategies/tests that don't care about policy content
+    // behave the way they did before this gate existed.
+    loadPolicy: vi.fn(async () => ({ evaluators: [], requireAll: true, minScore: 0.7 })),
+  };
+});
+
+vi.mock("../src/storage/changes", () => ({
+  getChange: vi.fn(),
+}));
 
 vi.mock("../src/storage/users", () => ({
   getUserByToken: vi.fn(async (_: unknown, token: string) => {
@@ -152,8 +176,10 @@ vi.mock("../src/storage/sync", () => ({
   updateProjectAfterSync: vi.fn(),
 }));
 
+import { loadPolicy } from "../src/evaluation/policy-loader";
 import app from "../src/index";
-import { resolveConflict } from "../src/storage/git-ops";
+import { getChange } from "../src/storage/changes";
+import { buildManualResolutionDiff, resolveConflict } from "../src/storage/git-ops";
 import { getProjectByPath, getWorkspace } from "../src/storage/state";
 
 const PROJECT = {
@@ -435,6 +461,116 @@ describe("POST /api/projects/conflicts/:id/resolve (route)", () => {
       data: { commitSha: "resolved-sha" },
     });
 
+    const db = makeDb();
+    const res = await app.fetch(
+      new Request("http://localhost/api/projects/conflicts/conflict-abc/resolve", {
+        method: "POST",
+        headers: { ...AUTH_HEADER, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          strategy: "manual",
+          resolutions: [{ file: "src/foo.ts", content: "export const x = 1;" }],
+        }),
+      }),
+      { STATE: kv, DB: db },
+    );
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(resolveConflict)).toHaveBeenCalledOnce();
+
+    // Provenance: who resolved, from which conflict, against which evaluated
+    // sha (#260) is recorded to the audit log once the push succeeds.
+    const prepareMock = vi.mocked(db.prepare).mock;
+    const auditCallIndex = prepareMock.calls.findIndex(([sql]) =>
+      sql.includes("INSERT INTO audit_log"),
+    );
+    expect(auditCallIndex).toBeGreaterThanOrEqual(0);
+    const stmt = prepareMock.results[auditCallIndex]?.value as {
+      bind: (...args: unknown[]) => unknown;
+    };
+    const boundArgs = vi.mocked(stmt.bind).mock.calls[0];
+    expect(boundArgs?.[1]).toBe("conflict.resolved_manually");
+    expect(boundArgs?.[3]).toBe("user_test"); // actorId
+    // Detail JSON (6th bound param) carries conflictId + evaluatedBaseSha.
+    const detail = JSON.parse(boundArgs?.[5] as string) as Record<string, unknown>;
+    expect(detail.conflictId).toBe("conflict-abc");
+    expect(detail.evaluatedBaseSha).toBe("base-sha-default");
+    expect(detail.commitSha).toBe("resolved-sha");
+  });
+
+  it("blocks a manual resolution when the configured evaluator suite fails (never pushes)", async () => {
+    const kv = makeKv();
+    vi.mocked(resolveConflict).mockClear();
+    vi.mocked(getProjectByPath).mockResolvedValue({
+      success: true,
+      data: { ...PROJECT, ownerId: "user_test" },
+    } as Awaited<ReturnType<typeof getProjectByPath>>);
+    vi.mocked(getWorkspace).mockResolvedValue({
+      success: true,
+      data: WORKSPACE,
+    } as Awaited<ReturnType<typeof getWorkspace>>);
+    vi.mocked(buildManualResolutionDiff).mockResolvedValueOnce({
+      success: true,
+      data: {
+        diff: "diff --git a/config/prod.yaml b/config/prod.yaml\n--- /dev/null\n+++ b/config/prod.yaml\n+not-a-secret-but-forbidden\n",
+        baseSha: "base-sha-1",
+      },
+    });
+    vi.mocked(loadPolicy).mockResolvedValueOnce({
+      evaluators: [{ type: "diff", forbiddenPatterns: ["config/prod"] }],
+      requireAll: true,
+      minScore: 0.9,
+    });
+
+    const res = await app.fetch(
+      new Request("http://localhost/api/projects/conflicts/conflict-abc/resolve", {
+        method: "POST",
+        headers: { ...AUTH_HEADER, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          strategy: "manual",
+          resolutions: [{ file: "config/prod.yaml", content: "not-a-secret-but-forbidden" }],
+        }),
+      }),
+      { STATE: kv, DB: makeDb() },
+    );
+
+    expect(res.status).toBe(422);
+    const body = await res.json<{ code: string }>();
+    expect(body.code).toBe("EVALUATION_FAILED");
+    expect(vi.mocked(resolveConflict)).not.toHaveBeenCalled();
+  });
+
+  it("blocks a manual resolution when merge protection requires more approvals than recorded (never pushes)", async () => {
+    const kv = makeKv();
+    // Overwrite with a conflict context carrying the originating changeId, so
+    // the protection check has a change to look up approvals against.
+    await kv.put("conflict:conflict-abc", JSON.stringify({ ...CONFLICT_CTX, changeId: "chg_1" }));
+    vi.mocked(resolveConflict).mockClear();
+    vi.mocked(getProjectByPath).mockResolvedValue({
+      success: true,
+      data: { ...PROJECT, ownerId: "user_test" },
+    } as Awaited<ReturnType<typeof getProjectByPath>>);
+    vi.mocked(getWorkspace).mockResolvedValue({
+      success: true,
+      data: WORKSPACE,
+    } as Awaited<ReturnType<typeof getWorkspace>>);
+    vi.mocked(loadPolicy).mockResolvedValueOnce({
+      evaluators: [],
+      requireAll: true,
+      minScore: 0.7,
+      merge: { requiredApprovals: 1 },
+    });
+    vi.mocked(getChange).mockResolvedValueOnce({
+      success: true,
+      data: {
+        id: "chg_1",
+        project: "@owner/my-repo",
+        workspace: "ws-1234",
+        status: "accepted",
+        createdAt: new Date().toISOString(),
+        createdByUserId: "user_test",
+      },
+    } as Awaited<ReturnType<typeof getChange>>);
+
     const res = await app.fetch(
       new Request("http://localhost/api/projects/conflicts/conflict-abc/resolve", {
         method: "POST",
@@ -447,8 +583,11 @@ describe("POST /api/projects/conflicts/:id/resolve (route)", () => {
       { STATE: kv, DB: makeDb() },
     );
 
-    expect(res.status).toBe(200);
-    expect(vi.mocked(resolveConflict)).toHaveBeenCalledOnce();
+    expect(res.status).toBe(403);
+    const body = await res.json<{ code: string; reasons: string[] }>();
+    expect(body.code).toBe("PROTECTION_BLOCKED");
+    expect(body.reasons[0]).toContain("Requires 1 approval");
+    expect(vi.mocked(resolveConflict)).not.toHaveBeenCalled();
   });
 
   it("404s a caller without project write access (never mints a token or pushes)", async () => {

--- a/tests/merge-protection.test.ts
+++ b/tests/merge-protection.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { diffTouchesProtectedConfig, loadPolicy } from "../src/evaluation/policy-loader";
 import type { EvalPolicy } from "../src/evaluation/types";
-import { checkMergeProtection } from "../src/merge/protection";
+import { checkMergeProtection, requiredEvaluatorReasons } from "../src/merge/protection";
 import { readFileFromRepo } from "../src/storage/git-ops";
 import type { Change } from "../src/types";
 import type { Logger } from "../src/utils/logger";
@@ -311,5 +311,45 @@ describe("policy loader merge rules", () => {
     const policy = await loadPolicy("remote", "token", mockLogger);
     expect(policy.merge).toBeUndefined();
     expect(policy.evaluators).toEqual([{ type: "diff" }]);
+  });
+});
+
+describe("requiredEvaluatorReasons", () => {
+  it("folds duplicate evaluator types with AND so a passing duplicate cannot mask a failure", () => {
+    // A policy may list the same type twice (e.g. two diff evaluators with
+    // different forbiddenPatterns). Whichever order the runs land in, one
+    // failure must keep the required type failed.
+    const failFirst = requiredEvaluatorReasons(
+      [
+        { evaluatorType: "diff", result: { passed: false } },
+        { evaluatorType: "diff", result: { passed: true } },
+      ],
+      ["diff"],
+    );
+    expect(failFirst).toEqual(["Required evaluator 'diff' failed"]);
+
+    const failSecond = requiredEvaluatorReasons(
+      [
+        { evaluatorType: "diff", result: { passed: true } },
+        { evaluatorType: "diff", result: { passed: false } },
+      ],
+      ["diff"],
+    );
+    expect(failSecond).toEqual(["Required evaluator 'diff' failed"]);
+
+    const bothPass = requiredEvaluatorReasons(
+      [
+        { evaluatorType: "diff", result: { passed: true } },
+        { evaluatorType: "diff", result: { passed: true } },
+      ],
+      ["diff"],
+    );
+    expect(bothPass).toEqual([]);
+  });
+
+  it("reports a required evaluator that never ran", () => {
+    expect(requiredEvaluatorReasons([], ["sandbox"])).toEqual([
+      "Required evaluator 'sandbox' has not run",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

SA-5 follow-up to #232. `POST /api/projects/conflicts/:id/resolve` with `strategy: "manual"` committed caller-supplied `{file, content}` pairs straight to the project's default branch. #232 restored the always-on secret scan for that path, but the resolution content still bypassed the project's configured evaluator suite, merge protection / required approvals, and provenance recording — undermining the eval-gated-merge invariant the issue calls the product's central promise.

Now, before `resolveConflict` ever pushes:

- New `buildManualResolutionDiff` (`src/storage/git-ops.ts`) builds a real unified diff of what the resolution would change against the project's current HEAD — reading only the resolution's own file paths, pushing nothing — and returns the base sha for provenance.
- The route runs that diff through the **same evaluator pipeline a Change runs** (`buildEvaluators` + `runEvaluation`), rejecting with 422 `EVALUATION_FAILED` on failure.
- New `checkResolutionMergeProtection` (`src/merge/protection.ts`) enforces `requiredEvaluators` (against the runs just produced) and `requiredApprovals` (against the Change whose merge attempt produced this conflict — `src/routes/changes.ts` now threads that `changeId` through the conflict KV context), rejecting with 403 `PROTECTION_BLOCKED`. A conflict with no known originating change fails closed on any required approval.
- On a successful push, an audit entry (`conflict.resolved_manually`) records who resolved, from which conflict, and against which evaluated base sha.
- `accept-project` / `accept-workspace` keep the lighter path — they re-stage already-committed, already-evaluated content — with the exemption documented inline, per the issue.

**Design note:** a manual resolution is not represented as a full `Change`. That would require an async, approval-driven merge flow that doesn't fit this endpoint's single-request contract, and reusing `checkMergeProtection`'s DB-backed `requiredEvaluators` check as-is would validate the *original* diff's eval runs rather than the resolution's actual content. This runs the identical evaluator pipeline plus an inline protection check matching `checkMergeProtection`'s semantics exactly (see `checkResolutionMergeProtection`'s doc comment).

## Related issues

Closes #260

## Type of change

- [x] Bug fix

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` (full suite: 2104 passed, 0 failed)
- [x] `npm run lint`

- New tests in `tests/conflict-resolution.test.ts`: failing evaluator blocks the resolution and nothing is pushed; insufficient approvals block and nothing is pushed; the passing case pushes and records the audit provenance entry. The existing SA-5 secret-scan tests from #232 keep passing, as do `merge-protection`, `changes`, `secret-scanner`, `change-reviews`, and `line-comments` suites.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate (none affected)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript (no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added safer manual conflict resolution with file-size, secret, evaluator, and merge-protection checks before changes are committed.
  - Manual resolutions now retain review context from the original change, including applicable approvals.
  - Added audit history for manually resolved conflicts with relevant resolution details.
  - Improved error reporting for resolution preparation and validation failures.

- **Bug Fixes**
  - Protected policy changes now require approval.
  - Missing review context and incomplete evaluator results are handled securely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->