### PR TITLE
Backfill route: audit partial runs, and attribute audits to the credential that authorized them

### DIFF
--- a/src/routes/backfill.ts
+++ b/src/routes/backfill.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { recordAudit } from "../storage/audit";
 import { backfillWebhookProjectIds, computeBackfillPlan } from "../storage/backfill-plan";
 import type { Env } from "../types";
-import { isAdminRequest } from "../utils/admin";
+import { resolveAdminAuth } from "../utils/admin";
 import { createLogger } from "../utils/logger";
 import { forbidden, internalError, ok } from "../utils/response";
 
@@ -12,19 +12,26 @@ const app = new Hono<{ Bindings: Env }>();
  * Accepts either the X-Admin-API-Key header or an authenticated admin user,
  * deliberately matching /plan's contract: an operator running the dry-run and
  * the apply back-to-back should not need two different credentials.
+ *
+ * Carries `via` out alongside `ok` so callers that write an audit entry can
+ * attribute the action to whichever credential actually authorized it,
+ * rather than to a `userId` that merely happened to be attached to the
+ * request (see resolveAdminAuth).
  */
 async function requireAdmin(c: {
   env: Env;
   req: { header: (n: string) => string | undefined; path: string; method: string };
   get: (k: "userId") => string | undefined;
-}): Promise<{ ok: true; logger: ReturnType<typeof createLogger> } | { ok: false }> {
+}): Promise<
+  { ok: true; logger: ReturnType<typeof createLogger>; via: "api-key" | "user" } | { ok: false }
+> {
   const logger = createLogger({
     requestId: crypto.randomUUID(),
     userId: c.get("userId"),
     path: c.req.path,
     method: c.req.method,
   });
-  const isAdmin = await isAdminRequest(
+  const auth = await resolveAdminAuth(
     c.env,
     {
       ...(c.req.header("X-Admin-API-Key") !== undefined
@@ -34,7 +41,7 @@ async function requireAdmin(c: {
     },
     logger,
   );
-  return isAdmin ? { ok: true, logger } : { ok: false };
+  return auth.authorized && auth.via ? { ok: true, logger, via: auth.via } : { ok: false };
 }
 
 // GET /api/admin/backfill-project-id/plan — DRY-RUN: how much legacy (NULL
@@ -65,13 +72,54 @@ app.post("/webhooks/apply", async (c) => {
   if (!auth.ok) return forbidden("Administrator access required");
   const { logger } = auth;
 
+  // Attribute the audit entry to whichever credential actually authorized
+  // this run, not to whatever `userId` happens to be attached to the
+  // request. `requireAdmin` checks the API-key branch first, so a run
+  // authorized purely by X-Admin-API-Key must record as "system" even when a
+  // non-admin user session also rode along on the same request — crediting
+  // that user would be misattribution in an audit trail, which is worse than
+  // an absent actorId.
+  const actor: { actorType: "user" | "system"; actorId?: string } =
+    auth.via === "user"
+      ? {
+          actorType: "user",
+          ...(c.get("userId") !== undefined ? { actorId: c.get("userId") } : {}),
+        }
+      : { actorType: "system" };
+
   const report = await backfillWebhookProjectIds(c.env, logger);
-  if (!report.success) return internalError(report.error.message);
+  if (!report.success) {
+    // D1 auto-commits each row's UPDATE independently, so a throw partway
+    // through the backfill can leave earlier rows already stamped even
+    // though this call reports failure. backfillWebhookProjectIds carries
+    // that partial progress out on the error's context; record it here,
+    // before returning the error, so a partially-applied privileged mutation
+    // never lands with zero provenance. This audit write is best-effort like
+    // the success-path one below -- if it also fails, log it and still
+    // return the original error untouched.
+    const failureAudit = await recordAudit(c.env.DB, logger, {
+      action: "webhook.project_id_backfilled",
+      ...actor,
+      detail: {
+        failed: true,
+        updated: report.error.context?.updated ?? 0,
+        skipped: report.error.context?.skipped ?? 0,
+        error: report.error.message,
+      },
+    });
+    if (!failureAudit.success) {
+      logger.error(
+        "Backfill failed and its failure-path audit entry also failed to persist",
+        failureAudit.error,
+        { updated: report.error.context?.updated ?? 0 },
+      );
+    }
+    return internalError(report.error.message);
+  }
 
   const auditResult = await recordAudit(c.env.DB, logger, {
     action: "webhook.project_id_backfilled",
-    actorType: c.get("userId") ? "user" : "system",
-    ...(c.get("userId") !== undefined ? { actorId: c.get("userId") } : {}),
+    ...actor,
     detail: {
       updated: report.data.updated,
       skipped: report.data.skipped.length,

--- a/src/storage/backfill-plan.ts
+++ b/src/storage/backfill-plan.ts
@@ -126,6 +126,13 @@ export async function backfillWebhookProjectIds(
   env: Pick<Env, "DB" | "STATE">,
   logger: Logger,
 ): Promise<Result<WebhookBackfillReport, AppError>> {
+  // Declared outside the try so a throw partway through the loop below can
+  // still report how far the run got: D1 auto-commits each UPDATE
+  // independently, so a failure on row N leaves rows 1..N-1 already committed
+  // with no way to unwind them. The caller needs those counts to audit what
+  // actually landed, not just that something failed.
+  const skipped: WebhookBackfillSkip[] = [];
+  let updated = 0;
   try {
     const projectsResult = await listProjects(env.STATE, logger);
     if (!projectsResult.success) return err(projectsResult.error);
@@ -149,8 +156,6 @@ export async function backfillWebhookProjectIds(
       "SELECT id, project FROM webhooks WHERE project_id IS NULL",
     ).all<{ id: string; project: string }>();
 
-    const skipped: WebhookBackfillSkip[] = [];
-    let updated = 0;
     for (const row of rows.results) {
       const projectId = nameToId.get(row.project);
       if (projectId === undefined) {
@@ -184,16 +189,31 @@ export async function backfillWebhookProjectIds(
 
     return ok({ updated, skipped, remainingNullRows: remaining?.n ?? 0 });
   } catch (error) {
+    // D1 auto-commits each UPDATE independently, so a throw here can land
+    // after some rows were already stamped. Carry that partial progress out
+    // on the error's context rather than discarding it -- the route needs it
+    // to audit what actually happened, not just that the run failed. Message,
+    // code, and statusCode are preserved as-is so existing callers are
+    // unaffected; only `context` gains the partial counts.
+    const context = {
+      ...(error instanceof AppError ? error.context : undefined),
+      operation: "backfillWebhookProjectIds",
+      updated,
+      skipped: skipped.length,
+    };
     const appError =
       error instanceof AppError
-        ? error
+        ? new AppError(error.message, error.code, error.statusCode, context)
         : new AppError(
             error instanceof Error ? error.message : "Failed to backfill webhook project_id",
             "DATABASE_ERROR",
             500,
-            { operation: "backfillWebhookProjectIds" },
+            context,
           );
-    logger.error("Failed to backfill webhook project_id", appError);
+    logger.error("Failed to backfill webhook project_id", appError, {
+      updated,
+      skipped: skipped.length,
+    });
     return err(appError);
   }
 }

--- a/src/utils/admin.ts
+++ b/src/utils/admin.ts
@@ -3,32 +3,62 @@ import type { Env } from "../types";
 import { constantTimeEqual } from "./crypto";
 import type { Logger } from "./logger";
 
+/** Which credential authorized an admin request. */
+export type AdminAuthSource = "api-key" | "user";
+
+export interface AdminAuthResult {
+  authorized: boolean;
+  /** Present only when `authorized` is true: which branch granted access. */
+  via?: AdminAuthSource;
+}
+
 /**
- * Whether the caller is an administrator. Two paths:
+ * Resolves *whether* the caller is an administrator and, when so, *which*
+ * credential granted it. Two paths, checked in this order:
  * - service-to-service: X-Admin-API-Key matching the ADMIN_API_KEY secret
  * - human: an authenticated user whose email matches the ADMIN_EMAIL secret
  *
+ * The API-key branch is authoritative on its own and short-circuits before
+ * ever looking at `userId` -- a request carrying a valid admin key is a
+ * system action regardless of which (if any) user session happens to be
+ * attached to it. Callers that need to attribute an action correctly (e.g.
+ * an audit entry) should use `via` rather than assuming a present `userId`
+ * means the user authorized the request.
+ *
  * Fails closed when neither secret is configured.
+ */
+export async function resolveAdminAuth(
+  env: Env,
+  opts: { adminApiKeyHeader?: string; userId?: string },
+  logger: Logger,
+): Promise<AdminAuthResult> {
+  if (
+    opts.adminApiKeyHeader &&
+    env.ADMIN_API_KEY &&
+    constantTimeEqual(opts.adminApiKeyHeader, env.ADMIN_API_KEY)
+  ) {
+    return { authorized: true, via: "api-key" };
+  }
+
+  if (opts.userId && env.ADMIN_EMAIL) {
+    const userResult = await getUser(env.DB, opts.userId, logger);
+    if (userResult.success && userResult.data.email === env.ADMIN_EMAIL) {
+      return { authorized: true, via: "user" };
+    }
+  }
+
+  return { authorized: false };
+}
+
+/**
+ * Whether the caller is an administrator. Thin boolean wrapper over
+ * {@link resolveAdminAuth} for callers that only need the yes/no answer.
  */
 export async function isAdminRequest(
   env: Env,
   opts: { adminApiKeyHeader?: string; userId?: string },
   logger: Logger,
 ): Promise<boolean> {
-  if (
-    opts.adminApiKeyHeader &&
-    env.ADMIN_API_KEY &&
-    constantTimeEqual(opts.adminApiKeyHeader, env.ADMIN_API_KEY)
-  ) {
-    return true;
-  }
-
-  if (opts.userId && env.ADMIN_EMAIL) {
-    const userResult = await getUser(env.DB, opts.userId, logger);
-    if (userResult.success && userResult.data.email === env.ADMIN_EMAIL) {
-      return true;
-    }
-  }
-
-  return false;
+  const result = await resolveAdminAuth(env, opts, logger);
+  return result.authorized;
 }

--- a/src/utils/admin.ts
+++ b/src/utils/admin.ts
@@ -3,12 +3,21 @@ import type { Env } from "../types";
 import { constantTimeEqual } from "./crypto";
 import type { Logger } from "./logger";
 
-/** Which credential authorized an admin request. */
+/**
+ * Which credential actually granted an admin request, kept so that callers
+ * writing an audit entry attribute the action to it rather than inferring an
+ * actor from whatever session happened to be attached to the request.
+ */
 export type AdminAuthSource = "api-key" | "user";
 
 export interface AdminAuthResult {
   authorized: boolean;
-  /** Present only when `authorized` is true: which branch granted access. */
+  /**
+   * Set only when `authorized` is true — there is no granting credential to
+   * name otherwise. Read this instead of a request's `userId` when deciding
+   * who to credit: a valid admin key authorizes on its own, so a `userId` can
+   * be present on a request the user did not authorize.
+   */
   via?: AdminAuthSource;
 }
 

--- a/tests/backfill-route.test.ts
+++ b/tests/backfill-route.test.ts
@@ -70,6 +70,19 @@ function applyReq(headers: Record<string, string> = {}): Request {
   });
 }
 
+/** Builds the app with a middleware that attaches `userId` before routing,
+ *  so mixed-credential requests (a valid admin API key alongside a non-admin
+ *  user session) can be exercised. */
+function makeAppWithUser(userId: string | undefined) {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", async (c, next) => {
+    if (userId !== undefined) c.set("userId", userId);
+    await next();
+  });
+  app.route("/api/admin/backfill-project-id", backfillRouter);
+  return app;
+}
+
 describe("POST /api/admin/backfill-project-id/webhooks/apply", () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -133,5 +146,81 @@ describe("POST /api/admin/backfill-project-id/webhooks/apply", () => {
     // operator into a re-run to recover counts they already earned.
     expect(body.report.updated).toBe(2);
     expect(body.report.remainingNullRows).toBe(0);
+  });
+
+  // D1 auto-commits each row's UPDATE independently, so a throw partway
+  // through the backfill can leave earlier rows already stamped even though
+  // the call reports failure. That partial mutation must not land with zero
+  // provenance: an audit entry has to be recorded before the 500 goes out.
+  it("records a failure-path audit entry carrying partial progress, and still 500s", async () => {
+    vi.mocked(backfillWebhookProjectIds).mockResolvedValue({
+      success: false,
+      error: new AppError("D1 write failed on row 3", "DATABASE_ERROR", 500, {
+        operation: "backfillWebhookProjectIds",
+        updated: 2,
+        skipped: 1,
+      }),
+    } as never);
+
+    const res = await makeApp().fetch(applyReq({ "X-Admin-API-Key": ADMIN_KEY }), env, ctx);
+
+    expect(res.status).toBe(500);
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.anything(),
+      expect.objectContaining({
+        action: "webhook.project_id_backfilled",
+        actorType: "system",
+        detail: expect.objectContaining({ failed: true, updated: 2, skipped: 1 }),
+      }),
+    );
+  });
+
+  it("still returns the original 500 when the failure-path audit write itself fails", async () => {
+    vi.mocked(backfillWebhookProjectIds).mockResolvedValue({
+      success: false,
+      error: new AppError("D1 write failed on row 3", "DATABASE_ERROR", 500, {
+        operation: "backfillWebhookProjectIds",
+        updated: 1,
+        skipped: 0,
+      }),
+    } as never);
+    vi.mocked(recordAudit).mockResolvedValueOnce({
+      success: false,
+      error: new AppError("D1 write failed", "DATABASE_ERROR", 500),
+    } as never);
+
+    const res = await makeApp().fetch(applyReq({ "X-Admin-API-Key": ADMIN_KEY }), env, ctx);
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("D1 write failed on row 3");
+  });
+
+  // requireAdmin checks the X-Admin-API-Key branch first: a request carrying
+  // a valid admin key is authorized by that key alone, regardless of which
+  // (if any) non-admin user session also rides along on the request. The
+  // audit entry must attribute the run to that key, not to the bystander
+  // user.
+  it("attributes the audit entry to the API key, not a non-admin user riding along", async () => {
+    vi.mocked(backfillWebhookProjectIds).mockResolvedValue({
+      success: true,
+      data: { updated: 1, skipped: [], remainingNullRows: 0 },
+    } as never);
+
+    const res = await makeAppWithUser("usr_non_admin").fetch(
+      applyReq({ "X-Admin-API-Key": ADMIN_KEY }),
+      env,
+      ctx,
+    );
+
+    expect(res.status).toBe(200);
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.anything(),
+      expect.objectContaining({ actorType: "system" }),
+    );
+    const recordedOpts = vi.mocked(recordAudit).mock.calls[0]?.[2];
+    expect(recordedOpts).not.toHaveProperty("actorId");
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #268, which merged before two review findings on it could land. Both are auditability defects in `POST /api/admin/backfill-project-id/webhooks/apply`, verified against `main` at `81704f8`:

**1. A partially-applied backfill left no audit trail.** `backfillWebhookProjectIds` issues one `UPDATE` per row, and D1 auto-commits each independently — there is no enclosing transaction. A throw on row N therefore leaves rows 1..N-1 already stamped, but the route returned `internalError(...)` *before* ever reaching `recordAudit`. A privileged mutation landed with zero provenance.

The backfill is deliberately idempotent and resumable, so partial application is expected and fine; doing it invisibly is not. Rather than force the whole run into one D1 `batch()` (which would put an unbounded number of statements in a single batch and defeat resumability), the function now carries its partial `updated`/`skipped` counts out on the returned `AppError`'s `context` — mirroring how `applySourceUpdate` attaches `context: { missingMergeBase }` — and the route records a `failed: true` audit entry from them before returning the 500. That write is best-effort, exactly like the success path: if it also fails, it is logged and the original error is returned untouched.

**2. API-key-authorized runs were attributed to the wrong actor.** `isAdminRequest` checks the `X-Admin-API-Key` branch first and returns without ever consulting `userId`, but the route derived `actorType` from `c.get("userId") ? "user" : "system"`. A service-to-service run that happened to carry any user session — including a non-admin one — recorded that user as the actor. Misattribution in an audit trail is worse than an absent `actorId`.

Added `resolveAdminAuth`, which returns which credential granted access. `isAdminRequest` becomes a thin boolean wrapper over it, so its **signature is unchanged** and its other five call sites (`audit.ts`, `backup.ts`, `deletion-jobs.ts`, `metrics.ts`, `restore.ts`) are untouched. Branch order, checks, and the fail-closed-when-neither-secret-is-configured behavior are all identical — only the reported attribution changed.

The `audited: false` success-path contract agreed on in #268 is unchanged: a failed audit write after a successful backfill is still a 200 with `audited: false`, not a 500, since `recordAudit` is best-effort by contract and a 500 would discard the `remainingNullRows` count the endpoint exists to report.

## Related issues

Follow-up to #268; part of #235 (steps 1–2).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How was this verified?

- `npm run typecheck` — clean.
- `npm run lint` — clean, 302 files.
- `npx vitest run` (full suite) — 141 files passed, 3 skipped; **2130 tests passed, 27 skipped, 0 failures**.
- New tests in `tests/backfill-route.test.ts`:
  - failure path records the partial `updated`/`skipped` with `failed: true` and still returns 500;
  - a failure-path audit write that itself fails still returns the original 500 and message untouched;
  - mixed credentials (valid `X-Admin-API-Key` + a non-admin `userId` attached by middleware) record `actorType: "system"` with no `actorId`.
- Re-ran the suites for every other `isAdminRequest` call site unmodified (`audit`, `metrics`, `backup`, `restore`, `deletion-jobs`, `deletion-routes`) — 46/46 pass.

## Checklist

- [x] Tests added/updated for the change
- [x] Full test suite passes locally
- [x] Lint and typecheck pass
- [x] No changes to public API signatures (`isAdminRequest` is unchanged; `resolveAdminAuth` is additive)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk1wNDsuwpt6q36oZaZhof)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin authorization handling for backfill operations.
  * Backfill failures now preserve the original error details and report partial progress.
  * Failed operations now receive audit records, including cases where only some items were processed.
  * Audit records more accurately identify whether an operation was authorized by an API key or user credentials.
  * Preserved the original operation error even when failure auditing encounters an additional error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->