### PR TITLE
Search every duplicate-head candidate in createOrReusePR, not just the first

### DIFF
--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -519,15 +519,17 @@ export class GitHubClient {
    * against whatever they trust enough to store, since a JSON parse alone
    * doesn't guarantee GitHub's documented fields are actually present.
    *
-   * `isReusablePr` gates the lookup hit before it's treated as a successful
+   * `isReusablePr` selects the lookup hit that gets treated as a successful
    * reuse: this client has no opinion on what a caller trusts enough to
    * accept as "the PR" (the promotion route, for one, only accepts an open
    * PR whose `html_url` is exactly this repo's canonical page for the
-   * matched number — see `isUsableGithubPr`). A lookup hit the predicate
-   * rejects behaves exactly like a lookup that failed or found nothing open:
-   * the ORIGINAL create error is what gets reported, not a new failure about
-   * the lookup response, since that's the one call the caller actually asked
-   * for.
+   * matched number — see `isUsableGithubPr`). It is applied across every PR
+   * the lookup returns, not just the first, since the lookup is head-scoped
+   * and a head can carry more than one open PR. A lookup whose entries the
+   * predicate all reject behaves exactly like a lookup that failed or found
+   * nothing open: the ORIGINAL create error is what gets reported, not a new
+   * failure about the lookup response, since that's the one call the caller
+   * actually asked for.
    *
    * Required, deliberately not defaulted. The code this replaced always ran
    * an owner/repo check on the lookup hit, and a parameter defaulting to
@@ -578,8 +580,15 @@ export class GitHubClient {
         {},
         { maxRetries: 0, timeoutMs: DEFAULT_TIMEOUT_MS },
       );
-      const candidate = lookup.success && Array.isArray(lookup.data) ? lookup.data[0] : undefined;
-      if (candidate !== undefined && isReusablePr(candidate)) {
+      // Searched rather than index-then-test: `GET /pulls?head=` is head-only
+      // and can legitimately return more than one open PR, and the predicate
+      // is what decides which of them belongs to the repository being pushed
+      // to. Testing only the first entry would fail the reuse path in exactly
+      // the case the predicate exists for. Order is GitHub's; no preference is
+      // expressed here beyond "the first one the caller accepts".
+      const candidates: unknown[] = lookup.success && Array.isArray(lookup.data) ? lookup.data : [];
+      const candidate = candidates.find(isReusablePr);
+      if (candidate !== undefined) {
         return { success: true, pr: candidate, reused: true, status: lookup.status };
       }
       // Lookup failed, found nothing open, or found something the caller

--- a/tests/github-client-create-or-reuse-pr.test.ts
+++ b/tests/github-client-create-or-reuse-pr.test.ts
@@ -179,6 +179,73 @@ describe("GitHubClient.createOrReusePR", () => {
     }
   });
 
+  it("reuses a later lookup entry when the caller's predicate rejects the first", async () => {
+    // `GET /pulls?head=` is head-only, so it can return an open PR that
+    // belongs to a repository this promotion is not pushing to — a project
+    // migrated between GitHub repos is the real case. The predicate is what
+    // tells them apart, so the accepted one may not be first.
+    const wrongRepoPr = { number: 4, html_url: "https://github.com/acme/legacy/pull/4" };
+    const rightRepoPr = { number: 9, html_url: "https://github.com/acme/widgets/pull/9" };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            message: "Validation Failed",
+            errors: [{ message: "A pull request already exists for acme:stratum/chg_1." }],
+          },
+          422,
+        ),
+      )
+      .mockResolvedValueOnce(jsonResponse([wrongRepoPr, rightRepoPr], 200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const belongsToWidgets = vi.fn(
+      (pr: unknown) =>
+        (pr as { html_url?: string }).html_url === "https://github.com/acme/widgets/pull/9",
+    );
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.createOrReusePR(opts, belongsToWidgets);
+
+    expect(result).toEqual({ success: true, reused: true, status: 200, pr: rightRepoPr });
+    expect(belongsToWidgets).toHaveBeenCalledWith(wrongRepoPr, 0, [wrongRepoPr, rightRepoPr]);
+    expect(belongsToWidgets).toHaveBeenCalledWith(rightRepoPr, 1, [wrongRepoPr, rightRepoPr]);
+  });
+
+  it("falls back to the original create error when the predicate rejects every lookup entry", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            message: "Validation Failed",
+            errors: [{ message: "A pull request already exists for acme:stratum/chg_1." }],
+          },
+          422,
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          [
+            { number: 4, html_url: "https://github.com/acme/legacy/pull/4" },
+            { number: 5, html_url: "https://github.com/acme/other/pull/5" },
+          ],
+          200,
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.createOrReusePR(opts, () => false);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.status).toBe(422);
+      expect(result.errors[0]?.message).toContain("pull request already exists");
+    }
+  });
+
   it("does not look up a duplicate head when the 422 is not a duplicate-head failure", async () => {
     const fetchMock = vi
       .fn()


### PR DESCRIPTION
## Summary

After a duplicate-head `422`, `createOrReusePR` looked up the open PRs for the head and tested **only `lookup.data[0]`** against the caller's predicate. If the first entry was rejected but a later one would have been accepted, the lookup was discarded and the original `422` reported instead.

That matters because the lookup is `GET /pulls?head=:&state=open` — head-only, so more than one open PR is legitimate — and the production caller passes `isUsableGithubPr`, which rejects PRs belonging to a repository the promotion is not pushing to (a project migrated between GitHub repos, or `sourceUrl` superseding a legacy `githubUrl`). The case where `[0]` is rejected and a later entry qualifies is exactly the case the predicate exists to handle, so the reuse path silently failed in its own motivating scenario: the user saw "pull request already exists" while an open, reusable PR sat there.

The fix folds the predicate into the search rather than applying it after an arbitrary pick:

```ts
const candidates: unknown[] = lookup.success && Array.isArray(lookup.data) ? lookup.data : [];
const candidate = candidates.find(isReusablePr);
if (candidate !== undefined) { ... }
```

Typing the list as `unknown[]` also drops the implicit `any` that `Array.isArray` narrowing produced on the old `lookup.data[0]`, which `AGENTS.md` forbids. The `createOrReusePR` JSDoc is updated where it described the predicate as gating one hit.

**Fall-through is unchanged.** When the predicate accepts nothing — lookup failed, found nothing open, or rejected every entry — the original create error is still what gets reported. A regression test now guards that across a multi-entry response, not just a single-entry one.

### Explicitly not in scope

- **Pagination of `GET /pulls`.** The lookup is head-scoped and open-only; GitHub's default page of 30 is far beyond any plausible count for one head ref.
- **Circuit-breaker accounting on the duplicate-head `422` (#288)** and **response-body settling on retry (#289)** — filed separately, shipping separately.

## Related issues

Closes #290

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

Ran the CI gate order locally (lint → typecheck → test).

The two new cases were confirmed to be genuine regression tests, not just passing assertions: with the test file in place and `src/github/client.ts` reverted to its pre-fix state, `reuses a later lookup entry when the caller's predicate rejects the first` **fails**; it passes once the fix is restored.

- [x] `npm run typecheck` — clean
- [x] `npm test` — 2195 passed, 27 skipped, 0 failed (145 files)
- [x] `npm run lint` — `Checked 308 files. No fixes applied.`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate — swept `README.md`, `AGENTS.md`, `CONTRIBUTING.md` and `docs/` for `createOrReusePR`; it is internal and documented only in its own JSDoc, which this PR updates. No other docs affected.
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript — no UI change

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7uYgThVDqBi9KUpgVaoaJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request reuse when multiple matching open pull requests exist.
  * The system now selects the first eligible matching pull request instead of stopping at an ineligible result.
  * Preserved the original creation error when no matching pull request can be reused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->