### PR TITLE
Cancel abandoned GitHub response bodies instead of retrying over them

### DIFF
--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -214,6 +214,35 @@ function recordCircuitResult(endpoint: string, success: boolean): void {
   circuitBreakers.set(key, cb);
 }
 
+/**
+ * Releases a response this client is about to abandon.
+ *
+ * In Cloudflare Workers an unconsumed response body keeps its connection
+ * resources held. The retry paths would otherwise hold theirs for the whole
+ * backoff sleep — seconds, on a rate-limit wait — under exactly the two
+ * conditions (rate limiting, 5xx) where connection pressure is least
+ * affordable. Cancelling beats draining here: the bytes are not wanted, and
+ * cancelling releases immediately instead of after a full read.
+ *
+ * A rejected cancel means the body was already disturbed or errored. That is
+ * not a reason to fail a retry that would otherwise succeed, so it is logged
+ * rather than propagated.
+ */
+async function discardResponseBody(
+  response: Response,
+  logger: Logger,
+  endpoint: string,
+): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch (error) {
+    logger.debug("Could not cancel an abandoned GitHub response body", {
+      endpoint,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 function getBackoffDelay(retryCount: number): number {
   const exponentialDelay = Math.min(BASE_DELAY_MS * 2 ** retryCount, MAX_DELAY_MS);
   const jitter = exponentialDelay * 0.25 * (Math.random() * 2 - 1);
@@ -393,9 +422,11 @@ export class GitHubClient {
               waitTime,
               retryCount,
             });
+            await discardResponseBody(response, this.logger, endpoint);
             await new Promise((resolve) => setTimeout(resolve, Math.max(waitTime, 1000)));
             return this.request(endpoint, options, { ...requestOpts, retryCount: retryCount + 1 });
           }
+          await discardResponseBody(response, this.logger, endpoint);
           recordCircuitResult(endpoint, false);
           return {
             success: false,
@@ -415,6 +446,7 @@ export class GitHubClient {
           retryCount,
           delay,
         });
+        await discardResponseBody(response, this.logger, endpoint);
         await new Promise((resolve) => setTimeout(resolve, delay));
         return this.request(endpoint, options, { ...requestOpts, retryCount: retryCount + 1 });
       }

--- a/tests/github-client-retry-body.test.ts
+++ b/tests/github-client-retry-body.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GitHubClient, resetCircuitBreakersForTests } from "../src/github/client";
+import type { Logger } from "../src/utils/logger";
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+};
+
+/**
+ * A `Response` whose body reports whether it was cancelled.
+ *
+ * Whether a retry released its connection is invisible to any assertion about
+ * the call's final result, so these cases observe the stream itself: a real
+ * `ReadableStream` whose `cancel` callback records the release. A response
+ * built from a plain string would be indistinguishable from one left open.
+ */
+function observableResponse(
+  body: string,
+  status: number,
+  headers: Record<string, string> = {},
+): { response: Response; wasCancelled: () => boolean } {
+  let cancelled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+  return {
+    response: new Response(stream, { status, headers }),
+    wasCancelled: () => cancelled,
+  };
+}
+
+/** A rate-limit 403 whose window resets `secondsFromNow` in the future. */
+function rateLimited(secondsFromNow: number) {
+  return observableResponse("rate limited", 403, {
+    "X-RateLimit-Remaining": "0",
+    "X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + secondsFromNow),
+  });
+}
+
+beforeEach(() => {
+  resetCircuitBreakersForTests();
+  vi.unstubAllGlobals();
+});
+
+describe("GitHubClient retry paths settle the response they abandon", () => {
+  it("cancels the body of a retried 5xx before backing off", async () => {
+    const failed = observableResponse("down", 502);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(failed.response)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ default_branch: "main" }), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.getRepo("acme", "widgets");
+
+    expect(result).toEqual({ success: true, default_branch: "main" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(failed.wasCancelled()).toBe(true);
+    expect(failed.response.bodyUsed).toBe(true);
+  }, 10000);
+
+  it("cancels the body of a retried rate-limit 403 before waiting out the window", async () => {
+    const limited = rateLimited(1);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(limited.response)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ default_branch: "main" }), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.getRepo("acme", "widgets");
+
+    expect(result).toEqual({ success: true, default_branch: "main" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(limited.wasCancelled()).toBe(true);
+  }, 10000);
+
+  it("cancels the body of a rate-limit 403 it gives up on rather than retries", async () => {
+    // A reset further out than MAX_DELAY_MS (32s) is not worth waiting for, so
+    // the client returns instead of retrying — abandoning the response on a
+    // path with no sleep to blame for holding it.
+    const limited = rateLimited(600);
+    const fetchMock = vi.fn().mockResolvedValueOnce(limited.response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.getRepo("acme", "widgets");
+
+    expect(result.success).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(limited.wasCancelled()).toBe(true);
+  });
+
+  it("still settles each attempt when every retry in the budget fails", async () => {
+    const attempts = [
+      observableResponse("down", 502),
+      observableResponse("down", 502),
+      observableResponse("down", 502),
+    ];
+    const fetchMock = vi.fn();
+    for (const attempt of attempts) fetchMock.mockResolvedValueOnce(attempt.response);
+    // The final attempt is not abandoned: the non-ok path reads it with
+    // `response.text()` to build the error message, which settles it already.
+    fetchMock.mockResolvedValueOnce(new Response("down", { status: 502 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.getRepo("acme", "widgets");
+
+    expect(result.success).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    for (const attempt of attempts) {
+      expect(attempt.wasCancelled()).toBe(true);
+    }
+  }, 30000);
+
+  it("does not fail the retry when cancelling the abandoned body throws", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("down"));
+      },
+      cancel() {
+        throw new Error("stream already errored");
+      },
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(stream, { status: 502 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ default_branch: "main" }), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    const result = await client.getRepo("acme", "widgets");
+
+    expect(result).toEqual({ success: true, default_branch: "main" });
+    expect(logger.debug).toHaveBeenCalledWith(
+      "Could not cancel an abandoned GitHub response body",
+      expect.objectContaining({ endpoint: "/repos/acme/widgets" }),
+    );
+  }, 10000);
+});


### PR DESCRIPTION
## Summary

`GitHubClient.request()` retried on a 403 rate-limit and on 5xx by awaiting a delay and recursing — while still holding the `Response` from the failed attempt, whose body it never read or cancelled. In Cloudflare Workers an unconsumed response body keeps its connection resources held, so every retried request pinned a connection it no longer needed for the whole backoff sleep. On a rate-limit wait that is seconds, and it happens under exactly the two conditions where GitHub is already degraded and connection pressure is least affordable.

This adds `discardResponseBody()`, which cancels the body inside a `try`/`catch`. Cancelling beats draining, as the issue notes: the bytes are unwanted, and cancelling releases immediately rather than after a full read. A rejected cancel means the body was already disturbed or errored — that is logged at `debug` rather than propagated, since failing a retry that was going to succeed would trade a resource concern for a correctness one. Logged, not swallowed, per `AGENTS.md`.

### One site beyond the issue text — flagging deliberately

The issue describes the two **retry** branches. There is a third abandonment point: the 403 rate-limit **give-up** return, taken when the retry budget is spent or the reset is further out than `MAX_DELAY_MS`. It is the same defect on the same `Response`, two lines below the retry it sits next to — a `return` that walks away from an unconsumed body. Fixing the first two while leaving it would knowingly leave the leak in place, so all three are handled.

Every other exit from `request()` already settles, which I verified rather than assumed: the `!response.ok` path reads `response.text()` to build its error message, and the success path reads `response.json()`.

### Explicitly not in scope

Retry counts, backoff, and which statuses are retried are unchanged. Circuit-breaker policy (#288) and the duplicate-head candidate search (#290) are separate PRs. No audit of abandoned responses outside `GitHubClient.request()`.

## Related issues

Closes #289

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

Ran the CI gate order locally (lint → typecheck → test).

The issue makes the point that this is *"invisible to any assertion about the final result"*, so the new tests do not assert on the result — they observe the stream. Each attempt is built from a real `ReadableStream` whose `cancel` callback records the release, so a response left open is distinguishable from one settled. A response built from a plain string would not be.

Five cases in `tests/github-client-retry-body.test.ts`, covering the retried 5xx, the retried rate-limit 403, the give-up 403, a full exhausted retry budget (asserting every abandoned attempt settled), and a `cancel()` that throws (asserting the retry still succeeds and the failure is logged). **All five fail against the pre-fix client** — confirmed by reverting `src/github/client.ts` with the test file in place — and pass with the fix.

- [x] `npm run typecheck` — clean
- [x] `npm test` — 2198 passed, 27 skipped, 0 failed (146 files)
- [x] `npm run lint` — `Checked 309 files. No fixes applied.`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate — swept `README.md`, `AGENTS.md`, `CONTRIBUTING.md` and `docs/` for retry/rate-limit resource handling; `request()` is private and nothing documents it. No doc changes needed.
- [x] No secrets, tokens, or personal data committed — the debug log carries the endpoint and error message, never body bytes
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript — no UI change

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7uYgThVDqBi9KUpgVaoaJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of abandoned GitHub responses during rate-limit and server-error retries.
  - Prevented stalled connections and resource leaks when requests are retried or ultimately fail.
  - Ensured cancellation issues do not prevent successful retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->