### PR TITLE
Keep request-scoped 4xx answers out of circuit-breaker accounting

### DIFF
--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -157,6 +157,37 @@ export function resetCircuitBreakersForTests(): void {
 }
 
 /**
+ * Statuses that GitHub uses to answer a *request* rather than to report on the
+ * *repository*.
+ *
+ * The breaker is keyed per repository, so what it measures is whether that
+ * repository is reachable and usable. A `422` saying "a pull request already
+ * exists for this head" is GitHub reached, GitHub answering, and the caller
+ * expected to interpret the answer — it says nothing about repository health,
+ * and it must not move a repository-health counter. That is not academic:
+ * duplicate-head `422`s are the ordinary result of re-promoting a change, and
+ * counting them let five routine re-promotions open the breaker that the
+ * duplicate-head RECOVERY path then has to pass through (see
+ * `createOrReusePR`), turning "PR already exists" into a failed promotion.
+ *
+ * Deliberately narrower than "no 4xx counts": `401`, `403`, and `404` stay
+ * counted, because a repository that is gone, renamed, or beyond the token's
+ * access is precisely the condition {@link isCircuitOpen} exists to stop
+ * rediscovering once per endpoint.
+ */
+const REQUEST_SCOPED_STATUSES = new Set([400, 409, 422]);
+
+/**
+ * Whether a failed response should feed its repository's breaker.
+ *
+ * Transport errors and rate limiting are recorded by their own call sites and
+ * never reach here; this decides only for responses carrying a status.
+ */
+function isCircuitFailureStatus(status: number): boolean {
+  return !REQUEST_SCOPED_STATUSES.has(status);
+}
+
+/**
  * Whether calls to `endpoint`'s repository are currently being short-circuited.
  *
  * Keyed by the first three path segments (`/repos/<owner>/<repo>`), so the
@@ -195,6 +226,14 @@ function isCircuitOpen(endpoint: string): boolean {
  * of failures, so an intervening success means whatever was wrong is no longer
  * reproducing and the tally should not carry forward into an unrelated later
  * incident.
+ *
+ * Not every failed call gets here. A response the caller is expected to
+ * interpret (see {@link isCircuitFailureStatus}) is NEITHER recorded as a
+ * failure nor as a success — it is skipped entirely. Recording it as a success
+ * would zero a genuine consecutive-failure run because one `422` landed in the
+ * middle of it, which is the opposite of what a consecutive counter is for; and
+ * while half-open, skipping correctly leaves the breaker half-open, since a
+ * probe that drew a request-scoped answer learned nothing about the repository.
  */
 function recordCircuitResult(endpoint: string, success: boolean): void {
   const key = endpoint.split("/").slice(0, 3).join("/");
@@ -427,7 +466,9 @@ export class GitHubClient {
           status: response.status,
           error: errorText,
         });
-        recordCircuitResult(endpoint, false);
+        if (isCircuitFailureStatus(response.status)) {
+          recordCircuitResult(endpoint, false);
+        }
         return {
           success: false,
           error: `GitHub API error: ${response.status} - ${errorText}`,

--- a/tests/github-client-circuit-breaker.test.ts
+++ b/tests/github-client-circuit-breaker.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GitHubClient, resetCircuitBreakersForTests } from "../src/github/client";
+import type { Logger } from "../src/utils/logger";
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+};
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const duplicateHead = () =>
+  jsonResponse(
+    {
+      message: "Validation Failed",
+      errors: [{ message: "A pull request already exists for acme:stratum/chg_1." }],
+    },
+    422,
+  );
+
+const existingPr = () =>
+  jsonResponse([{ number: 9, html_url: "https://github.com/acme/widgets/pull/9" }], 200);
+
+const opts = {
+  owner: "acme",
+  repo: "widgets",
+  title: "Stratum: chg_1",
+  body: "body",
+  head: "stratum/chg_1",
+  base: "main",
+};
+
+const acceptAny = () => true;
+
+/** The breaker opens on this many consecutive counted failures. */
+const CIRCUIT_BREAKER_THRESHOLD = 5;
+
+beforeEach(() => {
+  resetCircuitBreakersForTests();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("circuit-breaker failure policy", () => {
+  it("reuses on duplicate-head even when the breaker is one failure from opening", async () => {
+    // The reachable shape of the reported bug. A run of duplicate-head 422s
+    // alone does NOT open the breaker, because each round's successful reuse
+    // lookup zeroes the consecutive-failure tally between rounds. What does
+    // reach it is a duplicate-head 422 arriving on top of an existing failure
+    // run against the same repository — the breaker is per-repository, so any
+    // caller's failures count. Before this policy the 422 was that run's fifth
+    // failure, the reuse lookup it recovers through was short-circuited with a
+    // 503, and a benign "PR already exists" became a failed promotion.
+    const fetchMock = vi.fn(async () => new Response("Not Found", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new GitHubClient("tok", logger);
+
+    for (let i = 0; i < CIRCUIT_BREAKER_THRESHOLD - 1; i++) {
+      await client.getRepo("acme", "widgets");
+    }
+
+    fetchMock.mockResolvedValueOnce(duplicateHead()).mockResolvedValueOnce(existingPr());
+    const result = await client.createOrReusePR(opts, acceptAny);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.reused).toBe(true);
+      expect(result.pr).toEqual({ number: 9, html_url: "https://github.com/acme/widgets/pull/9" });
+    }
+  });
+
+  it("does not let a run of duplicate-head promotions open the breaker", async () => {
+    const fetchMock = vi.fn();
+    const rounds = CIRCUIT_BREAKER_THRESHOLD + 2;
+    for (let i = 0; i < rounds; i++) {
+      fetchMock.mockResolvedValueOnce(duplicateHead()).mockResolvedValueOnce(existingPr());
+    }
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    for (let i = 0; i < rounds; i++) {
+      const result = await client.createOrReusePR(opts, acceptAny);
+      expect(result.success, `round ${i + 1} should still reuse`).toBe(true);
+    }
+    // Two fetches per round throughout: nothing was ever short-circuited.
+    expect(fetchMock).toHaveBeenCalledTimes(rounds * 2);
+  });
+
+  it("still opens the breaker on repeated 404s, the case it was written for", async () => {
+    const fetchMock = vi.fn(async () => new Response("Not Found", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    for (let i = 0; i < CIRCUIT_BREAKER_THRESHOLD; i++) {
+      await client.getRepo("acme", "widgets");
+    }
+    fetchMock.mockClear();
+
+    const afterThreshold = await client.getRepo("acme", "widgets");
+    expect(afterThreshold).toEqual({
+      success: false,
+      error: "Service temporarily unavailable (circuit open)",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("treats a request-scoped 422 as neutral, neither counting it nor clearing the tally", async () => {
+    // A 422 must not reset an in-progress run of genuine failures: the counter
+    // measures CONSECUTIVE repository failures, and a 422 says nothing about
+    // the repository either way.
+    const fetchMock = vi.fn(async () => new Response("Not Found", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new GitHubClient("tok", logger);
+
+    for (let i = 0; i < CIRCUIT_BREAKER_THRESHOLD - 1; i++) {
+      await client.getRepo("acme", "widgets");
+    }
+
+    // A 422 that is NOT duplicate-head, so it takes the generic path and makes
+    // exactly one request.
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ message: "Validation Failed", errors: [{ message: "base is invalid" }] }, 422),
+    );
+    const validationFailure = await client.createOrReusePR(opts, acceptAny);
+    expect(validationFailure.success).toBe(false);
+
+    // One more counted failure reaches the threshold. Had the 422 reset the
+    // tally, this would be failure #1 of 5 and the next call would go through.
+    await client.getRepo("acme", "widgets");
+    fetchMock.mockClear();
+
+    const afterThreshold = await client.getRepo("acme", "widgets");
+    expect(afterThreshold).toEqual({
+      success: false,
+      error: "Service temporarily unavailable (circuit open)",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not open the breaker on 422s alone, however many arrive", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ message: "Validation Failed", errors: [{ message: "base is invalid" }] }, 422),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new GitHubClient("tok", logger);
+    for (let i = 0; i < CIRCUIT_BREAKER_THRESHOLD + 3; i++) {
+      const result = await client.createOrReusePR(opts, acceptAny);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        // Still GitHub's own answer, never the breaker's 503.
+        expect(result.status).toBe(422);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`createOrReusePR` treats a duplicate-head `422` as expected and recoverable — it falls through to a lookup that finds the existing PR and reuses it. But `request()` had already recorded that `422` as a circuit-breaker failure, and the reuse lookup goes through the same per-repository breaker. The mechanism that recovers from duplicate-head was counted as a failure by the mechanism that can block it.

This adds `isCircuitFailureStatus()`. The breaker is keyed **per repository**, so what it measures is whether that repository is reachable and usable. The policy follows from that:

| | Statuses | Why |
|---|---|---|
| **Counts** | transport errors, 5xx, rate limiting, `401`, `403`, `404`, `410` | The repository is unreachable, gone, or the credential cannot use it |
| **Neutral** | `400`, `409`, `422` | GitHub was reached, answered, and is describing *this request*. The caller interprets it. |

## Two things reviewers should weigh

**1. This is narrower than the issue's suggested policy, on purpose.** The issue proposes that 4xx responses generally should not count, and calls that the more durable shape. It is — but the literal reading collides with the breaker's own documented purpose. `isCircuitOpen`'s comment says it exists so that *"a repo that is gone, renamed, or whose token lost access"* is not rediscovered once per endpoint. Those are `404` and `401`/`403`. Excluding every 4xx would delete that behaviour, so `401`/`403`/`404` stay counted and a test now guards it. If maintainers prefer the literal reading, the change is one predicate — but `isCircuitOpen`'s doc comment would need updating to match.

**2. The issue's premise needs one refinement.** It says five duplicate-head `422`s "sequentially or concurrently" open the breaker. Sequentially, they do not: each round's reuse lookup returns `200`, and any success zeroes the consecutive-failure tally, so the count never climbs past one between rounds. I verified this — an early version of the regression test passed against the *unfixed* client for exactly that reason, which is what surfaced it.

The genuinely reachable shape is a duplicate-head `422` landing **on top of an existing failure run** against the same repository. The breaker is shared per repository, so any caller's failures count toward it — a burst of 404s from evaluation reporting leaves the breaker at 4, and the next promotion's `422` is failure #5. The lookup it recovers through is then short-circuited with `503`, and the promotion fails. That is what the headline test drives, and it is the case that fails without this fix.

The user-visible outcome and the fix are unchanged by this refinement; the trigger is somewhat narrower than the issue describes.

### Neutral, not success

A non-counting failure records neither outcome. Recording success would zero a genuine consecutive-failure run because one `422` landed in the middle of it, which is the opposite of what a consecutive counter is for. While half-open, skipping correctly leaves the breaker half-open — a probe that drew a request-scoped answer learned nothing about the repository.

### Explicitly not in scope

Threshold, cooldown, per-repository keying, and the half-open probe are unchanged. The duplicate-head candidate search (#290) and retry body settling (#289) are separate PRs.

## Related issues

Closes #288

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

Ran the CI gate order locally (lint → typecheck → test).

Five cases in `tests/github-client-circuit-breaker.test.ts`:

1. **Reuses on duplicate-head with the breaker one failure from opening** — the regression. Fails against the pre-fix client (`503`, circuit open); passes with the fix.
2. **A run of duplicate-head promotions never opens the breaker** — asserts two fetches per round throughout, so nothing was short-circuited.
3. **Repeated 404s still open the breaker** — guards the documented behaviour this PR deliberately preserves.
4. **A `422` is neutral, not a reset** — four genuine failures, then a `422`, then one more failure trips the threshold. Had the `422` cleared the tally, it would not.
5. **`422`s alone never open the breaker** — the caller always sees GitHub's `422`, never the breaker's `503`.

Cases 3 and 4 pass in both directions by design: they guard behaviour that must not change.

- [x] `npm run typecheck` — clean
- [x] `npm test` — 2198 passed, 27 skipped, 0 failed (146 files)
- [x] `npm run lint` — `Checked 309 files. No fixes applied.`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate — grepped `README.md`, `AGENTS.md`, `CONTRIBUTING.md` and `docs/` for circuit-breaker behaviour; the only descriptions are the JSDoc in `client.ts`, which this PR extends so the documented purpose and the code agree.
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript — no UI change

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7uYgThVDqBi9KUpgVaoaJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved circuit-breaker handling for expected GitHub responses.
  - Duplicate or validation-related responses no longer incorrectly open or alter repository circuit breakers.
  - Repeated not-found and other server failures continue to be tracked appropriately.
  - Prevented valid operations from returning circuit-open errors after non-failure responses.

- **Tests**
  - Added coverage for pull request operations near circuit-breaker thresholds.
  - Verified expected responses preserve breaker state while genuine failures continue to trigger protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->