### PR TITLE
Record the published revision on promotion's stored-PR reuse path

### DIFF
--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1803,6 +1803,31 @@ app.post("/changes/:id/github-pr", async (c) => {
       prNumber: storedPr.number,
       repo: `${repo.owner}/${repo.repo}`,
     });
+    // The force-push above moved the PR's head, so the stored `githubHeadSha`
+    // now describes the PREVIOUS revision. This path is every re-promotion, so
+    // without this write the recorded published revision is stale (or missing,
+    // on rows predating the column) for every change promoted more than once,
+    // and nothing surfaces the discrepancy. Undefined only for a legacy change
+    // with no `evaluatedSha`, where the gate above never ran and there is no
+    // confirmed revision to record — the same guard the create path uses.
+    if (publishedSha !== undefined) {
+      const headShaResult = await updateChangeStatus(c.env.DB, logger, id, "promoted", {
+        githubHeadSha: publishedSha,
+      });
+      if (!headShaResult.success) {
+        // Not fatal: the branch is pushed and the PR exists, so the promotion
+        // genuinely happened. Failing here would let a transient D1 error break
+        // a re-promotion that previously could not fail after the push, and the
+        // degraded outcome is exactly the stale sha this write is fixing.
+        // Contrast the create path below, where a failed write loses the PR
+        // number itself and the next promotion would re-create the PR.
+        logger.error(
+          "Re-promotion succeeded but the published revision was not recorded",
+          headShaResult.error,
+          { changeId: id, publishedSha },
+        );
+      }
+    }
     return okOrFormRedirect(c, id, {
       changeId: id,
       github: {

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -2953,19 +2953,20 @@ describe("POST /api/changes/:id/github-pr", () => {
     expect(updateChangeStatus).not.toHaveBeenCalled();
   });
 
+  const reusableStoredPr = {
+    status: "promoted" as const,
+    githubOwner: "acme",
+    githubRepo: "widgets",
+    githubBranch: "stratum/chg_abc123",
+    githubPrNumber: 7,
+    githubPrUrl: "https://github.com/acme/widgets/pull/7",
+    githubPrState: "open",
+  };
+
   it("re-promotion re-pushes the branch and reuses the existing PR", async () => {
     vi.mocked(getChange).mockResolvedValue({
       success: true,
-      data: {
-        ...acceptedChange,
-        status: "promoted",
-        githubOwner: "acme",
-        githubRepo: "widgets",
-        githubBranch: "stratum/chg_abc123",
-        githubPrNumber: 7,
-        githubPrUrl: "https://github.com/acme/widgets/pull/7",
-        githubPrState: "open",
-      },
+      data: { ...acceptedChange, ...reusableStoredPr },
     });
     const res = await promote();
     expect(res.status).toBe(200);
@@ -2978,7 +2979,77 @@ describe("POST /api/changes/:id/github-pr", () => {
         pullRequestUrl: "https://github.com/acme/widgets/pull/7",
       }),
     );
+  });
+
+  // The reuse path returns before the create path's updateChangeStatus, so the
+  // revision it just force-pushed has to be recorded here or not at all. This
+  // is every re-promotion, so a miss leaves github_head_sha describing the
+  // PREVIOUS head while the branch on GitHub has moved.
+  it("re-promotion records the revision it just published, not the one it replaced", async () => {
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: {
+        ...acceptedChange,
+        ...reusableStoredPr,
+        evaluatedSha: "sha-second",
+        githubHeadSha: "sha-first",
+      },
+    });
+    vi.mocked(resolveLocalTip).mockResolvedValue({ success: true, data: "sha-second" });
+
+    const res = await promote();
+
+    expect(res.status).toBe(200);
+    expect(updateChangeStatus).toHaveBeenCalledWith(
+      env.DB,
+      expect.anything(),
+      "chg_abc123",
+      "promoted",
+      { githubHeadSha: "sha-second" },
+    );
+    // Only the sha: re-promotion is not treated as a fresh promotion event, so
+    // promoted_at/promoted_by are deliberately left alone.
+    expect(updateChangeStatus).toHaveBeenCalledWith(
+      env.DB,
+      expect.anything(),
+      "chg_abc123",
+      "promoted",
+      expect.not.objectContaining({ promotedAt: expect.anything() }),
+    );
+  });
+
+  it("re-promotion of a legacy change with no evaluatedSha records no sha", async () => {
+    // No evaluatedSha means the staleness gate never ran, so there is no
+    // confirmed published revision to record — writing one would be inventing it.
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: { ...acceptedChange, ...reusableStoredPr, evaluatedSha: undefined },
+    });
+
+    const res = await promote();
+
+    expect(res.status).toBe(200);
+    expect(resolveLocalTip).not.toHaveBeenCalled();
     expect(updateChangeStatus).not.toHaveBeenCalled();
+  });
+
+  it("re-promotion still succeeds when recording the published revision fails", async () => {
+    // The branch is pushed and the PR exists, so the promotion genuinely
+    // happened; a D1 blip must not turn it into an error.
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: { ...acceptedChange, ...reusableStoredPr, evaluatedSha: "sha-second" },
+    });
+    vi.mocked(resolveLocalTip).mockResolvedValue({ success: true, data: "sha-second" });
+    vi.mocked(updateChangeStatus).mockResolvedValue({
+      success: false,
+      error: new AppError("d1 unavailable", "DATABASE_ERROR", 500),
+    });
+
+    const res = await promote();
+
+    expect(res.status).toBe(200);
+    expect(updateChangeStatus).toHaveBeenCalled();
   });
 
   // Rows written before this route validated GitHub responses can hold


### PR DESCRIPTION
## Summary

The promotion route computes `publishedSha`, validates it against `change.evaluatedSha`, and force-pushes — then, when the change already has usable stored PR metadata, returns early, before the `updateChangeStatus` call that writes `githubHeadSha`. The push succeeded and the published revision was known; it was simply not recorded.

Because this is the *re-promotion* path, it is not an edge case — it is the second and every subsequent promotion of any change. `githubHeadSha` is the record of which revision was actually published, so after a re-promotion it was stale (pointing at the previous head while the branch on GitHub had moved) or missing (rows predating the column). Anything reading that field to answer "what is currently published?" got a wrong answer, and nothing surfaced the discrepancy.

This writes the confirmed sha before the reuse path returns. **The reuse decision itself is untouched** — reusing a PR that matches the target is the correct answer, as the issue notes; only the write was missing.

### Scope held deliberately tight

- **Only the sha.** `buildUpdateChangeStatusStatement` skips `undefined` opts, so this assigns `status` and `github_head_sha` and nothing else. `promoted_at` / `promoted_by` are left alone — whether a re-promotion counts as a fresh promotion event is a product question this bug does not need answered, and I would rather it be a decision than a side effect.
- **Legacy rows.** When `publishedSha` is `undefined` (no `evaluatedSha`, so the staleness gate never ran) there is no confirmed revision and the write is skipped, matching the guard the create path already applies to its own `githubHeadSha` write.
- **No backfill** of rows already stale.

### One judgement call worth reviewing

**A failed write does not fail the promotion** — it is logged at `error` and the route still returns success. The branch is pushed and the PR exists, so the promotion genuinely happened; failing here would let a transient D1 error break a re-promotion that previously could not fail after the push, and the degraded outcome of a failed write is exactly today's behaviour, a stale sha. The create path stays strict because a failed write *there* loses the PR number itself and the next promotion would re-create the PR.

If you'd rather this path fail loudly, it is one branch to change.

### A pre-existing assertion had to go

`tests/changes.test.ts` asserted `expect(updateChangeStatus).not.toHaveBeenCalled()` on the re-promotion case. That assertion encoded the bug, so it is replaced rather than quietly relaxed — flagging it since a deleted assertion is the kind of thing worth a second look.

## Related issues

Closes #291

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

Ran the CI gate order locally (lint → typecheck → test).

Four cases on the re-promotion path, matching the regression the issue asks for — re-promotion with valid stored PR metadata after a force-push, asserting `githubHeadSha` is the new head rather than the old one:

1. **Records the revision it just published, not the one it replaced** — stored head `sha-first`, publishes `sha-second`, asserts the write carries `sha-second`, and asserts `promotedAt` is *not* in the payload.
2. **A legacy change with no `evaluatedSha` records no sha** — no gate ran, so nothing is written rather than something invented.
3. **Re-promotion still succeeds when the write fails** — covers the judgement call above.
4. The existing reuse case, retained, minus the assertion that encoded the bug.

Cases 1 and 3 **fail against the pre-fix route** — confirmed by stashing `src/routes/changes.ts` with the tests in place.

- [x] `npm run typecheck` — clean
- [x] `npm test` — 2196 passed, 27 skipped, 0 failed (145 files)
- [x] `npm run lint` — `Checked 308 files. No fixes applied.`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate — grepped `README.md`, `AGENTS.md`, `CONTRIBUTING.md` and `docs/` for `githubHeadSha` / `github_head_sha` / re-promotion semantics; no documentation describes this field. Nothing to correct.
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript — no UI change

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7uYgThVDqBi9KUpgVaoaJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * GitHub re-promotions now record the newly published workspace revision when evaluation is verified.
  * Promotions continue successfully even if recording the revision fails.
  * Legacy changes without an evaluated revision remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->