### PR TITLE
Recognise diff headers by position so a credential cannot dodge the secret scan

### DIFF
--- a/src/evaluation/secret-scanner.ts
+++ b/src/evaluation/secret-scanner.ts
@@ -149,12 +149,13 @@ function matchSecret(line: string): string | undefined {
 /**
  * Scan raw file content — not a diff — for secrets.
  *
- * Callers that hold the literal bytes about to be committed must use this
+ * Callers that hold the literal bytes about to be committed should use this
  * rather than synthesising a diff to feed `SecretScanEvaluator.evaluate`.
- * Prefixing content lines with "+" is not a lossless encoding: a content line
- * that itself starts with "++" becomes "+++…", which the diff reader skips as
- * a file header, and the secret on it is never scanned. Scanning the content
- * directly removes that escape entirely.
+ * Prefixing content lines with "+" is not a lossless encoding — a content line
+ * starting with "++" is indistinguishable from a "+++" file header by prefix
+ * alone — so the evaluator recovers the distinction from the diff's structure
+ * instead. Scanning content directly needs no such recovery, and is the
+ * simpler thing to reason about when the bytes are already in hand.
  *
  * @returns One issue string per finding, empty when the content is clean.
  */
@@ -177,15 +178,54 @@ export class SecretScanEvaluator implements Evaluator {
   ): Promise<Result<EvalResult, AppError>> {
     const issues: string[] = [];
 
+    // Headers are recognised by POSITION, not by prefix. A diff prefixes every
+    // added line with "+", so file content beginning with "++" arrives as
+    // "+++…" and content beginning with "++ " arrives as "+++ …" — both
+    // indistinguishable from a file header to any prefix test, and both
+    // therefore a way to walk a credential past an always-on blocking gate.
+    //
+    // Git's structure decides instead: "+++ b/path" always immediately follows
+    // "--- a/path", and only before the first hunk of a file. A "+++ …" line
+    // anywhere else is content, so there is no shape a line can take to be
+    // mistaken for a header.
+    //
+    // Anchored on the adjacent header pair rather than on "@@" deliberately.
+    // Scanning only after a hunk header would be the stricter reading, but a
+    // caller that hands over a diff with no "@@" — or a bare list of "+" lines
+    // — would then have every added line skipped, and a scanner that silently
+    // scans nothing is a worse failure than the one this fixes.
+    let inHunkBody = false;
+    let prevWasOldFileHeader = false;
+
     const lines = diff.split("\n");
     lines.forEach((line, idx) => {
-      // Only the unified-diff file header is skipped, and that header always
-      // has a space after the marker ("+++ b/path"). Testing for a bare "+++"
-      // also swallowed a genuine added line whose own text starts with "++",
-      // letting a secret on such a line through unscanned.
-      if (!line.startsWith("+") || line.startsWith("+++ ")) return;
+      if (line.startsWith("diff --git ")) {
+        inHunkBody = false;
+        prevWasOldFileHeader = false;
+        return;
+      }
+      if (line.startsWith("@@")) {
+        inHunkBody = true;
+        prevWasOldFileHeader = false;
+        return;
+      }
+      // Before any hunk, "--- " can only be the old-file header: content lines
+      // carry a "+"/"-"/" " marker and cannot appear here. Inside a hunk it is
+      // a removed line whose text starts with "-- ", which is skipped below.
+      if (!inHunkBody && line.startsWith("--- ")) {
+        prevWasOldFileHeader = true;
+        return;
+      }
+      const isNewFileHeader = !inHunkBody && prevWasOldFileHeader && line.startsWith("+++ ");
+      prevWasOldFileHeader = false;
+      if (isNewFileHeader) return;
+
+      if (!line.startsWith("+")) return;
+      // Exactly one marker, so the patterns see the real file line rather than
+      // one with a "+" welded to its first token.
+      const content = line.slice(1);
       const lineNumber = idx + 1;
-      const name = matchSecret(line);
+      const name = matchSecret(content);
       if (name) {
         issues.push(`${name}: line ${lineNumber}`);
       }

--- a/tests/secret-scanner.test.ts
+++ b/tests/secret-scanner.test.ts
@@ -325,16 +325,68 @@ describe("added lines whose own text starts with ++", () => {
     }
   });
 
+  it("scans an added line rendered as +++ text, where a trailing space is not enough", async () => {
+    // The one-character tightening ("+++ " with the space) closes the case
+    // above but not this one: a source line of `++ const k = "…"` renders as
+    // `+++ const k = "…"`, which still looks exactly like a header to any
+    // prefix test. Position is what tells them apart.
+    const diff = makeDiff([`++ const k = "${AWS_KEY}";`]);
+    const result = await evaluator.evaluate(diff, policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.passed).toBe(false);
+      expect(result.data.issues?.join("\n")).toContain("AWS Access Key");
+    }
+  });
+
   it("still skips the real +++ b/path file header", async () => {
     // The header carries the path only; a path that happens to contain a
-    // secret-shaped substring must not be reported as content.
+    // secret-shaped substring must not be reported as content. Git always
+    // emits the `--- `/`+++ ` pair adjacently, which is what marks this one as
+    // a header rather than content.
     const result = await evaluator.evaluate(
-      `+++ b/${AWS_KEY}.ts\n+const ok = 1;`,
+      `diff --git a/${AWS_KEY}.ts b/${AWS_KEY}.ts\n--- a/${AWS_KEY}.ts\n+++ b/${AWS_KEY}.ts\n@@ -0,0 +1 @@\n+const ok = 1;`,
       policy,
       mockLogger,
     );
     expect(result.success).toBe(true);
     if (result.success) expect(result.data.passed).toBe(true);
+  });
+
+  it("scans an unpaired +++ line, erring toward detection when it cannot be a header", async () => {
+    // A `+++ ` line with no `--- ` before it is not where git puts a header,
+    // so it is treated as content. That direction is deliberate for a blocking
+    // security gate: a false positive is a blocked change with a stated
+    // reason, a false negative is a leaked credential. A real diff always
+    // carries the pair, so a genuine header is never caught by this.
+    const result = await evaluator.evaluate(`+++ const k = "${AWS_KEY}";`, policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.passed).toBe(false);
+  });
+
+  it("does not carry header state across files in a multi-file diff", async () => {
+    const clean = "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -0,0 +1 @@\n+const a = 1;";
+    // Second file: the added line's own text starts with "++ ", so it renders
+    // as "+++ …" inside the hunk body — content, not a header.
+    const sneaky = `diff --git a/b.ts b/b.ts\n--- a/b.ts\n+++ b/b.ts\n@@ -0,0 +1 @@\n+++ const k = "${AWS_KEY}";`;
+    const result = await evaluator.evaluate(`${clean}\n${sneaky}`, policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.passed).toBe(false);
+      expect(result.data.issues?.join("\n")).toContain("AWS Access Key");
+    }
+  });
+
+  it("does not mistake a removed line starting with -- for a file header", async () => {
+    // A deleted SQL/Lua comment renders as "--- …" inside a hunk. It must not
+    // set up header state that then swallows the next added line.
+    const diff = `diff --git a/q.sql b/q.sql\n--- a/q.sql\n+++ b/q.sql\n@@ -1 +1 @@\n--- legacy comment\n+++ const k = "${AWS_KEY}";`;
+    const result = await evaluator.evaluate(diff, policy, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.passed).toBe(false);
+      expect(result.data.issues?.join("\n")).toContain("AWS Access Key");
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

`SecretScanEvaluator` decided which diff lines to inspect by prefix. `main` already carries the one-character tightening the issue anticipated — `startsWith("+++ ")`, with the trailing space — which closes `++`-prefixed content. It does **not** close the case the issue explicitly says it will not close: a file line whose own content begins with `++ ` (two pluses and a space) arrives in the diff as `+++ …`, is read as a file header, and is never scanned.

This is a blocking, always-on control every change passes through, and it could be stepped around by anyone who knows the implementation.

The fix is the structural parse the issue asks for. A single-pass walk holds two pieces of state — whether we are inside a hunk body, and whether the previous line was a `--- ` old-file header — and classifies from git's own structure:

- `diff --git ` starts a file and resets both flags.
- `@@` starts a hunk body.
- Before any hunk, `--- ` is the old-file header.
- `+++ ` is the new-file header **only when it immediately follows that `--- ` line**. Git always emits the pair adjacently, so a `+++ …` line anywhere else is content.
- Everything else beginning with `+` is an added line: strip exactly one `+`, scan the rest — so the patterns see the real file line rather than one with a marker welded to its first token.

There is now no shape a content line can take to be mistaken for a header.

## Two deliberate deviations, both worth review

**1. Anchored on the header pair, not on `@@`.** The issue says to "treat everything after a hunk header as content", which is the stricter reading. But the suite's own `makeDiff` helper emits `diff --git` / `--- ` / `+++ ` and then added lines with **no `@@` at all** — a parser gated on `@@` would skip every added line in the existing corpus. A scanner that silently scans nothing is a far worse failure than the one being fixed, so the parse is tolerant of a hunk-less diff (and of a bare list of `+` lines) while still classifying headers correctly.

**2. An unpaired `+++ ` line is now treated as content.** A `+++ ` with no `--- ` before it is not where git puts a header. Erring toward scanning is the right direction for a blocking security gate: a false positive is a blocked change with a stated reason, a false negative is a leaked credential. A real diff always carries the pair, so a genuine header is never caught by this.

That second point **changed an existing test.** `still skips the real +++ b/path file header` asserted that a bare `+++ b/<secret-shaped-path>.ts` fragment is skipped. It is rewritten to use a realistic `diff --git` / `--- ` / `+++ ` / `@@` sequence, where the intent it was protecting — a header path containing a secret-shaped substring must not be reported as content — still holds and is still asserted. Flagging it since a rewritten security assertion deserves a second pair of eyes.

### Explicitly not in scope

- New patterns, threshold changes, entropy tuning.
- **Changing the reported line number** from a diff-line index to a file-line number. The structural walk makes real file numbers derivable, but changing what the number means is behaviour-visible and existing consumers read the current one.
- Removed and context lines — the gate is about what a change *introduces*.

## Related issues

Closes #280

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

Ran the CI gate order locally (lint → typecheck → test).

Five cases in the `added lines whose own text starts with ++` block, covering both shapes the issue names as uncovered:

1. **`++`-prefixed content** (`+++text`) — already passing on `main`; retained as a guard.
2. **`++ `-prefixed content** (`+++ text`) — the case the trailing-space fix does not close.
3. **An unpaired `+++ ` line** — documents deviation 2 above.
4. **A multi-file diff** where the second file hides the credential — guards against header state leaking across files.
5. **A removed line starting with `-- `** (a SQL comment rendering as `--- …` inside a hunk) — guards against a removal setting up header state that then swallows the next added line.

Cases 2–5 **fail against the pre-fix scanner** and pass with it. I initially had cases 4 and 5 built with the wrong marker depth — they passed in both directions, which is how I caught it; the fixtures are corrected so both genuinely exercise the evasion.

- [x] `npm run typecheck` — clean
- [x] `npm test` — 2197 passed, 27 skipped, 0 failed (145 files)
- [x] `npm run lint` — `Checked 308 files. No fixes applied.`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate — swept `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/`, and `website/`. The markdown descriptions ("a secret scan is always on and always blocking") stay true. The one piece of prose this invalidates is the `scanContentForSecrets` JSDoc, which described the skipped-as-a-header behaviour as current; it is corrected in this diff.
- [x] No secrets, tokens, or personal data committed — new fixtures follow the file's existing convention of splitting every credential-shaped literal across at least two parts
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript — no UI change

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7uYgThVDqBi9KUpgVaoaJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret scanning in diffs to detect secrets in added lines beginning with `++`.
  * More accurately distinguishes file headers from content, including across multiple files.
  * Preserved correct handling of removed lines and diff boundaries.

* **Documentation**
  * Clarified how direct content scanning handles lines beginning with `++`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->