### PR TITLE
Stop a repository's name from deciding its import error message

### DIFF
--- a/src/ui/components/import-progress.tsx
+++ b/src/ui/components/import-progress.tsx
@@ -102,12 +102,33 @@ const REMOTE_SPAN = /\b[a-z][a-z0-9+.-]*:\/\/\S+|\b[\w.-]+@[\w.-]+:\S+/gi;
  * failure. A ref name is not inside a URL, so remote-stripping alone never
  * reached these.
  *
- * Only the `refs/...` form is removed. A message naming a bare branch (`couldn't
- * find remote ref my-branch`) is not structurally distinguishable from prose, so
- * the marker shape has to carry that case — which is why every marker below is a
- * phrase git emits rather than a word a name can contain.
+ * Only the `refs/...` form is removed here; a bare branch name is handled by
+ * {@link MISSING_REF_SPAN}, which needs git's phrasing to recognise one.
  */
 const REF_SPAN = /\brefs\/(?:heads|tags|remotes)\/\S+/gi;
+
+/**
+ * git's own wording for a ref the remote does not have. Shared by the stripper
+ * below and the not-found branch, so a phrase can never be taught to one and
+ * not the other.
+ */
+const MISSING_REF_MARKERS = ["couldn't find remote ref", "could not find remote ref"];
+
+/**
+ * The bare ref name in `couldn't find remote ref fix-401-redirect`.
+ *
+ * A bare name carries no `refs/` prefix, so {@link REF_SPAN} cannot see it and
+ * the marker shape cannot exclude it: a phrase marker holds a space and a name
+ * cannot, but an HTTP status is digits, and digits are something a branch is
+ * plausibly called. `fix-401-redirect` and `release-403` are ordinary branch
+ * names, and both reported an authentication failure for a ref that simply is
+ * not there.
+ *
+ * What makes the name recognisable is the phrase in front of it: git only says
+ * this about a ref, so the token that follows is a ref name by construction.
+ * The phrase itself is kept — the not-found branch classifies on it.
+ */
+const MISSING_REF_SPAN = new RegExp(`(${MISSING_REF_MARKERS.join("|")})\\s+\\S+`, "gi");
 
 /**
  * Markers of a real authentication failure, as git and the GitHub API phrase
@@ -201,9 +222,15 @@ export function classifyError(errorMessage: string): ErrorInfo {
   // read the full message on purpose: LFS_BATCH_RESPONSE_MARKERS requires the
   // path `/info/lfs/objects/batch`, which legitimately arrives inside a URL,
   // so stripping there would undo the LFS detection #218 added.
-  const prose = msg.replace(REMOTE_SPAN, " ").replace(REF_SPAN, " ");
+  const prose = msg
+    .replace(REMOTE_SPAN, " ")
+    .replace(REF_SPAN, " ")
+    .replace(MISSING_REF_SPAN, "$1 ");
   // The same text with its original case kept, for the transport codes above.
-  const proseRaw = errorMessage.replace(REMOTE_SPAN, " ").replace(REF_SPAN, " ");
+  const proseRaw = errorMessage
+    .replace(REMOTE_SPAN, " ")
+    .replace(REF_SPAN, " ")
+    .replace(MISSING_REF_SPAN, "$1 ");
 
   // Authentication errors
   // 401/403 carry the refusal on their own, so the original predicate's bare
@@ -289,8 +316,7 @@ export function classifyError(errorMessage: string): ErrorInfo {
     msg.includes("404") ||
     msg.includes("doesn't exist") ||
     msg.includes("does not exist") ||
-    msg.includes("couldn't find remote ref") ||
-    msg.includes("could not find remote ref")
+    MISSING_REF_MARKERS.some((marker) => msg.includes(marker))
   ) {
     return {
       type: "NOT_FOUND",

--- a/src/ui/components/import-progress.tsx
+++ b/src/ui/components/import-progress.tsx
@@ -96,6 +96,20 @@ const LFS_BATCH_RESPONSE_MARKERS = ["batch response", "/info/lfs/objects/batch"]
 const REMOTE_SPAN = /\b[a-z][a-z0-9+.-]*:\/\/\S+|\b[\w.-]+@[\w.-]+:\S+/gi;
 
 /**
+ * Fully-qualified ref spans, removed for the same reason as {@link REMOTE_SPAN}:
+ * a ref is named by whoever pushed it, so `refs/heads/401` must not be read as
+ * an HTTP status and `refs/heads/disk-cleanup` must not be read as a storage
+ * failure. A ref name is not inside a URL, so remote-stripping alone never
+ * reached these.
+ *
+ * Only the `refs/...` form is removed. A message naming a bare branch (`couldn't
+ * find remote ref my-branch`) is not structurally distinguishable from prose, so
+ * the marker shape has to carry that case — which is why every marker below is a
+ * phrase git emits rather than a word a name can contain.
+ */
+const REF_SPAN = /\brefs\/(?:heads|tags|remotes)\/\S+/gi;
+
+/**
  * Markers of a real authentication failure, as git and the GitHub API phrase
  * them.
  *
@@ -158,9 +172,13 @@ function hasTransportCode(rawText: string): boolean {
   return TRANSPORT_CODES.some((code) => new RegExp(`(?<![A-Z])${code}(?![A-Z])`).test(rawText));
 }
 
-/** Whether `text` carries `code` as a standalone HTTP status, not as digits inside a path. */
+/**
+ * Keeps digits that belong to a repository or ref path from being read as an
+ * HTTP status. `1403` is not a 403, and neither is `/v1/403/spec` — a real
+ * status is preceded by a space, a bracket, or nothing at all.
+ */
 function hasStatus(text: string, code: string): boolean {
-  return new RegExp(`(?<!\\d)${code}(?!\\d)`).test(text);
+  return new RegExp(`(?<![\\d/])${code}(?!\\d)`).test(text);
 }
 
 export function classifyError(errorMessage: string): ErrorInfo {
@@ -169,9 +187,9 @@ export function classifyError(errorMessage: string): ErrorInfo {
   // read the full message on purpose: LFS_BATCH_RESPONSE_MARKERS requires the
   // path `/info/lfs/objects/batch`, which legitimately arrives inside a URL,
   // so stripping there would undo the LFS detection #218 added.
-  const prose = msg.replace(REMOTE_SPAN, " ");
+  const prose = msg.replace(REMOTE_SPAN, " ").replace(REF_SPAN, " ");
   // The same text with its original case kept, for the transport codes above.
-  const proseRaw = errorMessage.replace(REMOTE_SPAN, " ");
+  const proseRaw = errorMessage.replace(REMOTE_SPAN, " ").replace(REF_SPAN, " ");
 
   // Authentication errors
   // 401/403 carry the refusal on their own, so the original predicate's bare
@@ -246,11 +264,19 @@ export function classifyError(errorMessage: string): ErrorInfo {
   }
 
   // Not found errors
+  //
+  // "couldn't find remote ref" is git's own wording for a ref that is absent
+  // from the remote, and it earns its place here: without it the message
+  // carries no not-found token at all, so once {@link REF_SPAN} removes the
+  // ref name the failure falls through to UNKNOWN_ERROR — a message that says
+  // precisely what went wrong, answered with "an unexpected error occurred".
   if (
     msg.includes("not found") ||
     msg.includes("404") ||
     msg.includes("doesn't exist") ||
-    msg.includes("does not exist")
+    msg.includes("does not exist") ||
+    msg.includes("couldn't find remote ref") ||
+    msg.includes("could not find remote ref")
   ) {
     return {
       type: "NOT_FOUND",

--- a/src/ui/components/import-progress.tsx
+++ b/src/ui/components/import-progress.tsx
@@ -87,15 +87,86 @@ const LFS_BATCH_RESPONSE_MARKERS = ["batch response", "/info/lfs/objects/batch"]
  * the ORDER of these branches is load-bearing, and order is exactly what a
  * rendering test cannot see.
  */
+/**
+ * Spans that carry a repository's own name into an error message: a URL, or
+ * git's scp-style `user@host:path` remote. Removed before classification so a
+ * repository called `oauth-server` or `fetch-utils` cannot decide how its
+ * failure is described.
+ */
+const REMOTE_SPAN = /\b[a-z][a-z0-9+.-]*:\/\/\S+|\b[\w.-]+@[\w.-]+:\S+/g;
+
+/**
+ * Markers of a real authentication failure, as git and the GitHub API phrase
+ * them.
+ *
+ * Every entry contains a space, and that is not decoration: neither a URL nor
+ * a ref name can, so a phrase git emits cannot also be something a repository
+ * is called. The bare nouns these replace (`auth`, `credentials`) are exactly
+ * the substrings that made `acme/oauth-server` report an authentication
+ * problem — and because this branch runs first, its answer won over every
+ * other classification.
+ */
+const AUTH_MARKERS = [
+  "authentication failed",
+  "authentication required",
+  "requires authentication",
+  "could not read username",
+  "could not read password",
+  "invalid username or password",
+  "permission denied",
+  "access denied",
+  "bad credentials",
+  "invalid credentials",
+];
+
+/**
+ * Markers of a real transport failure.
+ *
+ * Same rule as {@link AUTH_MARKERS}, with one deliberate exception: Node's
+ * transport codes are single tokens, and no repository is plausibly named
+ * `econnrefused`.
+ */
+const NETWORK_MARKERS = [
+  "connection refused",
+  "connection reset",
+  "connection closed",
+  "connection timed out",
+  "operation timed out",
+  "timed out",
+  "network is unreachable",
+  "network error",
+  "failed to connect",
+  "failed to fetch",
+  "fetch failed",
+  "socket hang up",
+  "econnrefused",
+  "econnreset",
+  "etimedout",
+  "enotfound",
+];
+
+/** Whether `text` carries `code` as a standalone HTTP status, not as digits inside a path. */
+function hasStatus(text: string, code: string): boolean {
+  return new RegExp(`(?<!\\d)${code}(?!\\d)`).test(text);
+}
+
 export function classifyError(errorMessage: string): ErrorInfo {
   const msg = errorMessage.toLowerCase();
+  // Matched against by every branch EXCEPT LFS and not-found below. Those two
+  // read the full message on purpose: LFS_BATCH_RESPONSE_MARKERS requires the
+  // path `/info/lfs/objects/batch`, which legitimately arrives inside a URL,
+  // so stripping there would undo the LFS detection #218 added.
+  const prose = msg.replace(REMOTE_SPAN, " ");
 
   // Authentication errors
+  // 401/403 and a bare "unauthorized" are kept from the original predicate:
+  // read from `prose` they can no longer come from a repository's URL, and
+  // dropping them would trade this bug for a false negative on a real refusal.
   if (
-    msg.includes("auth") ||
-    msg.includes("unauthorized") ||
-    msg.includes("403") ||
-    msg.includes("credentials")
+    AUTH_MARKERS.some((marker) => prose.includes(marker)) ||
+    prose.includes("unauthorized") ||
+    hasStatus(prose, "401") ||
+    hasStatus(prose, "403")
   ) {
     return {
       type: "AUTH_ERROR",
@@ -115,12 +186,7 @@ export function classifyError(errorMessage: string): ErrorInfo {
   }
 
   // Network errors
-  if (
-    msg.includes("network") ||
-    msg.includes("fetch") ||
-    msg.includes("connection") ||
-    msg.includes("timeout")
-  ) {
+  if (NETWORK_MARKERS.some((marker) => prose.includes(marker))) {
     return {
       type: "NETWORK_ERROR",
       title: "Network Error",
@@ -187,7 +253,11 @@ export function classifyError(errorMessage: string): ErrorInfo {
   }
 
   // Rate limiting
-  if (msg.includes("rate limit") || msg.includes("429") || msg.includes("too many requests")) {
+  if (
+    prose.includes("rate limit") ||
+    hasStatus(prose, "429") ||
+    prose.includes("too many requests")
+  ) {
     return {
       type: "RATE_LIMITED",
       title: "Rate Limited",
@@ -202,7 +272,10 @@ export function classifyError(errorMessage: string): ErrorInfo {
   }
 
   // Git errors
-  if (msg.includes("git") || msg.includes("clone") || msg.includes("repository")) {
+  // Still bare nouns, but read from `prose`: a repository named `git-tools` no
+  // longer reaches here through its URL. A ref name can still collide, which
+  // needs the corpus of real messages this branch produces to narrow safely.
+  if (prose.includes("git") || prose.includes("clone") || prose.includes("repository")) {
     return {
       type: "GIT_ERROR",
       title: "Git Operation Failed",
@@ -217,7 +290,7 @@ export function classifyError(errorMessage: string): ErrorInfo {
   }
 
   // Storage / naming conflict errors
-  if (msg.includes("already exists")) {
+  if (prose.includes("already exists")) {
     return {
       type: "ALREADY_EXISTS",
       title: "Import Conflict",
@@ -230,12 +303,14 @@ export function classifyError(errorMessage: string): ErrorInfo {
     };
   }
 
+  // As with the git branch: URL-borne collisions are closed, ref-name ones are
+  // not yet.
   if (
-    msg.includes("disk") ||
-    msg.includes("quota") ||
-    msg.includes("space") ||
-    msg.includes("storage") ||
-    msg.includes("artifacts")
+    prose.includes("disk") ||
+    prose.includes("quota") ||
+    prose.includes("space") ||
+    prose.includes("storage") ||
+    prose.includes("artifacts")
   ) {
     return {
       type: "STORAGE_ERROR",

--- a/src/ui/components/import-progress.tsx
+++ b/src/ui/components/import-progress.tsx
@@ -93,7 +93,7 @@ const LFS_BATCH_RESPONSE_MARKERS = ["batch response", "/info/lfs/objects/batch"]
  * repository called `oauth-server` or `fetch-utils` cannot decide how its
  * failure is described.
  */
-const REMOTE_SPAN = /\b[a-z][a-z0-9+.-]*:\/\/\S+|\b[\w.-]+@[\w.-]+:\S+/g;
+const REMOTE_SPAN = /\b[a-z][a-z0-9+.-]*:\/\/\S+|\b[\w.-]+@[\w.-]+:\S+/gi;
 
 /**
  * Markers of a real authentication failure, as git and the GitHub API phrase
@@ -122,9 +122,9 @@ const AUTH_MARKERS = [
 /**
  * Markers of a real transport failure.
  *
- * Same rule as {@link AUTH_MARKERS}, with one deliberate exception: Node's
- * transport codes are single tokens, and no repository is plausibly named
- * `econnrefused`.
+ * Same space-carrying rule as {@link AUTH_MARKERS}. Node's transport codes
+ * cannot follow it — they are single tokens — so they are matched separately
+ * by {@link hasTransportCode} rather than excepted from the rule here.
  */
 const NETWORK_MARKERS = [
   "connection refused",
@@ -139,11 +139,24 @@ const NETWORK_MARKERS = [
   "failed to fetch",
   "fetch failed",
   "socket hang up",
-  "econnrefused",
-  "econnreset",
-  "etimedout",
-  "enotfound",
 ];
+
+/**
+ * Node's transport codes, which no phrase can express.
+ *
+ * Matched against the message with its ORIGINAL case, because Node always
+ * emits them upper-case (`getaddrinfo ENOTFOUND`, `connect ECONNREFUSED`)
+ * while a ref name is conventionally lower-case. That is what separates a
+ * real DNS failure from a branch called `enotfound-handling` — treating them
+ * as case-insensitive single tokens reintroduced exactly the name collision
+ * this function exists to remove.
+ */
+const TRANSPORT_CODES = ["ECONNREFUSED", "ECONNRESET", "ETIMEDOUT", "ENOTFOUND", "EHOSTUNREACH"];
+
+/** Whether `rawText` carries a Node transport code as a standalone upper-case token. */
+function hasTransportCode(rawText: string): boolean {
+  return TRANSPORT_CODES.some((code) => new RegExp(`(?<![A-Z])${code}(?![A-Z])`).test(rawText));
+}
 
 /** Whether `text` carries `code` as a standalone HTTP status, not as digits inside a path. */
 function hasStatus(text: string, code: string): boolean {
@@ -157,14 +170,17 @@ export function classifyError(errorMessage: string): ErrorInfo {
   // path `/info/lfs/objects/batch`, which legitimately arrives inside a URL,
   // so stripping there would undo the LFS detection #218 added.
   const prose = msg.replace(REMOTE_SPAN, " ");
+  // The same text with its original case kept, for the transport codes above.
+  const proseRaw = errorMessage.replace(REMOTE_SPAN, " ");
 
   // Authentication errors
-  // 401/403 and a bare "unauthorized" are kept from the original predicate:
-  // read from `prose` they can no longer come from a repository's URL, and
-  // dropping them would trade this bug for a false negative on a real refusal.
+  // 401/403 carry the refusal on their own, so the original predicate's bare
+  // "unauthorized" token is gone: it is redundant beside them (every real
+  // message carrying the word carries the status too — `HTTP Error: 401
+  // Unauthorized`) and it broke the space rule, classifying a 404 for a ref
+  // named `fix-unauthorized-redirect` as an auth failure.
   if (
     AUTH_MARKERS.some((marker) => prose.includes(marker)) ||
-    prose.includes("unauthorized") ||
     hasStatus(prose, "401") ||
     hasStatus(prose, "403")
   ) {
@@ -186,7 +202,7 @@ export function classifyError(errorMessage: string): ErrorInfo {
   }
 
   // Network errors
-  if (NETWORK_MARKERS.some((marker) => prose.includes(marker))) {
+  if (NETWORK_MARKERS.some((marker) => prose.includes(marker)) || hasTransportCode(proseRaw)) {
     return {
       type: "NETWORK_ERROR",
       title: "Network Error",

--- a/src/ui/components/import-progress.tsx
+++ b/src/ui/components/import-progress.tsx
@@ -181,6 +181,20 @@ function hasStatus(text: string, code: string): boolean {
   return new RegExp(`(?<![\\d/])${code}(?!\\d)`).test(text);
 }
 
+/**
+ * Turns an import failure into guidance a person can act on.
+ *
+ * The message is the only input, and it carries the repository remote and the
+ * ref alongside git's own words — both named by whoever pushed them. So one
+ * rule governs every branch below: a marker must be something git says, not a
+ * word a name can contain. Two spans are removed before matching for what the
+ * rule cannot express, and the remaining markers are phrases, because neither
+ * a URL nor a ref name can hold a space.
+ *
+ * Branch order is load-bearing and separately covered by the LFS suite in
+ * #218; the earliest match wins, so a widened predicate here is answered on
+ * far more failures than the one it was widened for.
+ */
 export function classifyError(errorMessage: string): ErrorInfo {
   const msg = errorMessage.toLowerCase();
   // Matched against by every branch EXCEPT LFS and not-found below. Those two

--- a/tests/csp-nonce-sweep.test.tsx
+++ b/tests/csp-nonce-sweep.test.tsx
@@ -264,7 +264,17 @@ describe("CSP nonce sweep — components", () => {
       <ImportProgressCard
         {...importProgressBase}
         status="failed"
-        errors={[{ file: "repo", error: "unauthorized", timestamp: "2024-01-01T00:00:00Z" }]}
+        // A realistic auth failure rather than the bare word "unauthorized":
+        // classifyError deliberately no longer treats that token alone as an
+        // auth error (it collided with ref names — see #278), and this case
+        // needs a classification that renders the action button it asserts on.
+        errors={[
+          {
+            file: "repo",
+            error: "HTTP Error: 401 Unauthorized",
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ]}
         nonce={NONCE}
       />,
     );

--- a/tests/import-error-classification.test.ts
+++ b/tests/import-error-classification.test.ts
@@ -172,6 +172,40 @@ describe("classifyError — a repository's name must not decide its error messag
     expect(info.title).toBe("Network Error");
   });
 
+  // A ref name is not inside a URL, so stripping remotes cannot save it — only
+  // the marker shape can. Both of these were still misclassified after the
+  // first cut of this fix, because two single-token markers had been excepted
+  // from the space rule.
+  it.each([
+    [
+      "ref named ...unauthorized...",
+      "couldn't find remote ref refs/heads/fix-unauthorized-redirect (404)",
+    ],
+    ["ref named ...enotfound...", "couldn't find remote ref refs/heads/enotfound-handling (404)"],
+    ["ref named ...econnreset...", "couldn't find remote ref refs/heads/econnreset-retry (404)"],
+    ["ref named ...timed-out...", "couldn't find remote ref refs/heads/retry-timed-out (404)"],
+  ])("reports a missing ref as NOT_FOUND despite its name (%s)", (_label, message) => {
+    const info = classifyError(message);
+    expect(info.type).toBe("NOT_FOUND");
+  });
+
+  // The counterpart: Node emits its transport codes upper-case, which is what
+  // separates a real DNS/socket failure from a lower-case ref name above.
+  it.each([
+    ["dns", "request to https://github.com/acme/x.git failed, reason: getaddrinfo ENOTFOUND"],
+    ["refused", "connect ECONNREFUSED 140.82.121.4:443"],
+    ["reset", "read ECONNRESET"],
+    ["timeout code", "connect ETIMEDOUT 140.82.121.4:443"],
+  ])("still reports an upper-case Node transport code as NETWORK_ERROR (%s)", (_label, message) => {
+    const info = classifyError(message);
+    expect(info.type).toBe("NETWORK_ERROR");
+  });
+
+  // The word alone no longer classifies; the status beside it does.
+  it("still reports a 401 Unauthorized as AUTH_ERROR", () => {
+    expect(classifyError("HTTP Error: 401 Unauthorized").type).toBe("AUTH_ERROR");
+  });
+
   // A URL path that happens to contain three digits is not an HTTP status.
   it("does not read digits inside a repository path as a status code", () => {
     const info = classifyError(

--- a/tests/import-error-classification.test.ts
+++ b/tests/import-error-classification.test.ts
@@ -234,6 +234,7 @@ describe("classifyError — a repository's name must not decide its error messag
     ["name that is a status", "fatal: couldn't find remote ref 401"],
     ["status at the end", "fatal: couldn't find remote ref release-403"],
     ["the other phrasing", "fatal: could not find remote ref rate-limit-429"],
+    ["status mid-name", "fatal: couldn't find remote ref release-403-fix"],
   ])("does not read a bare ref's own name as an HTTP status (%s)", (_label, message) => {
     expect(classifyError(message).type).toBe("NOT_FOUND");
   });
@@ -245,6 +246,16 @@ describe("classifyError — a repository's name must not decide its error messag
     const info = classifyError("fatal: couldn't find remote ref my-branch");
     expect(info.type).toBe("NOT_FOUND");
     expect(info.title).toBe("Repository Not Found");
+  });
+
+  // Upper case is what separates a real Node transport code from a lower-case
+  // ref name, so a ref SHOUTING one is the case that rule cannot decide. The
+  // phrase settles it: this is a ref, whatever it is called.
+  it.each([
+    ["dns code", "fatal: couldn't find remote ref ENOTFOUND-retry"],
+    ["refused code", "fatal: couldn't find remote ref ECONNREFUSED-handling"],
+  ])("does not read an upper-case bare ref name as a transport code (%s)", (_label, message) => {
+    expect(classifyError(message).type).toBe("NOT_FOUND");
   });
 
   // The counterpart to the phrase above: a real disk failure still reaches the

--- a/tests/import-error-classification.test.ts
+++ b/tests/import-error-classification.test.ts
@@ -224,6 +224,29 @@ describe("classifyError — a repository's name must not decide its error messag
     expect(info.type).toBe("NOT_FOUND");
   });
 
+  // A bare name has no `refs/` prefix for the ref strip to see, and the marker
+  // shape cannot exclude it either: a phrase marker holds a space and a name
+  // cannot, but an HTTP status is digits — and digits are something a branch is
+  // plausibly called. What identifies the name is the phrase in front of it,
+  // since git says this only about a ref.
+  it.each([
+    ["status inside a name", "fatal: couldn't find remote ref fix-401-redirect"],
+    ["name that is a status", "fatal: couldn't find remote ref 401"],
+    ["status at the end", "fatal: couldn't find remote ref release-403"],
+    ["the other phrasing", "fatal: could not find remote ref rate-limit-429"],
+  ])("does not read a bare ref's own name as an HTTP status (%s)", (_label, message) => {
+    expect(classifyError(message).type).toBe("NOT_FOUND");
+  });
+
+  // The strip removes the name, not the phrase — the not-found branch
+  // classifies on the phrase, so eating it would trade one wrong answer for
+  // another.
+  it("still reports a missing bare ref as NOT_FOUND, not UNKNOWN", () => {
+    const info = classifyError("fatal: couldn't find remote ref my-branch");
+    expect(info.type).toBe("NOT_FOUND");
+    expect(info.title).toBe("Repository Not Found");
+  });
+
   // The counterpart to the phrase above: a real disk failure still reaches the
   // storage branch, which the strip must not have starved of its noun.
   it("still reports a real storage failure as STORAGE_ERROR", () => {

--- a/tests/import-error-classification.test.ts
+++ b/tests/import-error-classification.test.ts
@@ -189,6 +189,47 @@ describe("classifyError — a repository's name must not decide its error messag
     expect(info.type).toBe("NOT_FOUND");
   });
 
+  // Marker shape alone could not reach these: a ref named for a status code is
+  // digits, and a ref named for a bare noun ("git", "repository", "already
+  // exists") collides with branches that have no phrase-shaped alternative.
+  // Removing the whole `refs/...` span is what answers both — the ref's own
+  // name is never evidence about the failure.
+  it.each([
+    ["ref named 401", "couldn't find remote ref refs/heads/401 (404)"],
+    ["ref named 403", "couldn't find remote ref refs/heads/403 (404)"],
+    ["ref named 429", "couldn't find remote ref refs/heads/429-backoff (404)"],
+    ["tag named for a status", "couldn't find remote ref refs/tags/v1-403-fix (404)"],
+    [
+      "ref named for a status inside a path",
+      "couldn't find remote ref refs/heads/api/v1/403/spec (404)",
+    ],
+  ])("does not read a ref's own name as an HTTP status (%s)", (_label, message) => {
+    const info = classifyError(message);
+    expect(info.type).toBe("NOT_FOUND");
+  });
+
+  // git states a missing ref without ever emitting "404" or "not found", so
+  // these reach the branches whose markers are still bare nouns and are
+  // answered confidently wrong — `disk-cleanup` as a full disk, `429-backoff`
+  // as a rate limit. Removing the ref span takes that false evidence away;
+  // recognising git's own "couldn't find remote ref" supplies the true
+  // evidence, without which the strip would leave these as UNKNOWN_ERROR.
+  it.each([
+    ["storage noun", "fatal: couldn't find remote ref refs/heads/disk-cleanup"],
+    ["rate-limit noun", "fatal: couldn't find remote ref refs/heads/429-backoff"],
+    ["git noun", "fatal: couldn't find remote ref refs/heads/git-cleanup"],
+    ["repository noun", "fatal: could not find remote ref refs/heads/repository-rename"],
+  ])("does not read a ref's own name as the failure it names (%s)", (_label, message) => {
+    const info = classifyError(message);
+    expect(info.type).toBe("NOT_FOUND");
+  });
+
+  // The counterpart to the phrase above: a real disk failure still reaches the
+  // storage branch, which the strip must not have starved of its noun.
+  it("still reports a real storage failure as STORAGE_ERROR", () => {
+    expect(classifyError("fatal: write error: No space left on device").type).toBe("STORAGE_ERROR");
+  });
+
   // The counterpart: Node emits its transport codes upper-case, which is what
   // separates a real DNS/socket failure from a lower-case ref name above.
   it.each([
@@ -204,6 +245,15 @@ describe("classifyError — a repository's name must not decide its error messag
   // The word alone no longer classifies; the status beside it does.
   it("still reports a 401 Unauthorized as AUTH_ERROR", () => {
     expect(classifyError("HTTP Error: 401 Unauthorized").type).toBe("AUTH_ERROR");
+  });
+
+  // The strip removes the ref, not the message around it: a real refusal that
+  // happens to name a branch must keep classifying on the refusal.
+  it("still reports a 403 that also names a ref as AUTH_ERROR", () => {
+    const info = classifyError(
+      "remote: HTTP 403 while accessing refs/heads/main on https://github.com/acme/x.git",
+    );
+    expect(info.type).toBe("AUTH_ERROR");
   });
 
   // A URL path that happens to contain three digits is not an HTTP status.

--- a/tests/import-error-classification.test.ts
+++ b/tests/import-error-classification.test.ts
@@ -105,3 +105,87 @@ describe("classifyError — Git LFS ordering", () => {
     expect(classifyError("403 unauthorized").type).toBe("AUTH_ERROR");
   });
 });
+
+/**
+ * The message classification reads carries the repository URL, so a bare
+ * substring test lets the repository's NAME decide its error message. Invisible
+ * to any rendering test: the function returns a perfectly well-formed object,
+ * just the wrong one.
+ */
+describe("classifyError — a repository's name must not decide its error message", () => {
+  // Every row is a repository that does not exist, failing with a 404. The
+  // name contains a word that one of the branches used to match on.
+  it.each([
+    ["oauth ⊃ auth", "Repository not found: https://github.com/acme/oauth-server (404)"],
+    ["fetch-utils ⊃ fetch", "Repository not found: https://github.com/acme/fetch-utils (404)"],
+    ["timeout-rs ⊃ timeout", "Repository not found: https://github.com/acme/timeout-rs (404)"],
+    [
+      "connection-pool ⊃ connection",
+      "Repository not found: https://github.com/acme/connection-pool (404)",
+    ],
+    ["network ⊃ network", "Repository not found: https://github.com/acme/network-tools (404)"],
+    [
+      "credentials ⊃ credentials",
+      "fatal: repository 'https://github.com/acme/credentials' not found",
+    ],
+    // The scp-style remote carries the same names and must be stripped too.
+    ["scp-style remote", "fatal: repository 'git@github.com:acme/oauth-server.git' not found"],
+    // An owner, not a repo.
+    ["owner name", "Repository not found: https://github.com/timeout/demo (404)"],
+  ])("reports a missing %s repository as NOT_FOUND", (_label, message) => {
+    const info = classifyError(message);
+    expect(info.type).toBe("NOT_FOUND");
+    expect(info.title).toBe("Repository Not Found");
+  });
+
+  // Narrowing the predicates trades a false positive for a false negative if
+  // done carelessly, so every phrasing git and the GitHub API actually emit
+  // gets its own row.
+  it.each([
+    ["git over https", "fatal: Authentication failed for 'https://github.com/acme/private.git/'"],
+    [
+      "no terminal prompt",
+      "fatal: could not read Username for 'https://github.com': No such device",
+    ],
+    ["ssh refusal", "git@github.com: Permission denied (publickey)."],
+    ["github api", '{"message":"Bad credentials","status":"401"}'],
+    ["private repo via api", '{"message":"Must have admin rights. Requires authentication"}'],
+    ["bare 403", "remote: HTTP 403 while accessing the repository"],
+  ])("still reports a real authentication failure as AUTH_ERROR (%s)", (_label, message) => {
+    const info = classifyError(message);
+    expect(info.type).toBe("AUTH_ERROR");
+    expect(info.title).toBe("Authentication Failed");
+  });
+
+  it.each([
+    [
+      "connection refused",
+      "fatal: unable to access 'https://github.com/acme/x.git/': Failed to connect to github.com port 443: Connection refused",
+    ],
+    ["curl timeout", "error: RPC failed; curl 28 Operation timed out after 30001 milliseconds"],
+    ["dns", "request to https://github.com/acme/x.git failed, reason: getaddrinfo ENOTFOUND"],
+    ["socket", "fetch failed: socket hang up"],
+    ["unreachable", "connect: Network is unreachable"],
+  ])("still reports a real transport failure as NETWORK_ERROR (%s)", (_label, message) => {
+    const info = classifyError(message);
+    expect(info.type).toBe("NETWORK_ERROR");
+    expect(info.title).toBe("Network Error");
+  });
+
+  // A URL path that happens to contain three digits is not an HTTP status.
+  it("does not read digits inside a repository path as a status code", () => {
+    const info = classifyError(
+      "Repository not found: https://github.com/acme/error-403-demo (404)",
+    );
+    expect(info.type).toBe("NOT_FOUND");
+  });
+
+  // The URL strip must not disturb the LFS detection added in #218, whose
+  // batch marker is a path that can legitimately arrive inside a URL.
+  it("still classifies an LFS batch failure whose endpoint is a full URL", () => {
+    const info = classifyError(
+      "batch response: https://github.com/acme/x.git/info/lfs/objects/batch returned 404",
+    );
+    expect(info.title).toBe("Git LFS Not Supported");
+  });
+});


### PR DESCRIPTION
## Summary

`classifyError` routed an import failure to user-facing guidance by testing the lowercased message for bare substrings. The message contains the repository URL, so several of those substrings occur in ordinary repository, owner, and branch names — `auth` ⊂ `oauth`, `fetch` ⊂ `fetch-utils`, `connection` ⊂ `connection-pool`, `timeout` ⊂ `timeout-rs`. A plain 404 was answered according to what the repository is *called* rather than what went wrong.

Branch order compounded it: the auth branch runs first, so it won over every other classification, and its advice ("ensure your GitHub account has access", "check if the repository requires SSH keys") sent people hunting a permissions problem that did not exist.

Three layers, each catching what the others cannot.

**1. Classify against the message with remote spans removed.** The issue suggests classifying against the message rather than the concatenation *where the URL is available separately*. It is not separately available here, so URLs and git's scp-style `user@host:path` remotes are stripped before matching. That deletes the entire family of "repository is named after a diagnostic word".

Applied everywhere **except** the LFS and not-found branches, which keep reading the full message on purpose: `LFS_BATCH_RESPONSE_MARKERS` requires the path `/info/lfs/objects/batch`, which can legitimately arrive inside a URL. Stripping there would undo the LFS detection #218 added — there's a test for it.

**2. Anchor auth and network to git's own phrasing.** Stripping remotes alone is not enough: a ref name like `refs/heads/add-oauth-support` is not inside a URL and would still trip a bare `auth`. So the rule #218 established generalises — *a marker must be something git says, not a word a name can contain* — and in practice that means it carries a space, since neither a URL nor a ref name can.

**3. Strip the ref span too.** The shape rule has no purchase on two classes of ref name, both found by review (below). Fully-qualified `refs/{heads,tags,remotes}/…` spans are removed alongside the remote: a ref is named by whoever pushed it and is never evidence about the failure.

### Correction 1: two single tokens broke the shape rule

Flagging rather than quietly editing, because an earlier revision of this description claimed auth and network were fixed. They weren't.

I excepted two things from the space rule — a bare `unauthorized`, and Node's transport codes — reasoning that no repository would plausibly be called those. CodeRabbit's review found the hole, and I reproduced it before fixing:

| Message | Was | Should be |
|---|---|---|
| `couldn't find remote ref refs/heads/fix-unauthorized-redirect (404)` | **AUTH_ERROR** | NOT_FOUND |
| `couldn't find remote ref refs/heads/enotfound-handling (404)` | **NETWORK_ERROR** | NOT_FOUND |

- **`unauthorized` is dropped outright.** Redundant beside the 401/403 status checks: every real message carrying the word carries the status too (`HTTP Error: 401 Unauthorized`).
- **Transport codes are matched against the original-case message.** Node always emits them upper-case (`getaddrinfo ENOTFOUND`, `connect ECONNREFUSED`) while a ref name is conventionally lower-case — that is the discriminator. `REMOTE_SPAN` gains the `i` flag so remotes are stripped from the original-case text too.

### Correction 2: the shape rule cannot reach a ref that is digits

Same review, same finding — and when I probed all four of its cited names against the head it ran on, **two were still broken after correction 1**:

| Message | After correction 1 |
|---|---|
| `couldn't find remote ref refs/heads/fix-unauthorized-redirect (404)` | NOT_FOUND ✓ |
| `couldn't find remote ref refs/heads/econnrefused-handling (404)` | NOT_FOUND ✓ |
| `couldn't find remote ref refs/heads/401 (404)` | **AUTH_ERROR** ✗ |
| `couldn't find remote ref refs/heads/403 (404)` | **AUTH_ERROR** ✗ |

"Every marker carries a space" says nothing about a ref that is digits, and `hasStatus`'s guard was `(?<!\d)` — it blocks a match inside a longer number (`1403`) but not inside a path (`/v1/403/spec`). So the review's structured-strip suggestion is warranted after all, and it is what correction 2 implements, together with a tightened `(?<[\d/])` boundary.

**The strip alone would have traded a wrong answer for no answer.** git states a missing ref without ever emitting `404` or `not found`:

```
fatal: couldn't find remote ref refs/heads/disk-cleanup
```

Today that is reported as a full disk. Remove the ref name and nothing matches at all — a message that says precisely what went wrong, answered with "an unexpected error occurred". So the not-found branch now also recognises git's own `couldn't find remote ref` / `could not find remote ref`, which carries a space and so obeys the same rule as every other marker here.

### What this still does not fix

Rate-limit, git, and storage keep their bare-noun markers. Both collision sources are now closed for them — URL by the remote strip, ref by the ref strip — so what remains is only a noun appearing in *prose* the branch does not own. Narrowing them further needs the corpus of real messages each branch produces, which the issue supplies for auth and network but not for these.

Only fully-qualified `refs/…` spans are removed. A message naming a bare branch (`couldn't find remote ref my-branch`, without the prefix) is not structurally distinguishable from prose, so the marker shape still has to carry that case — which is why every auth and network marker is a phrase git emits rather than a word a name can contain.

Branch **order** is untouched — it is load-bearing and separately tested by #218. This narrows predicates; it does not move them.

## Related issues

Closes #278

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

Ran the CI gate order locally (lint → typecheck → test).

41 table-driven cases in `tests/import-error-classification.test.ts`, alongside the 16 pre-existing #218 LFS-ordering cases, which pass unchanged (57 total in the file):

- **All four rows of the issue's reproduction table** (`oauth-server`, `fetch-utils`, `timeout-rs`, `connection-pool`) report `NOT_FOUND`, plus an scp-style remote and an owner-name variant.
- **Four ref names that must stay `NOT_FOUND`** — `fix-unauthorized-redirect`, `enotfound-handling`, `econnreset-retry`, `retry-timed-out` — the class correction 1 addressed.
- **Four ref names that are, or contain, a status code** — `refs/heads/401`, `refs/heads/403`, `refs/tags/v1-403-fix`, `refs/heads/api/v1/403/spec` — the class correction 2 addressed. All four fail against the pre-correction-2 source.
- **Four ref names that are bare nouns on branches with no phrase-shaped alternative** — `disk-cleanup`, `429-backoff`, `git-cleanup`, `repository-rename` — stated in git's own `couldn't find remote ref` form so they carry no other not-found token. All four fail against the pre-correction-2 source.
- **Four upper-case Node transport codes** that must stay `NETWORK_ERROR`, the counterpart to the lower-case ref names above.
- **Six real auth phrasings** — git over HTTPS, no-terminal-prompt, SSH `Permission denied (publickey)`, GitHub API `Bad credentials`, `Requires authentication`, bare `403` — plus `401 Unauthorized`, since the bare word no longer classifies alone.
- **Five real transport phrasings** — `Connection refused`, curl 28 `Operation timed out`, `ENOTFOUND`, `socket hang up`, `Network is unreachable`.
- **Positive controls for the strip**, so it removes only the ref and not the message around it: a genuine `HTTP 403` that also names `refs/heads/main` stays `AUTH_ERROR`, and a real `No space left on device` stays `STORAGE_ERROR`.
- **A path containing `403`** is not read as a status code.
- **An LFS batch failure whose endpoint is a full URL** still classifies as LFS — guarding the one place the strip is deliberately not applied.

Every regression row was verified to fail against the pre-fix source by stashing `src/ui/components/import-progress.tsx` and re-running.

**One test outside this PR's scope changed**, flagged in [this comment](https://github.com/stratum-eng/stratum/pull/297#issuecomment-5451807705): `csp-nonce-sweep`'s `window.open` noopener case used the bare string `"unauthorized"` as its error fixture, which no longer classifies as an auth error and so rendered no action button to assert on. That case is about the noopener guard, not classification, so its fixture is now a realistic `HTTP Error: 401 Unauthorized`. The assertion is unchanged; the sibling case in the same file already used `"authentication failed"` and is untouched.

- [x] `npm run typecheck` — clean
- [x] `npm test` — 2234 passed, 27 skipped, 0 failed
- [x] `npm run lint` — `Checked 308 files. No fixes applied.`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate — grepped `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/` and `website/` for `classifyError` and import-error guidance; no documentation describes this mapping.
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript — `classifyError` is a pure function in a server-rendered component; no client-side JS added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import error classification to prevent repository URLs, remotes, branch names, and tags from causing incorrect error categories.
  * Enhanced detection of authentication, network, storage, Git, LFS, rate-limit, and not-found errors.
  * Corrected authentication error handling so the appropriate recovery action is displayed.

* **Tests**
  * Added comprehensive coverage for genuine failures and misleading repository or ref names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->