### PR TITLE
Persist the import clone depth so retry and re-import stop shallowing a full clone

### DIFF
--- a/migrations/040_import_jobs_depth.sql
+++ b/migrations/040_import_jobs_depth.sql
@@ -1,0 +1,13 @@
+-- Persist the clone depth an import job ran under (#279).
+--
+-- Without this column, retry, re-queue and both sync paths rebuild the job
+-- from the stored row and re-derive a hardcoded DEFAULT_CLONE_DEPTH, silently
+-- turning a deliberate full-history import into a shallow one at the first
+-- transient failure.
+--
+-- Nullable with no default, deliberately: 0 is a MEANINGFUL value meaning
+-- "full history", so NULL (never specified -> fall back to
+-- DEFAULT_CLONE_DEPTH) has to stay distinguishable from it. A
+-- `NOT NULL DEFAULT 0` column would read every pre-existing row as a
+-- full-history request.
+ALTER TABLE import_jobs ADD COLUMN depth INTEGER;

--- a/src/github/webhooks.ts
+++ b/src/github/webhooks.ts
@@ -125,10 +125,15 @@ async function handlePush(
 
   const importId = crypto.randomUUID();
   const sourceUrl = project.sourceUrl ?? project.remote;
-  // The depth the project was actually imported at. Read before the enqueue
-  // (and before the job below is created, which would otherwise become the
-  // "most recent" job this reads back) so a webhook-driven sync cannot quietly
-  // shallow a full-history project.
+  // The depth the project was actually imported at, replacing a hardcoded 10.
+  // Read before the enqueue (and before the job below is created, which would
+  // otherwise become the "most recent" job this reads back).
+  //
+  // Reaches the FALLBACK FULL IMPORT only — the branch `syncOrImportProject`
+  // takes for a project with no parseable Artifacts remote. The incremental
+  // fetch every established project takes ignores this and uses its own
+  // SYNC_FETCH_DEPTH window. Still worth carrying: the fallback re-imports the
+  // whole project, so a wrong depth there is exactly where it is costly.
   const syncDepth =
     (await getLatestImportDepth(env.DB, project.namespace, project.slug, logger)) ??
     DEFAULT_CLONE_DEPTH;

--- a/src/github/webhooks.ts
+++ b/src/github/webhooks.ts
@@ -6,11 +6,12 @@
 import { Hono } from "hono";
 import { createChange, getChangeByGitHubBranch, updateChangeStatus } from "../storage/changes";
 import { getProjectByGitHubRepo } from "../storage/github-bridge";
-import { createImportJob } from "../storage/imports";
+import { createImportJob, getLatestImportDepth } from "../storage/imports";
 import { getWorkspace } from "../storage/state";
 import { getSyncStatus, setSyncInProgress } from "../storage/sync";
 import { type Env, projectDefaultBranch } from "../types";
 import { type Logger, createLogger } from "../utils/logger";
+import { DEFAULT_CLONE_DEPTH } from "../utils/validation";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -124,6 +125,13 @@ async function handlePush(
 
   const importId = crypto.randomUUID();
   const sourceUrl = project.sourceUrl ?? project.remote;
+  // The depth the project was actually imported at. Read before the enqueue
+  // (and before the job below is created, which would otherwise become the
+  // "most recent" job this reads back) so a webhook-driven sync cannot quietly
+  // shallow a full-history project.
+  const syncDepth =
+    (await getLatestImportDepth(env.DB, project.namespace, project.slug, logger)) ??
+    DEFAULT_CLONE_DEPTH;
 
   // Enqueue FIRST — only write state flags after a successful send().
   const { queueSyncJob } = await import("../queue/import-queue");
@@ -134,7 +142,7 @@ async function handlePush(
     slug: project.slug,
     githubUrl: sourceUrl,
     branch: sourceBranch,
-    depth: 10,
+    depth: syncDepth,
     trigger: "webhook",
   });
 
@@ -149,6 +157,7 @@ async function handlePush(
       slug: project.slug,
       sourceUrl,
       branch: sourceBranch,
+      depth: syncDepth,
     },
     logger,
   );

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -22,6 +22,7 @@ import {
   createImportJob,
   deleteImportJob,
   getImportProgress,
+  getLatestImportDepth,
   isImportCancelled,
   recoverStalledImport,
   updateImportStatus,
@@ -450,7 +451,9 @@ app.post(
                   slug,
                   githubUrl: existingImport.data.sourceUrl,
                   branch: existingImport.data.branch ?? "main",
-                  depth: DEFAULT_CLONE_DEPTH,
+                  // The depth the job was created with, not a fresh literal —
+                  // a re-trigger must not quietly shallow a full-history import.
+                  depth: existingImport.data.depth ?? DEFAULT_CLONE_DEPTH,
                   initiatedBy: userId,
                 });
               } catch (queueError) {
@@ -564,6 +567,7 @@ app.post(
           slug,
           sourceUrl: body.url,
           branch,
+          depth,
         },
         logger,
       );
@@ -1442,7 +1446,7 @@ app.post(
           slug,
           githubUrl,
           branch,
-          depth: DEFAULT_CLONE_DEPTH,
+          depth: existing.depth ?? DEFAULT_CLONE_DEPTH,
           // Without this the retry path is the one case that never emails the
           // person waiting on the import — which is the gap this PR closes.
           initiatedBy: userId,
@@ -1477,7 +1481,7 @@ app.post(
           githubUrl,
           branch,
           logger,
-          DEFAULT_CLONE_DEPTH,
+          existing.depth ?? DEFAULT_CLONE_DEPTH,
         ).catch((error) => {
           logger.error(
             "Unhandled error in background import retry",
@@ -1596,6 +1600,11 @@ app.post("/:namespace/:slug/sync", async (c) => {
   // Create a new import job for the sync
   const importId = generateProjectId();
   const branch = projectDefaultBranch(project);
+  // Read BEFORE creating the job below: this looks up the most recent import
+  // job for the project, and the one about to be created would become that,
+  // so the lookup would read back the value it is trying to inherit.
+  const inheritedDepth = await getLatestImportDepth(c.env.DB, namespace, slug, logger);
+  const syncDepth = inheritedDepth ?? DEFAULT_CLONE_DEPTH;
   const createResult = await createImportJob(
     c.env.DB,
     {
@@ -1605,6 +1614,7 @@ app.post("/:namespace/:slug/sync", async (c) => {
       slug,
       sourceUrl,
       branch,
+      depth: syncDepth,
     },
     logger,
   );
@@ -1629,7 +1639,7 @@ app.post("/:namespace/:slug/sync", async (c) => {
         slug,
         githubUrl: sourceUrl,
         branch,
-        depth: 10,
+        depth: syncDepth,
         provider: provider ?? undefined,
       });
     } catch (queueError) {

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -475,6 +475,10 @@ app.post(
                   existingImport.data.sourceUrl,
                   existingImport.data.branch ?? "main",
                   logger,
+                  // Explicit, not left to processImportJob's DEFAULT_CLONE_DEPTH
+                  // default: omitting it silently re-triggers a full-history
+                  // import at depth 10, which is the bug this PR exists to fix.
+                  existingImport.data.depth ?? DEFAULT_CLONE_DEPTH,
                 ).catch((error) => {
                   logger.error(
                     "Unhandled error in background import re-trigger",
@@ -1684,17 +1688,19 @@ app.post("/:namespace/:slug/sync", async (c) => {
       slug,
     });
     c.executionCtx.waitUntil(
-      processSyncJob(c.env, project, importId, sourceUrl, branch, logger).catch((error) => {
-        logger.error(
-          "Unhandled error in background sync job",
-          error instanceof Error ? error : undefined,
-          {
-            namespace,
-            slug,
-            importId,
-          },
-        );
-      }),
+      processSyncJob(c.env, project, importId, sourceUrl, branch, logger, syncDepth).catch(
+        (error) => {
+          logger.error(
+            "Unhandled error in background sync job",
+            error instanceof Error ? error : undefined,
+            {
+              namespace,
+              slug,
+              importId,
+            },
+          );
+        },
+      ),
     );
   }
 
@@ -1796,6 +1802,12 @@ export async function processSyncJob(
   sourceUrl: string,
   branch: string,
   logger: Logger,
+  /**
+   * Clone depth for the legacy import fallback below. Required rather than
+   * defaulted: a default here is indistinguishable from a caller that forgot,
+   * which is exactly how this path kept re-importing at depth 10.
+   */
+  depth: number,
 ) {
   const { namespace, slug } = project;
   const artifactsRepoName = getArtifactsRepoName(namespace, slug);
@@ -1816,8 +1828,6 @@ export async function processSyncJob(
     // orphaned workspace forks. Only projects with no recorded Artifacts remote
     // (initial import never completed, so no forks can exist) still take the
     // import path.
-    const depth = 10; // Default depth for the legacy import fallback
-
     const outcome = await syncOrImportProject(
       env.ARTIFACTS,
       {

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -1603,6 +1603,11 @@ app.post("/:namespace/:slug/sync", async (c) => {
   // Read BEFORE creating the job below: this looks up the most recent import
   // job for the project, and the one about to be created would become that,
   // so the lookup would read back the value it is trying to inherit.
+  //
+  // As on the webhook path, this depth reaches the fallback full import rather
+  // than the incremental fetch, which uses its own SYNC_FETCH_DEPTH window
+  // (see `syncOrImportProject`). It is still the recorded depth rather than a
+  // literal, which is what the fallback needs.
   const inheritedDepth = await getLatestImportDepth(c.env.DB, namespace, slug, logger);
   const syncDepth = inheritedDepth ?? DEFAULT_CLONE_DEPTH;
   const createResult = await createImportJob(

--- a/src/storage/imports.ts
+++ b/src/storage/imports.ts
@@ -32,6 +32,7 @@ interface ImportJobRow {
   status: ImportStatus;
   source_url: string;
   branch: string;
+  depth: number | null;
   progress_processed_files: number;
   progress_total_files: number | null;
   progress_current_file: string | null;
@@ -124,6 +125,14 @@ function rowToImportProgress(row: ImportJobRow): ImportProgress {
     result.completedAt = row.completed_at;
   }
 
+  // Left absent when NULL rather than defaulted here: NULL means "no depth was
+  // ever recorded" (a row predating migration 040), which callers answer with
+  // DEFAULT_CLONE_DEPTH. Defaulting at this layer would erase the difference
+  // between that and a stored 0, which means full history.
+  if (row.depth !== null && row.depth !== undefined) {
+    result.depth = row.depth;
+  }
+
   return result;
 }
 
@@ -132,6 +141,47 @@ function validateStatus(status: string): ImportStatus {
     return status as ImportStatus;
   }
   throw new AppError(`Invalid import status: ${status}`, "INVALID_STATE", 400);
+}
+
+/**
+ * The clone depth the project's most recent import job ran under, or
+ * `undefined` when none was recorded.
+ *
+ * For the sync paths, which create a NEW job and have to inherit the depth the
+ * project was actually imported at rather than re-deriving a literal. Callers
+ * answer `undefined` with `DEFAULT_CLONE_DEPTH`; a stored `0` is full history
+ * and must survive that `??` intact.
+ *
+ * Narrower than `getImportProgress` on purpose: this reads one integer, where
+ * that returns the whole row and parses the `logs`/`errors` JSON blobs the
+ * webhook sync path has no use for.
+ *
+ * A lookup failure is logged and treated as "not recorded" rather than
+ * propagated — a sync must not fail because the previous job's depth could not
+ * be read, and the fallback is exactly the behavior that preceded this column.
+ */
+export async function getLatestImportDepth(
+  db: D1Database,
+  namespace: string,
+  slug: string,
+  logger: Logger,
+): Promise<number | undefined> {
+  try {
+    const row = await db
+      .prepare(
+        "SELECT depth FROM import_jobs WHERE namespace = ? AND slug = ? ORDER BY started_at DESC LIMIT 1",
+      )
+      .bind(namespace, slug)
+      .first<{ depth: number | null }>();
+    return row?.depth ?? undefined;
+  } catch (error) {
+    logger.error(
+      "Failed to read the previous import job's clone depth",
+      error instanceof Error ? error : undefined,
+      { namespace, slug },
+    );
+    return undefined;
+  }
 }
 
 export async function createImportJob(
@@ -143,6 +193,12 @@ export async function createImportJob(
     slug: string;
     sourceUrl: string;
     branch: string;
+    /**
+     * Clone depth this job runs under. Omitted when the caller has none to
+     * record, which stores NULL and lets later jobs fall back to
+     * DEFAULT_CLONE_DEPTH. `0` is full history and is NOT the same as omitted.
+     */
+    depth?: number;
   },
   logger: Logger,
 ): Promise<Result<ImportProgress, AppError>> {
@@ -166,9 +222,9 @@ export async function createImportJob(
     await db
       .prepare(
         `INSERT INTO import_jobs (
-          id, project_id, namespace, slug, status, source_url, branch,
+          id, project_id, namespace, slug, status, source_url, branch, depth,
           progress_processed_files, logs, errors, version, started_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .bind(
         params.id,
@@ -178,6 +234,7 @@ export async function createImportJob(
         "queued",
         params.sourceUrl,
         params.branch,
+        params.depth ?? null,
         0,
         JSON.stringify(initialLog),
         "[]",
@@ -195,6 +252,7 @@ export async function createImportJob(
       status: "queued",
       sourceUrl: params.sourceUrl,
       branch: params.branch,
+      ...(params.depth !== undefined ? { depth: params.depth } : {}),
       startedAt: now,
       updatedAt: now,
       version: 1, // Initial version for optimistic locking

--- a/src/types.ts
+++ b/src/types.ts
@@ -316,6 +316,13 @@ export interface ImportProgress {
   status: ImportStatus;
   sourceUrl: string;
   branch: string;
+  /**
+   * Clone depth this job ran under, when one was recorded. Absent on jobs
+   * created before migration 040 and on callers with no depth to record;
+   * absent means "fall back to DEFAULT_CLONE_DEPTH", which `0` (full history)
+   * explicitly does not.
+   */
+  depth?: number;
   startedAt: string;
   completedAt?: string;
   updatedAt: string; // For stall detection

--- a/tests/import-clone-depth.test.ts
+++ b/tests/import-clone-depth.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import { createImportJob, getImportProgress, getLatestImportDepth } from "../src/storage/imports";
+import { DEFAULT_CLONE_DEPTH } from "../src/utils/validation";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
+
+const logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(function (this: unknown) {
+    return logger;
+  }),
+};
+
+function jobParams(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "imp_1",
+    projectId: "prj_1",
+    namespace: "@acme",
+    slug: "widgets",
+    sourceUrl: "https://github.com/acme/widgets",
+    branch: "main",
+    ...overrides,
+  };
+}
+
+/**
+ * Exercised against a real SQLite engine with every migration applied, so the
+ * column added by 040 and the SQL that reads it are both genuinely executed.
+ */
+describe("import clone depth persistence", () => {
+  it("round-trips a shallow depth through the job row", async () => {
+    const { db, raw } = makeSqliteD1();
+    const created = await createImportJob(db, jobParams({ depth: 250 }), logger);
+    expect(created.success).toBe(true);
+
+    expect(await getLatestImportDepth(db, "@acme", "widgets", logger)).toBe(250);
+    const read = await getImportProgress(db, "@acme", "widgets", logger);
+    expect(read.success && read.data?.depth).toBe(250);
+    raw.close();
+  });
+
+  // The whole reason the column is nullable rather than NOT NULL DEFAULT 0.
+  // Every consumer reads it as `depth ?? DEFAULT_CLONE_DEPTH`, so a 0 that
+  // degrades to null or undefined anywhere in the round trip silently becomes
+  // a depth-10 clone — the exact failure this change exists to stop.
+  it("preserves a depth of 0 (full history) as distinct from unset", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(db, jobParams({ depth: 0 }), logger);
+
+    const depth = await getLatestImportDepth(db, "@acme", "widgets", logger);
+    expect(depth).toBe(0);
+    expect(depth ?? DEFAULT_CLONE_DEPTH).toBe(0);
+
+    const read = await getImportProgress(db, "@acme", "widgets", logger);
+    expect(read.success && read.data?.depth).toBe(0);
+    raw.close();
+  });
+
+  it("records no depth when the caller has none, so consumers fall back", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(db, jobParams(), logger);
+
+    const depth = await getLatestImportDepth(db, "@acme", "widgets", logger);
+    expect(depth).toBeUndefined();
+    expect(depth ?? DEFAULT_CLONE_DEPTH).toBe(DEFAULT_CLONE_DEPTH);
+
+    const read = await getImportProgress(db, "@acme", "widgets", logger);
+    expect(read.success && read.data && "depth" in read.data).toBe(false);
+    raw.close();
+  });
+
+  // A row written before migration 040 has depth NULL and must behave exactly
+  // as it did before the column existed.
+  it("treats a pre-migration row with a NULL depth as unset", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(db, jobParams({ depth: 250 }), logger);
+    raw.exec("UPDATE import_jobs SET depth = NULL WHERE id = 'imp_1'");
+
+    expect(await getLatestImportDepth(db, "@acme", "widgets", logger)).toBeUndefined();
+    raw.close();
+  });
+
+  it("reads the most recent job's depth, not an older one", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(db, jobParams({ id: "imp_old", depth: 0 }), logger);
+    // started_at defaults to the insert time; nudge the older row back so the
+    // ordering is unambiguous rather than resolved by insertion luck.
+    raw.exec("UPDATE import_jobs SET started_at = '2020-01-01T00:00:00.000Z' WHERE id = 'imp_old'");
+    await createImportJob(db, jobParams({ id: "imp_new", depth: 5 }), logger);
+
+    expect(await getLatestImportDepth(db, "@acme", "widgets", logger)).toBe(5);
+    raw.close();
+  });
+
+  it("returns unset for a project with no import jobs at all", async () => {
+    const { db, raw } = makeSqliteD1();
+    expect(await getLatestImportDepth(db, "@acme", "nothing-here", logger)).toBeUndefined();
+    raw.close();
+  });
+});

--- a/tests/import-fidelity.test.ts
+++ b/tests/import-fidelity.test.ts
@@ -80,6 +80,7 @@ vi.mock("../src/storage/imports", () => ({
       status: "queued",
       sourceUrl: params.sourceUrl,
       branch: params.branch,
+      ...(params.depth !== undefined ? { depth: params.depth } : {}),
       startedAt: now,
       updatedAt: now,
       version: 1,
@@ -97,6 +98,11 @@ vi.mock("../src/storage/imports", () => ({
     const job = mockImportJobs.get(`${namespace}:${slug}`);
     return { success: true, data: job ?? null };
   }),
+
+  getLatestImportDepth: vi.fn(
+    async (_db, namespace: string, slug: string) =>
+      mockImportJobs.get(`${namespace}:${slug}`)?.depth,
+  ),
 
   updateImportProgress: vi.fn(async (_db, namespace, slug, updates, _logger) => {
     const key = `${namespace}:${slug}`;
@@ -322,6 +328,7 @@ async function seedImportJob(params: {
   namespace: string;
   slug: string;
   projectId: string;
+  depth?: number;
 }): Promise<ImportProgress> {
   const { createImportJob } = await import("../src/storage/imports");
   const { createLogger } = await import("../src/utils/logger");
@@ -335,6 +342,7 @@ async function seedImportJob(params: {
       slug: params.slug,
       sourceUrl: "https://github.com/test/repo",
       branch: "main",
+      ...(params.depth !== undefined ? { depth: params.depth } : {}),
     },
     logger,
   );
@@ -718,6 +726,82 @@ describe("import route edge paths", () => {
     expect(send).toHaveBeenCalledWith(
       expect.objectContaining({ depth: DEFAULT_CLONE_DEPTH, initiatedBy: "user_A" }),
     );
+  });
+
+  /**
+   * The issue's headline case (#279): a user imports with full history, hits a
+   * transient failure, and retries. The retry used to rebuild the job from the
+   * stored row and re-derive a hardcoded depth, so a deliberate "full" became a
+   * depth-10 clone — silently, with no error and nothing saying the depth had
+   * changed.
+   *
+   * 0 is the value most likely to be eaten on the way through, since every
+   * consumer reads `depth ?? DEFAULT_CLONE_DEPTH`.
+   */
+  it("retries a full-history import at full history, not the default depth", async () => {
+    stubFetch(async () => githubRepoMetadata("main"));
+    const { default: app } = await import("../src/index");
+    const env = makeEnv();
+
+    await seedProject(env, { namespace: "@usera", slug: "fullhist", projectId: "proj_fh" });
+    await seedImportJob({
+      namespace: "@usera",
+      slug: "fullhist",
+      projectId: "proj_fh",
+      depth: 0,
+    });
+    const { updateImportStatus } = await import("../src/storage/imports");
+    const { createLogger } = await import("../src/utils/logger");
+    await updateImportStatus(
+      {} as D1Database,
+      "@usera",
+      "fullhist",
+      "failed",
+      createLogger({ component: "Test" }),
+    );
+
+    const { DEFAULT_CLONE_DEPTH } = await import("../src/utils/validation");
+    const res = await app.fetch(
+      request("POST", "/api/projects/@usera/fullhist/import/retry", {}, USER_A_HEADERS),
+      env,
+    );
+    expect(res.status).toBe(200);
+
+    const send = vi.mocked(env.IMPORT_QUEUE?.send as unknown as ReturnType<typeof vi.fn>);
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ depth: 0 }));
+    expect(send).not.toHaveBeenCalledWith(expect.objectContaining({ depth: DEFAULT_CLONE_DEPTH }));
+  });
+
+  it("retries a deep-but-shallow import at the depth it was created with", async () => {
+    stubFetch(async () => githubRepoMetadata("main"));
+    const { default: app } = await import("../src/index");
+    const env = makeEnv();
+
+    await seedProject(env, { namespace: "@usera", slug: "deepish", projectId: "proj_di" });
+    await seedImportJob({
+      namespace: "@usera",
+      slug: "deepish",
+      projectId: "proj_di",
+      depth: 500,
+    });
+    const { updateImportStatus } = await import("../src/storage/imports");
+    const { createLogger } = await import("../src/utils/logger");
+    await updateImportStatus(
+      {} as D1Database,
+      "@usera",
+      "deepish",
+      "failed",
+      createLogger({ component: "Test" }),
+    );
+
+    const res = await app.fetch(
+      request("POST", "/api/projects/@usera/deepish/import/retry", {}, USER_A_HEADERS),
+      env,
+    );
+    expect(res.status).toBe(200);
+
+    const send = vi.mocked(env.IMPORT_QUEUE?.send as unknown as ReturnType<typeof vi.fn>);
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ depth: 500 }));
   });
 
   it("re-triggers via direct processing when no queue is configured", async () => {

--- a/tests/import-fidelity.test.ts
+++ b/tests/import-fidelity.test.ts
@@ -850,6 +850,62 @@ describe("import route edge paths", () => {
     expect(mockImportJobs.get("@usera:retrig2")?.status).toBe("completed");
   });
 
+  /**
+   * The queue-less twin of the retry case. This branch called processImportJob
+   * without a depth argument at all, so it silently took the parameter's own
+   * DEFAULT_CLONE_DEPTH — invisible to a grep for depth literals, and it meant
+   * a full-history project was re-imported shallow whenever the queue was
+   * absent.
+   */
+  it("re-triggers via direct processing at the recorded depth, not the default", async () => {
+    stubFetch(async () => githubRepoMetadata("main"));
+    const { default: app } = await import("../src/index");
+    const { importFromGitHub } = await import("../src/storage/git-ops");
+    vi.mocked(importFromGitHub).mockResolvedValue({
+      success: true,
+      data: { name: "r", remote: "https://artifacts.example.com/repos/r", token: "t" },
+    });
+
+    const env = makeEnv({ IMPORT_QUEUE: undefined });
+    await seedProject(env, { namespace: "@usera", slug: "retrig3", projectId: "proj_r3" });
+    await seedImportJob({
+      namespace: "@usera",
+      slug: "retrig3",
+      projectId: "proj_r3",
+      depth: 0,
+    });
+    const { updateImportStatus } = await import("../src/storage/imports");
+    const { createLogger } = await import("../src/utils/logger");
+    await updateImportStatus(
+      {} as D1Database,
+      "@usera",
+      "retrig3",
+      "failed",
+      createLogger({ component: "Test" }),
+    );
+
+    const background: Promise<unknown>[] = [];
+    const ctx = {
+      waitUntil: (p: Promise<unknown>) => background.push(p),
+      passThroughOnException: () => undefined,
+    } as unknown as ExecutionContext;
+
+    const res = await app.fetch(
+      request(
+        "POST",
+        "/api/projects/@usera/retrig3/import",
+        { url: "https://github.com/test/repo" },
+        USER_A_HEADERS,
+      ),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    await Promise.all(background);
+
+    expect(vi.mocked(importFromGitHub).mock.calls[0]?.[5]).toBe(0);
+  });
+
   it("falls back to direct processing for a new import when no queue is configured", async () => {
     stubFetch(async () => githubRepoMetadata("main"));
     const { default: app } = await import("../src/index");

--- a/tests/incremental-sync-wiring.test.ts
+++ b/tests/incremental-sync-wiring.test.ts
@@ -375,7 +375,7 @@ describe("projects route processSyncJob (queue-less fallback)", () => {
     });
 
     const env = makeEnv();
-    await processFallbackSyncJob(env, project, "sync_1", GITHUB_URL, "main", noopLogger);
+    await processFallbackSyncJob(env, project, "sync_1", GITHUB_URL, "main", noopLogger, 10);
 
     expect(syncFromGitHub).toHaveBeenCalledWith(
       env.ARTIFACTS,
@@ -409,7 +409,7 @@ describe("projects route processSyncJob (queue-less fallback)", () => {
     });
 
     const env = makeEnv();
-    await processFallbackSyncJob(env, project, "sync_1", GITHUB_URL, "main", noopLogger);
+    await processFallbackSyncJob(env, project, "sync_1", GITHUB_URL, "main", noopLogger, 10);
 
     expect(importFromGitHub).not.toHaveBeenCalled();
     expect(env.ARTIFACTS.delete).not.toHaveBeenCalled();
@@ -430,6 +430,30 @@ describe("projects route processSyncJob (queue-less fallback)", () => {
     expect(writeSnapshotFromRepo).not.toHaveBeenCalled();
   });
 
+  it("carries the caller's depth into the fallback import rather than a hardcoded 10", async () => {
+    // This path hardcoded `const depth = 10`, so a project imported with full
+    // history was silently re-imported shallow whenever the queue was absent.
+    // 0 is the value that matters: it means full history, and it is what a
+    // `?? DEFAULT_CLONE_DEPTH` fallback would eat.
+    const project = makeProject({ remote: LEGACY_REMOTE });
+    vi.mocked(importFromGitHub).mockResolvedValue({
+      success: true,
+      data: { remote: ARTIFACTS_REMOTE, token: "tok" } as never,
+    });
+
+    const env = makeEnv();
+    await processFallbackSyncJob(env, project, "sync_1", GITHUB_URL, "main", noopLogger, 0);
+
+    expect(importFromGitHub).toHaveBeenCalledWith(
+      env.ARTIFACTS,
+      "test__repo",
+      GITHUB_URL,
+      expect.anything(),
+      "main",
+      0,
+    );
+  });
+
   it("falls back to full import for a project without an Artifacts remote", async () => {
     const project = makeProject({ remote: LEGACY_REMOTE });
     vi.mocked(importFromGitHub).mockResolvedValue({
@@ -438,7 +462,7 @@ describe("projects route processSyncJob (queue-less fallback)", () => {
     });
 
     const env = makeEnv();
-    await processFallbackSyncJob(env, project, "sync_1", GITHUB_URL, "main", noopLogger);
+    await processFallbackSyncJob(env, project, "sync_1", GITHUB_URL, "main", noopLogger, 10);
 
     expect(syncFromGitHub).not.toHaveBeenCalled();
     expect(importFromGitHub).toHaveBeenCalledWith(

--- a/tests/webhook-push.test.ts
+++ b/tests/webhook-push.test.ts
@@ -93,10 +93,12 @@ vi.mock("../src/queue/import-queue", () => ({
 
 vi.mock("../src/storage/imports", () => ({
   createImportJob: vi.fn().mockResolvedValue({ success: true }),
+  getLatestImportDepth: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { queueSyncJob } from "../src/queue/import-queue";
 import { getProjectByGitHubRepo } from "../src/storage/github-bridge";
+import { createImportJob, getLatestImportDepth } from "../src/storage/imports";
 
 // ---------------------------------------------------------------------------
 // We test handlePush indirectly by calling the internal function via the
@@ -241,6 +243,7 @@ describe("Webhook push handler: default branch resolution", () => {
       data: project,
     } as unknown as Awaited<ReturnType<typeof getProjectByGitHubRepo>>);
     vi.mocked(queueSyncJob).mockClear();
+    vi.mocked(createImportJob).mockClear();
 
     const { DB, STATE, IMPORT_QUEUE } = makeEnv();
     const { githubWebhookRouter } = await import("../src/github/webhooks");
@@ -285,6 +288,42 @@ describe("Webhook push handler: default branch resolution", () => {
     expect(queueSyncJob).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ branch: "master" }),
+    );
+  });
+
+  // A webhook-driven sync used to re-derive `depth: 10`, so a project imported
+  // with full history was quietly shallowed by the next push to its default
+  // branch.
+  it("carries the project's recorded clone depth into a webhook sync", async () => {
+    vi.mocked(getLatestImportDepth).mockResolvedValue(250);
+    await pushTo("main", PROJECT);
+    expect(queueSyncJob).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ depth: 250 }),
+    );
+    expect(createImportJob).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ depth: 250 }),
+      expect.anything(),
+    );
+  });
+
+  // The value that a `?? DEFAULT_CLONE_DEPTH` fallback is most likely to eat.
+  it("preserves a recorded depth of 0 (full history) rather than defaulting it", async () => {
+    vi.mocked(getLatestImportDepth).mockResolvedValue(0);
+    await pushTo("main", PROJECT);
+    expect(queueSyncJob).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ depth: 0 }),
+    );
+  });
+
+  it("falls back to the default depth when no prior job recorded one", async () => {
+    vi.mocked(getLatestImportDepth).mockResolvedValue(undefined);
+    await pushTo("main", PROJECT);
+    expect(queueSyncJob).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ depth: 10 }),
     );
   });
 


### PR DESCRIPTION
## Summary

`validateCloneDepth` lets a caller choose a clone depth (`1..1000`, or `0`/`"full"` for full history). The depth reached the first import job and was then thrown away — `import_jobs` had no `depth` column, so every later job for the project re-derived a hardcoded literal. A user who imported with `"full"` and hit a transient failure got a depth-10 retry: the opposite of what they asked for, with no error and no indication the depth had changed.

Depth is the difference between a usable clone and a broken one for anything needing history — `git log`, `git blame`, bisect, and the backup path that explicitly needs full history.

### The migration

`040_import_jobs_depth.sql` adds `depth INTEGER` to `import_jobs`. **Nullable with no default, and that is load-bearing rather than stylistic**: `0` means full history, so `NULL` (never specified → fall back to `DEFAULT_CLONE_DEPTH`) has to stay distinguishable from it. A `NOT NULL DEFAULT 0` column would read every pre-existing row as a full-history request — exactly the sentinel trap the issue flags.

036–039 are merged, so 040 is free, as the issue predicted.

### Reading it back

`createImportJob` writes it; `rowToImportJob` maps it **only when non-null**, so the default is applied by consumers rather than erased at the storage layer.

Every path that derives a later job from a stored one now reads it:

| Path | Source of depth |
|---|---|
| Retry (queued) | `existing.depth ?? DEFAULT_CLONE_DEPTH` |
| Retry (queue-less, direct) | `existing.depth ?? DEFAULT_CLONE_DEPTH` |
| Form re-submit (queued) | `existingImport.data.depth ?? DEFAULT_CLONE_DEPTH` |
| Form re-submit (queue-less, direct) | `existingImport.data.depth ?? DEFAULT_CLONE_DEPTH` |
| Sync route (queued) | `getLatestImportDepth() ?? DEFAULT_CLONE_DEPTH` |
| Sync route (queue-less fallback) | passed through as a **required** `processSyncJob` parameter |
| GitHub push webhook | `getLatestImportDepth() ?? DEFAULT_CLONE_DEPTH` |

The sync entry points create a *new* job, so they inherit via a new `getLatestImportDepth()` — a narrow single-column read rather than `getImportProgress`, which returns the whole row and parses the `logs`/`errors` JSON blobs the webhook path has no use for.

One trap worth calling out, since getting it wrong is silent: `getLatestImportDepth` is called **before** the new job is created. That job would otherwise become the "most recent" one and the lookup would read back the value it is trying to inherit. It is commented at both call sites.

`processSyncJob` takes `depth` as a **required** parameter rather than a defaulted one: a default there is indistinguishable from a caller that forgot, which is exactly how that path kept re-importing at 10.

### Two corrections to earlier revisions of this description

Flagging both rather than quietly editing, since each changed what the PR claims.

**1. The sync-path win is narrower than first stated.** `syncOrImportProject` routes a project with a parseable Artifacts remote — i.e. every established project — to an **incremental fetch that ignores this depth** and uses its own `SYNC_FETCH_DEPTH` window. The depth reaches only the **fallback full import**, taken when a project has no Artifacts remote because its initial import never completed. That routing is documented in `src/services/project-sync.ts` and predates this PR (untouched by #276). Carrying the recorded depth there is still right — the fallback re-imports the whole project, so a hardcoded 10 is precisely where a wrong depth costs history — it is just not the common path. The title was narrowed from "retry and sync" to "retry and re-import" to match.

**2. My audit claim was false.** An earlier revision said *"no hardcoded depth literal remains outside `validation.ts`'s own default — verified by grep."* That grep matched `depth: 10` with a colon, which finds neither an omitted argument nor an assignment with `=`, and it missed two real sites that CodeRabbit's review then caught (see the discussion below). Both are fixed in `20d2d43`. The audit was redone by enumerating every `processImportJob` / `processSyncJob` / `syncOrImportProject` call site rather than grepping for literals.

### Upgrade and deploy safety

Existing rows are `NULL` and fall back exactly as today, so **no project changes behaviour on upgrade**. `ALTER TABLE ADD COLUMN` is additive: old code ignores the column, new code tolerates `NULL`, so deploy order does not matter.

### Explicitly not in scope

- **The daily cron** (`syncAllProjects`, `src/routes/sync.ts`) passes no depth, so its legacy fallback import takes `importFromGitHub`'s own default. Same defect class, but six assertions in `tests/sync-cron.test.ts` encode "the cron passes no depth" as the current contract. Raised [in a comment](https://github.com/stratum-eng/stratum/pull/298#issuecomment-5439699851) with a ready patch rather than changed unilaterally — your call.
- **Making the incremental sync honour a recorded depth.** `SYNC_FETCH_DEPTH` plus the deepening loop is a deliberate design that #276 has just reworked.
- Letting a user *change* the depth at retry or sync time. This restores the depth they already chose.
- Backfilling `depth` on existing rows.
- `bulk-import.ts`, which has no depth to record and so stores `NULL` and falls back.

## Related issues

Closes #279

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

Ran the CI gate order locally (lint → typecheck → test), against the branch **with `origin/main` merged in** (#276 landed after this PR opened; it touches `src/storage/git-ops.ts` and its sync tests, none of which this PR touches, so the merge is clean).

Twelve new cases, all confirmed to fail against the pre-fix code by reverting the source with the tests in place:

**Storage round trip** (`tests/import-clone-depth.test.ts`) — against `makeSqliteD1`, a real SQLite engine with every migration applied, so migration 040 and the SQL reading it are genuinely executed rather than stubbed:
- a shallow depth round-trips;
- **`0` survives as distinct from unset**, asserted through `depth ?? DEFAULT_CLONE_DEPTH` itself — the exact expression that would eat it;
- a caller with no depth records `NULL` and consumers fall back;
- a row forced to `NULL` (simulating pre-migration) reads as unset;
- the *most recent* job's depth wins, with `started_at` nudged so ordering is not decided by insertion luck;
- a project with no jobs reads as unset.

**Retry and re-trigger** (`tests/import-fidelity.test.ts`) — the issue's headline case: a full-history import that fails and is retried is re-queued with `depth: 0`, asserted both positively and as *not* `DEFAULT_CLONE_DEPTH`; a shallow-but-deep (500) case; and the queue-less re-trigger importing at a recorded `0` rather than `10`.

**Queue-less sync fallback** (`tests/incremental-sync-wiring.test.ts`) — the fallback import receives its caller's depth rather than a hardcoded 10.

**Webhook sync path** (`tests/webhook-push.test.ts`) — a recorded depth reaches both `queueSyncJob` and `createImportJob`; `0` is preserved rather than defaulted; and no recorded depth falls back to the default.

Two pre-existing webhook tests failed when I first wired this up, because that file's `../src/storage/imports` module mock did not expose the new function — the stub is updated, not the assertions.

- [x] `npm run typecheck` — clean
- [x] `npm test` — 2214 passed, 27 skipped, 0 failed (146 files)
- [x] `npm run lint` — `Checked 309 files. No fixes applied.`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate — swept `docs/user-guide/importing.md`, `website/src/content/docs/guides/importing.md`, `README.md` and `AGENTS.md`. The `depth` option table stays accurate, and nothing documented claimed depth was *or* was not retained across retry — the docs are silent, not wrong, so nothing needed correcting.
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript — no UI change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import jobs now retain their configured clone depth, including full-history imports.
  * Webhook-triggered syncs, retries, and re-triggered imports reuse the previously recorded clone depth.
  * Imports without a recorded depth continue using the default setting.

* **Bug Fixes**
  * Prevented imports from unexpectedly reverting to the default or fixed depth during retries and webhook syncs.
  * Preserved explicit full-history (`0`) and custom-depth configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->