### PR TITLE
Unified New Project form with Blank/Import toggle (#306)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,16 @@ app.get("/ui.css", (c) => {
   return c.text(CSS, 200, { "Content-Type": "text/css; charset=UTF-8" });
 });
 
+// Browsers request /favicon.ico on pages with no <link rel="icon"> (raw JSON
+// responses, redirects); serve the same S-mark the layout inlines.
+const FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="#0d0d0d"/><text x="16" y="23" font-family="monospace" font-size="20" font-weight="700" fill="#7ca9f7" text-anchor="middle">S</text></svg>`;
+app.get("/favicon.ico", (c) =>
+  c.body(FAVICON_SVG, 200, {
+    "Content-Type": "image/svg+xml",
+    "Cache-Control": "public, max-age=86400",
+  }),
+);
+
 // Health check endpoint
 app.route("/api/health", healthRouter);
 

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -247,6 +247,12 @@ app.post("/", async (c) => {
     project.id,
   );
 
+  // A browser form lands on the new project; API callers keep the JSON body.
+  // (The import endpoint below does the same.)
+  if (!contentType.includes("application/json")) {
+    return c.redirect(`/${namespace}/${slug}`, 303);
+  }
+
   return created({
     id: projectId,
     name: project.name,

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -222,6 +222,7 @@ app.post("/settings/rotate-token", async (c) => {
       user={user}
       agents={agents}
       freshToken={{ kind: "api-key", value: rotateResult.data }}
+      nonce={c.get("cspNonce") ?? ""}
     />,
   );
 });
@@ -260,6 +261,7 @@ app.post("/settings/agents", async (c) => {
       user={user}
       agents={agents}
       freshToken={{ kind: "agent", value: createResult.data.plaintext, agentName: name }}
+      nonce={c.get("cspNonce") ?? ""}
     />,
   );
 });

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -75,12 +75,22 @@ async function requireProjectAdmin(
 
 function sanitizeEvents(value: unknown): string | null {
   if (value === undefined || value === null || value === "" || value === "*") return "*";
-  if (typeof value !== "string") return null;
-  const entries = value
-    .split(",")
+  // Accept both API shapes ("a,b" string) and the management form's repeated
+  // checkboxes (string[]; a checked "All events" box contributes "*").
+  let raw: string[];
+  if (Array.isArray(value)) {
+    if (!value.every((entry): entry is string => typeof entry === "string")) return null;
+    raw = value;
+  } else if (typeof value === "string") {
+    raw = [value];
+  } else {
+    return null;
+  }
+  const entries = raw
+    .flatMap((entry) => entry.split(","))
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
-  if (entries.length === 0) return "*";
+  if (entries.length === 0 || entries.includes("*")) return "*";
   const unknown = entries.filter((entry) => !SUBSCRIBABLE_EVENTS.includes(entry));
   if (unknown.length > 0) return null;
   return entries.join(",");
@@ -106,7 +116,8 @@ app.post("/:namespace/:slug/webhooks", async (c) => {
   if (contentType.includes("application/json")) {
     body = await c.req.json<typeof body>().catch(() => ({}));
   } else {
-    const form = await c.req.parseBody();
+    // all:true keeps every checked events checkbox instead of only the last one.
+    const form = await c.req.parseBody({ all: true });
     body = { url: form.url, events: form.events };
   }
 
@@ -157,13 +168,25 @@ app.post("/:namespace/:slug/webhooks", async (c) => {
 
   if (!contentType.includes("application/json")) {
     // The management page redacts the signing secret, so a form-based creator
-    // would otherwise never see it. Show it exactly once here (not persisted, not
-    // in the URL, no client JS) with a link back to the management page.
+    // would otherwise never see it. Show it exactly once here (not persisted,
+    // not in the URL) with a copy control and a link back to the management page.
     const wh = webhookResult.data;
     const backUrl = `/${project.namespace}/${project.slug}/webhooks`;
+    const nonce = c.get("cspNonce") ?? "";
+    const copyScript = `(function () {
+  var btn = document.getElementById('copy-secret');
+  var secret = document.getElementById('webhook-secret');
+  if (!btn || !secret) return;
+  btn.addEventListener('click', function () {
+    navigator.clipboard.writeText(secret.textContent).then(function () {
+      btn.textContent = 'Copied';
+      setTimeout(function () { btn.textContent = 'Copy'; }, 2000);
+    });
+  });
+})();`;
     return noStore(
       c.html(
-        `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Webhook created</title><link rel="stylesheet" href="/ui.css"></head><body><main style="max-width:640px;margin:3rem auto;padding:0 1rem;font-family:monospace"><h1>Webhook created</h1><p><strong>Copy the signing secret now — it will not be shown again.</strong></p><p>URL: <code>${escapeHtml(wh.url)}</code></p><p>Signing secret: <code>${escapeHtml(wh.secret)}</code></p><p>Verify each delivery's <code>X-Stratum-Signature</code> (HMAC-SHA256) with this secret.</p><p><a href="${escapeHtml(backUrl)}">&larr; Back to webhooks</a></p></main></body></html>`,
+        `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Webhook created — Stratum</title><link rel="stylesheet" href="/ui.css"></head><body><main class="main" style="max-width:640px"><div class="card settings-token-reveal"><h3 style="margin-top:0">Webhook created</h3><p class="settings-help"><strong>Copy the signing secret now — it will not be shown again.</strong></p><p class="settings-help">Payload URL: <code>${escapeHtml(wh.url)}</code></p><div class="token-reveal-row"><code class="settings-token" id="webhook-secret">${escapeHtml(wh.secret)}</code><button type="button" class="btn btn-small" id="copy-secret">Copy</button></div><p class="settings-help" style="margin-top:0.75rem">Verify each delivery's <code>X-Stratum-Signature</code> (HMAC-SHA256) with this secret.</p><p style="margin-top:1rem"><a href="${escapeHtml(backUrl)}">&larr; Back to webhooks</a></p></div></main><script nonce="${escapeHtml(nonce)}">${copyScript}</script></body></html>`,
         201,
       ),
     );

--- a/src/ui/components/import-progress.tsx
+++ b/src/ui/components/import-progress.tsx
@@ -208,6 +208,7 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
   const isComplete = status === "completed";
   const isFailed = status === "failed";
   const isCancelled = status === "cancelled";
+  const isCancelling = status === "cancelling";
 
   const percent = progress.totalFiles
     ? Math.round((progress.processedFiles / progress.totalFiles) * 100)
@@ -233,7 +234,7 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
     <div class="card import-progress-card" data-import-status={status}>
       <div class="import-header">
         <h2>
-          {isActive && <span class="spinner" />}
+          {(isActive || isCancelling) && <span class="spinner" />}
           {isComplete && <span class="icon-success">✓</span>}
           {isFailed && <span class="icon-error">✗</span>}
           {isCancelled && <span class="icon-cancelled">○</span>}
@@ -244,7 +245,9 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
               ? "Failed"
               : isCancelled
                 ? "Cancelled"
-                : "in Progress"}
+                : isCancelling
+                  ? "Cancelling…"
+                  : "in Progress"}
         </h2>
         <span class={`badge badge-${status}`}>{status}</span>
       </div>
@@ -354,7 +357,7 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
         </div>
       )}
 
-      {(isFailed || isCancelled) && (
+      {(isFailed || isCancelled || isCancelling) && (
         <div class="actions-section failed-actions">
           <form
             method="post"
@@ -362,9 +365,14 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
             class="retry-form"
           >
             <button type="submit" class="btn btn-primary">
-              🔄 Retry Import
+              Retry import
             </button>
           </form>
+          {isCancelling && (
+            <p class="help-text">
+              Cancelling can take a moment. If it stays stuck, Retry re-queues the import.
+            </p>
+          )}
         </div>
       )}
 

--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -33,6 +33,9 @@ export const Layout: FC<LayoutProps> = ({ title, user, refreshSeconds, children 
             {user ? (
               <>
                 <span class="nav-user">{user.username ?? user.email}</span>
+                <a href="/new" class="nav-auth-link">
+                  new project
+                </a>
                 <a href="/settings" class="nav-auth-link">
                   settings
                 </a>

--- a/src/ui/pages/changes.tsx
+++ b/src/ui/pages/changes.tsx
@@ -49,7 +49,17 @@ export const ChangesPage: FC<ChangesProps> = ({ project, changes, canWrite, user
         <div class="empty-state">
           <p>No changes yet.</p>
           <p class="empty-state-hint">
-            Open a change to propose edits and gate them on tests and review before they merge.
+            Changes are proposed from a workspace — a private fork of this project — and gated on
+            tests and review before they merge. From your terminal:
+          </p>
+          <pre class="cli-hint">
+            {`stratum workspace create ${project.namespace}/${project.slug}
+stratum change create --project ${project.namespace}/${project.slug} --workspace <name>`}
+          </pre>
+          <p class="empty-state-hint">
+            <a href="https://docs.usestratum.dev" target="_blank" rel="noopener noreferrer">
+              CLI setup guide →
+            </a>
           </p>
         </div>
       ) : (

--- a/src/ui/pages/home.tsx
+++ b/src/ui/pages/home.tsx
@@ -65,7 +65,9 @@ export const HomePage: FC<HomeProps> = ({ projects, user }) => {
               <div class="card-meta">
                 {project.namespace}/{project.slug}
               </div>
-              <div class="card-meta">{new Date(project.createdAt).toLocaleDateString()}</div>
+              <div class="card-meta">
+                Created {new Date(project.createdAt).toLocaleDateString()}
+              </div>
             </a>
           ))}
         </div>

--- a/src/ui/pages/new-project.tsx
+++ b/src/ui/pages/new-project.tsx
@@ -4,204 +4,135 @@ import { Layout } from "../layout";
 interface NewProjectProps {
   user?: { id: string; email: string; username: string } | null;
   error?: string;
-  /** Per-request CSP nonce — required so the import-form script passes `script-src`. */
+  /** Per-request CSP nonce — required so the form script passes `script-src`. */
   nonce: string;
 }
 
 /**
- * Rewrites the GitHub import form's action to the namespaced import endpoint on
- * submit (or blocks it with a login prompt). CSP-safe replacement for the old
- * inline `onsubmit=` handler — identical behavior: returning false became
- * `event.preventDefault()`, the mutated `action` still submits normally.
+ * One form, two modes. The script only does what markup can't: it points the
+ * form at the right endpoint per mode (blank -> POST /api/projects, import ->
+ * the namespaced import endpoint), keeps `required` on the URL field in sync
+ * with the mode (a hidden required field would block submission), and suggests
+ * a project name from a pasted GitHub URL until the user edits the name
+ * themselves. Mode switching itself is pure CSS (`:has()` on the checked radio).
  */
-const IMPORT_FORM_SCRIPT = `
+const NEW_PROJECT_SCRIPT = `
 (function () {
-  var form = document.getElementById('import-form');
+  var form = document.getElementById('new-project-form');
   if (!form) return;
+  var urlInput = form.querySelector('[name=url]');
+  var nameInput = form.querySelector('[name=name]');
+
+  function mode() {
+    var checked = form.querySelector('input[name=mode]:checked');
+    return checked ? checked.value : 'blank';
+  }
+
+  function syncMode() {
+    urlInput.required = mode() === 'import';
+  }
+  form.querySelectorAll('input[name=mode]').forEach(function (radio) {
+    radio.addEventListener('change', syncMode);
+  });
+  syncMode();
+
+  // Suggest a name from the pasted URL until the user types their own.
+  var nameEdited = false;
+  nameInput.addEventListener('input', function () { nameEdited = true; });
+  urlInput.addEventListener('input', function () {
+    if (nameEdited) return;
+    var match = urlInput.value.match(/github\\.com\\/[^/]+\\/([^/?#]+)/);
+    if (!match) return;
+    nameInput.value = match[1]
+      .replace(/\\.git$/, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9-]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  });
+
   form.addEventListener('submit', function (event) {
-    var name = form.querySelector('[name=name]').value;
-    var userData = document.getElementById('user-data');
-    var username = userData ? userData.dataset.username : '';
-    if (!username) {
-      alert('Please log in first');
-      event.preventDefault();
-      return;
+    if (mode() === 'import') {
+      var userData = document.getElementById('user-data');
+      var username = userData ? userData.dataset.username : '';
+      if (!username) {
+        alert('Please sign in first');
+        event.preventDefault();
+        return;
+      }
+      form.action =
+        '/api/projects/@' + encodeURIComponent(username) +
+        '/' + encodeURIComponent(nameInput.value) + '/import';
+    } else {
+      form.action = '/api/projects';
     }
-    form.action = '/api/projects/@' + encodeURIComponent(username) + '/' + encodeURIComponent(name) + '/import';
   });
 })();
 `;
 
 export const NewProjectPage: FC<NewProjectProps> = ({ user, error, nonce }) => {
-  // Always set username data, fallback to empty string if not available
   const username = user?.username || "";
 
   return (
     <Layout title="New Project" user={user}>
-      {/* Set username for import form JavaScript - always render even if empty */}
+      {/* Username for the import endpoint path — read by the form script. */}
       <div data-username={username} style="display:none" id="user-data" />
 
       <div class="page-header">
-        <h1>Create New Project</h1>
+        <h1>New project</h1>
         <a class="btn" href="/">
           Cancel
         </a>
       </div>
 
       {error && (
-        <div class="card" style="background: #3d1a1a; border-color: #6e2a2a; margin-bottom: 1rem;">
-          <p style="color: #f87171; margin: 0;">{error}</p>
+        <div class="error-message" style={{ marginBottom: "1.25rem" }}>
+          {error}
         </div>
       )}
 
-      <div class="card">
-        <form method="post" action="/api/projects">
-          <div style="margin-bottom: 1rem;">
-            <label style={{ display: "block", marginBottom: "0.5rem", color: "#888" }}>
-              Project Name
+      <div class="card" style={{ maxWidth: "560px" }}>
+        <form id="new-project-form" method="post" action="/api/projects" class="new-project-form">
+          <div class="mode-toggle" role="radiogroup" aria-label="How to start">
+            <label>
+              <input type="radio" name="mode" value="blank" checked />
+              Start blank
             </label>
+            <label>
+              <input type="radio" name="mode" value="import" />
+              Import from GitHub
+            </label>
+          </div>
+
+          <div class="form-field import-only">
+            <label for="np-url">GitHub URL</label>
             <input
-              type="text"
-              name="name"
-              placeholder="my-project"
-              pattern="[a-z0-9-]+"
-              title="Lowercase letters, numbers, and hyphens only"
-              required
-              style={{
-                width: "100%",
-                padding: "0.5rem",
-                background: "#0a0a0a",
-                border: "1px solid #333",
-                borderRadius: "4px",
-                color: "#f0f0f0",
-                fontFamily: "inherit",
-              }}
-            />
-            <small style={{ color: "#666", display: "block", marginTop: "0.25rem" }}>
-              Use lowercase letters, numbers, and hyphens only
-            </small>
-          </div>
-
-          <div style="margin-bottom: 1rem;">
-            <label style={{ display: "block", marginBottom: "0.5rem", color: "#888" }}>
-              Visibility
-            </label>
-            <select
-              name="visibility"
-              style={{
-                width: "100%",
-                padding: "0.5rem",
-                background: "#0a0a0a",
-                border: "1px solid #333",
-                borderRadius: "4px",
-                color: "#f0f0f0",
-                fontFamily: "inherit",
-              }}
-            >
-              <option value="public">Public (anyone can see it)</option>
-              <option value="private" selected>
-                Private (only you can see it)
-              </option>
-            </select>
-          </div>
-
-          <div style="margin-bottom: 1rem;">
-            <label
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "0.5rem",
-                color: "#888",
-                cursor: "pointer",
-              }}
-            >
-              <input
-                type="checkbox"
-                name="seed"
-                value="true"
-                checked
-                style={{ cursor: "pointer" }}
-              />
-              Seed with sample files (README.md and src/index.ts)
-            </label>
-          </div>
-
-          <button type="submit" class="btn btn-primary">
-            Create Project
-          </button>
-        </form>
-      </div>
-
-      <div class="card" style={{ marginTop: "1.5rem" }}>
-        <h3 style={{ marginTop: 0 }}>Or import from GitHub</h3>
-        <form
-          id="import-form"
-          method="post"
-          action="/api/projects/import"
-          style={{ marginTop: "1rem" }}
-        >
-          <div style="margin-bottom: 1rem;">
-            <label style={{ display: "block", marginBottom: "0.5rem", color: "#888" }}>
-              Project Name
-            </label>
-            <input
-              type="text"
-              name="name"
-              placeholder="my-project"
-              pattern="[a-z0-9-]+"
-              title="Lowercase letters, numbers, and hyphens only"
-              required
-              style={{
-                width: "100%",
-                padding: "0.5rem",
-                background: "#0a0a0a",
-                border: "1px solid #333",
-                borderRadius: "4px",
-                color: "#f0f0f0",
-                fontFamily: "inherit",
-              }}
-            />
-          </div>
-
-          <div style="margin-bottom: 1rem;">
-            <label style={{ display: "block", marginBottom: "0.5rem", color: "#888" }}>
-              GitHub URL
-            </label>
-            <input
+              id="np-url"
               type="url"
               name="url"
               placeholder="https://github.com/owner/repo"
               pattern="https://github.com/.*"
               title="Must be a valid GitHub URL"
-              required
-              style={{
-                width: "100%",
-                padding: "0.5rem",
-                background: "#0a0a0a",
-                border: "1px solid #333",
-                borderRadius: "4px",
-                color: "#f0f0f0",
-                fontFamily: "inherit",
-              }}
             />
+            <p class="help-text">Public repositories import directly; the name fills in for you.</p>
           </div>
 
-          <div style="margin-bottom: 1rem;">
-            <label style={{ display: "block", marginBottom: "0.5rem", color: "#888" }}>
-              Visibility
-            </label>
-            <select
-              name="visibility"
-              style={{
-                width: "100%",
-                padding: "0.5rem",
-                background: "#0a0a0a",
-                border: "1px solid #333",
-                borderRadius: "4px",
-                color: "#f0f0f0",
-                fontFamily: "inherit",
-              }}
-            >
+          <div class="form-field">
+            <label for="np-name">Project name</label>
+            <input
+              id="np-name"
+              type="text"
+              name="name"
+              placeholder="my-project"
+              pattern="[a-z0-9-]+"
+              title="Lowercase letters, numbers, and hyphens only"
+              required
+            />
+            <p class="help-text">Lowercase letters, numbers, and hyphens only.</p>
+          </div>
+
+          <div class="form-field">
+            <label for="np-visibility">Visibility</label>
+            <select id="np-visibility" name="visibility">
               <option value="public">Public (anyone can see it)</option>
               <option value="private" selected>
                 Private (only you can see it)
@@ -209,13 +140,21 @@ export const NewProjectPage: FC<NewProjectProps> = ({ user, error, nonce }) => {
             </select>
           </div>
 
+          <div class="form-field blank-only">
+            <label class="checkbox-label">
+              <input type="checkbox" name="seed" value="true" checked />
+              Seed with sample files (README.md and src/index.ts)
+            </label>
+          </div>
+
           <button type="submit" class="btn btn-primary">
-            Import from GitHub
+            <span class="submit-label-blank">Create project</span>
+            <span class="submit-label-import">Import project</span>
           </button>
         </form>
       </div>
 
-      <script nonce={nonce} dangerouslySetInnerHTML={{ __html: IMPORT_FORM_SCRIPT }} />
+      <script nonce={nonce} dangerouslySetInnerHTML={{ __html: NEW_PROJECT_SCRIPT }} />
     </Layout>
   );
 };

--- a/src/ui/pages/repo.tsx
+++ b/src/ui/pages/repo.tsx
@@ -270,7 +270,7 @@ export const RepoPage: FC<RepoProps> = ({
         </div>
       )}
 
-      {hasSource && canSync && project.sourceProvider === "github" && (
+      {hasSource && canSync && files.length > 0 && project.sourceProvider === "github" && (
         <div class="card" style={{ marginTop: "1rem" }}>
           <h3 style={{ marginTop: 0 }}>Prepare a pull request</h3>
           <p style={{ color: "#aaa", marginBottom: "1rem" }}>
@@ -288,7 +288,7 @@ export const RepoPage: FC<RepoProps> = ({
         </div>
       )}
 
-      {hasSource && canSync && project.sourceProvider !== "github" && (
+      {hasSource && canSync && files.length > 0 && project.sourceProvider !== "github" && (
         <div class="card" style={{ marginTop: "1rem" }}>
           <h3 style={{ marginTop: 0 }}>Review your changes</h3>
           <p style={{ color: "#aaa", marginBottom: "1rem" }}>

--- a/src/ui/pages/settings.tsx
+++ b/src/ui/pages/settings.tsx
@@ -13,9 +13,26 @@ interface SettingsPageProps {
   agents: AgentSummary[];
   /** Freshly created credential, shown exactly once after a rotate/create POST. */
   freshToken?: { kind: "api-key" | "agent"; value: string; agentName?: string };
+  /** Per-request CSP nonce for the copy-button script (only rendered with a fresh token). */
+  nonce?: string;
 }
 
-export const SettingsPage: FC<SettingsPageProps> = ({ user, agents, freshToken }) => {
+/** Clipboard needs script; the value is read from the DOM, never re-serialized. */
+const COPY_TOKEN_SCRIPT = `
+(function () {
+  var btn = document.getElementById('copy-fresh-token');
+  var token = document.getElementById('fresh-token');
+  if (!btn || !token) return;
+  btn.addEventListener('click', function () {
+    navigator.clipboard.writeText(token.textContent).then(function () {
+      btn.textContent = 'Copied';
+      setTimeout(function () { btn.textContent = 'Copy'; }, 2000);
+    });
+  });
+})();
+`;
+
+export const SettingsPage: FC<SettingsPageProps> = ({ user, agents, freshToken, nonce }) => {
   return (
     <Layout title="Settings" user={user}>
       <div class="page-header">
@@ -33,7 +50,17 @@ export const SettingsPage: FC<SettingsPageProps> = ({ user, agents, freshToken }
             Copy it now — it is shown only once.{" "}
             {freshToken.kind === "api-key" ? "Your previous key no longer works." : ""}
           </p>
-          <code class="settings-token">{freshToken.value}</code>
+          <div class="token-reveal-row">
+            <code class="settings-token" id="fresh-token">
+              {freshToken.value}
+            </code>
+            <button type="button" class="btn btn-small" id="copy-fresh-token">
+              Copy
+            </button>
+          </div>
+          {nonce !== undefined && (
+            <script nonce={nonce} dangerouslySetInnerHTML={{ __html: COPY_TOKEN_SCRIPT }} />
+          )}
         </div>
       )}
 

--- a/src/ui/pages/tags.tsx
+++ b/src/ui/pages/tags.tsx
@@ -38,7 +38,9 @@ export const TagsPage: FC<TagsProps> = ({ project, tags, canWrite, user }) => {
           <p>No tags yet.</p>
           <p class="empty-state-hint">
             Push a tag to a workspace remote to create one — the project remote refuses tag pushes.
+            From a cloned workspace:
           </p>
+          <pre class="cli-hint">{"git tag v1.0.0\ngit push origin v1.0.0"}</pre>
         </div>
       ) : (
         <div class="card">

--- a/src/ui/pages/webhooks.tsx
+++ b/src/ui/pages/webhooks.tsx
@@ -54,11 +54,24 @@ export const WebhooksPage: FC<WebhooksPageProps> = ({
             Payload URL
             <input type="url" name="url" placeholder="https://example.com/hooks/stratum" required />
           </label>
-          <label>
-            Events (comma-separated, or * for all)
-            <input type="text" name="events" placeholder="*" />
-          </label>
-          <p class="webhook-help">Available: {subscribableEvents.join(", ")}</p>
+          <fieldset class="webhook-events">
+            <legend>Events to deliver</legend>
+            <label class="checkbox-label">
+              <input type="checkbox" name="events" value="*" checked />
+              All events
+            </label>
+            <div class="webhook-events-grid">
+              {subscribableEvents.map((event) => (
+                <label class="checkbox-label" key={event}>
+                  <input type="checkbox" name="events" value={event} />
+                  {event}
+                </label>
+              ))}
+            </div>
+            <p class="webhook-help">
+              "All events" wins when checked; otherwise only the selected events are delivered.
+            </p>
+          </fieldset>
           <button type="submit" class="btn btn-primary">
             Add webhook
           </button>

--- a/src/ui/pages/workspaces.tsx
+++ b/src/ui/pages/workspaces.tsx
@@ -25,6 +25,16 @@ export const WorkspacesPage: FC<WorkspacesProps> = ({ project, workspaces, canWr
       {workspaces.length === 0 ? (
         <div class="empty-state">
           <p>No workspaces yet.</p>
+          <p class="empty-state-hint">
+            A workspace is your private fork of this project — agents and humans commit there, then
+            open a change. From your terminal:
+          </p>
+          <pre class="cli-hint">{`stratum workspace create ${project.namespace}/${project.slug}`}</pre>
+          <p class="empty-state-hint">
+            <a href="https://docs.usestratum.dev" target="_blank" rel="noopener noreferrer">
+              CLI setup guide →
+            </a>
+          </p>
         </div>
       ) : (
         <div class="table-scroll">

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -52,6 +52,9 @@ export const CSS = `
   --danger-surface: #3d1a1a;
   --danger-border: #6e2a2a;
 
+  /* Long-form prose (READMEs) reads better in a text face; UI stays mono. */
+  --font-prose: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+
   /* Aliases the auth pages already reference */
   --bg-primary: var(--bg-page);
   --bg-secondary: var(--bg-card);
@@ -187,6 +190,7 @@ button.nav-auth-link {
 
 .badge {
   display: inline-block;
+  white-space: nowrap;
   padding: 0.15rem 0.5rem;
   border-radius: 3px;
   font-size: 0.8rem;
@@ -534,8 +538,8 @@ button.nav-auth-link {
 .file-tree-file a:hover { color: var(--text-primary); text-decoration: underline; }
 .file-tree-notice { font-size: 0.8rem; color: var(--text-muted); margin-top: 0.75rem; font-style: italic; }
 .file-tree-controls { margin-bottom: 0.5rem; }
-.file-tree-toggle-btn { background: none; border: none; color: var(--text-muted); font-size: 0.75rem; cursor: pointer; padding: 0; font-family: inherit; }
-.file-tree-toggle-btn:hover { color: var(--text-body); }
+.file-tree-toggle-btn { background: none; border: none; color: var(--accent-text); font-size: 0.8rem; cursor: pointer; padding: 0; font-family: inherit; }
+.file-tree-toggle-btn:hover { color: var(--accent-text-hover); text-decoration: underline; }
 
 /* Activity Feed */
 .activity-list { list-style: none; padding: 0; margin: 0; }
@@ -565,7 +569,7 @@ button.nav-auth-link {
 
 /* Webhooks */
 .webhook-form { display: flex; flex-direction: column; gap: 0.75rem; max-width: 480px; }
-.webhook-form label { display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.85rem; color: var(--text-body); }
+.webhook-form > label { display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.85rem; color: var(--text-body); }
 .webhook-form input {
   background: var(--bg-card); border: 1px solid var(--border-strong); color: #eee;
   padding: 0.5rem; border-radius: 4px; font-family: inherit;
@@ -877,7 +881,7 @@ button.nav-auth-link {
 /* README rendered markdown */
 .readme-card h2 { margin-bottom: 1rem; }
 
-.readme-content { font-size: 0.875rem; line-height: 1.7; color: var(--text-body); }
+.readme-content { font-family: var(--font-prose); font-size: 0.9rem; line-height: 1.7; color: var(--text-body); }
 .readme-content h1 { font-size: 1.3rem; color: var(--text-primary); margin: 1.25rem 0 0.5rem; border-bottom: 1px solid var(--divider); padding-bottom: 0.3rem; }
 .readme-content h2 { font-size: 1.1rem; color: #e0e0e0; margin: 1.1rem 0 0.4rem; border-bottom: 1px solid var(--bg-raised); padding-bottom: 0.25rem; }
 .readme-content h3 { font-size: 0.95rem; color: #d0d0d0; margin: 0.9rem 0 0.3rem; }
@@ -899,6 +903,28 @@ button.nav-auth-link {
 .readme-content hr { border: none; border-top: 1px solid var(--divider); margin: 1rem 0; }
 .readme-content details { margin: 0.5rem 0; }
 .readme-content summary { cursor: pointer; color: var(--text-muted); }
+
+/* Copyable CLI commands inside empty states */
+.cli-hint {
+  display: inline-block; text-align: left; margin: 0.75rem auto 0.25rem;
+  padding: 0.7rem 1rem; background: var(--bg-panel);
+  border: 1px solid var(--border); border-radius: 6px;
+  font-size: 0.8rem; line-height: 1.7; color: var(--text-body);
+  user-select: all; overflow-x: auto; max-width: 100%; white-space: pre;
+}
+
+/* Webhook event subscription checkboxes */
+.webhook-events { border: none; padding: 0; display: flex; flex-direction: column; gap: 0.4rem; }
+.webhook-events legend { font-size: 0.85rem; color: var(--text-body); padding: 0; margin-bottom: 0.35rem; }
+.webhook-events-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 0.25rem 1rem; padding-left: 1.4rem;
+}
+.webhook-events .checkbox-label { font-size: 0.82rem; }
+
+/* Reveal-once credential + copy control */
+.token-reveal-row { display: flex; gap: 0.5rem; align-items: stretch; flex-wrap: wrap; }
+.token-reveal-row .settings-token { flex: 1; min-width: 240px; }
 
 /* New project form: CSS-only mode toggle (script only re-points the action) */
 .mode-toggle { display: flex; gap: 0.5rem; margin-bottom: 1.25rem; flex-wrap: wrap; }
@@ -981,7 +1007,7 @@ button.nav-auth-link {
 
 /* Commit table */
 .commit-table { table-layout: fixed; width: 100%; }
-.commit-sha { width: 72px; font-size: 0.8rem; color: var(--accent-text); }
+.commit-sha { width: 72px; font-size: 0.8rem; color: var(--text-muted); }
 .commit-message { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 0; }
 .commit-author { width: 160px; font-size: 0.82rem; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .commit-date { width: 96px; font-size: 0.82rem; color: var(--text-muted); text-align: right; }

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -900,6 +900,46 @@ button.nav-auth-link {
 .readme-content details { margin: 0.5rem 0; }
 .readme-content summary { cursor: pointer; color: var(--text-muted); }
 
+/* New project form: CSS-only mode toggle (script only re-points the action) */
+.mode-toggle { display: flex; gap: 0.5rem; margin-bottom: 1.25rem; flex-wrap: wrap; }
+.mode-toggle label {
+  display: inline-flex; align-items: center; gap: 0.45rem;
+  padding: 0.45rem 0.9rem; border: 1px solid var(--border-strong);
+  border-radius: 4px; cursor: pointer; color: var(--text-muted);
+  font-size: 0.9rem; user-select: none;
+}
+.mode-toggle label:hover { color: var(--text-body); border-color: var(--border-hover); }
+.mode-toggle label:has(input:checked) {
+  background: var(--accent); border-color: var(--accent-border); color: var(--accent-text);
+}
+.mode-toggle label:has(input:focus-visible) { outline: 2px solid var(--accent-text); outline-offset: 2px; }
+.mode-toggle input[type="radio"] {
+  position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none;
+}
+
+.new-project-form .form-field { margin-bottom: 1.1rem; }
+.new-project-form .form-field > label:not(.checkbox-label) { display: block; color: var(--text-body); font-size: 0.85rem; margin-bottom: 0.35rem; }
+.new-project-form input[type="text"],
+.new-project-form input[type="url"],
+.new-project-form select {
+  width: 100%; padding: 0.5rem 0.65rem; background: var(--bg-page);
+  border: 1px solid var(--border-strong); border-radius: 4px;
+  color: var(--text-primary); font-family: inherit; font-size: 0.9rem;
+}
+.new-project-form input:focus-visible,
+.new-project-form select:focus-visible {
+  outline: none; border-color: var(--accent-border);
+  box-shadow: 0 0 0 3px rgba(42, 90, 174, 0.3);
+}
+
+/* Import-mode fields appear (and blank-only ones hide) with the toggle. */
+.new-project-form .import-only { display: none; }
+.new-project-form:has(input[name="mode"][value="import"]:checked) .import-only { display: block; }
+.new-project-form:has(input[name="mode"][value="import"]:checked) .blank-only { display: none; }
+.new-project-form .submit-label-import { display: none; }
+.new-project-form:has(input[name="mode"][value="import"]:checked) .submit-label-blank { display: none; }
+.new-project-form:has(input[name="mode"][value="import"]:checked) .submit-label-import { display: inline; }
+
 /* Project header: identity crumb + tab navigation */
 .project-header { margin-bottom: 1.5rem; }
 .project-header-row {

--- a/tests/csp-nonce-sweep.test.tsx
+++ b/tests/csp-nonce-sweep.test.tsx
@@ -138,10 +138,10 @@ describe("CSP nonce sweep — pages", () => {
     });
   }
 
-  it("NewProjectPage: import-form script is nonce'd, no inline handlers remain", () => {
+  it("NewProjectPage: unified form script is nonce'd, no inline handlers remain", () => {
     const html = renderToString(<NewProjectPage user={user} nonce={NONCE} />);
     expectCspClean(html, { expectScripts: true });
-    expect(html).toContain('id="import-form"');
+    expect(html).toContain('id="new-project-form"');
   });
 
   it("RepoPage with files and an active import: all scripts nonce'd", () => {

--- a/tests/repo-page-fork-ui.test.tsx
+++ b/tests/repo-page-fork-ui.test.tsx
@@ -61,6 +61,7 @@ describe("RepoPage — 'Prepare a pull request' card (GitHub)", () => {
     const html = renderToString(
       <RepoPage
         {...baseProps}
+        files={["README.md"]}
         canSync={true}
         project={{
           ...baseProject,
@@ -75,6 +76,23 @@ describe("RepoPage — 'Prepare a pull request' card (GitHub)", () => {
     expect(html).toContain("Open Changes");
     expect(html).toContain("/@alice/my-repo/changes");
     expect(html).toContain("as a pull request");
+  });
+
+  it("(c2) hides the PR card while the repo has no content (import not done)", () => {
+    const html = renderToString(
+      <RepoPage
+        {...baseProps}
+        canSync={true}
+        project={{
+          ...baseProject,
+          sourceUrl: "https://github.com/acme/api",
+          sourceProvider: "github",
+          sourceOwner: "acme",
+          sourceRepo: "api",
+        }}
+      />,
+    );
+    expect(html).not.toContain("Prepare a pull request");
   });
 
   it("(d) hides the GitHub PR card when canSync=false (non-owner)", () => {
@@ -100,6 +118,7 @@ describe("RepoPage — 'Review your changes' card (non-GitHub)", () => {
     const html = renderToString(
       <RepoPage
         {...baseProps}
+        files={["README.md"]}
         canSync={true}
         project={{
           ...baseProject,


### PR DESCRIPTION
Part of #311. **Stacked on #315** (→ #314 → #313 → #312).

## What

**#306 — the page stacked two near-identical forms** (name + visibility asked twice; the import form sat below the fold).

- One form, two modes: a **Start blank / Import from GitHub** pill toggle. Mode switching is pure CSS (`:has()` on the checked radio) — the URL field appears, the seed checkbox hides, the submit label flips between *Create project* and *Import project*.
- The nonce'd script does only what markup can't: re-points the form action per mode, keeps `required` on the URL field in sync (a hidden required field blocks submission), and **suggests a project name from a pasted GitHub URL** until the user edits it (`github.com/vercel/Next.js` → `next-js`).
- Inputs move off inline styles onto tokenized form styles with visible focus rings; errors use the shared `.error-message` treatment.
- Bonus fix in scope: `POST /api/projects` now 303s browser form posts to the new project page instead of dumping the JSON body at `/api/projects` — matching what the import endpoint already did. API callers keep the JSON contract.

## Verification

Playwright against `wrangler dev`: toggle shows/hides the right fields, URL paste suggests `next-js`, `required` follows the mode, and a blank-mode submit lands on the created project's page (test projects deleted after).

Gates: `npm test` (1663 passed; CSP nonce sweep updated to the new form id), `typecheck`, `lint` — green.

Closes #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)