### PR TITLE
Multi-branch support, webhook project_id scoping, and a base commit in the evaluator payload (#181, #235, #274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Stratum issues opaque bearer tokens and has no `token_endpoint` or `jwks_uri`, and RFC 9728
   metadata is resolved from the API origin, which these docs do not serve. Advertising either
   would send agents to a URL that cannot answer them.
+- **Multi-branch support (#181).** Create, list and delete branches on a project
+  (`GET/POST/DELETE /api/projects/:ns/:slug/branches`), browse any of them with
+  `?ref=` on the files, content and log endpoints and in the web UI, and switch
+  between them from a no-JavaScript branch switcher. Branch creation is the
+  enabling piece: no path previously put a second `refs/heads/*` on a project
+  repo, so there was nothing to list. A new branch can only start from a commit
+  the repository already holds, so creating one can never introduce content.
+  Backups now record branch refs and restore rebuilds them.
+- **The diff's base commit reaches CI (#274).** Evaluation webhooks now carry
+  `baseSha`, the commit the diff was actually taken against, so a receiver can
+  apply the hunks to the right revision instead of guessing at whatever the
+  default branch happened to be when the request landed.
 - **Per-user telemetry opt-out.** Settings → Privacy now has a switch to stop sending product
   analytics for your account, alongside a plain-language disclosure of exactly what is sent.
   An agent inherits its owner's choice. Telemetry remains on by default; the existing
@@ -33,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   onto a named token first — disabling cannot be undone.
 
 ### Fixed
+- Approvals are dismissed when the evaluated **base** moves, not only when the
+  tip does. A change re-evaluated against a newer base kept approvals that were
+  granted against different code.
 - `STRATUM_TELEMETRY_DISABLED` had no effect on `deploy:production` or `deploy:staging`. It was
   declared only under top-level `[vars]`, which named wrangler environments replace rather than
   inherit, so self-hosters who set it were still sending telemetry. It is now declared per
@@ -49,6 +64,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than under a name.
 
 ### Security
+- **Webhooks are scoped on project id alone (#235).** `webhookBelongsToProject`
+  and `listWebhooks` still matched `project_id = ? OR (project_id IS NULL AND
+  project = ?)`, so a pre-migration-025 row could be read, modified and
+  delivered to by a same-named project in another namespace. `listWebhooks` now
+  takes the project id rather than its name, so a name-scoped lookup is not
+  expressible at the call site, and `createWebhook` requires `projectId` so no
+  new unstamped row can undo the backfill.
 - Sandbox evaluation of a pinned commit no longer clones a workspace's entire reachable
   history into memory: `readRepoFiles` now clones shallow and grows the fetch window only
   as far as needed to reach the pinned commit, capped at 500 commits, instead of an

--- a/docs/api/endpoints/projects.md
+++ b/docs/api/endpoints/projects.md
@@ -26,3 +26,54 @@ body must confirm the exact path:
 Returns `202 Accepted` with `{ "status": "deleting", "jobId": "del_…" }` — the
 cascade runs asynchronously and is idempotent/resumable. A mismatched `confirm`
 returns `400`; a non-owner returns `404`.
+
+## List Branches
+
+`GET /api/projects/{namespace}/{slug}/branches`
+
+Returns `{ defaultBranch, branches: [{ name, oid }], truncated, totalBranchCount }`.
+Read from the remote's ref advertisement, so the cost does not grow with the
+branch count. Capped at 200 — `truncated` says so explicitly, and the default
+branch is never the entry dropped.
+
+## Create Branch
+
+`POST /api/projects/{namespace}/{slug}/branches`
+
+```json
+{ "name": "release/2.x", "startPoint": "trunk" }
+```
+
+`startPoint` may be a branch name or a full 40-character commit sha, and
+defaults to the default branch's tip. Short shas and **tag names** are refused:
+a tag can point at a non-commit, its peeled commit is not advertised on the push
+path, and a tag may sit outside both the default branch's history and the tag
+set a backup captures — so a branch created from one could fail to push or
+vanish on restore. The new ref can only point at an object the repository
+already holds, so branch creation cannot introduce content that has not passed
+the change gate.
+
+**Writers only** (a non-writer gets `404`). `400` for an invalid name or an
+unresolvable start point. Three distinct `409`s: `BRANCH_EXISTS` if the name is
+taken, `BRANCH_NAME_CONFLICT` if it collides with an existing ref path (`release`
+when `release/2.x` exists — git stores refs as paths, so one cannot be both a
+file and a directory), and `NO_DEFAULT_BRANCH` if the configured default branch
+is not advertised by the remote and there is therefore nothing to default to.
+
+## Delete Branch
+
+`DELETE /api/projects/{namespace}/{slug}/branches/{name}`
+
+Hierarchical names are passed as real path segments
+(`.../branches/release/2.x`); a percent-encoded slash (`release%2F2.x`) names
+the same branch, since each path segment is decoded individually.
+**Writers only.** The default branch cannot be deleted —
+`409 DEFAULT_BRANCH_PROTECTED`.
+
+## Browsing a branch
+
+`GET .../files`, `.../content`, and `.../log` accept `?ref=<branch>`, defaulting
+to the project's default branch. Branch names only: an unknown ref is a `404`
+(never a silent fall back to the default), and a name that is both a branch and
+a tag is a `409 AMBIGUOUS_REF` rather than a guess at which was meant. The
+response echoes the `ref` actually read.

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -493,6 +493,8 @@ paths:
       tags: [projects]
       summary: List files in the project repository
       security: [{ bearerAuth: [] }, {}]
+      parameters:
+        - $ref: "#/components/parameters/Ref"
       responses:
         "200":
           description: File listing
@@ -504,6 +506,9 @@ paths:
                   namespace: { type: string }
                   slug: { type: string }
                   path: { type: string }
+                  ref:
+                    type: string
+                    description: The branch actually read
                   files:
                     type: array
                     items: { type: string }
@@ -527,6 +532,7 @@ paths:
           required: true
           schema: { type: string }
           description: File path within the repository
+        - $ref: "#/components/parameters/Ref"
       responses:
         "200":
           description: File content, or a marker for binary/oversized files
@@ -539,6 +545,9 @@ paths:
                   namespace: { type: string }
                   slug: { type: string }
                   path: { type: string }
+                  ref:
+                    type: string
+                    description: The branch actually read
                   kind:
                     type: string
                     description: '"content" when `value` carries the text; other kinds (e.g. binary/too-large) omit `value`.'
@@ -566,6 +575,7 @@ paths:
           in: query
           schema: { type: integer, default: 20 }
           description: Number of commits to return
+        - $ref: "#/components/parameters/Ref"
       responses:
         "200":
           description: Commit log
@@ -577,11 +587,148 @@ paths:
                   namespace: { type: string }
                   slug: { type: string }
                   path: { type: string }
+                  ref:
+                    type: string
+                    description: The branch actually read
                   log:
                     type: array
                     items: { $ref: "#/components/schemas/CommitLogEntry" }
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/branches:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: listProjectBranches
+      tags: [projects]
+      summary: List the repository's branches
+      description: >
+        Reads the remote's ref advertisement, so the cost does not grow with the
+        number of branches. Capped at 200; `truncated` reports when the list was
+        cut, and the default branch is always retained.
+      security: [{ bearerAuth: [] }, {}]
+      responses:
+        "200":
+          description: Branch listing
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  path: { type: string }
+                  defaultBranch: { type: string }
+                  branches:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name: { type: string }
+                        oid: { type: string }
+                  truncated: { type: boolean }
+                  totalBranchCount: { type: integer }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      operationId: createProjectBranch
+      tags: [projects]
+      summary: Create a branch
+      description: >
+        Creates `refs/heads/{name}` pointing at an object the repository already
+        contains. The start point may be a branch name or a full 40-character
+        commit sha; short shas and tag names are refused. Because the ref can
+        only be aimed at an existing object, this cannot introduce unevaluated
+        content and does not bypass the change gate. Writers only.
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+                startPoint:
+                  type: string
+                  description: >
+                    Branch name or full 40-hex commit sha. Defaults to the default
+                    branch's tip. Tag names are rejected: a tag can point at a
+                    non-commit, and one may sit outside the history a backup captures.
+      responses:
+        "201":
+          description: Branch created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  branch:
+                    type: object
+                    properties:
+                      name: { type: string }
+                      oid: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: >
+            The branch already exists (`BRANCH_EXISTS`); the name collides with
+            an existing ref path, such as `release` when `release/2.x` exists
+            (`BRANCH_NAME_CONFLICT`); the configured default branch is not
+            advertised by the remote, so there is no start point to default to
+            (`NO_DEFAULT_BRANCH`); or the project is being deleted
+            (`TARGET_DELETING`)
+        "413":
+          description: Request body too large
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/branches/{name}:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: name
+        in: path
+        required: true
+        schema: { type: string }
+        description: >
+          Branch name. May contain slashes (`release/2.x`), passed as real path
+          segments. A percent-encoded slash (`%2F`) is accepted too and names the
+          same branch — each path segment is decoded individually.
+    delete:
+      operationId: deleteProjectBranch
+      tags: [projects]
+      summary: Delete a branch
+      description: Writers only. The project's default branch cannot be deleted.
+      security: [{ bearerAuth: [] }]
+      responses:
+        "200":
+          description: Branch deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  namespace: { type: string }
+                  slug: { type: string }
+                  deleted: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The branch is the default branch (`DEFAULT_BRANCH_PROTECTED`), or the project is being deleted (`TARGET_DELETING`)
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -3337,6 +3484,17 @@ components:
       required: true
       schema: { type: string }
       description: Project slug
+    Ref:
+      name: ref
+      in: query
+      required: false
+      schema: { type: string }
+      description: >
+        Branch to read. Defaults to the project's default branch. Branch names
+        only — tags and raw commit shas are not resolved, and a name that is
+        both a branch and a tag is refused as ambiguous (409) rather than
+        resolved to either. An unknown branch is a 404; there is no fall back
+        to the default branch.
     ProjectName:
       name: name
       in: path

--- a/docs/user-guide/ci-integration.md
+++ b/docs/user-guide/ci-integration.md
@@ -84,13 +84,30 @@ merge:
 ### Request (Stratum → your endpoint)
 
 - `POST` with `Content-Type: application/json`.
-- Body: `{"diff": "<unified diff of the change>", "policy": {...}}` — the
-  policy object is the parsed evaluation policy, so your endpoint can read
-  its own config from `policy.evaluators`. It is passed through
+- Body: `{"diff": "<unified diff of the change>", "policy": {...}, "baseSha": "<commit>"}`
+  — the policy object is the parsed evaluation policy, so your endpoint can
+  read its own config from `policy.evaluators`. It is passed through
   `sanitizePolicy` first (`src/evaluation/sanitize-policy.ts`), which strips
   `secret` from every webhook evaluator entry, so no receiver sees any
   evaluator's signing secret — including its own. Provision your receiver's
   copy of the secret out of band; do not expect to read it from the payload.
+- `baseSha` is the commit the diff was computed against, resolved from the
+  same clone that produced the diff. **Check out that exact commit and apply
+  the diff to it.** Do not apply the diff to your mirror's current default
+  branch: the branch can advance between diff generation and delivery, and
+  `git apply` will often succeed anyway wherever the context lines still
+  match — producing a pass or fail for a tree the change never proposed.
+- `baseSha` is **omitted**, not null, when Stratum had no base to name. Treat
+  its absence as "I cannot reproduce this" and reject the request rather than
+  falling back to your branch tip.
+- `baseSha` is inside the signed body, so it cannot be swapped in transit —
+  **but only when `secret` is configured**, because that is what produces the
+  `X-Stratum-Signature` header at all. Without a secret nothing about the
+  payload is authenticated, and an unsigned receiver must be reached over
+  `https://` so the transport protects what the HMAC otherwise would.
+- The field is additive: a receiver written against the earlier
+  `{diff, policy}` contract keeps working, and simply keeps the failure mode
+  described above.
 - If `secret` is set, the header `X-Stratum-Signature: sha256=<hex>` carries
   an HMAC-SHA256 of the exact request body, keyed with the secret. Verify it
   before trusting the payload.
@@ -99,16 +116,15 @@ merge:
   rejected and the evaluation fails closed (score 0). Redirects are **not
   followed**; a 3xx counts as failure.
 
-Two properties of the current contract are worth knowing before you point a
+One property of the current contract is worth knowing before you point a
 receiver at it. This section describes what ships today.
 
-- **`http://` URLs are accepted**, and the HMAC authenticates the body without
-  encrypting it. Over plain HTTP the diff and the policy travel in cleartext.
-  Use an `https://` URL, and terminate TLS in front of your receiver.
-- **The payload does not name the base commit** the diff was generated
-  against. A receiver that checks out its own `main` may evaluate against a
-  newer tree than Stratum diffed, and `git apply` may succeed against the wrong
-  base. Keep the mirror pinned rather than tracking a moving branch ([#274](https://github.com/stratum-eng/stratum/issues/274)).
+- **`http://` URLs are accepted**, and even a configured HMAC authenticates the
+  body without encrypting it. Over plain HTTP the diff, the policy, and
+  `baseSha` travel in cleartext, and an unsigned request over plain HTTP is
+  neither authenticated nor confidential — anyone on the path can substitute the
+  base the suite runs against. Use an `https://` URL and terminate TLS in front
+  of your receiver; treat that as required, not advisory, when no secret is set.
 
 ### Response (your endpoint → Stratum)
 
@@ -169,8 +185,15 @@ function signatureValid(rawBody, header) {
 if (!signatureValid(rawBody, headers["x-stratum-signature"])) {
   respond(401, { error: "bad signature" });
 } else {
-  const { diff, policy } = JSON.parse(rawBody);
-  const verdict = await yourCi(diff, policy); // whatever "run the checks" means for you
+  const { diff, policy, baseSha } = JSON.parse(rawBody);
+  if (!baseSha) {
+    // Nothing to reproduce against — a verdict here would describe a tree the
+    // change never proposed. Fail loudly rather than guessing at a base.
+    respond(400, { error: "payload carries no baseSha" });
+    return;
+  }
+  // `yourCi` must check out baseSha and apply the diff to THAT commit.
+  const verdict = await yourCi(diff, policy, baseSha);
   respond(200, {
     score: verdict.score,     // 0..1, as in the contract above
     passed: verdict.passed,   // boolean — this is what gates the merge

--- a/src/backup/repo-restore.ts
+++ b/src/backup/repo-restore.ts
@@ -1,5 +1,12 @@
 import git from "isomorphic-git";
-import { type NodeFS, artifactsRepoNameFromRemote, pushMain, pushTags } from "../storage/git-ops";
+import {
+  type NodeFS,
+  artifactsRepoNameFromRemote,
+  pushBranches,
+  pushMain,
+  pushTags,
+} from "../storage/git-ops";
+import { isValidBranchName } from "../storage/git-ops";
 import { MemoryFS } from "../storage/memory-fs";
 import { placeLooseObject, unpackObjects } from "../storage/object-loader";
 import type { Env } from "../types";
@@ -7,22 +14,18 @@ import { projectDefaultBranch } from "../types";
 import { AppError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
 import { type Result, err, fromPromise, ok } from "../utils/result";
+import { isValidRefName } from "../utils/validation";
 import type { RepoManifest, RepoSnapshot } from "./repo-snapshot";
 
 const DIR = "/";
-/**
- * Upper bound on a manifest tag name. Not a git rule — git bounds ref names by
- * the filesystem, not a fixed count — but a restore writes the name into a ref
- * path, so a hostile manifest gets a cap rather than an unbounded path.
- */
-const MAX_TAG_NAME_LENGTH = 255;
 const GITDIR = "/.git";
 
 /**
  * Reconstructs a repository in an in-memory Git store from a snapshot.
  *
- * Restores the default branch and any tagged references, and verifies that
- * their referenced objects are present in the snapshot.
+ * Restores the default branch, any tagged references, and any other branch
+ * refs the manifest carries, verifying that their referenced objects are
+ * present in the snapshot.
  *
  * The verification matters because the backup captured the FULL reachable
  * object set: the reconstructed pack is closed under reachability, so the
@@ -35,14 +38,19 @@ const GITDIR = "/.git";
  * @param pack - Serialized Git objects from the snapshot
  * @param manifest - Snapshot metadata containing the tip and optional tags
  * @param branch - The branch to point at the tip; defaults to `main`, but imported repos keep their source branch name (master/trunk/…), and restoring one under the wrong name would leave the repo with no branch at its own default
- * @returns The in-memory filesystem and repository directory, or a backup error
+ * @returns The in-memory filesystem, the repository directory, and the names of
+ * the extra branch refs actually written — which is NOT simply
+ * `manifest.branches`, since hostile, default-branch, and dangling entries are
+ * skipped here. The caller pushes that list rather than the manifest's, so the
+ * skip decisions live in one place and a push can never name a ref this repo
+ * does not hold.
  */
 export async function reconstructRepo(
   pack: Uint8Array,
   manifest: RepoManifest,
   logger: Logger,
   branch = "main",
-): Promise<Result<{ fs: NodeFS; dir: string }, AppError>> {
+): Promise<Result<{ fs: NodeFS; dir: string; branches: string[] }, AppError>> {
   try {
     const fs = new MemoryFS().toNodeFS();
     await git.init({ fs, dir: DIR, defaultBranch: branch });
@@ -81,7 +89,7 @@ export async function reconstructRepo(
       // and the manifest is read back from storage — so validate here rather
       // than trust the snapshot writer. A name containing `..` would resolve
       // outside refs/tags/ and could overwrite refs/heads/main.
-      if (!isValidTagName(tag.name)) {
+      if (!isValidRefName(tag.name)) {
         return err(new AppError(`Invalid tag name in manifest: ${tag.name}`, "BACKUP_ERROR", 500));
       }
       await git.writeRef({
@@ -96,68 +104,115 @@ export async function reconstructRepo(
       await git.readObject({ fs, dir: DIR, oid: tag.oid });
     }
 
+    // Branch refs (#181). `branches` is OPTIONAL, and here absence and `[]` are
+    // handled identically on purpose: a legacy manifest, a snapshot whose ref
+    // advertisement failed, and a repo with genuinely no branches all restore
+    // to "tip only", which is exactly what each of them should do. The manifest
+    // keeps the three distinguishable (see `RepoManifest.branches`) for a reader
+    // reporting on backup completeness; restore does not need the distinction.
+    //
+    // The tip ref written above is `refs/heads/${branch}`; `restoreProjectRepo`
+    // passes the project's default branch for it, but a direct caller need not,
+    // so both names are held back below rather than assuming the two agree.
+    const tipBranches = new Set([branch, projectDefaultBranch(manifest.project)]);
+    const branches: string[] = [];
+    for (const branchRef of manifest.branches ?? []) {
+      // Same untrusted-input reasoning as the tag loop: the manifest is read
+      // back from storage and the name becomes a ref path written with
+      // force:true. Here it matters more, not less — `refs/heads/` is the very
+      // namespace a `../heads/main` traversal aims at.
+      //
+      // Unlike the tag loop this SKIPS rather than failing the restore, per the
+      // spec's edge-case 16. The two other guards below already degrade that
+      // way, and one unusable branch ref is not worth withholding the tip and
+      // every tag from an operator: branch refs are the one part of a repo that
+      // can be recreated by hand afterwards.
+      // `isValidBranchName`, not `isValidRefName`: the restore path is the
+      // designated UNTRUSTED input, so it must not be one guard weaker than the
+      // request path. `HEAD` is the difference — legal for a tag, and refused
+      // as a branch because it collides with the symbolic ref every client
+      // resolves to find the default branch.
+      if (!isValidBranchName(branchRef.name)) {
+        logger.warn("Restore: skipping branch with an invalid name in manifest", {
+          name: branchRef.name,
+        });
+        continue;
+      }
+      // The verified tip is already written at this exact ref, and a manifest
+      // oid can be stale — overwriting it would restore a different history
+      // than the one the tip check above just proved. No such guard exists on
+      // the tag path because tags land in refs/tags/, a namespace the tip does
+      // not occupy.
+      if (tipBranches.has(branchRef.name)) {
+        // Equal oids are the ordinary case and warrant no noise. A DISAGREEING
+        // oid is the one an operator needs: it means the branch moved between
+        // the ref advertisement and the object walk, so the tip this restore
+        // verified is not the commit the manifest recorded for that name.
+        if (branchRef.oid !== manifest.tipSha) {
+          logger.warn("Restore: manifest entry for the tip branch is stale; keeping verified tip", {
+            name: branchRef.name,
+            manifestOid: branchRef.oid,
+            tipSha: manifest.tipSha,
+          });
+        }
+        continue;
+      }
+      // Dangling-tip guard, checked BEFORE the write rather than after it as
+      // the tag loop does: skipping means leaving no ref behind at all.
+      const tip = await fromPromise(git.readObject({ fs, dir: DIR, oid: branchRef.oid }));
+      if (!tip.success) {
+        logger.warn("Restore: skipping branch whose tip is absent from the restored objects", {
+          name: branchRef.name,
+          oid: branchRef.oid,
+        });
+        continue;
+      }
+      // A branch must point at a COMMIT. The create path enforces this, so a
+      // manifest saying otherwise is corrupt or hostile — and writing it would
+      // fail the push with an ObjectTypeError AFTER the tip and every tag had
+      // already landed, leaving a forced restore in partial state.
+      if (tip.data.type !== "commit") {
+        logger.warn("Restore: skipping branch whose tip is not a commit", {
+          name: branchRef.name,
+          oid: branchRef.oid,
+          type: tip.data.type,
+        });
+        continue;
+      }
+      // Refs are files in a directory tree, so `main` and `main/x` cannot both
+      // exist and `writeRef` throws ENOTDIR on the second. Caught per branch:
+      // an unguarded throw here escapes to the outer catch and withholds the
+      // tip and every tag over one unusable ref — exactly what the skip-don't-
+      // fail choice above exists to avoid.
+      const written = await fromPromise(
+        git.writeRef({
+          fs,
+          dir: DIR,
+          ref: `refs/heads/${branchRef.name}`,
+          value: branchRef.oid,
+          force: true,
+        }),
+      );
+      if (!written.success) {
+        logger.warn("Restore: skipping branch whose ref path collides with one already written", {
+          name: branchRef.name,
+          error: written.error instanceof Error ? written.error.message : String(written.error),
+        });
+        continue;
+      }
+      branches.push(branchRef.name);
+    }
+
     logger.debug("Reconstructed repo", {
       tipSha: manifest.tipSha,
       tagCount: manifest.tags?.length ?? 0,
+      branchCount: branches.length,
     });
-    return ok({ fs, dir: DIR });
+    return ok({ fs, dir: DIR, branches });
   } catch (error) {
     logger.error("Failed to reconstruct repo", error instanceof Error ? error : undefined);
     return err(new AppError("Failed to reconstruct repo", "BACKUP_ERROR", 500));
   }
-}
-
-/**
- * Whether a manifest tag name is safe to write as `refs/tags/<name>`.
- *
- * Restore consumes stored manifest data, so the ref path is validated here
- * rather than trusted from the snapshot writer: an unchecked `../` escapes
- * `refs/tags/` and, with `force: true`, can overwrite `refs/heads/main`.
- *
- * These are git's own `check-ref-format` rules, expressed as a denylist. An
- * allowlist was tried first and was wrong in a way that matters for a restore
- * path: it rejected `release@prod`, every non-ASCII name, and `%`, `,`, `!`,
- * `(`, `'`, `=`, `&`, `;`, `{` — all of which git accepts. A backup holding
- * such a tag could be written but never restored, which is worse than the
- * traversal the allowlist was defending against.
- *
- * The oracle here is isomorphic-git's `writeRef`, not the `git` CLI, because
- * that is what performs the write. It is the stricter of the two: it treats a
- * ref as valid only if `clean-git-ref` leaves it unchanged, so it refuses
- * `v1./next` (`./` collapses to `/`) even though `git check-ref-format`
- * accepts it. Validating against the CLI's looser rules would let such a name
- * past this guard and throw from `writeRef` half-way through the tag loop,
- * leaving a partially restored repository — so `./` is rejected here.
- *
- * Differentially fuzzed against `writeRef` over ~1300 generated names with a
- * fresh MemoryFS per name: no name is accepted here that `writeRef` refuses.
- *
- * @param name - The candidate tag name, straight from the manifest.
- * @returns `true` if `refs/tags/<name>` is a ref name git would accept.
- */
-function isValidTagName(name: unknown): name is string {
-  if (typeof name !== "string" || name.length === 0) return false;
-  // Not a git rule: a Stratum bound so a hostile manifest can't push an
-  // arbitrarily long path at the ref store.
-  if (name.length > MAX_TAG_NAME_LENGTH) return false;
-
-  // Control characters (including DEL) and space, compared by code point. A
-  // regex range spanning them is what lint rules about control characters in
-  // patterns object to, and the comparison states the bound outright.
-  for (let i = 0; i < name.length; i++) {
-    const code = name.charCodeAt(i);
-    if (code <= 0x20 || code === 0x7f) return false;
-  }
-  // The characters git reserves for its revision syntax.
-  if (/[~^:?*[\\]/.test(name)) return false;
-
-  if (name.includes("..") || name.includes("@{")) return false;
-  if (name.startsWith("/") || name.endsWith("/")) return false;
-  // `./` and a trailing `.` are both rewritten by clean-git-ref, so writeRef
-  // rejects them.
-  if (name.includes("./") || name.endsWith(".")) return false;
-
-  return name.split("/").every((c) => c.length > 0 && !c.startsWith(".") && !c.endsWith(".lock"));
 }
 
 /**
@@ -297,10 +352,44 @@ export async function restoreProjectRepo(
     }
   }
 
+  // Branch refs (#181): pushed last, after main and the tags, so every object
+  // a branch tip needs is already on the remote. The names come from the
+  // reconstruction, not from the manifest, so a skipped branch is never pushed.
+  const branchNames = rebuilt.data.branches;
+  // `pushBranches`, not `pushBranchToRemote`: the latter is the GitHub helper
+  // and authenticates as `x-access-token` with the token verbatim. An Artifacts
+  // token is `<secret>?expires=<ts>` and the suffix must be stripped, so the
+  // GitHub helper would have failed EVERY restore that carried a branch — after
+  // main and the tags had already landed.
+  const branchesPushed = await pushBranches(
+    remote,
+    token,
+    rebuilt.data.fs,
+    rebuilt.data.dir,
+    branchNames,
+    logger,
+    { force: repoExists },
+  );
+  if (!branchesPushed.success) {
+    if (repoExists) {
+      logger.error("Forced restore left partial state on an existing repo", undefined, {
+        name,
+        tipSha: snapshot.manifest.tipSha,
+        mainPushed: true,
+        tagCount: tagNames.length,
+        branchCount: branchNames.length,
+        detail: branchesPushed.error.message,
+      });
+    }
+    await rollbackIfCreated();
+    return err(branchesPushed.error);
+  }
+
   logger.info("Restored project repo", {
     name,
     tipSha: snapshot.manifest.tipSha,
     tagCount: tagNames.length,
+    branchCount: branchNames.length,
   });
   return ok({ tipSha: snapshot.manifest.tipSha });
 }

--- a/src/backup/repo-snapshot.ts
+++ b/src/backup/repo-snapshot.ts
@@ -1,5 +1,11 @@
 import git from "isomorphic-git";
-import { type NodeFS, cloneRepo, extractTreeObjects, freshRepoToken } from "../storage/git-ops";
+import {
+  type NodeFS,
+  cloneRepo,
+  extractTreeObjects,
+  freshRepoToken,
+  listRepoBranches,
+} from "../storage/git-ops";
 import { packObjects } from "../storage/object-loader";
 import type { Env, ProjectEntry } from "../types";
 import { projectDefaultBranch } from "../types";
@@ -24,6 +30,13 @@ export interface TagRefRecord {
   oid: string;
 }
 
+/** A branch ref captured in a snapshot: refs/heads/<name> → the commit oid the
+ * remote advertised for it. */
+export interface BranchRefRecord {
+  name: string;
+  oid: string;
+}
+
 export interface RepoManifest {
   projectId: string;
   /** Full identity so restore can recreate the correctly-named Artifacts repo
@@ -37,6 +50,23 @@ export interface RepoManifest {
    * compatibility: manifests written before tag support omit it, and restore
    * must treat a missing field as "no tags". */
   tags?: TagRefRecord[];
+  /** Branch refs captured with the pack (#181). OPTIONAL, but — unlike `tags`
+   * — absence and `[]` mean DIFFERENT things here, because the snapshot omits
+   * the field when the ref advertisement fails:
+   *   - absent  -> branch refs were not captured (a legacy manifest, or a
+   *                failed advertisement). Nothing is known about them.
+   *   - `[]`    -> the remote answered, and there are genuinely no branches.
+   * Restore skips branch publication in both cases, so the distinction costs it
+   * nothing; a reader that reports on backup completeness must not treat the
+   * first as a confirmed empty set. */
+  branches?: BranchRefRecord[];
+  /** Total branches the remote advertised when the snapshot was taken, present
+   * only when that exceeded the listing cap and `branches` is therefore a
+   * SUBSET. Recorded in the manifest rather than left to a log line: a restore
+   * that silently recreates 200 of 250 branches is the lossy-and-quiet failure
+   * #251 exists to prevent, and an operator reading the manifest is the one who
+   * needs to know. */
+  branchesTruncatedTotal?: number;
 }
 
 export interface RepoSnapshot {
@@ -356,12 +386,18 @@ export async function walkRepoObjects(
  * @param project - The project associated with the snapshot
  * @param walk - The collected repository objects, tip commit, and tag references
  * @param capturedAt - The snapshot capture timestamp
+ * @param branches - Branch refs read from the ref advertisement (#181). They do
+ * not come from the walk because listing them needs no object access at all;
+ * omitting the argument writes no `branches` key, which is precisely the shape
+ * of a pre-branch-support manifest.
  * @returns A packed repository snapshot with its manifest
  */
 export function buildSnapshot(
   project: ProjectEntry,
   walk: WalkResult,
   capturedAt: string,
+  branches?: BranchRefRecord[],
+  opts?: { branchesTruncatedTotal?: number },
 ): RepoSnapshot {
   const byteCount = walk.objects.reduce((n, o) => n + o.bytes.byteLength, 0);
   return {
@@ -374,6 +410,10 @@ export function buildSnapshot(
       byteCount,
       capturedAt,
       tags: walk.tags,
+      ...(branches ? { branches } : {}),
+      ...(opts?.branchesTruncatedTotal !== undefined
+        ? { branchesTruncatedTotal: opts.branchesTruncatedTotal }
+        : {}),
     },
   };
 }
@@ -434,5 +474,53 @@ export async function snapshotRepo(
   if ("empty" in walk.data) return ok({ status: "skipped", reason: "empty" });
   if ("tooLarge" in walk.data) return ok({ status: "skipped", reason: "too large" });
 
-  return ok({ status: "ok", snapshot: buildSnapshot(project, walk.data, capturedAt) });
+  // Branch refs (#181) come from ONE ref advertisement — 2 subrequests, no
+  // extra clone, no object reads, no change to the byte budget.
+  //
+  // Recording the refs is enough; the walk is deliberately untouched. A branch
+  // ref can only be pointed at an object the repo already holds: `createBranchRef`
+  // resolves its start point to the default tip, another branch's tip, a tag's
+  // tip, or a commit in the default branch's history — every one of which
+  // `walkRepoObjects` already packs. A tip that is nonetheless absent from the
+  // pack is skipped at restore rather than written dangling, so the pack stays
+  // closed under reachability either way.
+  //
+  // Listed AFTER the walk so an empty or over-cap repo — which is skipped
+  // anyway — never spends the subrequests.
+  const listed = await listRepoBranches(
+    project.remote,
+    token.data,
+    logger,
+    projectDefaultBranch(project),
+  );
+  if (!listed.success) {
+    // Best-effort, like the tag-listing failure above: the pack is the valuable
+    // part of a backup, so a failed advertisement records no branches instead of
+    // losing the snapshot of the whole repository.
+    logger.warn("Failed to list branches for snapshot; backing up without branch refs", {
+      projectId: project.id,
+      error: listed.error.message,
+    });
+  }
+  // `undefined`, not `[]`, when the advertisement failed. An empty array is a
+  // positive claim — "this repository has no branches" — which is exactly what
+  // a failed listing cannot support, and it would be indistinguishable from a
+  // genuine zero-branch repo to anyone reading the stored manifest.
+  const branches = listed.success ? listed.data.branches : undefined;
+  if (listed.success && listed.data.truncated) {
+    logger.warn("Snapshot records only part of this repo's branches (listing cap reached)", {
+      projectId: project.id,
+      recordedBranchCount: listed.data.branches.length,
+      totalBranchCount: listed.data.totalBranchCount,
+    });
+  }
+
+  return ok({
+    status: "ok",
+    snapshot: buildSnapshot(project, walk.data, capturedAt, branches, {
+      ...(listed.success && listed.data.truncated
+        ? { branchesTruncatedTotal: listed.data.totalBranchCount }
+        : {}),
+    }),
+  });
 }

--- a/src/evaluation/composite-evaluator.ts
+++ b/src/evaluation/composite-evaluator.ts
@@ -2,7 +2,7 @@ import type { AppError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
 import type { Result } from "../utils/result";
 import { err, ok } from "../utils/result";
-import type { EvalPolicy, EvalResult, Evaluator } from "./types";
+import type { EvalPolicy, EvalResult, EvaluationContext, Evaluator } from "./types";
 
 export class CompositeEvaluator {
   constructor(private evaluators: Evaluator[]) {}
@@ -11,13 +11,14 @@ export class CompositeEvaluator {
     diff: string,
     policy: EvalPolicy,
     logger: Logger,
+    context?: EvaluationContext,
   ): Promise<Result<EvalResult[], AppError>> {
     logger.debug("Starting composite evaluation", { evaluatorCount: this.evaluators.length });
 
     try {
       const results: EvalResult[] = [];
       for (const evaluator of this.evaluators) {
-        const result = await evaluator.evaluate(diff, policy, logger);
+        const result = await evaluator.evaluate(diff, policy, logger, context);
         if (result.success) {
           results.push(result.data);
         } else {
@@ -39,10 +40,11 @@ export class CompositeEvaluator {
     diff: string,
     policy: EvalPolicy,
     logger: Logger,
+    context?: EvaluationContext,
   ): Promise<Result<EvalResult, AppError>> {
     logger.debug("Starting aggregated evaluation");
 
-    const results = await this.evaluate(diff, policy, logger);
+    const results = await this.evaluate(diff, policy, logger, context);
     if (!results.success) {
       return results;
     }

--- a/src/evaluation/types.ts
+++ b/src/evaluation/types.ts
@@ -11,8 +11,32 @@ export interface EvalResult {
   costs?: Array<{ kind: "llm_tokens" | "sandbox_ms"; quantity: number; estimated?: boolean }>;
 }
 
+/**
+ * What the diff is a diff *of*. A diff alone does not identify the tree it
+ * applies to, so an evaluator that reproduces the change out-of-process (the
+ * webhook evaluator) cannot tell which base it should apply the hunks to
+ * (#274).
+ */
+export interface EvaluationContext {
+  /**
+   * The base commit the diff was computed against, resolved from the same
+   * clone that produced it.
+   *
+   * Absent only where the caller genuinely has no base to name. It is never a
+   * best-guess re-resolution of the project head: `main` can advance between
+   * diff generation and delivery, and a receiver that checked out the newer
+   * commit would report a verdict for a combination the change never proposed.
+   */
+  baseSha?: string;
+}
+
 export interface Evaluator {
-  evaluate(diff: string, policy: EvalPolicy, logger: Logger): Promise<Result<EvalResult, AppError>>;
+  evaluate(
+    diff: string,
+    policy: EvalPolicy,
+    logger: Logger,
+    context?: EvaluationContext,
+  ): Promise<Result<EvalResult, AppError>>;
 }
 
 export interface EvalPolicy {

--- a/src/evaluation/webhook-evaluator.ts
+++ b/src/evaluation/webhook-evaluator.ts
@@ -5,7 +5,7 @@ import type { Result } from "../utils/result";
 import { err, ok } from "../utils/result";
 import { validateWebhookUrl } from "../utils/validation";
 import { sanitizePolicy } from "./sanitize-policy";
-import type { EvalPolicy, EvalResult, Evaluator } from "./types";
+import type { EvalPolicy, EvalResult, EvaluationContext, Evaluator } from "./types";
 
 async function computeHmacSha256(secret: string, body: string): Promise<string> {
   const encoder = new TextEncoder();
@@ -27,6 +27,7 @@ export class WebhookEvaluator implements Evaluator {
     diff: string,
     policy: EvalPolicy,
     logger: Logger,
+    context?: EvaluationContext,
   ): Promise<Result<EvalResult, AppError>> {
     logger.debug("Starting webhook evaluation");
 
@@ -52,7 +53,19 @@ export class WebhookEvaluator implements Evaluator {
     const timeoutMs = config.timeoutMs ?? 10000;
     // The payload leaves the Worker, so strip credentials (webhook secrets)
     // from the policy first — the secret signs the request, it is not content.
-    const body = JSON.stringify({ diff, policy: sanitizePolicy(policy) });
+    //
+    // `baseSha` names the commit the diff was computed against (#274). Without
+    // it a receiver can only apply the hunks to whatever the default branch
+    // happens to be when the request lands: if the branch advanced in between,
+    // `git apply` still succeeds wherever the context lines survive, and the
+    // suite runs against a tree no change ever proposed. The key is omitted
+    // rather than guessed when the caller has no base to name, so its absence
+    // is a signal a receiver can act on instead of a plausible wrong answer.
+    const body = JSON.stringify({
+      diff,
+      policy: sanitizePolicy(policy),
+      ...(context?.baseSha !== undefined ? { baseSha: context.baseSha } : {}),
+    });
     const headers: Record<string, string> = { "Content-Type": "application/json" };
 
     if (config.secret) {

--- a/src/queue/webhook-delivery.ts
+++ b/src/queue/webhook-delivery.ts
@@ -116,11 +116,24 @@ export async function deliverEventToWebhooks(
   event: EventRecord,
   logger: Logger,
 ): Promise<void> {
-  // Scope delivery by the canonical project_id when the event carries one, so a
-  // same-named project in another namespace never receives these events.
-  const webhooksResult = await listWebhooks(env.DB, logger, event.project, {
+  // Delivery is scoped by the canonical project_id only (#235). An outbox row
+  // that carries no project_id cannot be scoped to a tenant: resolving its
+  // free-form `project` name would deliver to whichever same-named project
+  // happened to match, across namespaces. Drop it loudly instead — every
+  // current emitter threads the id through `emitEvent`, so a row without one is
+  // legacy, and a missed delivery is recoverable where a cross-tenant one is
+  // not.
+  if (event.projectId === undefined) {
+    logger.warn("Skipping webhook delivery for an event with no project_id", {
+      eventId: event.id,
+      eventType: event.type,
+      project: event.project,
+    });
+    return;
+  }
+
+  const webhooksResult = await listWebhooks(env.DB, logger, event.projectId, {
     activeOnly: true,
-    ...(event.projectId !== undefined ? { projectId: event.projectId } : {}),
   });
   if (!webhooksResult.success) return;
 

--- a/src/routes/backfill.ts
+++ b/src/routes/backfill.ts
@@ -63,10 +63,13 @@ app.get("/plan", async (c) => {
 // `remainingNullRows` is reported because it is the step-2 verification for
 // issue #235 — it should read 0 after a clean run.
 //
-// This is step 1-2 of a 3-step coordinated fix (issue #235); the name-based
-// fallback in webhookBelongsToProject/listWebhooks intentionally stays in
-// place until this has actually run in production and the remaining NULL
-// count is verified at zero.
+// This is step 1-2 of the 3-step coordinated fix for issue #235. Step 3 has
+// since landed: `webhookBelongsToProject` and `listWebhooks` scope on
+// project_id alone, so a row this run leaves NULL (ambiguous or unresolved) is
+// no longer reachable by name — it is invisible to management and receives no
+// deliveries. `remainingNullRows` is therefore the count of webhooks that were
+// orphaned, and resolving them means giving the colliding projects distinct
+// names and re-running, or deleting the rows.
 app.post("/webhooks/apply", async (c) => {
   const auth = await requireAdmin(c);
   if (!auth.ok) return forbidden("Administrator access required");

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -1367,6 +1367,7 @@ app.post("/changes/:id/evaluate", async (c) => {
     workspaceOid: evaluatedSha,
     workspaceTreeOid: evaluatedTreeOid,
     workspaceSha: workspaceHeadSha,
+    baseOid,
   } = diffResult.data;
 
   const evaluators = buildEvaluators(c.env, policy, change.project, logger, {
@@ -1374,7 +1375,12 @@ app.post("/changes/:id/evaluate", async (c) => {
     token: workspaceReadToken.data,
     ref: evaluatedSha,
   });
-  const { evalRuns, evalResult } = await runEvaluation(evaluators, diff, policy, logger);
+  // The base this re-evaluation's diff was built against — not `change.baseSha`,
+  // which records the base at creation and is exactly the value that has gone
+  // stale by the time a change is re-evaluated (#274).
+  const { evalRuns, evalResult } = await runEvaluation(evaluators, diff, policy, logger, {
+    baseSha: baseOid,
+  });
 
   const recordResult = await recordEvalRuns(c.env.DB, logger, id, evalRuns);
   if (!recordResult.success) {
@@ -1405,6 +1411,12 @@ app.post("/changes/:id/evaluate", async (c) => {
     evalReason: evalResult.reason,
     evaluatedSha,
     evaluatedTreeOid,
+    // Re-pin the base as well as the tip. `change.baseSha` is what the merge
+    // gate compares against the project head under `merge.requireFreshBase`;
+    // left at its creation-time value, a change whose base advanced could never
+    // be un-staled, and re-evaluating it — the documented remedy — would report
+    // a fresh pass while the merge kept returning STALE_BASE.
+    baseSha: baseOid,
     // Re-pin to the commit this re-evaluation actually ran against (#115).
     ...(workspaceHeadSha ? { workspaceHeadSha } : {}),
     // Recompute the protected-config flag from the diff this run actually saw
@@ -1423,6 +1435,15 @@ app.post("/changes/:id/evaluate", async (c) => {
   // the same sha (including legacy changes with no recorded sha) keeps
   // approvals.
   //
+  // A changed BASE dismisses for the same reason, and this PR is what makes
+  // that reachable. `baseSha` used to be frozen at creation, so a change whose
+  // base advanced stayed permanently STALE_BASE and could not merge on an old
+  // approval at all. Now that re-evaluation re-pins it (above), an unchanged
+  // workspace tip against a moved base would clear the merge gate while
+  // carrying approvals given for `diff(oldBase..tip)` — a different diff than
+  // the one that would merge. Reviewers approve a diff, not a tip, so either
+  // endpoint moving invalidates the verdict.
+  //
   // The dismissal and the evaluatedSha/status re-pin run as ONE D1 batch
   // (#238): dismissApprovals (DELETE on change_reviews) and updateChangeStatus
   // (UPDATE on changes) used to be two separate writes, so a transient D1
@@ -1431,7 +1452,11 @@ app.post("/changes/:id/evaluate", async (c) => {
   // still-pinned sha found none left to lose. Batching them makes the two
   // writes all-or-nothing, and the review.approvals_dismissed audit entry is
   // only recorded once the batch itself has actually succeeded.
-  if (change.evaluatedSha !== undefined && change.evaluatedSha !== evaluatedSha) {
+  // Absent on legacy rows; absence keeps approvals rather than dismissing on
+  // every re-evaluation of a change that predates the field.
+  const tipChanged = change.evaluatedSha !== undefined && change.evaluatedSha !== evaluatedSha;
+  const baseChanged = change.baseSha !== undefined && change.baseSha !== baseOid;
+  if (tipChanged || baseChanged) {
     const batchResult = await dismissApprovalsAndUpdateStatus(
       c.env.DB,
       logger,
@@ -1459,6 +1484,11 @@ app.post("/changes/:id/evaluate", async (c) => {
           dismissedReviewerIds,
           previousEvaluatedSha: change.evaluatedSha,
           evaluatedSha,
+          // Which endpoint moved — an audit reader otherwise cannot tell a
+          // re-push from a base advance, and the two have different causes.
+          previousBaseSha: change.baseSha,
+          baseSha: baseOid,
+          dismissedFor: tipChanged && baseChanged ? "tip+base" : tipChanged ? "tip" : "base",
         },
       });
       if (!auditResult.success) {

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -4,16 +4,21 @@ import { importRateLimitMiddleware, releaseImportLock } from "../middleware/rate
 import { emitEvent } from "../queue/events";
 import { syncOrImportProject } from "../services/project-sync";
 import { recordAudit } from "../storage/audit";
-import { captureDeletionTarget } from "../storage/deletion";
+import { captureDeletionTarget, isTargetDeleting } from "../storage/deletion";
 import { createDeletionJob } from "../storage/deletion-jobs";
 import { listProjectEvents } from "../storage/events";
 import {
+  createBranchRef,
+  deleteBranchRef,
   freshRepoToken,
   getCommitLog,
   importFromGitHub,
   initAndPush,
+  isValidBranchName,
   listFilesInRepo,
+  listRepoBranches,
   listRepoTags,
+  resolveBranchRef,
 } from "../storage/git-ops";
 import { buildAuthConfig, resolveDefaultBranch } from "../storage/git-providers";
 import { finalizeImportSnapshot } from "../storage/import-finalize";
@@ -43,7 +48,12 @@ import {
 import type { ArtifactsCreateResult, Env, ProjectEntry } from "../types";
 import { getArtifactsRepoName, projectDefaultBranch } from "../types";
 import { getFileContent, isValidFilePath } from "../ui/file-content";
-import { canReadProject, filterReadableProjects, isDirectOwner } from "../utils/authz";
+import {
+  canReadProject,
+  canWriteProject,
+  filterReadableProjects,
+  isDirectOwner,
+} from "../utils/authz";
 import { createLogger } from "../utils/logger";
 import type { Logger } from "../utils/logger";
 import { readJsonWithLimit } from "../utils/request-body";
@@ -931,22 +941,27 @@ app.get("/:namespace/:slug/files", async (c) => {
 
   const readToken = await freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger);
   if (!readToken.success) return internalError(readToken.error.message);
-  const filesResult = await listFilesInRepo(
-    project.remote,
-    readToken.data,
-    logger,
-    projectDefaultBranch(project),
-  );
+
+  const ref = await resolveRequestedRef(c, project, readToken.data, logger);
+  if ("response" in ref) return ref.response;
+
+  const filesResult = await listFilesInRepo(project.remote, readToken.data, logger, ref.branch);
   if (!filesResult.success) {
     logger.error("Failed to list files in repo", filesResult.error);
     return internalError(filesResult.error.message);
   }
 
-  logger.info("Project files listed", { namespace, slug, fileCount: filesResult.data.length });
+  logger.info("Project files listed", {
+    namespace,
+    slug,
+    ref: ref.branch,
+    fileCount: filesResult.data.length,
+  });
   return ok({
     namespace,
     slug,
     path: `/${namespace}/${slug}`,
+    ref: ref.branch,
     files: filesResult.data,
   });
 });
@@ -982,29 +997,46 @@ app.get("/:namespace/:slug/content", async (c) => {
 
   const readToken = await freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger);
   if (!readToken.success) return internalError(readToken.error.message);
+
+  const ref = await resolveRequestedRef(c, project, readToken.data, logger);
+  if ("response" in ref) return ref.response;
+
   const contentResult = await getFileContent(
     project.remote,
     readToken.data,
     filePath,
     logger,
-    projectDefaultBranch(project),
+    ref.branch,
   );
   if (!contentResult.success) {
     return internalError(contentResult.error.message);
   }
 
   const result = contentResult.data;
-  logger.info("File content retrieved", { namespace, slug, path: filePath, kind: result.kind });
+  logger.info("File content retrieved", {
+    namespace,
+    slug,
+    path: filePath,
+    ref: ref.branch,
+    kind: result.kind,
+  });
 
   if (result.kind === "not-found") {
     return notFound("File", filePath);
   }
 
   if (result.kind === "content") {
-    return ok({ namespace, slug, path: filePath, kind: "content", value: result.value });
+    return ok({
+      namespace,
+      slug,
+      path: filePath,
+      ref: ref.branch,
+      kind: "content",
+      value: result.value,
+    });
   }
 
-  return ok({ namespace, slug, path: filePath, kind: result.kind });
+  return ok({ namespace, slug, path: filePath, ref: ref.branch, kind: result.kind });
 });
 
 // GET /projects/:namespace/:slug/log - Get commit log
@@ -1036,13 +1068,11 @@ app.get("/:namespace/:slug/log", async (c) => {
   const depth = Number(c.req.query("depth") ?? 20);
   const readToken = await freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger);
   if (!readToken.success) return internalError(readToken.error.message);
-  const logResult = await getCommitLog(
-    project.remote,
-    readToken.data,
-    logger,
-    depth,
-    projectDefaultBranch(project),
-  );
+
+  const ref = await resolveRequestedRef(c, project, readToken.data, logger);
+  if ("response" in ref) return ref.response;
+
+  const logResult = await getCommitLog(project.remote, readToken.data, logger, depth, ref.branch);
   if (!logResult.success) {
     logger.error("Failed to get commit log", logResult.error);
     return internalError(logResult.error.message);
@@ -1052,12 +1082,14 @@ app.get("/:namespace/:slug/log", async (c) => {
     namespace,
     slug,
     depth,
+    ref: ref.branch,
     commitCount: logResult.data.length,
   });
   return ok({
     namespace,
     slug,
     path: `/${namespace}/${slug}`,
+    ref: ref.branch,
     log: logResult.data,
   });
 });
@@ -1108,6 +1140,386 @@ app.get("/:namespace/:slug/tags", async (c) => {
     truncated: tagsResult.data.truncated,
     totalTagCount: tagsResult.data.totalTagCount,
   });
+});
+
+/**
+ * Longest `POST /branches` body accepted. A branch request is two short
+ * strings; anything larger is a client bug or an attempt to make the parser do
+ * work, and every other JSON route in this codebase caps its body the same way.
+ */
+const MAX_BRANCH_BODY_BYTES = 4 * 1024;
+
+/**
+ * Recovers the branch name from a `DELETE .../branches/*` URL.
+ *
+ * Reads the RAW pathname rather than `c.req.path`, because the two decode
+ * differently: Hono gives route params through `decodeURIComponent` but the
+ * path through `decodeURI`, which leaves `%40` alone. A client that builds the
+ * URL with `encodeURIComponent` — as this codebase's own UI does — therefore
+ * sends `%40alice`, and matching a `/@alice/api/branches/` prefix against the
+ * path finds nothing.
+ *
+ * So each segment is decoded here, and the anchor is the decoded
+ * namespace/slug pair rather than a bare "branches" segment: a project whose
+ * slug IS `branches` would otherwise match the slug and lop the name in half,
+ * while taking the first match keeps a branch legitimately named
+ * `refs/branches/x` intact.
+ *
+ * Decoding per segment also means `%2F` becomes a real `/`, so a client may
+ * send a hierarchical name either way and gets the same branch.
+ */
+function branchNameFromPath(url: string, namespace: string, slug: string): string {
+  let segments: string[];
+  try {
+    segments = new URL(url).pathname.split("/").map(decodeURIComponent);
+  } catch {
+    // A malformed percent-escape cannot name any branch; an empty name is
+    // refused by the caller's validity check.
+    return "";
+  }
+  for (let i = 0; i + 2 < segments.length; i++) {
+    if (segments[i] === namespace && segments[i + 1] === slug && segments[i + 2] === "branches") {
+      return segments.slice(i + 3).join("/");
+    }
+  }
+  return "";
+}
+
+/** Loads a project and confirms the caller may WRITE to it.
+ *
+ * Non-writers get 404, not 403 — the same choice the other project-scoped
+ * sub-resource routers make (`webhooks.ts`, `changes.ts`), so a private
+ * project's existence is not disclosed by the status code. `agentOwnerId` is
+ * passed through: agents are first-class contributors here, and a token
+ * belonging to a writer's agent gets that writer's access.
+ */
+async function requireProjectWriter(
+  c: {
+    env: Env;
+    get: (key: "userId" | "agentOwnerId") => string | undefined;
+    req: { param: (key: string) => string };
+  },
+  logger: Logger,
+): Promise<{ project: ProjectEntry } | { response: Response }> {
+  const namespace = c.req.param("namespace");
+  const slug = c.req.param("slug");
+  const projectResult = await getProjectByPath(c.env.STATE, namespace, slug, logger);
+  if (!projectResult.success) {
+    if (projectResult.error.code === "NOT_FOUND") {
+      return { response: notFound("Project", `${namespace}/${slug}`) };
+    }
+    logger.error("Failed to get project", projectResult.error);
+    return { response: internalError(projectResult.error.message) };
+  }
+  const project = projectResult.data;
+
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  if (!(await canWriteProject(c.env.DB, project, userId, agentOwnerId))) {
+    return { response: notFound("Project", `${project.namespace}/${project.slug}`) };
+  }
+  // An import still in flight is pushing refs of its own, so the advertisement
+  // a branch write reads is a moving target: the answer would be either "no
+  // default branch yet" or a branch pinned to a tip the import is about to move
+  // past. `importCompleted` is absent on legacy projects; absence means done.
+  if (project.importCompleted === false) {
+    return {
+      response: c409("Project import is still in progress", "IMPORT_IN_PROGRESS"),
+    };
+  }
+  return { project };
+}
+
+/** Maps a branch write refusal onto this API's status codes.
+ *
+ * There is no 422 in `src/utils/errors.ts`; invalid input is a 400 here, as it
+ * is everywhere else in this codebase.
+ */
+function branchWriteFailureResponse(
+  failure: { kind: string; name?: string; startPoint?: string; existing?: string },
+  namespace: string,
+  slug: string,
+): Response {
+  switch (failure.kind) {
+    case "invalid-name":
+      return badRequest(`Invalid branch name: ${failure.name}`);
+    case "exists":
+      return c409(`Branch already exists: ${failure.name}`, "BRANCH_EXISTS");
+    case "conflicts-with":
+      return c409(
+        `Cannot create branch '${failure.name}': it collides with the existing branch '${failure.existing}'. Git stores refs as files, so one name cannot also be a directory containing the other.`,
+        "BRANCH_NAME_CONFLICT",
+      );
+    case "no-default-branch":
+      return c409(
+        `This repository does not advertise its default branch ('${failure.name}'), so there is nothing to branch from.`,
+        "NO_DEFAULT_BRANCH",
+      );
+    case "not-found":
+      return notFound("Branch", `${namespace}/${slug}#${failure.name}`);
+    case "default-branch":
+      return c409(`Cannot delete the default branch: ${failure.name}`, "DEFAULT_BRANCH_PROTECTED");
+    case "bad-start-point":
+      return badRequest(
+        `Start point not found in this repository: ${failure.startPoint}. Use a branch name or a full 40-character commit sha that the repository already contains. Tag names are not accepted.`,
+      );
+    default:
+      return internalError("Branch operation failed");
+  }
+}
+
+/** Who to credit an audited branch write to. An agent token carries its
+ * owner's id, so the acting user is still recorded — the actor TYPE is what
+ * distinguishes the two, and an audit trail that flattened them would lose the
+ * distinction the provenance model exists to keep. */
+function auditActor(c: {
+  get: (key: "userId" | "agentOwnerId") => string | undefined;
+}): { actorType: "user" | "agent"; actorId?: string } {
+  const agentOwnerId = c.get("agentOwnerId");
+  const actorId = c.get("userId") ?? agentOwnerId;
+  return {
+    actorType: agentOwnerId !== undefined ? "agent" : "user",
+    ...(actorId !== undefined ? { actorId } : {}),
+  };
+}
+
+/** A 409 carrying a machine-readable code, matching how the other routers
+ * report conflicts (`{ error, code }` at 409). */
+function c409(message: string, code: string): Response {
+  return new Response(JSON.stringify({ error: message, code }), {
+    status: 409,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Resolves a read route's `?ref=` query parameter to the branch it should read.
+ *
+ * Absent means the project's default branch, exactly as before this parameter
+ * existed. Present means the ref must actually be a branch on the remote:
+ * there is deliberately no fall back to the default, because serving the
+ * default branch's tree under a URL that names another ref is the precise bug
+ * ref-scoped browsing exists to avoid.
+ *
+ * Costs one ref advertisement (two subrequests) when a ref is given, and
+ * nothing at all when it is not — so the common, unparameterized read is
+ * unchanged.
+ */
+async function resolveRequestedRef(
+  c: { env: Env; req: { query: (key: string) => string | undefined } },
+  project: ProjectEntry,
+  readToken: string,
+  logger: Logger,
+): Promise<{ branch: string } | { response: Response }> {
+  // An empty `ref=` is treated as absent rather than as an invalid name: a GET
+  // form that submits with nothing chosen sends exactly that, and answering a
+  // browser's default submission with a 400 would be a worse contract than
+  // reading it as "no preference".
+  const requested = c.req.query("ref");
+  if (requested === undefined || requested === "") {
+    return { branch: projectDefaultBranch(project) };
+  }
+
+  const resolved = await resolveBranchRef(project.remote, readToken, logger, requested);
+  if (resolved.success) return { branch: resolved.data.name };
+
+  if (!("kind" in resolved.error)) {
+    logger.error("Failed to resolve requested ref", resolved.error);
+    return { response: internalError(resolved.error.message) };
+  }
+  switch (resolved.error.kind) {
+    case "invalid":
+      return { response: badRequest(`Invalid ref: ${resolved.error.name}`) };
+    case "ambiguous":
+      return {
+        response: c409(
+          `Ambiguous ref '${resolved.error.name}': it names both a branch and a tag. Browsing resolves branches only.`,
+          "AMBIGUOUS_REF",
+        ),
+      };
+    default:
+      return {
+        response: notFound("Branch", `${project.namespace}/${project.slug}#${resolved.error.name}`),
+      };
+  }
+}
+
+// GET /projects/:namespace/:slug/branches - List branches (#181).
+// Reads the remote's ref advertisement — two subrequests, no clone — so this
+// endpoint costs the same on a repo with three branches as on one with three
+// thousand. See listRepoBranches for why a clone cannot answer this.
+app.get("/:namespace/:slug/branches", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const { namespace, slug } = c.req.param();
+
+  const projectResult = await getProjectByPath(c.env.STATE, namespace, slug, logger);
+  if (!projectResult.success) {
+    if (projectResult.error.code === "NOT_FOUND") {
+      return notFound("Project", `${namespace}/${slug}`);
+    }
+    logger.error("Failed to get project", projectResult.error);
+    return internalError(projectResult.error.message);
+  }
+  const project = projectResult.data;
+
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId)))
+    return notFound("Project", `${project.namespace}/${project.slug}`);
+
+  const readToken = await freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger);
+  if (!readToken.success) return internalError(readToken.error.message);
+
+  const defaultBranch = projectDefaultBranch(project);
+  const branchesResult = await listRepoBranches(
+    project.remote,
+    readToken.data,
+    logger,
+    defaultBranch,
+  );
+  if (!branchesResult.success) {
+    logger.error("Failed to list branches", branchesResult.error);
+    return internalError(branchesResult.error.message);
+  }
+
+  logger.info("Branches retrieved", {
+    namespace,
+    slug,
+    branchCount: branchesResult.data.branches.length,
+  });
+  return ok({
+    namespace,
+    slug,
+    path: `/${namespace}/${slug}`,
+    defaultBranch,
+    branches: branchesResult.data.branches,
+    truncated: branchesResult.data.truncated,
+    totalBranchCount: branchesResult.data.totalBranchCount,
+  });
+});
+
+// POST /projects/:namespace/:slug/branches - Create a branch (#181).
+// The new ref can only ever point at an object the repository already holds, so
+// this cannot introduce unevaluated content and the change gate is untouched —
+// see createBranchRef, which is where that invariant is enforced.
+app.post("/:namespace/:slug/branches", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const { namespace, slug } = c.req.param();
+  const access = await requireProjectWriter(c, logger);
+  if ("response" in access) return access.response;
+  const { project } = access;
+
+  if (await isTargetDeleting(c.env, project, logger)) {
+    return c409("Project is being deleted", "TARGET_DELETING");
+  }
+
+  type BranchCreateBody = { name?: unknown; startPoint?: unknown };
+  const parsed = await readJsonWithLimit<BranchCreateBody>(c, MAX_BRANCH_BODY_BYTES, logger).catch(
+    (): BranchCreateBody => ({}),
+  );
+  if (parsed instanceof Response) return parsed;
+  // `readJsonWithLimit` returns whatever JSON.parse produced, so a literal
+  // `null` body throws nothing and arrives here — destructuring it is a
+  // TypeError, i.e. a 500 for input that is merely malformed.
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return badRequest("Request body must be a JSON object");
+  }
+
+  const { name, startPoint } = parsed;
+  if (!isValidBranchName(name)) {
+    return badRequest("Invalid branch name");
+  }
+  if (startPoint !== undefined && typeof startPoint !== "string") {
+    return badRequest("startPoint must be a string");
+  }
+
+  const writeToken = await freshRepoToken(c.env.ARTIFACTS, project.remote, "write", logger);
+  if (!writeToken.success) return internalError(writeToken.error.message);
+
+  const createResult = await createBranchRef(project.remote, writeToken.data, logger, {
+    name,
+    ...(startPoint !== undefined ? { startPoint } : {}),
+    defaultBranch: projectDefaultBranch(project),
+  });
+  if (!createResult.success) {
+    if ("kind" in createResult.error) {
+      return branchWriteFailureResponse(createResult.error, namespace, slug);
+    }
+    logger.error("Failed to create branch", createResult.error);
+    return internalError(createResult.error.message);
+  }
+
+  await recordAudit(c.env.DB, logger, {
+    action: "branch.created",
+    ...auditActor(c),
+    subject: `${project.namespace}/${project.slug}`,
+    detail: { branch: createResult.data.name, oid: createResult.data.oid },
+  });
+
+  return created({ namespace, slug, branch: createResult.data });
+});
+
+// DELETE /projects/:namespace/:slug/branches/* - Delete a branch (#181).
+// Wildcard path so a hierarchical name (`release/2.x`) survives as real path
+// segments. Hono decodes the path with decodeURI, not decodeURIComponent, so a
+// percent-encoded `%2F` stays literal and is refused by the name guard.
+app.delete("/:namespace/:slug/branches/*", async (c) => {
+  const logger = createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+
+  const { namespace, slug } = c.req.param();
+  const access = await requireProjectWriter(c, logger);
+  if ("response" in access) return access.response;
+  const { project } = access;
+
+  if (await isTargetDeleting(c.env, project, logger)) {
+    return c409("Project is being deleted", "TARGET_DELETING");
+  }
+
+  const name = branchNameFromPath(c.req.url, namespace, slug);
+  if (!isValidBranchName(name)) {
+    return badRequest("Invalid branch name");
+  }
+
+  const writeToken = await freshRepoToken(c.env.ARTIFACTS, project.remote, "write", logger);
+  if (!writeToken.success) return internalError(writeToken.error.message);
+
+  const deleteResult = await deleteBranchRef(project.remote, writeToken.data, logger, {
+    name,
+    defaultBranch: projectDefaultBranch(project),
+  });
+  if (!deleteResult.success) {
+    if ("kind" in deleteResult.error) {
+      return branchWriteFailureResponse(deleteResult.error, namespace, slug);
+    }
+    logger.error("Failed to delete branch", deleteResult.error);
+    return internalError(deleteResult.error.message);
+  }
+
+  await recordAudit(c.env.DB, logger, {
+    action: "branch.deleted",
+    ...auditActor(c),
+    subject: `${project.namespace}/${project.slug}`,
+    detail: { branch: name },
+  });
+
+  return ok({ namespace, slug, deleted: name });
 });
 
 // GET /projects/:namespace/:slug/provenance - Get provenance records

--- a/src/routes/sync-management.ts
+++ b/src/routes/sync-management.ts
@@ -663,7 +663,11 @@ app.post("/projects/conflicts/:id/resolve", async (c) => {
     // could check out. A policy naming `sandbox` fails closed via
     // UnavailableEvaluator, same as any other missing prerequisite.
     const evaluators = buildEvaluators(c.env, policy, projectName, logger);
-    const { evalRuns, evalResult } = await runEvaluation(evaluators, diff, policy, logger);
+    // `buildManualResolutionDiff` resolved this base from the clone it built the
+    // diff on, so it names the tree the resolution actually applies to (#274).
+    const { evalRuns, evalResult } = await runEvaluation(evaluators, diff, policy, logger, {
+      baseSha,
+    });
 
     if (!evalResult.passed) {
       logger.warn("Manual conflict resolution blocked by evaluator suite", {

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -16,13 +16,16 @@ import { getChange, listChanges } from "../storage/changes";
 import { getChangeCostSummary } from "../storage/costs";
 import { listEvalRuns } from "../storage/eval-runs";
 import { listProjectEvents } from "../storage/events";
+import type { RefResolutionFailure } from "../storage/git-ops";
 import {
   freshRepoToken,
   getCommitLog,
   getDiffBetweenRepos,
   listFilesInRepo,
+  listRepoBranches,
   listRepoTags,
   readFileFromRepo,
+  resolveBranchRef,
 } from "../storage/git-ops";
 import { getImportProgress } from "../storage/imports";
 import { listIssueComments } from "../storage/issue-comments";
@@ -50,6 +53,7 @@ import { projectDefaultBranch } from "../types";
 import { parseUnifiedDiff } from "../ui/components/diff-view";
 import { getFileContent, isValidFilePath } from "../ui/file-content";
 import { ActivityPage } from "../ui/pages/activity";
+import { BranchesPage } from "../ui/pages/branches";
 import { ChangeDetailPage } from "../ui/pages/change-detail";
 import { ChangesPage } from "../ui/pages/changes";
 import { ErrorPage } from "../ui/pages/error";
@@ -65,6 +69,8 @@ import { TagsPage } from "../ui/pages/tags";
 import { WebhooksPage } from "../ui/pages/webhooks";
 import { WorkspacesPage } from "../ui/pages/workspaces";
 import { canReadProject, canWriteProject, filterMemberProjects } from "../utils/authz";
+import type { AppError } from "../utils/errors";
+import type { Logger } from "../utils/logger";
 import { createLogger } from "../utils/logger";
 import { isValidNamespace, isValidSlug } from "../utils/validation";
 import { DEFAULT_COMMENTS_PAGE, DEFAULT_ISSUES_PAGE } from "./issues";
@@ -1167,6 +1173,167 @@ app.get("/:namespace/:slug/tags", async (c) => {
 });
 
 /**
+ * The hand-rolled error block the routes in this file already render inline.
+ * Kept as one helper so the ref-scoped views report failures on the same
+ * surface as their neighbours instead of inventing a second one.
+ */
+const uiErrorBody = (message: string) => (
+  <div style="padding:2rem;font-family:monospace;color:#f87171;">{message}</div>
+);
+
+const REF_LOAD_ERROR = "Error loading repository. Please try again.";
+
+/**
+ * `resolveBranchRef` reports a request-shaped refusal as a tagged object and a
+ * transport failure as an `AppError`; only the former carries a `kind`.
+ */
+function isRefResolutionFailure(
+  error: RefResolutionFailure | AppError,
+): error is RefResolutionFailure {
+  return "kind" in error;
+}
+
+/** How a UI view should answer a `?ref=` it could not honour. */
+function refFailureAnswer(failure: RefResolutionFailure): {
+  message: string;
+  status: 400 | 404 | 409;
+} {
+  switch (failure.kind) {
+    case "invalid":
+      return { message: `Invalid branch name '${failure.name}'.`, status: 400 };
+    case "not-found":
+      return {
+        message: `Branch '${failure.name}' not found in this repository.`,
+        status: 404,
+      };
+    case "ambiguous":
+      return {
+        message: `Ref '${failure.name}' is ambiguous: it names both refs/heads/${failure.name} and refs/tags/${failure.name}. Rename one of them, or browse by a name that is unique.`,
+        status: 409,
+      };
+  }
+}
+
+type UiRefResolution =
+  | { resolved: true; branch: string }
+  | { resolved: false; message: string; status: 400 | 404 | 409 | 500 };
+
+/**
+ * Resolves `?ref=` for a ref-scoped UI view.
+ *
+ * Absent means the project's default branch — the behaviour these views had
+ * before multi-branch support, unchanged. Present is checked against the
+ * remote's own advertisement and, if it does not name exactly one branch, the
+ * view says so: an unknown ref must never fall back to the default branch, or
+ * the page would show one tree under a URL naming another (PRD edge case 1).
+ */
+async function resolveUiRef(
+  requestedRef: string | undefined,
+  remote: string,
+  readToken: string | null,
+  defaultBranch: string,
+  logger: Logger,
+): Promise<UiRefResolution> {
+  // An empty `ref=` means "no preference", matching `resolveRequestedRef` in
+  // routes/projects.ts: a GET form submitted with nothing chosen sends exactly
+  // that, and answering a browser's default submission with a 400 would be a
+  // worse contract than reading it as unspecified.
+  if (requestedRef === undefined || requestedRef === "") {
+    return { resolved: true, branch: defaultBranch };
+  }
+  if (readToken === null) return { resolved: false, message: REF_LOAD_ERROR, status: 500 };
+
+  const resolved = await resolveBranchRef(remote, readToken, logger, requestedRef);
+  if (resolved.success) return { resolved: true, branch: resolved.data.name };
+  if (isRefResolutionFailure(resolved.error)) {
+    return { resolved: false, ...refFailureAnswer(resolved.error) };
+  }
+  logger.error("Failed to resolve requested ref", resolved.error, { ref: requestedRef });
+  return { resolved: false, message: REF_LOAD_ERROR, status: 500 };
+}
+
+/**
+ * Branch names for the switcher.
+ *
+ * Best-effort on purpose: a page that rendered before this feature existed must
+ * not start failing because a ref advertisement did. A failure is logged and
+ * yields no switcher, never an error page.
+ */
+async function loadSwitcherBranchNames(
+  remote: string,
+  readToken: string | null,
+  defaultBranch: string,
+  logger: Logger,
+): Promise<string[]> {
+  if (readToken === null) return [];
+  const result = await listRepoBranches(remote, readToken, logger, defaultBranch);
+  if (!result.success) {
+    logger.warn("Failed to list branches for the switcher", { error: result.error });
+    return [];
+  }
+  return result.data.branches.map((branch) => branch.name);
+}
+
+// GET /:namespace/:slug/branches — Branch listing (registered before the
+// catch-all repo view at the bottom of this file, which would otherwise swallow
+// it as a slug).
+app.get("/:namespace/:slug/branches", async (c) => {
+  const { namespace, slug } = c.req.param();
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const logger = createLogger({ path: c.req.path, userId });
+
+  if (!isValidNamespace(namespace) || !isValidSlug(slug)) {
+    return c.html(uiErrorBody("Invalid project path."), 400);
+  }
+
+  const [userResult, projectResult] = await Promise.all([
+    getCurrentUser(c, logger),
+    getProjectByPath(c.env.STATE, namespace, slug, logger),
+  ]);
+
+  if (!projectResult.success) {
+    return c.html(uiErrorBody(`Project '${namespace}/${slug}' not found.`), 404);
+  }
+  const project = projectResult.data;
+
+  // A private project must be indistinguishable from a missing one.
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
+    return c.html(uiErrorBody(`Project '${namespace}/${slug}' not found.`), 404);
+  }
+
+  const branchesError = uiErrorBody("Error loading branches. Please try again.");
+  const readToken = await freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger);
+  if (!readToken.success) {
+    logger.error("Failed to mint read token for branches page", readToken.error);
+    return c.html(branchesError, 500);
+  }
+
+  const defaultBranch = projectDefaultBranch(project);
+  const branchesResult = await listRepoBranches(
+    project.remote,
+    readToken.data,
+    logger,
+    defaultBranch,
+  );
+  if (!branchesResult.success) {
+    logger.error("Failed to list branches", branchesResult.error);
+    return c.html(branchesError, 500);
+  }
+
+  return c.html(
+    <BranchesPage
+      project={{ name: project.name, namespace: project.namespace, slug: project.slug }}
+      branches={branchesResult.data.branches}
+      defaultBranch={defaultBranch}
+      truncated={branchesResult.data.truncated}
+      totalBranchCount={branchesResult.data.totalBranchCount}
+      user={userResult}
+    />,
+  );
+});
+
+/**
  * Three issue routes share the same preamble, and getting it wrong leaks
  * project existence. A private project must 404 rather than 403, so an
  * unreadable project is indistinguishable from a missing one — that is why
@@ -1397,9 +1564,7 @@ app.get("/:namespace/:slug/webhooks", async (c) => {
     return c.html(errorPage(404, `Project '${namespace}/${slug}' not found.`, userResult), 404);
   }
 
-  const webhooksResult = await listWebhooks(c.env.DB, logger, project.name, {
-    projectId: project.id,
-  });
+  const webhooksResult = await listWebhooks(c.env.DB, logger, project.id);
   if (!webhooksResult.success) {
     logger.error("Failed to list webhooks", webhooksResult.error);
     return c.html(errorPage(500, "Error loading webhooks. Please try again.", userResult), 500);
@@ -1619,12 +1784,28 @@ app.get("/:namespace/:slug/blob/*", async (c) => {
   if (!readToken.success) {
     return c.html(errorPage(500, "Error loading file.", userResult), 500);
   }
+
+  // Hono's getPath stops at "?", so the wildcard above never contains the query
+  // string — `?ref=` is read here, from the query, and nowhere else.
+  const defaultBranch = projectDefaultBranch(project);
+  const refResolution = await resolveUiRef(
+    c.req.query("ref"),
+    project.remote,
+    readToken.data,
+    defaultBranch,
+    logger,
+  );
+  if (!refResolution.resolved) {
+    return c.html(uiErrorBody(refResolution.message), refResolution.status);
+  }
+  const branch = refResolution.branch;
+
   const contentResult = await getFileContent(
     project.remote,
     readToken.data,
     filePath,
     logger,
-    projectDefaultBranch(project),
+    branch,
   );
   if (!contentResult.success) {
     return c.html(errorPage(500, "Error loading file.", userResult), 500);
@@ -1638,6 +1819,12 @@ app.get("/:namespace/:slug/blob/*", async (c) => {
     );
   }
 
+  const branchNames = await loadSwitcherBranchNames(
+    project.remote,
+    readToken.data,
+    defaultBranch,
+    logger,
+  );
   const canWrite = await canWriteProject(c.env.DB, project, userId);
   return c.html(
     <FileViewerPage
@@ -1646,6 +1833,9 @@ app.get("/:namespace/:slug/blob/*", async (c) => {
       content={content}
       canWrite={canWrite}
       user={userResult}
+      refName={branch === defaultBranch ? undefined : branch}
+      defaultBranch={defaultBranch}
+      branchNames={branchNames}
     />,
   );
 });
@@ -1689,6 +1879,43 @@ app.get("/:namespace/:slug", async (c) => {
     return c.html(errorPage(404, `Project '${namespace}/${slug}' not found.`, userResult), 404);
   }
 
+  // Minted lazily and at most once. This is the highest-traffic page in the
+  // product and, served from the KV snapshot, it did no git work at all before
+  // multi-branch support: minting here unconditionally would add a fixed round
+  // trip to every view for the benefit of the minority that actually needs it.
+  // Best-effort, as before — an unreachable repo renders as an empty page
+  // rather than an error.
+  let readTokenLoaded = false;
+  let readToken: string | null = null;
+  const getReadToken = async (): Promise<string | null> => {
+    if (readTokenLoaded) return readToken;
+    readTokenLoaded = true;
+    const minted = await freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger);
+    if (!minted.success) {
+      logger.warn("Failed to mint read token for repo view", { error: minted.error.message });
+      return readToken;
+    }
+    readToken = minted.data;
+    return readToken;
+  };
+
+  const defaultBranch = projectDefaultBranch(project);
+  const requestedRef = c.req.query("ref");
+  // Only a request that actually names a ref pays for resolving it.
+  const hasRequestedRef = requestedRef !== undefined && requestedRef !== "";
+  const refResolution = await resolveUiRef(
+    requestedRef,
+    project.remote,
+    hasRequestedRef ? await getReadToken() : null,
+    defaultBranch,
+    logger,
+  );
+  if (!refResolution.resolved) {
+    return c.html(uiErrorBody(refResolution.message), refResolution.status);
+  }
+  const branch = refResolution.branch;
+  const isDefaultBranch = branch === defaultBranch;
+
   let files: string[] = [];
   let log: Array<{ sha: string; message: string; author: string; timestamp: number }> = [];
   let readme: string | null = null;
@@ -1716,21 +1943,28 @@ app.get("/:namespace/:slug", async (c) => {
   const canSync = !!getProjectSourceUrl(project) && isOwner && project.importCompleted !== false;
   const canWrite = await canWriteProject(c.env.DB, project, userId);
 
-  const snapshotResult2 = await readRepoSnapshot(c.env.STATE, project, logger);
-  if (snapshotResult2.success && snapshotResult2.data) {
+  // The snapshot is keyed `repo_snapshot:<ns>:<slug>` with no branch component
+  // and only ever describes the default branch, so a non-default ref must not
+  // read it at all — serving it would show the default branch's tree under a URL
+  // naming another branch (PRD edge case 15).
+  const snapshotResult2 = isDefaultBranch
+    ? await readRepoSnapshot(c.env.STATE, project, logger)
+    : null;
+  const snapshotServedThePage = Boolean(snapshotResult2?.success && snapshotResult2.data);
+  // Minted only when the snapshot cannot serve the page — a hit does no git work.
+  const cloneToken = snapshotServedThePage ? null : await getReadToken();
+  if (snapshotResult2?.success && snapshotResult2.data) {
     files = snapshotResult2.data.files;
     log = snapshotResult2.data.commits;
     readme = snapshotResult2.data.readme;
-  } else {
-    // Cache miss or corrupt entry — fall back to git clone
+  } else if (cloneToken !== null) {
+    // Cache miss, corrupt entry, or a non-default ref — fall back to git clone.
+    // A token that could not be minted was already warned about above and leaves
+    // the page rendering empty, exactly as it did before.
     try {
-      const tokenResult = await freshRepoToken(c.env.ARTIFACTS, project.remote, "read", logger);
-      if (!tokenResult.success) throw tokenResult.error;
-      const readToken = tokenResult.data;
-      const branch = projectDefaultBranch(project);
       const [filesResult, logResult] = await Promise.all([
-        listFilesInRepo(project.remote, readToken, logger, branch),
-        getCommitLog(project.remote, readToken, logger, 20, branch),
+        listFilesInRepo(project.remote, cloneToken, logger, branch),
+        getCommitLog(project.remote, cloneToken, logger, 20, branch),
       ]);
 
       if (filesResult.success) {
@@ -1750,7 +1984,7 @@ app.get("/:namespace/:slug", async (c) => {
       if (readmePath) {
         const readmeResult = await readFileFromRepo(
           project.remote,
-          readToken,
+          cloneToken,
           readmePath,
           logger,
           branch,
@@ -1767,9 +2001,19 @@ app.get("/:namespace/:slug", async (c) => {
     }
   }
 
+  // The switcher is a convenience, not the page. When the view was served from
+  // the snapshot and no ref was requested, this request has touched git zero
+  // times — so it offers just the branch being shown rather than spending a ref
+  // advertisement (two subrequests) on the product's busiest page. A reader who
+  // wants the full list is one click away on /branches.
+  const branchNames = readTokenLoaded
+    ? await loadSwitcherBranchNames(project.remote, readToken, defaultBranch, logger)
+    : [defaultBranch];
+
   logger.debug("Rendering project page", {
     namespace,
     slug,
+    branch,
     fileCount: files.length,
     hasImport: !!importProgress,
   });
@@ -1802,6 +2046,9 @@ app.get("/:namespace/:slug", async (c) => {
       isOwner={isOwner}
       canWrite={canWrite}
       nonce={c.get("cspNonce") ?? ""}
+      refName={isDefaultBranch ? undefined : branch}
+      defaultBranch={defaultBranch}
+      branchNames={branchNames}
     />,
   );
 });

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -232,9 +232,7 @@ app.get("/:namespace/:slug/webhooks", async (c) => {
   if ("response" in access) return access.response;
   const { project } = access;
 
-  const webhooksResult = await listWebhooks(c.env.DB, logger, project.name, {
-    projectId: project.id,
-  });
+  const webhooksResult = await listWebhooks(c.env.DB, logger, project.id);
   if (!webhooksResult.success) {
     return internalError(webhooksResult.error.message);
   }

--- a/src/services/change-flow.ts
+++ b/src/services/change-flow.ts
@@ -9,7 +9,7 @@ import {
   loadPolicy,
 } from "../evaluation";
 import type { SandboxRepoAccess } from "../evaluation/sandbox-evaluator";
-import type { EvalPolicy, EvalResult, Evaluator } from "../evaluation/types";
+import type { EvalPolicy, EvalResult, EvaluationContext, Evaluator } from "../evaluation/types";
 import { buildEvaluationReport, reportEvaluationToGitHub } from "../github/sync";
 import { type EventActor, emitEvent } from "../queue/events";
 import { getAgent } from "../storage/agents";
@@ -191,10 +191,15 @@ export async function runEvaluation(
   diff: string,
   policy: EvalPolicy,
   logger: Logger,
+  /** What the diff is a diff of. Forwarded to every evaluator so one that
+   * reproduces the change out-of-process can pin the base it applies to (#274).
+   * Callers pass the base resolved from the clone the diff came from, never a
+   * fresh read of the project head. */
+  context?: EvaluationContext,
 ): Promise<{ evalRuns: EvaluationRun[]; evalResult: EvalResult }> {
   const evalRuns = await Promise.all(
     evaluators.map(async ({ type, evaluator }) => {
-      const result = await evaluator.evaluate(diff, policy, logger);
+      const result = await evaluator.evaluate(diff, policy, logger, context);
       return {
         evaluatorType: type,
         result: result.success
@@ -385,6 +390,7 @@ export async function createChangeWithEvaluation(
     workspaceOid: evaluatedSha,
     workspaceTreeOid: evaluatedTreeOid,
     workspaceSha: workspaceHeadSha,
+    baseOid,
   } = diffResult.data;
 
   const evaluators = buildEvaluators(env, policy, projectName, logger, {
@@ -392,7 +398,12 @@ export async function createChangeWithEvaluation(
     token: workspaceReadToken.data,
     ref: evaluatedSha,
   });
-  const { evalRuns, evalResult } = await runEvaluation(evaluators, diff, policy, logger);
+  // `baseOid`, not the `baseSha` resolved further up: that one is read before
+  // the diff clone, so the default branch can advance in between. The evaluated
+  // base must be the one the diff was actually built against (#274).
+  const { evalRuns, evalResult } = await runEvaluation(evaluators, diff, policy, logger, {
+    baseSha: baseOid,
+  });
 
   const newStatus: Change["status"] = evalResult.passed ? "accepted" : "needs_changes";
 

--- a/src/storage/audit.ts
+++ b/src/storage/audit.ts
@@ -25,6 +25,8 @@ export type AuditAction =
   | "deletion.incomplete"
   | "deletion.redrive"
   | "webhook.project_id_backfilled"
+  | "branch.created"
+  | "branch.deleted"
   | "telemetry.preference_changed";
 
 export interface AuditEntry {

--- a/src/storage/changes.ts
+++ b/src/storage/changes.ts
@@ -291,6 +291,13 @@ export async function getChangeByGitHubBranch(
 }
 
 export interface UpdateChangeStatusOpts {
+  /** The base commit the evaluation actually ran against. Re-evaluation re-pins
+   * it for the same reason it re-pins `evaluatedSha`: the merge gate compares
+   * `change.baseSha` against the current project head under
+   * `merge.requireFreshBase`, so leaving it at its creation-time value means a
+   * re-evaluated change stays STALE_BASE forever and re-evaluation can never
+   * clear it. */
+  baseSha?: string;
   evalScore?: number;
   evalPassed?: boolean;
   evalReason?: string;
@@ -331,6 +338,7 @@ function buildUpdateChangeStatusStatement(
     bindings.push(value);
   };
 
+  addOptional("base_sha", opts?.baseSha);
   addOptional("eval_score", opts?.evalScore);
   addOptional(
     "eval_passed",

--- a/src/storage/git-ops.ts
+++ b/src/storage/git-ops.ts
@@ -5,7 +5,7 @@ import { AppError, ExternalServiceError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
 import type { PhaseTimer } from "../utils/phase-timer";
 import { type Result, err, fromPromise, ok } from "../utils/result";
-import { isTraversalPath } from "../utils/validation";
+import { isTraversalPath, isValidRefName } from "../utils/validation";
 import { commitObject } from "./git-objects";
 import { MODE_SYMLINK, MemoryFS } from "./memory-fs";
 import { packObjects, placeLooseObject, unpackObjects } from "./object-loader";
@@ -491,6 +491,67 @@ export async function pushTags(
       );
     }
     pushedTags.push(name);
+  }
+  return ok(undefined);
+}
+
+/**
+ * Pushes local `refs/heads/*` to an **Artifacts** remote.
+ *
+ * Distinct from {@link pushBranchToRemote}, which exists for GitHub and
+ * authenticates as `x-access-token` with the token verbatim. Artifacts tokens
+ * are `<secret>?expires=<timestamp>` and every Artifacts push strips the suffix
+ * (see {@link extractTokenSecret}); handing one to the GitHub helper sends the
+ * whole string as the password and the remote refuses it. Restore is the only
+ * caller, and it pushes to Artifacts, so it needs this one.
+ *
+ * Reports partial progress exactly as {@link pushTags} does, and for the same
+ * reason: refs go one at a time and a forced restore is not rolled back.
+ *
+ * @param branchNames - Branch names (without the `refs/heads/` prefix) to push.
+ * @param opts - Whether an existing remote ref may be replaced.
+ */
+export async function pushBranches(
+  remote: string,
+  token: string,
+  fs: NodeFS,
+  dir: string,
+  branchNames: string[],
+  logger: Logger,
+  opts?: { force?: boolean },
+): Promise<Result<void, AppError>> {
+  const pushedBranches: string[] = [];
+  for (const [index, name] of branchNames.entries()) {
+    const ref = `refs/heads/${name}`;
+    const res = await fromPromise(
+      git.push({
+        fs,
+        dir,
+        http,
+        url: remote,
+        ref,
+        remoteRef: ref,
+        onAuth: makeAuth(token),
+        force: opts?.force ?? false,
+      }),
+    );
+    if (!res.success) {
+      logger.error("Failed to push branch during restore", res.error, {
+        remote,
+        ref,
+        failedBranch: name,
+        pushedBranches,
+        unpushedBranches: branchNames.slice(index + 1),
+      });
+      return err(
+        new ExternalServiceError(
+          "Git",
+          `Failed to push branch ${name} during restore (${pushedBranches.length}/${branchNames.length} branches pushed before the failure)`,
+          res.error,
+        ),
+      );
+    }
+    pushedBranches.push(name);
   }
   return ok(undefined);
 }
@@ -3711,7 +3772,18 @@ export async function getDiffBetweenRepos(
   branch = "main",
 ): Promise<
   Result<
-    { diff: string; workspaceOid: string; workspaceTreeOid: string; workspaceSha: string },
+    {
+      diff: string;
+      workspaceOid: string;
+      workspaceTreeOid: string;
+      workspaceSha: string;
+      /** The base commit the diff was computed against, resolved from the same
+       * clone that produced it. Callers forward this to evaluators so a
+       * receiver can reproduce the exact tree the diff applies to (#274);
+       * re-resolving the project head separately would name a commit the diff
+       * may not have been built from. */
+      baseOid: string;
+    },
     AppError
   >
 > {
@@ -3810,7 +3882,7 @@ export async function getDiffBetweenRepos(
 
   const diff = buildUnifiedDiff(baseContent, workspaceContent);
   logger.info("Successfully generated diff between repos", { baseRemote, workspaceRemote });
-  return ok({ diff, workspaceOid, workspaceTreeOid, workspaceSha });
+  return ok({ diff, workspaceOid, workspaceTreeOid, workspaceSha, baseOid });
 }
 
 export function buildUnifiedDiff(
@@ -4065,4 +4137,489 @@ export async function listRepoTags(
     truncated,
   });
   return ok({ tags: collected.data, truncated, totalTagCount });
+}
+
+/**
+ * Hard cap on how many branches a listing returns.
+ *
+ * Unlike {@link MAX_TAGS} this is not a subrequest budget: branch listing reads
+ * the ref advertisement and nothing else (see {@link listRepoBranches}), so a
+ * repo with ten thousand branches costs the same two subrequests as one with
+ * three. The cap bounds the RESPONSE — the JSON body, the `<select>` the UI
+ * renders from it, and the manifest a backup records — rather than the request
+ * count. Truncation is reported, never silent.
+ */
+export const MAX_BRANCHES = 200;
+
+/** One entry in a branch listing: the branch name and the commit it points at.
+ *
+ * There is deliberately no `unresolvable` flag, unlike {@link RepoTagEntry}. A
+ * tag can be unresolvable because it peels to a target outside a shallow
+ * clone's window; a branch tip read from the ref advertisement IS the oid the
+ * remote holds, so the state cannot arise. */
+export interface RepoBranchEntry {
+  name: string;
+  oid: string;
+}
+
+/** Result of {@link listRepoBranches}. */
+export interface ListRepoBranchesResult {
+  /** The branches listed, ascending by name, capped at {@link MAX_BRANCHES}. */
+  branches: RepoBranchEntry[];
+  /** True when the remote advertised more than {@link MAX_BRANCHES} branches
+   * and the listing was capped — reported so callers show it rather than
+   * presenting a quietly-partial list as complete. */
+  truncated: boolean;
+  /** Total branches the remote advertised, independent of how many are listed. */
+  totalBranchCount: number;
+}
+
+/** Branch and tag names a remote currently advertises, from one handshake. */
+interface AdvertisedRefs {
+  branches: Record<string, string>;
+  /** Tag name -> the oid `refs/tags/<name>` points at. For an annotated tag
+   * that is the TAG OBJECT, not the commit — see {@link AdvertisedRefs.peeledTags}. */
+  tags: Record<string, string>;
+  /** Tag name -> the commit an annotated tag peels to, from the remote's own
+   * `<name>^{}` advertisement. Absent for a lightweight tag, whose `tags` entry
+   * is already the commit. */
+  peeledTags: Record<string, string>;
+}
+
+/**
+ * Reads a remote's advertised `refs/heads/*` and `refs/tags/*` in a single
+ * handshake — two subrequests, no object data, nothing written to memory.
+ *
+ * This is the whole read path for branches. Listing them by CLONING, the way
+ * tags are listed, does not work: isomorphic-git translates fetched head refs
+ * through the remote's refspec into `refs/remotes/origin/*`, so a clone's
+ * `refs/heads/` holds exactly one branch — the one it checked out — no matter
+ * how many were fetched. The advertisement already carries every branch name
+ * and its tip oid, which is all a listing needs.
+ */
+async function readAdvertisedRefs(
+  remote: string,
+  token: string,
+  logger: Logger,
+  httpClient: HttpClient = http,
+): Promise<Result<AdvertisedRefs, AppError>> {
+  const infoResult = await fromPromise(
+    git.getRemoteInfo({ http: httpClient, url: remote, onAuth: makeAuth(token) }),
+  );
+  if (!infoResult.success) {
+    logger.error("Failed to read remote ref advertisement", infoResult.error, { remote });
+    return err(new ExternalServiceError("Git", "Failed to read remote refs", infoResult.error));
+  }
+
+  const refs = infoResult.data.refs as { heads?: RemoteRefTree; tags?: RemoteRefTree } | undefined;
+  // `<name>^{}` is the remote advertising an annotated tag's PEELED commit
+  // alongside the tag object itself. It is not a ref name, so it never enters
+  // `tags` — but it is exactly what a branch must point at when someone
+  // branches from an annotated tag, so it is kept separately rather than
+  // discarded.
+  const tags: Record<string, string> = {};
+  const peeledTags: Record<string, string> = {};
+  for (const [name, oid] of Object.entries(flattenRefTree(refs?.tags))) {
+    if (name.endsWith("^{}")) {
+      peeledTags[name.slice(0, -3)] = oid;
+    } else {
+      tags[name] = oid;
+    }
+  }
+  return ok({ branches: flattenRefTree(refs?.heads), tags, peeledTags });
+}
+
+/**
+ * Whether `name` may be used as a branch name on a project repo.
+ *
+ * Git's own ref rules ({@link isValidRefName}) plus one Stratum restriction:
+ * `HEAD` is refused. Git would accept `refs/heads/HEAD`, but it collides with
+ * the symbolic ref every client resolves to find the default branch, and a
+ * repository carrying it misbehaves in ways that are not this product's to
+ * explain. Tags keep accepting it — a backup holding one must stay restorable.
+ */
+export function isValidBranchName(name: unknown): name is string {
+  return isValidRefName(name) && name !== "HEAD";
+}
+
+/**
+ * Lists a repository's branches, newest advertisement, no clone.
+ *
+ * @param defaultBranch - The project's resolved default branch. Used only to
+ * decide what survives truncation: it is always retained, because a listing
+ * that dropped the one branch every other operation resolves would be worse
+ * than useless. The rest are taken in ascending name order — unlike tags there
+ * is no version ordering to exploit, so any stable rule is arbitrary and this
+ * one is at least predictable.
+ */
+export async function listRepoBranches(
+  remote: string,
+  token: string,
+  logger: Logger,
+  defaultBranch: string,
+  httpClient: HttpClient = http,
+): Promise<Result<ListRepoBranchesResult, AppError>> {
+  logger.debug("Listing repo branches", { remote });
+
+  const advertised = await readAdvertisedRefs(remote, token, logger, httpClient);
+  if (!advertised.success) return err(advertised.error);
+
+  const entries = Object.entries(advertised.data.branches)
+    .map(([name, oid]) => ({ name, oid }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const totalBranchCount = entries.length;
+  const truncated = totalBranchCount > MAX_BRANCHES;
+  let branches = entries;
+  if (truncated) {
+    const isDefault = (entry: RepoBranchEntry): boolean => entry.name === defaultBranch;
+    const defaultEntry = entries.find(isDefault);
+    const rest = entries.filter((entry) => !isDefault(entry));
+    branches = defaultEntry
+      ? [defaultEntry, ...rest.slice(0, MAX_BRANCHES - 1)].sort((a, b) =>
+          a.name.localeCompare(b.name),
+        )
+      : rest.slice(0, MAX_BRANCHES);
+    logger.warn("Remote branch count exceeds MAX_BRANCHES; truncating listing", {
+      remote,
+      totalBranchCount,
+      returnedBranchCount: branches.length,
+      maxBranches: MAX_BRANCHES,
+    });
+  }
+
+  logger.info("Successfully listed repo branches", {
+    remote,
+    branchCount: branches.length,
+    truncated,
+  });
+  return ok({ branches, truncated, totalBranchCount });
+}
+
+/** How a requested `?ref=` failed to resolve to exactly one branch. */
+export type RefResolutionFailure =
+  | { kind: "invalid"; name: string }
+  | { kind: "not-found"; name: string }
+  | { kind: "ambiguous"; name: string };
+
+/**
+ * Resolves a caller-supplied ref to a branch that exists on the remote.
+ *
+ * Ambiguity is REJECTED, not resolved. `cloneRepo` hands `ref` to `git.clone`,
+ * which walks isomorphic-git's `refpaths` — and that list checks
+ * `refs/tags/<ref>` BEFORE `refs/heads/<ref>`. A repo holding both
+ * `refs/tags/v1` and `refs/heads/v1` would pass a branch-name check and then
+ * clone the TAG, serving one tree under a URL that names the other. The same
+ * advertisement already carries both namespaces, so the collision is detectable
+ * for free and is reported rather than silently picked.
+ */
+export async function resolveBranchRef(
+  remote: string,
+  token: string,
+  logger: Logger,
+  name: string,
+  httpClient: HttpClient = http,
+): Promise<Result<RepoBranchEntry, RefResolutionFailure | AppError>> {
+  if (!isValidBranchName(name)) return err({ kind: "invalid", name } as const);
+
+  const advertised = await readAdvertisedRefs(remote, token, logger, httpClient);
+  if (!advertised.success) return err(advertised.error);
+
+  const oid = advertised.data.branches[name];
+  if (oid === undefined) return err({ kind: "not-found", name } as const);
+  if (advertised.data.tags[name] !== undefined) {
+    logger.warn("Refusing an ambiguous ref that names both a branch and a tag", { remote, name });
+    return err({ kind: "ambiguous", name } as const);
+  }
+  return ok({ name, oid });
+}
+
+/** Why {@link createBranchRef} or {@link deleteBranchRef} refused. */
+export type BranchWriteFailure =
+  | { kind: "invalid-name"; name: string }
+  | { kind: "exists"; name: string }
+  | { kind: "conflicts-with"; name: string; existing: string }
+  | { kind: "not-found"; name: string }
+  | { kind: "default-branch"; name: string }
+  | { kind: "no-default-branch"; name: string }
+  | { kind: "bad-start-point"; startPoint: string };
+
+/**
+ * Creates `refs/heads/<name>` on a project remote, pointing at an object the
+ * repository ALREADY holds.
+ *
+ * That restriction is the security property, not a convenience: a branch push
+ * here goes straight to the Artifacts remote with a minted write token and
+ * never passes through `src/routes/git-http.ts`, so the change gate cannot
+ * vet it. Because the ref can only ever be aimed at an existing object, there
+ * is nothing for it to smuggle in — no unevaluated content enters, and the
+ * gate's guarantee is untouched. Enforcement is this function; there is no
+ * second line of defence behind it.
+ *
+ * It is also what keeps backup whole. Every reachable start point — the default
+ * tip, another branch's tip (inductively), a tag's tip, or a commit in the
+ * default branch's history — is already inside the object set `walkRepoObjects`
+ * packs, so a created branch never needs objects the snapshot does not have.
+ *
+ * The existence pre-check is load-bearing and cannot be replaced by the push:
+ * a non-forced `git.push` does NOT reject an existing branch when the new oid
+ * is a descendant of its tip — it fast-forwards it, and reports success. The
+ * push is only the backstop for a branch created between the check and the
+ * write.
+ *
+ * @param opts.startPoint - A branch name or a full 40-hex commit sha. Omitted
+ * means the default branch's tip. A TAG NAME is refused — see
+ * `resolveStartPoint` for why (a tag can point at a blob, its peel is not
+ * advertised by receive-pack, and it may sit outside both the default branch's
+ * history and a backup's capped tag fetch). A short sha is refused too: it
+ * would have to be resolved against history this function has not fetched, and
+ * guessing is exactly what the invariant above forbids.
+ */
+export async function createBranchRef(
+  remote: string,
+  token: string,
+  logger: Logger,
+  opts: { name: string; startPoint?: string; defaultBranch: string },
+  httpClient: HttpClient = http,
+): Promise<Result<RepoBranchEntry, BranchWriteFailure | AppError>> {
+  const { name, startPoint, defaultBranch } = opts;
+  if (!isValidBranchName(name)) return err({ kind: "invalid-name", name } as const);
+
+  const advertised = await readAdvertisedRefs(remote, token, logger, httpClient);
+  if (!advertised.success) return err(advertised.error);
+  if (advertised.data.branches[name] !== undefined) {
+    return err({ kind: "exists", name } as const);
+  }
+  // Refs are files in a directory tree, so `feature` and `feature/x` cannot
+  // both exist — one would have to be a file and a directory at once. The
+  // remote refuses the second, and isomorphic-git surfaces that as a
+  // `GitPushError` the caller would see as an opaque 502. The advertisement
+  // already in hand answers it for free, and with the name that collides.
+  const collision = Object.keys(advertised.data.branches).find(
+    (existing) => existing.startsWith(`${name}/`) || name.startsWith(`${existing}/`),
+  );
+  if (collision !== undefined) {
+    return err({ kind: "conflicts-with", name, existing: collision } as const);
+  }
+
+  const resolved = await resolveStartPoint(
+    remote,
+    token,
+    logger,
+    { startPoint, defaultBranch, advertised: advertised.data },
+    httpClient,
+  );
+  if (!resolved.success) return err(resolved.error);
+  const { oid, fs, dir } = resolved.data;
+
+  const ref = `refs/heads/${name}`;
+  const written = await fromPromise(git.writeRef({ fs, dir, ref, value: oid, force: true }));
+  if (!written.success) {
+    logger.error("Failed to write local branch ref", written.error, { remote, name });
+    return err(new ExternalServiceError("Git", "Failed to write branch ref", written.error));
+  }
+
+  const pushed = await fromPromise(
+    git.push({
+      fs,
+      dir,
+      http: httpClient,
+      url: remote,
+      ref,
+      remoteRef: ref,
+      // Never forced. The branch did not exist a moment ago; if it does now,
+      // another writer won the race and must not be overwritten.
+      force: false,
+      onAuth: makeAuth(token),
+    }),
+  );
+  if (!pushed.success) {
+    // A rejection means the remote refused the ref update — the branch was
+    // created between the pre-check above and this push, and a non-forced push
+    // will not clobber it. Anything else (network, auth, a broken remote) is
+    // NOT a conflict, and reporting it as one would tell a caller to pick a
+    // different name for a problem a different name cannot fix.
+    // Two different rejections mean the same thing to a caller. isomorphic-git
+    // throws `PushRejectedError` from its own pre-flight check, and
+    // `GitPushError` when the REMOTE answers `ng <ref>` — matching only the
+    // first reports a refused ref update as a 502.
+    if (
+      matchesGitError(pushed.error, GitErrors.PushRejectedError) ||
+      matchesGitError(pushed.error, GitErrors.GitPushError)
+    ) {
+      logger.warn("Remote refused the branch ref update", { remote, name });
+      return err({ kind: "exists", name } as const);
+    }
+    logger.error("Failed to push new branch", pushed.error, { remote, name, oid });
+    return err(new ExternalServiceError("Git", "Failed to create branch", pushed.error));
+  }
+
+  logger.info("Created branch", { remote, name, oid });
+  return ok({ name, oid });
+}
+
+/**
+ * Resolves a create request's start point to an oid already in the repository,
+ * and hands back the clone the push must be made from.
+ *
+ * The clone comes back with the oid rather than being made separately, and the
+ * depth is not incidental. `git.push` sends a ref update alone when the target
+ * oid is one the remote already advertises; when it is not — a historical
+ * commit — it walks the local object graph from that oid down to something the
+ * remote knows, and that walk fails if the commit sits outside the clone's
+ * window. Verifying a sha against full history and then pushing from a
+ * SHALLOW clone would therefore pass every check and fail at the push, on
+ * exactly the old commits this option exists to branch from.
+ *
+ * So: a start point named in the advertisement is already a remote-known tip
+ * and needs no objects, which a shallow clone satisfies. A raw sha needs full
+ * history, and is verified in the same clone it will be pushed from.
+ *
+ * KNOWN NARROWNESS, deliberate: `cloneRepo` is `singleBranch`, so `fullHistory`
+ * means the complete history OF THE DEFAULT BRANCH. A raw sha reachable only
+ * from some other branch is therefore reported `bad-start-point` even though
+ * the repository holds it. That direction is the safe one — the check fails
+ * closed, never admitting an object the repo lacks — and no path here can
+ * currently produce such a commit: every branch this API creates points at the
+ * default tip, another branch's tip, or a sha already in default history, so
+ * branch tips stay reachable from the default branch by induction, and both
+ * import and restore write a single branch's history. Widening the fetch to
+ * every advertised branch would multiply the clone (the whole tree lands in
+ * worker memory) against a ~1000-subrequest budget, to validate one sha. If a
+ * path ever does introduce divergent branch history — a force-push gate, or a
+ * default-branch switch — this becomes reachable and wants revisiting.
+ */
+async function resolveStartPoint(
+  remote: string,
+  token: string,
+  logger: Logger,
+  ctx: { startPoint?: string; defaultBranch: string; advertised: AdvertisedRefs },
+  httpClient: HttpClient,
+): Promise<Result<{ oid: string; fs: NodeFS; dir: string }, BranchWriteFailure | AppError>> {
+  const { startPoint, defaultBranch, advertised } = ctx;
+
+  // Nothing can be branched from a repository whose own default branch the
+  // remote does not advertise — an empty repo, or a project whose recorded
+  // `sourceDefaultBranch` has drifted from reality. Answered here, before any
+  // clone, so the caller gets a named refusal instead of the 502 a clone of a
+  // ref that isn't there would produce.
+  const defaultTip = advertised.branches[defaultBranch];
+  if (defaultTip === undefined) {
+    return err({ kind: "no-default-branch", name: defaultBranch } as const);
+  }
+
+  // A branch tip, and only a branch tip. Tags are deliberately NOT accepted as
+  // start points:
+  //
+  //  - A tag can point at a blob or a tree (git.git's own `junio-gpg-pub`
+  //    does), and `refs/heads/x` at a blob is a branch no client can check out.
+  //  - An annotated tag's peeled commit is advertised by upload-pack but NOT by
+  //    receive-pack, so `git.push` cannot tell the remote already has it and
+  //    walks the local object graph instead — which fails whenever that commit
+  //    lies outside the shallow window.
+  //  - The tag itself may sit outside the default branch's history, and may not
+  //    even be in a backup: the tag fetch is capped at MAX_TAGS. A branch
+  //    created there would vanish on restore.
+  //
+  // A full sha covers the real use (branch from an old commit) with none of
+  // this, because it is verified against history that is actually present.
+  const advertisedOid = startPoint === undefined ? defaultTip : advertised.branches[startPoint];
+
+  if (advertisedOid !== undefined) {
+    // Cheap path: the oid is a ref tip receive-pack advertises, so the push
+    // sends a ref update and no objects, and a shallow clone is enough.
+    const clone = await cloneRepo(remote, token, logger, { ref: defaultBranch }, httpClient);
+    if (!clone.success) return err(clone.error);
+    return ok({ oid: advertisedOid, fs: clone.data.fs, dir: clone.data.dir });
+  }
+
+  if (startPoint === undefined || !/^[0-9a-f]{40}$/.test(startPoint)) {
+    return err({ kind: "bad-start-point", startPoint: startPoint ?? defaultBranch } as const);
+  }
+
+  const clone = await cloneRepo(
+    remote,
+    token,
+    logger,
+    { ref: defaultBranch, fullHistory: true },
+    httpClient,
+  );
+  if (!clone.success) return err(clone.error);
+  const object = await fromPromise(
+    git.readObject({ fs: clone.data.fs, dir: clone.data.dir, oid: startPoint }),
+  );
+  if (!object.success || object.data.type !== "commit") {
+    logger.warn("Rejecting a start point that is not a commit in this repository", {
+      remote,
+      startPoint,
+    });
+    return err({ kind: "bad-start-point", startPoint } as const);
+  }
+  return ok({ oid: startPoint, fs: clone.data.fs, dir: clone.data.dir });
+}
+
+/**
+ * Deletes `refs/heads/<name>` from a project remote.
+ *
+ * The local `writeRef` before the push is required, not defensive: `git.push`
+ * calls `GitRefManager.expand` on the LOCAL ref before it looks at `delete`,
+ * and throws `NotFoundError` when that ref is absent. A clone of the default
+ * branch has no ref for the branch being deleted, so one is written at the oid
+ * the remote advertised. The oid is not sent — a delete pushes zeros — it only
+ * has to make the local ref resolvable.
+ */
+export async function deleteBranchRef(
+  remote: string,
+  token: string,
+  logger: Logger,
+  opts: { name: string; defaultBranch: string },
+  httpClient: HttpClient = http,
+): Promise<Result<void, BranchWriteFailure | AppError>> {
+  const { name, defaultBranch } = opts;
+  if (!isValidBranchName(name)) return err({ kind: "invalid-name", name } as const);
+  // Refused before the advertisement so the answer does not depend on a network
+  // call: every internal op resolves this ref, and deleting it would break
+  // browse, merge, sync and backup at once.
+  if (name === defaultBranch) return err({ kind: "default-branch", name } as const);
+
+  const advertised = await readAdvertisedRefs(remote, token, logger, httpClient);
+  if (!advertised.success) return err(advertised.error);
+  const oid = advertised.data.branches[name];
+  if (oid === undefined) return err({ kind: "not-found", name } as const);
+
+  // A delete needs no default-branch content — only a local ref for `_push`'s
+  // `expand` to resolve — so it clones the branch BEING DELETED rather than the
+  // default. That keeps a project whose recorded default branch has drifted
+  // from the remote able to clean up its branches instead of getting a 502 on
+  // a clone of a ref that is not there.
+  const clone = await cloneRepo(remote, token, logger, { ref: name }, httpClient);
+  if (!clone.success) return err(clone.error);
+  const { fs, dir } = clone.data;
+
+  const ref = `refs/heads/${name}`;
+  const written = await fromPromise(git.writeRef({ fs, dir, ref, value: oid, force: true }));
+  if (!written.success) {
+    logger.error("Failed to write local branch ref before delete", written.error, { remote, name });
+    return err(new ExternalServiceError("Git", "Failed to prepare branch delete", written.error));
+  }
+
+  const pushed = await fromPromise(
+    git.push({
+      fs,
+      dir,
+      http: httpClient,
+      url: remote,
+      ref,
+      remoteRef: ref,
+      delete: true,
+      onAuth: makeAuth(token),
+    }),
+  );
+  if (!pushed.success) {
+    logger.error("Failed to delete branch", pushed.error, { remote, name });
+    return err(new ExternalServiceError("Git", "Failed to delete branch", pushed.error));
+  }
+
+  logger.info("Deleted branch", { remote, name, oid });
+  return ok(undefined);
 }

--- a/src/storage/webhooks.ts
+++ b/src/storage/webhooks.ts
@@ -7,7 +7,9 @@ import { type Result, err, ok } from "../utils/result";
 export interface Webhook {
   id: string;
   project: string;
-  /** Globally-unique project UUID; NULL on rows written before dual-write. */
+  /** Globally-unique project UUID, and the only thing project scoping consults.
+   * Optional because rows written before dual-write carry NULL; such a row is
+   * unreachable through every management and delivery path (#235). */
   projectId?: string;
   url: string;
   secret: string;
@@ -98,17 +100,19 @@ function toAppError(error: unknown, operation: string, context: Record<string, u
 /**
  * Does this webhook belong to the given project?
  *
- * Scopes by the globally-unique project id when the webhook row carries one,
- * and falls back to the free-form `project` name only for legacy rows written
- * before project_id was backfilled. Comparing on name alone lets a same-named
- * project in another namespace read or mutate this webhook (cross-tenant).
+ * Scopes on the globally-unique project id and nothing else (#235, step 3).
+ * The free-form `project` name is deliberately not consulted: a bare name can
+ * collide across namespaces, so matching on it lets a same-named project in
+ * another tenant read or mutate this webhook.
+ *
+ * A row with no `projectId` therefore belongs to NO project and is unreachable
+ * through every management path. That is the intended fail-closed outcome: the
+ * admin backfill (`POST /api/admin/backfill/webhooks/apply`) stamps every
+ * legacy row first, and reports `remainingNullRows` so the operator can verify
+ * it read zero before this scoping took effect.
  */
-export function webhookBelongsToProject(
-  webhook: Webhook,
-  project: { id: string; name: string },
-): boolean {
-  if (webhook.projectId != null) return webhook.projectId === project.id;
-  return webhook.project === project.name;
+export function webhookBelongsToProject(webhook: Webhook, project: { id: string }): boolean {
+  return webhook.projectId === project.id;
 }
 
 /** Does this webhook subscribe to the given event type? */
@@ -120,10 +124,24 @@ export function webhookMatchesEvent(webhook: Webhook, eventType: string): boolea
     .includes(eventType);
 }
 
+/**
+ * Creates a webhook for a project, returning it with its generated signing
+ * secret — the only time the plaintext secret is returned to a client. It stays
+ * readable to internal callers (`rowToWebhook` keeps it, which is how delivery
+ * signs), but no other route serializes it into a response.
+ *
+ * `projectId` is required (#235): a row written without one is unreachable
+ * through every management and delivery path the moment it exists, so making it
+ * structural is what stops a new NULL row from undoing the backfill.
+ */
 export async function createWebhook(
   db: D1Database,
   logger: Logger,
-  opts: { project: string; projectId?: string; url: string; events?: string; createdBy: string },
+  // `projectId` is required: a row written without one would be unreachable
+  // through every management path (see `webhookBelongsToProject`) the moment it
+  // was created. Making it structural means the backfill can never be undone by
+  // a new NULL row.
+  opts: { project: string; projectId: string; url: string; events?: string; createdBy: string },
 ): Promise<Result<Webhook, AppError>> {
   const id = newId("wh");
   const secret = await generateApiKey("stm_whsec");
@@ -135,16 +153,7 @@ export async function createWebhook(
       .prepare(
         "INSERT INTO webhooks (id, project, project_id, url, secret, events, active, created_by, created_at) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)",
       )
-      .bind(
-        id,
-        opts.project,
-        opts.projectId ?? null,
-        opts.url,
-        secret,
-        events,
-        opts.createdBy,
-        createdAt,
-      )
+      .bind(id, opts.project, opts.projectId, opts.url, secret, events, opts.createdBy, createdAt)
       .run();
 
     logger.info("Webhook created", { webhookId: id, project: opts.project });
@@ -158,7 +167,7 @@ export async function createWebhook(
       createdBy: opts.createdBy,
       createdAt,
     };
-    if (opts.projectId !== undefined) webhook.projectId = opts.projectId;
+    webhook.projectId = opts.projectId;
     return ok(webhook);
   } catch (error) {
     const appError = toAppError(error, "createWebhook", { project: opts.project });
@@ -189,33 +198,34 @@ export async function getWebhook(
   }
 }
 
+/**
+ * Lists a project's webhooks, scoped by the canonical project id.
+ *
+ * Takes the project **id**, not its name, so a name-scoped lookup is not
+ * expressible here (#235, step 3). Both callers of this function — management
+ * and queue delivery — previously reached a name-only branch, which would hand
+ * one tenant's events to a same-named project in another namespace.
+ *
+ * A legacy row whose `project_id` was never backfilled matches nothing and is
+ * neither listed nor delivered to. See {@link webhookBelongsToProject} for why
+ * that fail-closed outcome is preferred to a name match.
+ */
 export async function listWebhooks(
   db: D1Database,
   logger: Logger,
-  project: string,
-  opts?: { activeOnly?: boolean; projectId?: string },
+  projectId: string,
+  opts?: { activeOnly?: boolean },
 ): Promise<Result<Webhook[], AppError>> {
   try {
     const activeClause = opts?.activeOnly ? " AND active = 1" : "";
-    // When a canonical project_id is known (delivery path), match on it and fall
-    // back to the name only for legacy webhooks whose project_id wasn't backfilled.
-    // Matching purely on the free-form `project` name would deliver one tenant's
-    // events to a same-named project in ANOTHER namespace (cross-tenant leak).
-    const result = opts?.projectId
-      ? await db
-          .prepare(
-            `SELECT * FROM webhooks WHERE (project_id = ? OR (project_id IS NULL AND project = ?))${activeClause}`,
-          )
-          .bind(opts.projectId, project)
-          .all<WebhookRow>()
-      : await db
-          .prepare(`SELECT * FROM webhooks WHERE project = ?${activeClause}`)
-          .bind(project)
-          .all<WebhookRow>();
+    const result = await db
+      .prepare(`SELECT * FROM webhooks WHERE project_id = ?${activeClause}`)
+      .bind(projectId)
+      .all<WebhookRow>();
     return ok(result.results.map(rowToWebhook));
   } catch (error) {
-    const appError = toAppError(error, "listWebhooks", { project });
-    logger.error("Failed to list webhooks", appError, { project });
+    const appError = toAppError(error, "listWebhooks", { projectId });
+    logger.error("Failed to list webhooks", appError, { projectId });
     return err(appError);
   }
 }

--- a/src/ui/components/file-tree.tsx
+++ b/src/ui/components/file-tree.tsx
@@ -7,6 +7,22 @@ interface FileTreeProps {
   slug: string;
   /** Per-request CSP nonce — required so the toggle script passes `script-src`. */
   nonce: string;
+  /** Branch the tree was read from, threaded into every blob link so clicking a
+   * file stays on it. `undefined` means the default branch — see {@link refQuery}. */
+  refName?: string;
+}
+
+/**
+ * The `?ref=` suffix a generated link needs to keep the reader on the branch
+ * they are browsing.
+ *
+ * `undefined` — the default branch — deliberately yields the empty string.
+ * Every URL this UI produced before multi-branch support pointed at the default
+ * branch implicitly, so appending a redundant parameter to all of them would
+ * churn every existing link and bookmark for no change in behaviour.
+ */
+export function refQuery(refName: string | undefined): string {
+  return refName === undefined ? "" : `?ref=${encodeURIComponent(refName)}`;
 }
 
 /**
@@ -38,11 +54,13 @@ interface NodeProps {
   namespace: string;
   slug: string;
   depth: number;
+  refName?: string;
 }
 
-const FileTreeNodeItem: FC<NodeProps> = ({ node, namespace, slug, depth }) => {
+const FileTreeNodeItem: FC<NodeProps> = ({ node, namespace, slug, depth, refName }) => {
   if (node.type === "file") {
-    const href = `/${namespace}/${slug}/blob/${node.path.split("/").map(encodeURIComponent).join("/")}`;
+    const path = node.path.split("/").map(encodeURIComponent).join("/");
+    const href = `/${namespace}/${slug}/blob/${path}${refQuery(refName)}`;
     return (
       <div class="file-tree-file">
         <a href={href}>{node.name}</a>
@@ -61,6 +79,7 @@ const FileTreeNodeItem: FC<NodeProps> = ({ node, namespace, slug, depth }) => {
             namespace={namespace}
             slug={slug}
             depth={depth + 1}
+            refName={refName}
           />
         ))}
       </div>
@@ -68,7 +87,14 @@ const FileTreeNodeItem: FC<NodeProps> = ({ node, namespace, slug, depth }) => {
   );
 };
 
-export const FileTree: FC<FileTreeProps> = ({ nodes, namespace, slug, nonce }) => {
+/**
+ * The collapsible repository file tree.
+ *
+ * `refName` is the branch being browsed; every blob link carries it so a reader
+ * who switched branches stays on that branch as they navigate. Omitted on the
+ * default branch so those links keep their existing shape.
+ */
+export const FileTree: FC<FileTreeProps> = ({ nodes, namespace, slug, nonce, refName }) => {
   if (nodes.length === 0) {
     return (
       <div class="empty-state">
@@ -85,7 +111,14 @@ export const FileTree: FC<FileTreeProps> = ({ nodes, namespace, slug, nonce }) =
         </button>
       </div>
       {nodes.map((node) => (
-        <FileTreeNodeItem key={node.path} node={node} namespace={namespace} slug={slug} depth={0} />
+        <FileTreeNodeItem
+          key={node.path}
+          node={node}
+          namespace={namespace}
+          slug={slug}
+          depth={0}
+          refName={refName}
+        />
       ))}
       <script nonce={nonce} dangerouslySetInnerHTML={{ __html: FILE_TREE_SCRIPT }} />
     </div>

--- a/src/ui/components/project-header.tsx
+++ b/src/ui/components/project-header.tsx
@@ -1,6 +1,13 @@
 import type { FC } from "hono/jsx";
 
-export type ProjectTab = "code" | "changes" | "issues" | "activity" | "tags" | "settings";
+export type ProjectTab =
+  | "code"
+  | "changes"
+  | "issues"
+  | "activity"
+  | "branches"
+  | "tags"
+  | "settings";
 
 export interface ProjectRef {
   name: string;
@@ -31,6 +38,9 @@ export const ProjectHeader: FC<ProjectHeaderProps> = ({ project, active, canWrit
     { key: "changes", label: "Changes", href: `${base}/changes` },
     { key: "issues", label: "Issues", href: `${base}/issues` },
     { key: "activity", label: "Activity", href: `${base}/activity` },
+    // Next to Tags: both list refs, and grouping them keeps the ref-shaped
+    // sections together rather than burying branches under Code.
+    { key: "branches", label: "Branches", href: `${base}/branches` },
     { key: "tags", label: "Tags", href: `${base}/tags` },
     ...(canWrite
       ? [{ key: "settings" as const, label: "Settings", href: `${base}/settings` }]

--- a/src/ui/pages/branches.tsx
+++ b/src/ui/pages/branches.tsx
@@ -1,0 +1,157 @@
+import type { FC } from "hono/jsx";
+import type { RepoBranchEntry } from "../../storage/git-ops";
+import { refQuery } from "../components/file-tree";
+import { ProjectHeader } from "../components/project-header";
+import { Layout } from "../layout";
+
+interface BranchSwitcherProps {
+  /** Where the form submits — the page the reader is already on, so switching
+   * branches keeps them on the same view rather than bouncing them to the root. */
+  action: string;
+  /** Branch names to offer. Empty renders nothing at all: a select with no
+   * options is worse than no switcher, and the listing is allowed to fail
+   * without taking the page down with it. */
+  branchNames: string[];
+  /** The branch currently being browsed, preselected in the dropdown. */
+  currentRef: string;
+}
+
+/**
+ * Switches branches with a plain GET form: the browser serialises the `<select>`
+ * into `?ref=<name>` and navigates, so no client-side JavaScript is involved —
+ * which is the house rule for this UI (AGENTS.md), not a preference.
+ *
+ * A GET form replaces the query string wholesale, which is exactly right here:
+ * `ref` is the only parameter these views read, so nothing is silently dropped.
+ */
+export const BranchSwitcher: FC<BranchSwitcherProps> = ({ action, branchNames, currentRef }) => {
+  if (branchNames.length === 0) return <></>;
+
+  // The current ref can be missing from the listing when it was truncated at
+  // MAX_BRANCHES; showing the dropdown with nothing selected would misreport
+  // which branch is on screen, so it is added back rather than dropped.
+  const options = branchNames.includes(currentRef) ? branchNames : [currentRef, ...branchNames];
+
+  return (
+    <form class="branch-switcher" method="get" action={action} style="display:inline;">
+      <label for="branch-switcher-ref" style="margin-right:0.35rem;">
+        Branch
+      </label>
+      <select id="branch-switcher-ref" name="ref">
+        {options.map((name) => (
+          <option key={name} value={name} selected={name === currentRef}>
+            {name}
+          </option>
+        ))}
+      </select>
+      <button type="submit" class="btn">
+        Switch
+      </button>
+    </form>
+  );
+};
+
+interface BranchesProps {
+  project: {
+    name: string;
+    namespace: string;
+    slug: string;
+  };
+  branches: RepoBranchEntry[];
+  /** The project's default branch. Marked in the listing because every
+   * operation that does not name a ref resolves to it. */
+  defaultBranch: string;
+  /** True when the remote advertised more branches than the listing cap and the
+   * list was cut — surfaced in place rather than passing a partial list off as
+   * complete, the same contract the tags page keeps (#241). */
+  truncated: boolean;
+  /** Total branches the remote advertised, independent of how many are listed.
+   *
+   * Required, not optional, for the reason spelled out on `TagsPage`: without
+   * it a truncated listing can only describe itself in terms of its own length,
+   * which reads as a complete list and defeats the notice. */
+  totalBranchCount: number;
+  user?: { id: string; email: string; username: string } | null;
+}
+
+/**
+ * The `/:namespace/:slug/branches` page: every branch the remote advertises,
+ * its tip, and a link that browses it.
+ *
+ * Reads a listing, never a clone — the cost does not grow with the branch
+ * count. A capped listing is labelled as capped rather than presented as the
+ * whole set, the same contract the tags page keeps.
+ */
+export const BranchesPage: FC<BranchesProps> = ({
+  project,
+  branches,
+  defaultBranch,
+  truncated,
+  totalBranchCount,
+  user,
+}) => {
+  return (
+    <Layout title={`Branches — ${project.name}`} user={user}>
+      {/* The shared project chrome carries the Branches tab, so the old
+          "Back to repo" button is redundant — every section is one click away. */}
+      <ProjectHeader project={project} active="branches" />
+      <div class="page-header">
+        <h1>Branches</h1>
+      </div>
+
+      {truncated && (
+        <div class="empty-state-hint" style="margin-bottom: 1rem;">
+          Showing {branches.length} of {totalBranchCount} branches. The rest were not listed; the
+          default branch is always kept.
+        </div>
+      )}
+
+      {branches.length === 0 ? (
+        <div class="empty-state">
+          <p>No branches yet.</p>
+          <p class="empty-state-hint">
+            An empty repository advertises no refs. Push a commit to create the default branch, or
+            create a branch through the API.
+          </p>
+        </div>
+      ) : (
+        <div class="card">
+          <div class="table-scroll">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Branch</th>
+                  <th>Tip</th>
+                  <th>Browse</th>
+                </tr>
+              </thead>
+              <tbody>
+                {branches.map((branch) => {
+                  const isDefault = branch.name === defaultBranch;
+                  return (
+                    <tr key={branch.name}>
+                      <td class="mono">
+                        {branch.name} {isDefault && <span class="badge badge-open">default</span>}
+                      </td>
+                      <td class="mono">{branch.oid.slice(0, 7)}</td>
+                      <td>
+                        {/* The default branch keeps its bare URL — see refQuery. */}
+                        <a
+                          href={`/${project.namespace}/${project.slug}${refQuery(
+                            isDefault ? undefined : branch.name,
+                          )}`}
+                        >
+                          Browse
+                        </a>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </Layout>
+  );
+};

--- a/src/ui/pages/file-viewer.tsx
+++ b/src/ui/pages/file-viewer.tsx
@@ -1,9 +1,11 @@
 import { Fragment } from "hono/jsx";
 import type { FC } from "hono/jsx";
+import { refQuery } from "../components/file-tree";
 import { ProjectHeader } from "../components/project-header";
 import type { FileContentResult } from "../file-content";
 import { highlightCode } from "../highlight";
 import { Layout } from "../layout";
+import { BranchSwitcher } from "./branches";
 
 const extensionToLanguage: Record<string, string> = {
   ts: "typescript",
@@ -50,21 +52,27 @@ interface BreadcrumbProps {
   namespace: string;
   slug: string;
   filePath: string;
+  refName?: string;
 }
 
 /**
  * Only the project crumb is a link: there is no user-profile route for the
  * namespace and no directory-listing route for intermediate path segments,
  * so rendering those as links would promise navigation that doesn't exist.
+ * That one link still carries `refName`, so the trip back stays on the branch
+ * the reader came from.
  */
-const Breadcrumb: FC<BreadcrumbProps> = ({ namespace, slug, filePath }) => {
+const Breadcrumb: FC<BreadcrumbProps> = ({ namespace, slug, filePath, refName }) => {
   const segments = filePath.split("/").filter((s) => s.length > 0);
+  // Every crumb points back at the repo view; carrying the ref keeps the trip
+  // back on the branch the reader came from.
+  const repoHref = `/${namespace}/${slug}${refQuery(refName)}`;
 
   return (
     <div class="file-viewer-breadcrumb">
       <span>{namespace}</span>
       <span class="sep">/</span>
-      <a href={`/${namespace}/${slug}`}>{slug}</a>
+      <a href={repoHref}>{slug}</a>
       {segments.map((segment, i) => {
         const isLast = i === segments.length - 1;
         return (
@@ -88,24 +96,54 @@ interface FileViewerPageProps {
   content: FileContentResult;
   canWrite?: boolean;
   user?: { id: string; email: string; username: string } | null;
+  /** Branch this file was read from, or `undefined` for the default branch —
+   * whose links stay bare, see `refQuery`. */
+  refName?: string;
+  /** The project's default branch, so the switcher can show what `refName:
+   * undefined` actually means. */
+  defaultBranch?: string;
+  /** Branch names for the switcher. Empty hides it — the listing is best-effort
+   * and its failure must not take the file view down. */
+  branchNames?: string[];
 }
 
+/**
+ * Renders one file's contents.
+ *
+ * Branch-aware (#181): `refName` is the branch being viewed and is threaded
+ * into every generated link so navigation stays on it. It is omitted on the
+ * default branch, which keeps pre-existing URLs byte-identical.
+ */
 export const FileViewerPage: FC<FileViewerPageProps> = ({
   project,
   path,
   content,
   canWrite,
   user,
+  refName,
+  defaultBranch,
+  branchNames = [],
 }) => {
   const { namespace, slug } = project;
   const language = languageFromPath(path);
   const fileName = path.split("/").pop() ?? path;
+  const currentRef = refName ?? defaultBranch;
+  // Switching branches re-requests THIS file on the chosen branch, so the form
+  // posts back to the blob URL rather than to the repo root.
+  const blobPath = path.split("/").map(encodeURIComponent).join("/");
 
   return (
     <Layout title={`${fileName} — ${project.name}`} user={user}>
       <ProjectHeader project={project} active="code" canWrite={canWrite ?? false} />
       <div class="page-header">
-        <Breadcrumb namespace={namespace} slug={slug} filePath={path} />
+        <Breadcrumb namespace={namespace} slug={slug} filePath={path} refName={refName} />
+        {currentRef !== undefined && (
+          <BranchSwitcher
+            action={`/${namespace}/${slug}/blob/${blobPath}`}
+            branchNames={branchNames}
+            currentRef={currentRef}
+          />
+        )}
       </div>
 
       <div class="card file-viewer-content">

--- a/src/ui/pages/repo.tsx
+++ b/src/ui/pages/repo.tsx
@@ -7,6 +7,7 @@ import { ImportProgressCard } from "../components/import-progress";
 import { ProjectHeader } from "../components/project-header";
 import { buildFileTree } from "../file-tree";
 import { Layout } from "../layout";
+import { BranchSwitcher } from "./branches";
 
 marked.setOptions({ gfm: true, breaks: false });
 
@@ -103,6 +104,16 @@ interface RepoProps {
   canWrite?: boolean;
   /** Per-request CSP nonce, threaded to every script-rendering child. */
   nonce: string;
+  /** Branch this tree and log were read from, or `undefined` for the default
+   * branch — whose links stay bare, see `refQuery`. Threaded into every file
+   * link so browsing does not silently drop back to the default branch. */
+  refName?: string;
+  /** The project's default branch, so the switcher can show what `refName:
+   * undefined` actually means. */
+  defaultBranch?: string;
+  /** Branch names for the switcher. Empty hides it — the listing is best-effort
+   * and its failure must not take the repo page down. */
+  branchNames?: string[];
 }
 
 function getProviderIcon(provider?: GitProvider): string {
@@ -152,6 +163,16 @@ function truncateCommit(sha?: string): string {
   return sha.slice(0, 7);
 }
 
+/**
+ * The project overview: file tree, recent commits, README, and the import and
+ * sync cards.
+ *
+ * Branch-aware (#181): `refName` names the branch being browsed and is absent
+ * on the default branch, so the common URL is unchanged. `branchNames` feeds
+ * the switcher and may hold only the current branch — the listing is
+ * best-effort and is deliberately skipped when the page was served from the KV
+ * snapshot, which is the path that must stay free of git work.
+ */
 export const RepoPage: FC<RepoProps> = ({
   project,
   files,
@@ -164,8 +185,12 @@ export const RepoPage: FC<RepoProps> = ({
   isOwner,
   canWrite,
   nonce,
+  refName,
+  defaultBranch,
+  branchNames = [],
 }) => {
   const hasSource = !!project.sourceUrl;
+  const currentRef = refName ?? defaultBranch;
   const isSyncing = project.lastSyncStatus === "in_progress";
   const hasUpdates = syncStatus?.hasUpdates;
   const syncFailed = project.lastSyncStatus === "failed";
@@ -200,6 +225,13 @@ export const RepoPage: FC<RepoProps> = ({
               )}
             </button>
           </form>
+        )}
+        {currentRef !== undefined && (
+          <BranchSwitcher
+            action={`/${project.namespace}/${project.slug}`}
+            branchNames={branchNames}
+            currentRef={currentRef}
+          />
         )}
       </ProjectHeader>
 
@@ -323,6 +355,7 @@ export const RepoPage: FC<RepoProps> = ({
               namespace={project.namespace}
               slug={project.slug}
               nonce={nonce}
+              refName={refName}
             />
           </div>
         </div>

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -390,3 +390,68 @@ export function validateCloneDepth(
 
   return { valid: true, depth: num };
 }
+
+/** Longest ref name a manifest or request may ask to write. */
+const MAX_REF_NAME_LENGTH = 255;
+
+/**
+ * Whether `name` is safe to write as the trailing component of a git ref —
+ * `refs/tags/<name>` or `refs/heads/<name>`.
+ *
+ * Both callers consume input they did not produce: restore reads names back
+ * out of a stored manifest, and the branch API takes them from a request. The
+ * ref path is therefore validated here rather than trusted: an unchecked `../`
+ * escapes its namespace and, with `force: true`, can overwrite the default
+ * branch's ref.
+ *
+ * These are git's own `check-ref-format` rules, expressed as a denylist. An
+ * allowlist was tried first and was wrong in a way that matters for a restore
+ * path: it rejected `release@prod`, every non-ASCII name, and `%`, `,`, `!`,
+ * `(`, `'`, `=`, `&`, `;`, `{` — all of which git accepts. A backup holding
+ * such a tag could be written but never restored, which is worse than the
+ * traversal the allowlist was defending against.
+ *
+ * The oracle here is isomorphic-git's `writeRef`, not the `git` CLI, because
+ * that is what performs the write. It is the stricter of the two: it treats a
+ * ref as valid only if `clean-git-ref` leaves it unchanged, so it refuses
+ * `v1./next` (`./` collapses to `/`) even though `git check-ref-format`
+ * accepts it. Validating against the CLI's looser rules would let such a name
+ * past this guard and throw from `writeRef` half-way through the tag loop,
+ * leaving a partially restored repository — so `./` is rejected here.
+ *
+ * Differentially fuzzed against `writeRef` over ~1300 generated names with a
+ * fresh MemoryFS per name: no name is accepted here that `writeRef` refuses.
+ *
+ * Deliberately NOT rejected here: `HEAD`. It is a ref name git accepts, and a
+ * backup holding a tag called `HEAD` must stay restorable — this guard's whole
+ * point is that it never refuses a name the ref store would have taken.
+ * Callers that additionally cannot accept it (branch creation) say so
+ * themselves; see `isValidBranchName` in `../storage/git-ops`.
+ *
+ * @param name - The candidate ref name, straight from a manifest or a request.
+ * @returns `true` if `refs/<namespace>/<name>` is a ref name git would accept.
+ */
+export function isValidRefName(name: unknown): name is string {
+  if (typeof name !== "string" || name.length === 0) return false;
+  // Not a git rule: a Stratum bound so a hostile manifest or request can't
+  // push an arbitrarily long path at the ref store.
+  if (name.length > MAX_REF_NAME_LENGTH) return false;
+
+  // Control characters (including DEL) and space, compared by code point. A
+  // regex range spanning them is what lint rules about control characters in
+  // patterns object to, and the comparison states the bound outright.
+  for (let i = 0; i < name.length; i++) {
+    const code = name.charCodeAt(i);
+    if (code <= 0x20 || code === 0x7f) return false;
+  }
+  // The characters git reserves for its revision syntax.
+  if (/[~^:?*[\\]/.test(name)) return false;
+
+  if (name.includes("..") || name.includes("@{")) return false;
+  if (name.startsWith("/") || name.endsWith("/")) return false;
+  // `./` and a trailing `.` are both rewritten by clean-git-ref, so writeRef
+  // rejects them.
+  if (name.includes("./") || name.endsWith(".")) return false;
+
+  return name.split("/").every((c) => c.length > 0 && !c.startsWith(".") && !c.endsWith(".lock"));
+}

--- a/tests/backup-branches.test.ts
+++ b/tests/backup-branches.test.ts
@@ -1,0 +1,544 @@
+import git from "isomorphic-git";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { reconstructRepo, restoreProjectRepo } from "../src/backup/repo-restore";
+import {
+  type BranchRefRecord,
+  type RepoManifest,
+  buildSnapshot,
+  snapshotRepo,
+  walkRepoObjects,
+} from "../src/backup/repo-snapshot";
+import type { NodeFS } from "../src/storage/git-ops";
+import { MemoryFS } from "../src/storage/memory-fs";
+import type { Env, ProjectEntry } from "../src/types";
+import { AppError } from "../src/utils/errors";
+import type { Logger } from "../src/utils/logger";
+
+// Only the calls that touch Artifacts are mocked -- `push`, the clone, and the
+// ref advertisement. Every other git call runs for real against MemoryFS, so
+// the round trips below prove genuine ref stores rather than stubs.
+const { mockPush, mockCloneRepo, mockListRepoBranches } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockCloneRepo: vi.fn(),
+  mockListRepoBranches: vi.fn(),
+}));
+
+vi.mock("isomorphic-git", async (importActual) => {
+  const actual = await importActual<typeof import("isomorphic-git")>();
+  return {
+    ...actual,
+    default: { ...actual.default, push: (args: unknown) => mockPush(args) },
+  };
+});
+
+vi.mock("../src/storage/git-ops", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/git-ops")>();
+  return {
+    ...actual,
+    freshRepoToken: vi.fn(async () => ({ success: true, data: "tok" })),
+    cloneRepo: (...args: unknown[]) => mockCloneRepo(...args),
+    listRepoBranches: (...args: unknown[]) => mockListRepoBranches(...args),
+  };
+});
+
+const logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+} as unknown as Logger;
+
+const SRC = "/src";
+const author = { name: "t", email: "t@x.com", timestamp: 1_700_000_000, timezoneOffset: 0 };
+const MISSING_OID = "f".repeat(40);
+
+const project: ProjectEntry = {
+  id: "p1",
+  name: "repo",
+  slug: "repo",
+  namespace: "@owner",
+  ownerId: "u1",
+  ownerType: "user",
+  remote: "https://acct.artifacts.cloudflare.net/git/@owner/repo.git",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+/** The same project, imported from a repo whose default branch is not `main`. */
+const trunkProject: ProjectEntry = { ...project, sourceDefaultBranch: "trunk" };
+
+async function buildRepo(
+  commits: Record<string, string>[],
+  defaultBranch = "main",
+): Promise<{ fs: NodeFS; shas: string[] }> {
+  const fs = new MemoryFS().toNodeFS() as unknown as NodeFS;
+  await git.init({ fs, dir: SRC, defaultBranch });
+  const shas: string[] = [];
+  for (const files of commits) {
+    for (const [path, content] of Object.entries(files)) {
+      // biome-ignore lint/suspicious/noExplicitAny: isomorphic-git fs shape
+      await (fs as any).promises.writeFile(`${SRC}/${path}`, content);
+      await git.add({ fs, dir: SRC, filepath: path });
+    }
+    shas.push(await git.commit({ fs, dir: SRC, message: "c", author }));
+  }
+  return { fs, shas };
+}
+
+/**
+ * A two-commit repo plus the snapshot a backup of it would produce, with
+ * `branches` filled the way the ref advertisement fills it: the default branch
+ * at the tip, and `feature/x` at the first commit — an object the HEAD walk has
+ * already packed, which is the only case branch creation can produce.
+ */
+async function snapshotWithFeatureBranch(entry: ProjectEntry = project) {
+  const branch = entry.sourceDefaultBranch ?? "main";
+  const { fs, shas } = await buildRepo([{ "a.txt": "one" }, { "b.txt": "two" }], branch);
+  const [c1, c2] = shas as [string, string];
+  const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+  if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+  const branches: BranchRefRecord[] = [
+    { name: "feature/x", oid: c1 },
+    { name: branch, oid: c2 },
+  ];
+  return { snap: buildSnapshot(entry, walk.data, "2026-08-28T00:00:00Z", branches), c1, c2 };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("snapshotRepo branch refs", () => {
+  async function clonedRepo() {
+    const { fs, shas } = await buildRepo([{ "a.txt": "one" }]);
+    mockCloneRepo.mockResolvedValue({ success: true, data: { fs, dir: SRC } });
+    return { tipSha: shas[0] as string };
+  }
+
+  it("records the advertised branch refs in the manifest without a second clone", async () => {
+    const { tipSha } = await clonedRepo();
+    mockListRepoBranches.mockResolvedValue({
+      success: true,
+      data: {
+        branches: [
+          { name: "feature/x", oid: tipSha },
+          { name: "main", oid: tipSha },
+        ],
+        truncated: false,
+        totalBranchCount: 2,
+      },
+    });
+
+    const result = await snapshotRepo({ ARTIFACTS: {} } as unknown as Env, project, "t0", logger);
+
+    expect(result.success).toBe(true);
+    if (!result.success || result.data.status !== "ok") throw new Error("snapshot failed");
+    expect(result.data.snapshot.manifest.branches).toEqual([
+      { name: "feature/x", oid: tipSha },
+      { name: "main", oid: tipSha },
+    ]);
+    // One advertisement, told which branch must survive truncation…
+    expect(mockListRepoBranches).toHaveBeenCalledTimes(1);
+    expect(mockListRepoBranches.mock.calls[0]?.slice(0, 4)).toEqual([
+      project.remote,
+      "tok",
+      logger,
+      "main",
+    ]);
+    // …and exactly one clone, with its option set unchanged: capturing branches
+    // must not have grown a fetch of its own.
+    expect(mockCloneRepo).toHaveBeenCalledTimes(1);
+    expect(mockCloneRepo.mock.calls[0]?.[3]).toEqual({
+      fullHistory: true,
+      ref: "main",
+      includeTags: true,
+      timeoutMs: 300_000,
+    });
+  });
+
+  it("still produces a snapshot when the ref advertisement fails", async () => {
+    const { tipSha } = await clonedRepo();
+    mockListRepoBranches.mockResolvedValue({
+      success: false,
+      error: new AppError("Failed to read remote refs", "GIT_ERROR", 502),
+    });
+
+    const result = await snapshotRepo({ ARTIFACTS: {} } as unknown as Env, project, "t0", logger);
+
+    expect(result.success).toBe(true);
+    if (!result.success || result.data.status !== "ok") throw new Error("snapshot failed");
+    // The pack is the valuable part and is intact. The manifest carries NO
+    // `branches` key: an empty array would positively assert "this repository
+    // has no branches", which a failed advertisement cannot support and which a
+    // reader could not tell apart from a genuine zero-branch repo.
+    expect(result.data.snapshot.manifest.tipSha).toBe(tipSha);
+    expect(result.data.snapshot.manifest).not.toHaveProperty("branches");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Failed to list branches for snapshot; backing up without branch refs",
+      expect.objectContaining({ projectId: project.id }),
+    );
+  });
+
+  it("records an empty branches list when the remote genuinely advertises none", async () => {
+    await clonedRepo();
+    mockListRepoBranches.mockResolvedValue({
+      success: true,
+      data: { branches: [], truncated: false, totalBranchCount: 0 },
+    });
+
+    const result = await snapshotRepo({ ARTIFACTS: {} } as unknown as Env, project, "t0", logger);
+    expect(result.success).toBe(true);
+    if (!result.success || result.data.status !== "ok") throw new Error("snapshot failed");
+    // Present and empty — distinguishable from the failure case above.
+    expect(result.data.snapshot.manifest.branches).toEqual([]);
+  });
+
+  it("records the true branch total when the listing was capped", async () => {
+    await clonedRepo();
+    mockListRepoBranches.mockResolvedValue({
+      success: true,
+      data: {
+        branches: [{ name: "feature/x", oid: "a".repeat(40) }],
+        truncated: true,
+        totalBranchCount: 250,
+      },
+    });
+
+    const result = await snapshotRepo({ ARTIFACTS: {} } as unknown as Env, project, "t0", logger);
+    expect(result.success).toBe(true);
+    if (!result.success || result.data.status !== "ok") throw new Error("snapshot failed");
+    // Without this an operator cannot tell a restore recreated 200 of 250
+    // branches — the quiet lossiness the field exists to prevent.
+    expect(result.data.snapshot.manifest.branchesTruncatedTotal).toBe(250);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Snapshot records only part of this repo's branches (listing cap reached)",
+      expect.objectContaining({ projectId: project.id, totalBranchCount: 250 }),
+    );
+  });
+});
+
+describe("reconstructRepo branch refs", () => {
+  it("reproduces a non-default branch on the round trip", async () => {
+    const { snap, c1, c2 } = await snapshotWithFeatureBranch();
+
+    const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger);
+
+    expect(rebuilt.success).toBe(true);
+    if (!rebuilt.success) throw new Error(rebuilt.error.message);
+    const { fs: rfs, dir } = rebuilt.data;
+    expect(await git.resolveRef({ fs: rfs, dir, ref: "refs/heads/feature/x" })).toBe(c1);
+    expect(await git.resolveRef({ fs: rfs, dir, ref: "refs/heads/main" })).toBe(c2);
+    // The default branch is not reported as a written branch ref: the verified
+    // tip write owns it.
+    expect(rebuilt.data.branches).toEqual(["feature/x"]);
+  });
+
+  it("restores a pre-change manifest with no branches key exactly as before", async () => {
+    const { snap, c2 } = await snapshotWithFeatureBranch();
+    // A JSON round trip is how a stored manifest comes back; deleting the key
+    // reproduces one written before branch support existed.
+    const legacy = JSON.parse(JSON.stringify(snap.manifest)) as RepoManifest;
+    // biome-ignore lint/performance/noDelete: constructing the legacy shape exactly
+    delete legacy.branches;
+
+    const rebuilt = await reconstructRepo(snap.pack, legacy, logger);
+
+    expect(rebuilt.success).toBe(true);
+    if (!rebuilt.success) throw new Error(rebuilt.error.message);
+    expect(rebuilt.data.branches).toEqual([]);
+    expect(await git.resolveRef({ fs: rebuilt.data.fs, dir: rebuilt.data.dir, ref: "main" })).toBe(
+      c2,
+    );
+    expect(await git.listBranches({ fs: rebuilt.data.fs, dir: rebuilt.data.dir })).toEqual([
+      "main",
+    ]);
+  });
+
+  // The manifest is untrusted input: its names are interpolated into
+  // `refs/heads/<name>` and written with force:true — the very namespace a
+  // traversing name is aiming at.
+  it.each([
+    ["path traversal into refs/heads", "../heads/main"],
+    ["parent-dir segment", "feature/../../heads/main"],
+    ["empty name", ""],
+    ["a space", "feature x"],
+    ["a control character", "feature\u0000evil"],
+    ["reflog syntax", "feature@{0}"],
+    ["lock suffix", "feature.lock"],
+  ])("skips a manifest branch name with %s", async (_label, branchName) => {
+    const { snap, c1, c2 } = await snapshotWithFeatureBranch();
+    // A real, present object id: only the NAME is hostile here.
+    snap.manifest.branches = [{ name: branchName, oid: c1 }];
+
+    const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger);
+
+    // Skipped, not fatal: the tip still restores.
+    expect(rebuilt.success).toBe(true);
+    if (!rebuilt.success) throw new Error(rebuilt.error.message);
+    expect(rebuilt.data.branches).toEqual([]);
+    expect(
+      await git.resolveRef({ fs: rebuilt.data.fs, dir: rebuilt.data.dir, ref: "refs/heads/main" }),
+    ).toBe(c2);
+    expect(await git.listBranches({ fs: rebuilt.data.fs, dir: rebuilt.data.dir })).toEqual([
+      "main",
+    ]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Restore: skipping branch with an invalid name in manifest",
+      { name: branchName },
+    );
+  });
+
+  it("does not let a stale manifest entry for the default branch overwrite the verified tip", async () => {
+    const { snap, c1, c2 } = await snapshotWithFeatureBranch();
+    // A manifest whose `main` entry is one commit behind the verified tip —
+    // what a branch that moved between the advertisement and the pack walk
+    // would leave behind.
+    snap.manifest.branches = [{ name: "main", oid: c1 }];
+    expect(snap.manifest.tipSha).toBe(c2);
+
+    const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger);
+
+    expect(rebuilt.success).toBe(true);
+    if (!rebuilt.success) throw new Error(rebuilt.error.message);
+    expect(
+      await git.resolveRef({ fs: rebuilt.data.fs, dir: rebuilt.data.dir, ref: "refs/heads/main" }),
+    ).toBe(snap.manifest.tipSha);
+    expect(rebuilt.data.branches).toEqual([]);
+  });
+
+  it("holds back the project's default branch even when the tip is restored under another name", async () => {
+    // `reconstructRepo`'s `branch` argument and the project's default branch
+    // are separate inputs; a manifest entry naming either must not be written.
+    const { snap, c1, c2 } = await snapshotWithFeatureBranch(trunkProject);
+    snap.manifest.branches = [
+      { name: "trunk", oid: c1 },
+      { name: "feature/x", oid: c1 },
+    ];
+
+    const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger, "trunk");
+
+    expect(rebuilt.success).toBe(true);
+    if (!rebuilt.success) throw new Error(rebuilt.error.message);
+    expect(rebuilt.data.branches).toEqual(["feature/x"]);
+    expect(
+      await git.resolveRef({ fs: rebuilt.data.fs, dir: rebuilt.data.dir, ref: "refs/heads/trunk" }),
+    ).toBe(c2);
+  });
+
+  it("skips (with a warning) a branch whose tip is absent from the restored objects", async () => {
+    const { snap } = await snapshotWithFeatureBranch();
+    snap.manifest.branches = [{ name: "ghost", oid: MISSING_OID }];
+
+    const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger);
+
+    expect(rebuilt.success).toBe(true);
+    if (!rebuilt.success) throw new Error(rebuilt.error.message);
+    expect(rebuilt.data.branches).toEqual([]);
+    // Not written dangling: the ref is absent, not present-and-unresolvable.
+    expect(await git.listBranches({ fs: rebuilt.data.fs, dir: rebuilt.data.dir })).toEqual([
+      "main",
+    ]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Restore: skipping branch whose tip is absent from the restored objects",
+      { name: "ghost", oid: MISSING_OID },
+    );
+  });
+
+  it("skips a branch whose tip is present but is not a commit", async () => {
+    const { fs, shas } = await buildRepo([{ "a.txt": "one" }]);
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    const snap = buildSnapshot(project, walk.data, "2026-08-18T00:00:00Z");
+    const commit = await git.readCommit({ fs, dir: SRC, oid: shas[0] as string });
+    // A tree oid: present in the pack, but a branch pointing at it is a branch
+    // no client can check out, and the push would fail with ObjectTypeError
+    // after main and every tag had already landed.
+    snap.manifest.branches = [{ name: "bad", oid: commit.commit.tree }];
+
+    const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger);
+    expect(rebuilt.success).toBe(true);
+    if (!rebuilt.success) return;
+    expect(rebuilt.data.branches).not.toContain("bad");
+  });
+
+  it("skips a branch whose ref path collides with one already written, keeping the rest", async () => {
+    const { fs } = await buildRepo([{ "a.txt": "one" }]);
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    const snap = buildSnapshot(project, walk.data, "2026-08-18T00:00:00Z");
+    // `refs/heads/main` is already a file, so `refs/heads/main/x` cannot also be
+    // a directory. An unguarded writeRef throws ENOTDIR and the outer catch
+    // withholds the tip and every tag over one unusable ref.
+    snap.manifest.branches = [
+      { name: "main/x", oid: snap.manifest.tipSha },
+      { name: "fine", oid: snap.manifest.tipSha },
+    ];
+
+    const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger);
+    expect(rebuilt.success).toBe(true);
+    if (!rebuilt.success) return;
+    expect(rebuilt.data.branches).toEqual(["fine"]);
+    expect(await git.resolveRef({ fs: rebuilt.data.fs, dir: rebuilt.data.dir, ref: "main" })).toBe(
+      snap.manifest.tipSha,
+    );
+  });
+
+  it("refuses a manifest branch named HEAD, which the tag guard alone allows", async () => {
+    const { fs } = await buildRepo([{ "a.txt": "one" }]);
+    const walk = await walkRepoObjects(fs, SRC, 10_000_000, logger);
+    if (!walk.success || !("objects" in walk.data)) throw new Error("walk failed");
+    const snap = buildSnapshot(project, walk.data, "2026-08-18T00:00:00Z");
+    snap.manifest.branches = [{ name: "HEAD", oid: snap.manifest.tipSha }];
+
+    const rebuilt = await reconstructRepo(snap.pack, snap.manifest, logger);
+    expect(rebuilt.success).toBe(true);
+    if (!rebuilt.success) return;
+    // The untrusted-input path must not be one guard weaker than the request
+    // path, which refuses HEAD as a branch name.
+    expect(rebuilt.data.branches).toEqual([]);
+  });
+});
+
+describe("restoreProjectRepo branch push", () => {
+  function makeEnv(deleteFn = vi.fn(async () => true)): { env: Env; deleteFn: typeof deleteFn } {
+    const env = {
+      ARTIFACTS: {
+        get: vi.fn(async () => null),
+        create: vi.fn(async () => ({ name: "repo", remote: project.remote, token: "tok" })),
+        delete: deleteFn,
+      } as unknown as Env["ARTIFACTS"],
+    } as Env;
+    return { env, deleteFn };
+  }
+
+  /** A pre-existing repo: a forced restore over it is deliberately not rolled back. */
+  function makeExistingEnv(deleteFn = vi.fn(async () => true)) {
+    const env = {
+      ARTIFACTS: {
+        get: vi.fn(async () => ({
+          name: "repo",
+          remote: project.remote,
+          createToken: vi.fn(async () => ({ plaintext: "tok" })),
+        })),
+        create: vi.fn(),
+        delete: deleteFn,
+      } as unknown as Env["ARTIFACTS"],
+    } as Env;
+    return { env, deleteFn };
+  }
+
+  const pushedRefs = (): string[] => mockPush.mock.calls.map((c) => (c[0] as { ref: string }).ref);
+
+  it("authenticates the branch push the way Artifacts requires, not the way GitHub does", async () => {
+    mockPush.mockResolvedValue({ ok: true });
+    const { env } = makeEnv();
+    const { snap } = await snapshotWithFeatureBranch();
+    // An Artifacts token carries an expiry suffix that must be stripped before
+    // it is used as a password.
+    const artifactsToken = "secret123?expires=1799999999";
+    env.ARTIFACTS.create = vi.fn(async () => ({
+      name: "repo",
+      remote: project.remote,
+      token: artifactsToken,
+    })) as unknown as Env["ARTIFACTS"]["create"];
+
+    const result = await restoreProjectRepo(env, snap, {}, logger);
+    expect(result.success).toBe(true);
+
+    const branchPush = mockPush.mock.calls
+      .map(
+        (call) => call[0] as { ref: string; onAuth: () => { username: string; password: string } },
+      )
+      .find((args) => args.ref === "refs/heads/feature/x");
+    expect(branchPush).toBeDefined();
+    // The GitHub helper would send the whole string as the password and the
+    // remote would refuse it — failing every restore that carries a branch,
+    // after main and the tags had already landed.
+    expect(branchPush?.onAuth()).toEqual({ username: "x", password: "secret123" });
+  });
+
+  it("pushes main first, then each branch ref", async () => {
+    mockPush.mockResolvedValue({ ok: true });
+    const { env } = makeEnv();
+    const { snap } = await snapshotWithFeatureBranch();
+
+    const result = await restoreProjectRepo(env, snap, {}, logger);
+
+    expect(result.success).toBe(true);
+    expect(pushedRefs()).toEqual(["main", "refs/heads/feature/x"]);
+    // Pushed to the same ref it holds locally, and not forced onto a repo this
+    // restore just created.
+    const branchPush = mockPush.mock.calls[1]?.[0] as { remoteRef: string; force: boolean };
+    expect(branchPush.remoteRef).toBe("refs/heads/feature/x");
+    expect(branchPush.force).toBe(false);
+  });
+
+  it("pushes only main for a pre-change manifest without branches", async () => {
+    mockPush.mockResolvedValue({ ok: true });
+    const { env } = makeEnv();
+    const { snap } = await snapshotWithFeatureBranch();
+    const legacy = JSON.parse(JSON.stringify(snap.manifest)) as RepoManifest;
+    // biome-ignore lint/performance/noDelete: constructing the legacy shape exactly
+    delete legacy.branches;
+
+    const result = await restoreProjectRepo(env, { pack: snap.pack, manifest: legacy }, {}, logger);
+
+    expect(result.success).toBe(true);
+    expect(pushedRefs()).toEqual(["main"]);
+  });
+
+  it("never pushes a branch that reconstruction skipped", async () => {
+    mockPush.mockResolvedValue({ ok: true });
+    const { env } = makeEnv();
+    const { snap, c1 } = await snapshotWithFeatureBranch();
+    snap.manifest.branches = [
+      { name: "ghost", oid: MISSING_OID },
+      { name: "feature/x", oid: c1 },
+    ];
+
+    const result = await restoreProjectRepo(env, snap, {}, logger);
+
+    expect(result.success).toBe(true);
+    expect(pushedRefs()).toEqual(["main", "refs/heads/feature/x"]);
+  });
+
+  it("reports how many branches landed when a forced restore fails mid-list", async () => {
+    // main ok, first branch ok, second branch fails -> 1 of 2 branches pushed.
+    mockPush
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValueOnce(new Error("branch rejected"));
+    const { env, deleteFn } = makeExistingEnv();
+    const { snap, c1 } = await snapshotWithFeatureBranch();
+    snap.manifest.branches = [
+      { name: "feature/x", oid: c1 },
+      { name: "feature/y", oid: c1 },
+    ];
+
+    const result = await restoreProjectRepo(env, snap, { force: true }, logger);
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("expected failure");
+    expect(result.error.message).toContain("1/2 branches pushed");
+    // A pre-existing repo is never deleted by the rollback path.
+    expect(deleteFn).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      "Forced restore left partial state on an existing repo",
+      undefined,
+      expect.objectContaining({ mainPushed: true, branchCount: 2 }),
+    );
+  });
+
+  it("rolls back a freshly created repo when a branch push fails", async () => {
+    mockPush.mockResolvedValueOnce({ ok: true }).mockRejectedValueOnce(new Error("nope"));
+    const { env, deleteFn } = makeEnv();
+    const { snap } = await snapshotWithFeatureBranch();
+
+    const result = await restoreProjectRepo(env, snap, {}, logger);
+
+    expect(result.success).toBe(false);
+    expect(deleteFn).toHaveBeenCalledWith("repo");
+  });
+});

--- a/tests/branch-routes.test.ts
+++ b/tests/branch-routes.test.ts
@@ -1,0 +1,570 @@
+/**
+ * Issue #181: the branch API — listing, creation, deletion, and `?ref=` on the
+ * read routes.
+ *
+ * The git layer is mocked here; its own behaviour is covered against real
+ * in-memory repos in `tests/git-branches.test.ts`. What these tests pin down is
+ * the route contract: which status code each refusal produces, that a
+ * non-writer cannot tell a private project exists, that writes are audited and
+ * mint a WRITE token, and that a bad `?ref=` never silently falls back to the
+ * default branch.
+ */
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../src/types";
+
+vi.mock("../src/storage/state", () => ({
+  getProjectByPath: vi.fn(),
+  listProjectsByNamespace: vi.fn(),
+  setProject: vi.fn(),
+}));
+vi.mock("../src/storage/audit", () => ({ recordAudit: vi.fn(async () => ({ success: true })) }));
+vi.mock("../src/storage/deletion", () => ({
+  captureDeletionTarget: vi.fn(),
+  isTargetDeleting: vi.fn(async () => false),
+}));
+vi.mock("../src/utils/authz", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/utils/authz")>()),
+  canReadProject: vi.fn(async () => true),
+  canWriteProject: vi.fn(async () => true),
+}));
+vi.mock("../src/storage/git-ops", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/storage/git-ops")>()),
+  freshRepoToken: vi.fn(async () => ({ success: true, data: "tok" })),
+  listRepoBranches: vi.fn(),
+  createBranchRef: vi.fn(),
+  deleteBranchRef: vi.fn(),
+  resolveBranchRef: vi.fn(),
+  listFilesInRepo: vi.fn(async () => ({ success: true, data: ["a.txt"] })),
+  getCommitLog: vi.fn(async () => ({ success: true, data: [] })),
+}));
+
+import { projectsRouter } from "../src/routes/projects";
+import { recordAudit } from "../src/storage/audit";
+import { isTargetDeleting } from "../src/storage/deletion";
+import {
+  createBranchRef,
+  deleteBranchRef,
+  freshRepoToken,
+  listFilesInRepo,
+  listRepoBranches,
+  resolveBranchRef,
+} from "../src/storage/git-ops";
+import { getProjectByPath } from "../src/storage/state";
+import { canWriteProject } from "../src/utils/authz";
+
+function makeApp(identity: { userId?: string; agentOwnerId?: string } = { userId: "usr_1" }) {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", async (c, next) => {
+    if (identity.userId) c.set("userId", identity.userId);
+    if (identity.agentOwnerId) c.set("agentOwnerId", identity.agentOwnerId);
+    await next();
+  });
+  app.route("/api/projects", projectsRouter);
+  return app;
+}
+
+const env = { DB: {}, STATE: {}, ARTIFACTS: {} } as unknown as Env;
+const ctx = {
+  waitUntil: () => {},
+  passThroughOnException: () => {},
+} as unknown as ExecutionContext;
+
+const project = {
+  id: "proj_1",
+  name: "api",
+  slug: "api",
+  namespace: "@alice",
+  ownerId: "usr_1",
+  ownerType: "user",
+  remote: "https://artifacts/x.git",
+  sourceDefaultBranch: "trunk",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+function req(method: string, path: string, body?: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getProjectByPath).mockResolvedValue({ success: true, data: project } as never);
+  vi.mocked(freshRepoToken).mockResolvedValue({ success: true, data: "tok" } as never);
+  vi.mocked(isTargetDeleting).mockResolvedValue(false as never);
+  vi.mocked(canWriteProject).mockResolvedValue(true as never);
+});
+
+describe("GET /api/projects/:namespace/:slug/branches", () => {
+  it("lists branches and names the project's resolved default branch", async () => {
+    vi.mocked(listRepoBranches).mockResolvedValue({
+      success: true,
+      data: {
+        branches: [
+          { name: "trunk", oid: "a".repeat(40) },
+          { name: "release/2.x", oid: "b".repeat(40) },
+        ],
+        truncated: false,
+        totalBranchCount: 2,
+      },
+    } as never);
+
+    const res = await makeApp().fetch(req("GET", "/api/projects/@alice/api/branches"), env, ctx);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { defaultBranch: string; branches: unknown[] };
+    // The project's own default, not a hardcoded "main".
+    expect(body.defaultBranch).toBe("trunk");
+    expect(body.branches).toHaveLength(2);
+    expect(listRepoBranches).toHaveBeenCalledWith(
+      project.remote,
+      "tok",
+      expect.any(Object),
+      "trunk",
+    );
+  });
+
+  it("surfaces truncation rather than presenting a partial list as complete", async () => {
+    vi.mocked(listRepoBranches).mockResolvedValue({
+      success: true,
+      data: {
+        branches: [{ name: "trunk", oid: "a".repeat(40) }],
+        truncated: true,
+        totalBranchCount: 900,
+      },
+    } as never);
+
+    const res = await makeApp().fetch(req("GET", "/api/projects/@alice/api/branches"), env, ctx);
+    const body = (await res.json()) as { truncated: boolean; totalBranchCount: number };
+    expect(body.truncated).toBe(true);
+    expect(body.totalBranchCount).toBe(900);
+  });
+});
+
+describe("POST /api/projects/:namespace/:slug/branches", () => {
+  it("creates a branch, mints a WRITE token, and audits it", async () => {
+    vi.mocked(createBranchRef).mockResolvedValue({
+      success: true,
+      data: { name: "feature/x", oid: "a".repeat(40) },
+    } as never);
+
+    const res = await makeApp().fetch(
+      req("POST", "/api/projects/@alice/api/branches", { name: "feature/x" }),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(201);
+    // A read token here would fail the push with an opaque 502.
+    expect(freshRepoToken).toHaveBeenCalledWith(
+      env.ARTIFACTS,
+      project.remote,
+      "write",
+      expect.any(Object),
+    );
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({ action: "branch.created", actorType: "user", actorId: "usr_1" }),
+    );
+  });
+
+  it("passes the project's default branch, not main, to the git layer", async () => {
+    vi.mocked(createBranchRef).mockResolvedValue({
+      success: true,
+      data: { name: "x", oid: "a".repeat(40) },
+    } as never);
+
+    await makeApp().fetch(
+      req("POST", "/api/projects/@alice/api/branches", { name: "x", startPoint: "trunk" }),
+      env,
+      ctx,
+    );
+    expect(createBranchRef).toHaveBeenCalledWith(project.remote, "tok", expect.any(Object), {
+      name: "x",
+      startPoint: "trunk",
+      defaultBranch: "trunk",
+    });
+  });
+
+  it("credits an agent's write to the agent, not to a bare user", async () => {
+    vi.mocked(createBranchRef).mockResolvedValue({
+      success: true,
+      data: { name: "x", oid: "a".repeat(40) },
+    } as never);
+
+    await makeApp({ agentOwnerId: "usr_1" }).fetch(
+      req("POST", "/api/projects/@alice/api/branches", { name: "x" }),
+      env,
+      ctx,
+    );
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({ actorType: "agent", actorId: "usr_1" }),
+    );
+  });
+
+  it("404s a non-writer without disclosing that the project exists", async () => {
+    vi.mocked(canWriteProject).mockResolvedValue(false as never);
+    const res = await makeApp().fetch(
+      req("POST", "/api/projects/@alice/api/branches", { name: "x" }),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(404);
+    expect(createBranchRef).not.toHaveBeenCalled();
+  });
+
+  it("409s while the project is being deleted", async () => {
+    vi.mocked(isTargetDeleting).mockResolvedValue(true as never);
+    const res = await makeApp().fetch(
+      req("POST", "/api/projects/@alice/api/branches", { name: "x" }),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()) as { code: string }).toMatchObject({ code: "TARGET_DELETING" });
+    expect(createBranchRef).not.toHaveBeenCalled();
+  });
+
+  it("400s an invalid branch name before reaching the git layer", async () => {
+    const res = await makeApp().fetch(
+      req("POST", "/api/projects/@alice/api/branches", { name: "../heads/trunk" }),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(400);
+    expect(createBranchRef).not.toHaveBeenCalled();
+  });
+
+  it("409s a branch that already exists", async () => {
+    vi.mocked(createBranchRef).mockResolvedValue({
+      success: false,
+      error: { kind: "exists", name: "feature/x" },
+    } as never);
+    const res = await makeApp().fetch(
+      req("POST", "/api/projects/@alice/api/branches", { name: "feature/x" }),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()) as { code: string }).toMatchObject({ code: "BRANCH_EXISTS" });
+  });
+
+  it("400s an unresolvable start point", async () => {
+    vi.mocked(createBranchRef).mockResolvedValue({
+      success: false,
+      error: { kind: "bad-start-point", startPoint: "0".repeat(40) },
+    } as never);
+    const res = await makeApp().fetch(
+      req("POST", "/api/projects/@alice/api/branches", { name: "x", startPoint: "0".repeat(40) }),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("400s a JSON body of null rather than throwing a 500", async () => {
+    const res = await makeApp().fetch(
+      new Request("http://localhost/api/projects/@alice/api/branches", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "null",
+      }),
+      env,
+      ctx,
+    );
+    // `readJsonWithLimit` returns whatever JSON.parse produced, so `null`
+    // throws nothing and used to reach the destructure as a TypeError.
+    expect(res.status).toBe(400);
+    expect(createBranchRef).not.toHaveBeenCalled();
+  });
+
+  it("409s a name that collides with an existing branch's ref path", async () => {
+    vi.mocked(createBranchRef).mockResolvedValue({
+      success: false,
+      error: { kind: "conflicts-with", name: "release", existing: "release/2.x" },
+    } as never);
+    const res = await makeApp().fetch(
+      req("POST", "/api/projects/@alice/api/branches", { name: "release" }),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()) as { code: string }).toMatchObject({
+      code: "BRANCH_NAME_CONFLICT",
+    });
+  });
+
+  it("409s when the remote does not advertise the project's default branch", async () => {
+    vi.mocked(createBranchRef).mockResolvedValue({
+      success: false,
+      error: { kind: "no-default-branch", name: "trunk" },
+    } as never);
+    const res = await makeApp().fetch(
+      req("POST", "/api/projects/@alice/api/branches", { name: "x" }),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()) as { code: string }).toMatchObject({ code: "NO_DEFAULT_BRANCH" });
+  });
+
+  it("409s a branch write while the project's import is still running", async () => {
+    vi.mocked(getProjectByPath).mockResolvedValue({
+      success: true,
+      data: { ...project, importCompleted: false },
+    } as never);
+    const res = await makeApp().fetch(
+      req("POST", "/api/projects/@alice/api/branches", { name: "x" }),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()) as { code: string }).toMatchObject({ code: "IMPORT_IN_PROGRESS" });
+    expect(createBranchRef).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized body before parsing it", async () => {
+    const res = await makeApp().fetch(
+      new Request("http://localhost/api/projects/@alice/api/branches", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "content-length": String(64 * 1024) },
+        body: JSON.stringify({ name: "x" }),
+      }),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(413);
+    expect(createBranchRef).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/projects/:namespace/:slug/branches/*", () => {
+  it("deletes a branch and audits it", async () => {
+    vi.mocked(deleteBranchRef).mockResolvedValue({ success: true, data: undefined } as never);
+    const res = await makeApp().fetch(
+      req("DELETE", "/api/projects/@alice/api/branches/stale"),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    expect(deleteBranchRef).toHaveBeenCalledWith(project.remote, "tok", expect.any(Object), {
+      name: "stale",
+      defaultBranch: "trunk",
+    });
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({ action: "branch.deleted" }),
+    );
+  });
+
+  it("carries a hierarchical name through the wildcard path intact", async () => {
+    vi.mocked(deleteBranchRef).mockResolvedValue({ success: true, data: undefined } as never);
+    await makeApp().fetch(req("DELETE", "/api/projects/@alice/api/branches/release/2.x"), env, ctx);
+    expect(deleteBranchRef).toHaveBeenCalledWith(
+      project.remote,
+      "tok",
+      expect.any(Object),
+      expect.objectContaining({ name: "release/2.x" }),
+    );
+  });
+
+  it("does not lop the name in half when the project slug is itself 'branches'", async () => {
+    vi.mocked(getProjectByPath).mockResolvedValue({
+      success: true,
+      data: { ...project, slug: "branches", name: "branches" },
+    } as never);
+    vi.mocked(deleteBranchRef).mockResolvedValue({ success: true, data: undefined } as never);
+
+    await makeApp().fetch(req("DELETE", "/api/projects/@alice/branches/branches/stale"), env, ctx);
+    expect(deleteBranchRef).toHaveBeenCalledWith(
+      project.remote,
+      "tok",
+      expect.any(Object),
+      expect.objectContaining({ name: "stale" }),
+    );
+  });
+
+  it("keeps a branch legitimately named refs/branches/x intact", async () => {
+    vi.mocked(deleteBranchRef).mockResolvedValue({ success: true, data: undefined } as never);
+    await makeApp().fetch(
+      req("DELETE", "/api/projects/@alice/api/branches/refs/branches/x"),
+      env,
+      ctx,
+    );
+    expect(deleteBranchRef).toHaveBeenCalledWith(
+      project.remote,
+      "tok",
+      expect.any(Object),
+      expect.objectContaining({ name: "refs/branches/x" }),
+    );
+  });
+
+  it("finds the branch name when the namespace arrives percent-encoded", async () => {
+    vi.mocked(deleteBranchRef).mockResolvedValue({ success: true, data: undefined } as never);
+    // Hono decodes route params with decodeURIComponent but the path with
+    // decodeURI, which leaves %40 alone — so a client that builds the URL with
+    // encodeURIComponent (as this codebase's own UI does) used to land here
+    // with an empty name and a 400.
+    const res = await makeApp().fetch(
+      req("DELETE", "/api/projects/%40alice/api/branches/stale"),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    expect(deleteBranchRef).toHaveBeenCalledWith(
+      project.remote,
+      "tok",
+      expect.any(Object),
+      expect.objectContaining({ name: "stale" }),
+    );
+  });
+
+  it("reads a percent-encoded slash as a real hierarchical name", async () => {
+    vi.mocked(deleteBranchRef).mockResolvedValue({ success: true, data: undefined } as never);
+    const res = await makeApp().fetch(
+      req("DELETE", "/api/projects/@alice/api/branches/release%2F2.x"),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    // Either encoding names the same branch.
+    expect(deleteBranchRef).toHaveBeenCalledWith(
+      project.remote,
+      "tok",
+      expect.any(Object),
+      expect.objectContaining({ name: "release/2.x" }),
+    );
+  });
+
+  it("409s a delete while the project is being deleted", async () => {
+    vi.mocked(isTargetDeleting).mockResolvedValue(true as never);
+    const res = await makeApp().fetch(
+      req("DELETE", "/api/projects/@alice/api/branches/stale"),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(409);
+    expect(deleteBranchRef).not.toHaveBeenCalled();
+  });
+
+  it("409s a delete of the default branch", async () => {
+    vi.mocked(deleteBranchRef).mockResolvedValue({
+      success: false,
+      error: { kind: "default-branch", name: "trunk" },
+    } as never);
+    const res = await makeApp().fetch(
+      req("DELETE", "/api/projects/@alice/api/branches/trunk"),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()) as { code: string }).toMatchObject({
+      code: "DEFAULT_BRANCH_PROTECTED",
+    });
+  });
+
+  it("404s an unknown branch", async () => {
+    vi.mocked(deleteBranchRef).mockResolvedValue({
+      success: false,
+      error: { kind: "not-found", name: "ghost" },
+    } as never);
+    const res = await makeApp().fetch(
+      req("DELETE", "/api/projects/@alice/api/branches/ghost"),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("404s a non-writer", async () => {
+    vi.mocked(canWriteProject).mockResolvedValue(false as never);
+    const res = await makeApp().fetch(
+      req("DELETE", "/api/projects/@alice/api/branches/stale"),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(404);
+    expect(deleteBranchRef).not.toHaveBeenCalled();
+  });
+});
+
+describe("?ref= on the read routes", () => {
+  it("reads the default branch when no ref is given, at no extra cost", async () => {
+    const res = await makeApp().fetch(req("GET", "/api/projects/@alice/api/files"), env, ctx);
+    expect(res.status).toBe(200);
+    // No ref means no advertisement round trip.
+    expect(resolveBranchRef).not.toHaveBeenCalled();
+    expect(listFilesInRepo).toHaveBeenCalledWith(
+      project.remote,
+      "tok",
+      expect.any(Object),
+      "trunk",
+    );
+  });
+
+  it("reads the requested branch when the ref resolves", async () => {
+    vi.mocked(resolveBranchRef).mockResolvedValue({
+      success: true,
+      data: { name: "release/2.x", oid: "b".repeat(40) },
+    } as never);
+
+    const res = await makeApp().fetch(
+      req("GET", "/api/projects/@alice/api/files?ref=release/2.x"),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { ref: string }).toMatchObject({ ref: "release/2.x" });
+    expect(listFilesInRepo).toHaveBeenCalledWith(
+      project.remote,
+      "tok",
+      expect.any(Object),
+      "release/2.x",
+    );
+  });
+
+  it("404s an unknown ref instead of quietly serving the default branch", async () => {
+    vi.mocked(resolveBranchRef).mockResolvedValue({
+      success: false,
+      error: { kind: "not-found", name: "ghost" },
+    } as never);
+
+    const res = await makeApp().fetch(
+      req("GET", "/api/projects/@alice/api/files?ref=ghost"),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(404);
+    expect(listFilesInRepo).not.toHaveBeenCalled();
+  });
+
+  it("409s a ref that names both a branch and a tag", async () => {
+    vi.mocked(resolveBranchRef).mockResolvedValue({
+      success: false,
+      error: { kind: "ambiguous", name: "v1" },
+    } as never);
+
+    const res = await makeApp().fetch(req("GET", "/api/projects/@alice/api/log?ref=v1"), env, ctx);
+    expect(res.status).toBe(409);
+    expect((await res.json()) as { code: string }).toMatchObject({ code: "AMBIGUOUS_REF" });
+  });
+
+  it("400s a syntactically invalid ref", async () => {
+    vi.mocked(resolveBranchRef).mockResolvedValue({
+      success: false,
+      error: { kind: "invalid", name: "../heads/trunk" },
+    } as never);
+
+    const res = await makeApp().fetch(
+      req("GET", "/api/projects/@alice/api/files?ref=../heads/trunk"),
+      env,
+      ctx,
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/branches-ui.test.tsx
+++ b/tests/branches-ui.test.tsx
@@ -1,0 +1,507 @@
+import { renderToString } from "hono/jsx/dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../src/index";
+import {
+  freshRepoToken,
+  listFilesInRepo,
+  listRepoBranches,
+  resolveBranchRef,
+} from "../src/storage/git-ops";
+import { readRepoSnapshot } from "../src/storage/repo-snapshot";
+import type { Env, ProjectEntry } from "../src/types";
+import { FileTree } from "../src/ui/components/file-tree";
+import { getFileContent } from "../src/ui/file-content";
+import { buildFileTree } from "../src/ui/file-tree";
+import { BranchSwitcher, BranchesPage } from "../src/ui/pages/branches";
+import { AppError } from "../src/utils/errors";
+import { err } from "../src/utils/result";
+
+// Ref-scoped browsing (#181, task 6): the branches page, the no-JS switcher, and
+// `?ref=` on the repo and blob views. The git leg is mocked at the git-ops
+// boundary — it has its own suite (tests/git-branches.test.ts).
+
+const DEFAULT_TIP = "a".repeat(40);
+const FEATURE_TIP = "b".repeat(40);
+
+vi.mock("../src/storage/git-ops", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/git-ops")>();
+  return {
+    ...actual,
+    freshRepoToken: vi.fn(async () => ({ success: true, data: "mock-token" })),
+    listRepoBranches: vi.fn(async () => ({
+      success: true,
+      data: {
+        branches: [
+          { name: "main", oid: "a".repeat(40) },
+          { name: "release/2.x", oid: "b".repeat(40) },
+        ],
+        truncated: false,
+        totalBranchCount: 2,
+      },
+    })),
+    resolveBranchRef: vi.fn(
+      async (_remote: string, _token: string, _logger: unknown, name: string) => ({
+        success: true,
+        data: { name, oid: "b".repeat(40) },
+      }),
+    ),
+    listFilesInRepo: vi.fn(async () => ({ success: true, data: ["src/index.ts"] })),
+    getCommitLog: vi.fn(async () => ({ success: true, data: [] })),
+    readFileFromRepo: vi.fn(async () => ({ success: false, error: new Error("no readme") })),
+  };
+});
+
+vi.mock("../src/storage/repo-snapshot", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/repo-snapshot")>();
+  return {
+    ...actual,
+    readRepoSnapshot: vi.fn(async () => ({
+      success: true,
+      data: {
+        v: 1 as const,
+        files: ["SNAPSHOT_ONLY.md"],
+        commits: [],
+        readme: null,
+        readmeTruncated: false,
+        snapshotAt: "2026-01-01T00:00:00.000Z",
+      },
+    })),
+  };
+});
+
+vi.mock("../src/ui/file-content", async (importActual) => {
+  const actual = await importActual<typeof import("../src/ui/file-content")>();
+  return {
+    ...actual,
+    getFileContent: vi.fn(async () => ({
+      success: true,
+      data: { kind: "content" as const, value: "console.log(1);\n" },
+    })),
+  };
+});
+
+vi.mock("../src/storage/users", () => ({
+  getUserByToken: vi.fn(async () => ({ success: false, error: { message: "not found" } })),
+  getUser: vi.fn(async () => ({ success: false, error: { message: "not found" } })),
+}));
+
+function makeKV(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    list: async () => ({ keys: [], list_complete: true, cursor: "" }),
+    getWithMetadata: async () => ({ value: null, metadata: null }),
+  } as unknown as KVNamespace;
+}
+
+function makeEnv(): Env {
+  return {
+    ARTIFACTS: {} as Env["ARTIFACTS"],
+    STATE: makeKV(),
+    DB: {} as D1Database,
+  } as Env;
+}
+
+async function seedProject(env: Env, overrides: Partial<ProjectEntry> = {}): Promise<ProjectEntry> {
+  const project: ProjectEntry = {
+    id: "proj_1",
+    name: "repo",
+    slug: "repo",
+    namespace: "@owner",
+    ownerId: "user_test",
+    ownerType: "user",
+    remote: "https://acct.artifacts.cloudflare.net/git/@owner/repo.git",
+    createdAt: new Date().toISOString(),
+    visibility: "public",
+    ...overrides,
+  };
+  await env.STATE.put(`project:${project.namespace}:${project.slug}`, JSON.stringify(project));
+  return project;
+}
+
+function req(path: string): Request {
+  return new Request(`http://localhost${path}`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("BranchesPage", () => {
+  const project = { name: "repo", namespace: "@owner", slug: "repo" };
+
+  it("renders every branch with its short tip sha, a browse link, and the default marked", () => {
+    const html = renderToString(
+      <BranchesPage
+        project={project}
+        branches={[
+          { name: "main", oid: DEFAULT_TIP },
+          { name: "release/2.x", oid: FEATURE_TIP },
+        ]}
+        defaultBranch="main"
+        truncated={false}
+        totalBranchCount={2}
+      />,
+    );
+
+    expect(html).toContain("main");
+    expect(html).toContain("release/2.x");
+    expect(html).toContain(DEFAULT_TIP.slice(0, 7));
+    expect(html).toContain(FEATURE_TIP.slice(0, 7));
+    expect(html).toContain("default");
+    // The default branch keeps its bare URL; every other branch carries the ref.
+    expect(html).toContain('href="/@owner/repo"');
+    expect(html).toContain('href="/@owner/repo?ref=release%2F2.x"');
+  });
+
+  it("says so in place when the listing was truncated, never passing it off as complete", () => {
+    const html = renderToString(
+      <BranchesPage
+        project={project}
+        branches={[{ name: "main", oid: DEFAULT_TIP }]}
+        defaultBranch="main"
+        truncated={true}
+        totalBranchCount={640}
+      />,
+    );
+
+    expect(html).toContain("640");
+    expect(html.toLowerCase()).toContain("not listed");
+  });
+
+  it("renders an empty state for a repo that advertises no branches", () => {
+    const html = renderToString(
+      <BranchesPage
+        project={project}
+        branches={[]}
+        defaultBranch="main"
+        truncated={false}
+        totalBranchCount={0}
+      />,
+    );
+
+    expect(html).toContain("No branches yet");
+  });
+});
+
+describe("BranchSwitcher", () => {
+  it("is a GET form over a select, with the current ref selected and no script", () => {
+    const html = renderToString(
+      <BranchSwitcher
+        action="/@owner/repo"
+        branchNames={["main", "release/2.x"]}
+        currentRef="release/2.x"
+      />,
+    );
+
+    expect(html).toContain('method="get"');
+    expect(html).toContain('action="/@owner/repo"');
+    expect(html).toContain('name="ref"');
+    expect(html).toContain('<option value="release/2.x" selected');
+    expect(html).not.toContain('<option value="main" selected');
+    // No client-side JavaScript in this UI (AGENTS.md) — the browser's own GET
+    // form serialisation is the whole mechanism.
+    expect(html).not.toContain("<script");
+    expect(html).not.toContain("onchange");
+  });
+
+  it("renders nothing at all when no branches are known", () => {
+    const html = renderToString(
+      <BranchSwitcher action="/@owner/repo" branchNames={[]} currentRef="main" />,
+    );
+
+    expect(html).not.toContain("<select");
+  });
+
+  it("keeps the branch on screen selectable when a truncated listing omitted it", () => {
+    const html = renderToString(
+      <BranchSwitcher action="/@owner/repo" branchNames={["main"]} currentRef="zz-experiment" />,
+    );
+
+    expect(html).toContain('<option value="zz-experiment" selected');
+  });
+});
+
+describe("FileTree ref threading", () => {
+  const nodes = buildFileTree(["src/index.ts"]);
+
+  it("carries the ref on every blob link when browsing a non-default branch", () => {
+    const html = renderToString(
+      <FileTree
+        nodes={nodes}
+        namespace="@owner"
+        slug="repo"
+        nonce="test-nonce"
+        refName="release/2.x"
+      />,
+    );
+
+    expect(html).toContain('href="/@owner/repo/blob/src/index.ts?ref=release%2F2.x"');
+  });
+
+  it("omits the parameter on the default branch so existing URLs are unchanged", () => {
+    const html = renderToString(
+      <FileTree nodes={nodes} namespace="@owner" slug="repo" nonce="test-nonce" />,
+    );
+
+    expect(html).toContain('href="/@owner/repo/blob/src/index.ts"');
+    expect(html).not.toContain("?ref=");
+  });
+});
+
+describe("UI GET /:namespace/:slug/branches", () => {
+  it("renders the branch table with tips and the default marked", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+
+    const res = await app.fetch(req("/@owner/repo/branches"), env);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Branches");
+    expect(html).toContain("release/2.x");
+    expect(html).toContain(DEFAULT_TIP.slice(0, 7));
+    expect(html).toContain("default");
+  });
+
+  it("lists against the project's own default branch, not a hardcoded 'main'", async () => {
+    const env = makeEnv();
+    await seedProject(env, { sourceDefaultBranch: "trunk" });
+
+    await app.fetch(req("/@owner/repo/branches"), env);
+
+    expect(vi.mocked(listRepoBranches)).toHaveBeenCalledWith(
+      expect.any(String),
+      "mock-token",
+      expect.anything(),
+      "trunk",
+    );
+  });
+
+  it("404s a missing project and a private one seen anonymously", async () => {
+    const env = makeEnv();
+    const missing = await app.fetch(req("/@owner/nope/branches"), env);
+    expect(missing.status).toBe(404);
+
+    await seedProject(env, { visibility: "private" });
+    const hidden = await app.fetch(req("/@owner/repo/branches"), env);
+    expect(hidden.status).toBe(404);
+  });
+
+  it("400s an invalid project path", async () => {
+    const env = makeEnv();
+    const res = await app.fetch(req("/@bad__ns!/repo/branches"), env);
+    expect(res.status).toBe(400);
+  });
+
+  it("500s when the advertisement fails", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    vi.mocked(listRepoBranches).mockResolvedValueOnce(
+      err(new AppError("Failed to read remote refs", "EXTERNAL_SERVICE_ERROR", 502)),
+    );
+
+    const res = await app.fetch(req("/@owner/repo/branches"), env);
+
+    expect(res.status).toBe(500);
+    expect(await res.text()).toContain("Error loading branches");
+  });
+});
+
+describe("UI GET /:namespace/:slug — ?ref=", () => {
+  it("serves the KV snapshot on the default branch, as before", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+
+    const res = await app.fetch(req("/@owner/repo"), env);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("SNAPSHOT_ONLY.md");
+    expect(vi.mocked(listFilesInRepo)).not.toHaveBeenCalled();
+  });
+
+  it("does no git work at all when the snapshot serves the default branch", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+
+    const res = await app.fetch(req("/@owner/repo"), env);
+    expect(res.status).toBe(200);
+
+    // This is the busiest page in the product and, on a snapshot hit, it made
+    // zero git calls before multi-branch support. Minting a read token or
+    // advertising refs for the switcher would add a fixed round trip to every
+    // view for a control most readers never touch.
+    expect(vi.mocked(freshRepoToken)).not.toHaveBeenCalled();
+    expect(vi.mocked(listRepoBranches)).not.toHaveBeenCalled();
+  });
+
+  it("treats an empty ?ref= as unspecified rather than an invalid name", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+
+    // A GET form submitted with nothing chosen sends exactly this. Answering a
+    // browser's own default submission with a 400 would be a worse contract
+    // than reading it as "no preference" — which is what the API route does.
+    const res = await app.fetch(req("/@owner/repo?ref="), env);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("SNAPSHOT_ONLY.md");
+    expect(vi.mocked(resolveBranchRef)).not.toHaveBeenCalled();
+  });
+
+  it("bypasses the snapshot for a non-default ref and clones that branch instead", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+
+    const res = await app.fetch(req("/@owner/repo?ref=release/2.x"), env);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // The snapshot is keyed by project alone and only describes the default
+    // branch, so it must not be read at all for another ref.
+    expect(vi.mocked(readRepoSnapshot)).not.toHaveBeenCalled();
+    expect(html).not.toContain("SNAPSHOT_ONLY.md");
+    expect(vi.mocked(listFilesInRepo)).toHaveBeenCalledWith(
+      expect.any(String),
+      "mock-token",
+      expect.anything(),
+      "release/2.x",
+    );
+    // File links stay on the branch the reader chose.
+    expect(html).toContain('href="/@owner/repo/blob/src/index.ts?ref=release%2F2.x"');
+  });
+
+  it("round-trips the percent-encoded ref its own links generate", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+
+    // The branches page and file tree emit `?ref=release%2F2.x`; hierarchical
+    // branch names only work if that arrives back as a real slash.
+    const res = await app.fetch(req("/@owner/repo?ref=release%2F2.x"), env);
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(resolveBranchRef)).toHaveBeenCalledWith(
+      expect.any(String),
+      "mock-token",
+      expect.anything(),
+      "release/2.x",
+    );
+  });
+
+  it("renders the switcher with the requested ref selected", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+
+    const res = await app.fetch(req("/@owner/repo?ref=release/2.x"), env);
+
+    const html = await res.text();
+    expect(html).toContain('name="ref"');
+    expect(html).toContain('<option value="release/2.x" selected');
+  });
+
+  it("404s an unknown ref, naming it, rather than falling back to the default", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    vi.mocked(resolveBranchRef).mockResolvedValueOnce(err({ kind: "not-found", name: "nope" }));
+
+    const res = await app.fetch(req("/@owner/repo?ref=nope"), env);
+
+    expect(res.status).toBe(404);
+    expect(await res.text()).toContain("nope");
+    expect(vi.mocked(listFilesInRepo)).not.toHaveBeenCalled();
+  });
+
+  it("409s a ref that names both a branch and a tag, naming both namespaces", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    vi.mocked(resolveBranchRef).mockResolvedValueOnce(err({ kind: "ambiguous", name: "v1" }));
+
+    const res = await app.fetch(req("/@owner/repo?ref=v1"), env);
+
+    expect(res.status).toBe(409);
+    const html = await res.text();
+    expect(html).toContain("refs/heads/v1");
+    expect(html).toContain("refs/tags/v1");
+  });
+
+  it("400s an invalid ref name", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    vi.mocked(resolveBranchRef).mockResolvedValueOnce(err({ kind: "invalid", name: "../etc" }));
+
+    const res = await app.fetch(req("/@owner/repo?ref=../etc"), env);
+
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("Invalid branch name");
+  });
+});
+
+describe("UI GET /:namespace/:slug/blob/* — ?ref=", () => {
+  it("reads the file from the requested branch and keeps its links on it", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+
+    const res = await app.fetch(req("/@owner/repo/blob/src/index.ts?ref=release/2.x"), env);
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(getFileContent)).toHaveBeenCalledWith(
+      expect.any(String),
+      "mock-token",
+      "src/index.ts",
+      expect.anything(),
+      "release/2.x",
+    );
+    const html = await res.text();
+    // The query string never leaks into the wildcard file path.
+    expect(html).toContain('href="/@owner/repo?ref=release%2F2.x"');
+    expect(html).toContain('<option value="release/2.x" selected');
+  });
+
+  it("reads the default branch when no ref is given", async () => {
+    const env = makeEnv();
+    await seedProject(env, { sourceDefaultBranch: "trunk" });
+
+    const res = await app.fetch(req("/@owner/repo/blob/src/index.ts"), env);
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(getFileContent)).toHaveBeenCalledWith(
+      expect.any(String),
+      "mock-token",
+      "src/index.ts",
+      expect.anything(),
+      "trunk",
+    );
+    expect(vi.mocked(resolveBranchRef)).not.toHaveBeenCalled();
+  });
+
+  it("404s an unknown ref before reading any file", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+    vi.mocked(resolveBranchRef).mockResolvedValueOnce(err({ kind: "not-found", name: "nope" }));
+
+    const res = await app.fetch(req("/@owner/repo/blob/src/index.ts?ref=nope"), env);
+
+    expect(res.status).toBe(404);
+    expect(await res.text()).toContain("nope");
+    expect(vi.mocked(getFileContent)).not.toHaveBeenCalled();
+  });
+});
+
+describe("RepoPage branches link", () => {
+  it("offers the branches page beside Tags", async () => {
+    const env = makeEnv();
+    await seedProject(env);
+
+    const res = await app.fetch(req("/@owner/repo"), env);
+
+    const html = await res.text();
+    expect(html).toContain('href="/@owner/repo/branches"');
+    expect(html).toContain('href="/@owner/repo/tags"');
+  });
+});

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -382,6 +382,7 @@ describe("POST /api/projects/:name/changes", () => {
         workspaceOid: "ws_tip_sha",
         workspaceTreeOid: "ws_tree_oid",
         workspaceSha: "ws_tip_sha",
+        baseOid: "base_sha_from_diff_clone",
       },
     });
     vi.mocked(updateChangeStatus).mockResolvedValue({
@@ -3328,6 +3329,7 @@ describe("POST /api/changes/:id/evaluate — stale approval dismissal (#193)", (
         workspaceOid: "new_sha",
         workspaceTreeOid: "new_tree",
         workspaceSha: "new_sha",
+        baseOid: "base_sha_from_diff_clone",
       },
     });
     vi.mocked(updateChangeStatus).mockResolvedValue({ success: true, data: undefined });
@@ -3388,6 +3390,10 @@ describe("POST /api/changes/:id/evaluate — stale approval dismissal (#193)", (
         dismissedReviewerIds: ["user_1", "user_2"],
         previousEvaluatedSha: "old_sha",
         evaluatedSha: "new_sha",
+        // The fixture change carries no baseSha, so only the tip moved here.
+        previousBaseSha: undefined,
+        baseSha: "base_sha_from_diff_clone",
+        dismissedFor: "tip",
       },
     });
     // The audit entry is only recorded once the batch itself has succeeded.
@@ -3432,6 +3438,7 @@ describe("POST /api/changes/:id/evaluate — stale approval dismissal (#193)", (
         workspaceOid: "new_sha",
         workspaceTreeOid: "new_tree",
         workspaceSha: "new_sha",
+        baseOid: "base_sha_from_diff_clone",
       },
     });
     vi.mocked(diffTouchesProtectedConfig).mockReturnValue(true);
@@ -3454,6 +3461,26 @@ describe("POST /api/changes/:id/evaluate — stale approval dismissal (#193)", (
       "chg_abc123",
       expect.any(String),
       expect.objectContaining({ touchesProtectedConfig: true }),
+    );
+  });
+
+  it("#274: re-pins the recorded base to the one the re-evaluation ran against", async () => {
+    const res = await app.fetch(
+      request("POST", "/api/changes/chg_abc123/evaluate", {}, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(200);
+
+    // Without this the merge gate keeps comparing `change.baseSha` — the base at
+    // CREATION — against the current project head, so a change whose base moved
+    // stays STALE_BASE no matter how often it is re-evaluated, and re-evaluation
+    // (the documented remedy) reports a fresh pass that can never be merged.
+    expect(dismissApprovalsAndUpdateStatus).toHaveBeenCalledWith(
+      env.DB,
+      expect.anything(),
+      "chg_abc123",
+      expect.any(String),
+      expect.objectContaining({ baseSha: "base_sha_from_diff_clone" }),
     );
   });
 
@@ -3487,6 +3514,7 @@ describe("POST /api/changes/:id/evaluate — stale approval dismissal (#193)", (
         workspaceOid: "old_sha",
         workspaceTreeOid: "old_tree",
         workspaceSha: "old_sha",
+        baseOid: "base_sha_from_diff_clone",
       },
     });
 
@@ -3498,6 +3526,84 @@ describe("POST /api/changes/:id/evaluate — stale approval dismissal (#193)", (
     expect(dismissApprovalsAndUpdateStatus).not.toHaveBeenCalled();
     expect(recordAudit).not.toHaveBeenCalled();
     // No approvals at risk here, so the plain single-write path is used.
+    expect(updateChangeStatus).toHaveBeenCalled();
+  });
+
+  it("dismisses approvals when the BASE moved even though the tip did not", async () => {
+    // The bypass this closes is one this PR opened. `baseSha` used to be frozen
+    // at creation, so a change whose base advanced stayed permanently
+    // STALE_BASE and could not merge on an old approval at all. Re-pinning the
+    // base (#274) makes re-evaluation the remedy for staleness — and without
+    // this, an unchanged workspace tip would clear the merge gate carrying
+    // approvals given for a diff against the OLD base. Reviewers approve a
+    // diff, not a tip, so either endpoint moving invalidates the verdict.
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: { ...evaluatedChange, baseSha: "base_at_creation" },
+    });
+    vi.mocked(getDiffBetweenRepos).mockResolvedValue({
+      success: true,
+      data: {
+        diff: "diff --git a/src/index.ts b/src/index.ts\n+new line",
+        workspaceOid: "old_sha",
+        workspaceTreeOid: "old_tree",
+        workspaceSha: "old_sha",
+        baseOid: "base_sha_from_diff_clone",
+      },
+    });
+
+    const res = await app.fetch(
+      request("POST", "/api/changes/chg_abc123/evaluate", {}, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(dismissApprovalsAndUpdateStatus).toHaveBeenCalledWith(
+      env.DB,
+      expect.anything(),
+      "chg_abc123",
+      expect.any(String),
+      expect.objectContaining({ baseSha: "base_sha_from_diff_clone" }),
+    );
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.anything(),
+      expect.objectContaining({
+        action: "review.approvals_dismissed",
+        // The audit has to name WHICH endpoint moved: a reader otherwise
+        // cannot tell a re-push from a base advance, and the causes differ.
+        detail: expect.objectContaining({
+          dismissedFor: "base",
+          previousBaseSha: "base_at_creation",
+          baseSha: "base_sha_from_diff_clone",
+        }),
+      }),
+    );
+  });
+
+  it("keeps approvals when neither the tip nor the base moved", async () => {
+    // The paired negative: without it, the test above would also pass against
+    // an implementation that dismissed on every re-evaluation.
+    vi.mocked(getChange).mockResolvedValue({
+      success: true,
+      data: { ...evaluatedChange, baseSha: "base_sha_from_diff_clone" },
+    });
+    vi.mocked(getDiffBetweenRepos).mockResolvedValue({
+      success: true,
+      data: {
+        diff: "diff --git a/src/index.ts b/src/index.ts\n+new line",
+        workspaceOid: "old_sha",
+        workspaceTreeOid: "old_tree",
+        workspaceSha: "old_sha",
+        baseOid: "base_sha_from_diff_clone",
+      },
+    });
+
+    const res = await app.fetch(
+      request("POST", "/api/changes/chg_abc123/evaluate", {}, USER_AUTH),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(dismissApprovalsAndUpdateStatus).not.toHaveBeenCalled();
     expect(updateChangeStatus).toHaveBeenCalled();
   });
 

--- a/tests/evaluate-github-report.test.ts
+++ b/tests/evaluate-github-report.test.ts
@@ -231,6 +231,7 @@ describe("POST /api/changes/:id/evaluate — GitHub verdict reporting", () => {
         workspaceOid: "ws-oid",
         workspaceTreeOid: "ws-tree-oid",
         workspaceSha: "ws-sha",
+        baseOid: "base_sha_from_diff_clone",
       },
     });
     vi.mocked(recordEvalRuns).mockResolvedValue({ success: true, data: [] });

--- a/tests/evaluation.test.ts
+++ b/tests/evaluation.test.ts
@@ -299,6 +299,80 @@ describe("WebhookEvaluator", () => {
     expect(capturedHeaders["X-Stratum-Signature"]).toMatch(/^sha256=[0-9a-f]{64}$/);
   });
 
+  it("#274: sends the base commit the diff was computed against", async () => {
+    let capturedBody = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+        capturedBody = init.body as string;
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ score: 1, passed: true, reason: "ok" }),
+        });
+      }),
+    );
+
+    const policy = makePolicy({
+      evaluators: [{ type: "webhook", url: "https://example.com/eval" }],
+    });
+    await evaluator.evaluate("diff content", policy, mockLogger, { baseSha: "base_abc123" });
+
+    const body = JSON.parse(capturedBody);
+    expect(body.baseSha).toBe("base_abc123");
+    expect(body.diff).toBe("diff content");
+  });
+
+  it("#274: omits baseSha rather than guessing when the caller has no base", async () => {
+    let capturedBody = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+        capturedBody = init.body as string;
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ score: 1, passed: true, reason: "ok" }),
+        });
+      }),
+    );
+
+    const policy = makePolicy({
+      evaluators: [{ type: "webhook", url: "https://example.com/eval" }],
+    });
+    await evaluator.evaluate("diff content", policy, mockLogger, {});
+
+    const body = JSON.parse(capturedBody);
+    // Absent, not null and not a stand-in value: a receiver can act on the
+    // absence, but cannot be misled by a base that was never verified.
+    expect(body).not.toHaveProperty("baseSha");
+  });
+
+  it("#274: baseSha is covered by the request signature", async () => {
+    const bodies: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+        bodies.push(init.body as string);
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ score: 1, passed: true, reason: "ok" }),
+        });
+      }),
+    );
+
+    const policy = makePolicy({
+      evaluators: [{ type: "webhook", url: "https://example.com/eval", secret: "mysecret" }],
+    });
+    await evaluator.evaluate("diff content", policy, mockLogger, { baseSha: "base_abc123" });
+    await evaluator.evaluate("diff content", policy, mockLogger, { baseSha: "base_def456" });
+
+    // The signature is computed over the serialized body, so a tampered base
+    // cannot be swapped in transit without invalidating it.
+    expect(bodies[0]).not.toBe(bodies[1]);
+  });
+
   it("fails closed with a generic reason when URL validation reports no detail", async () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal("fetch", fetchSpy);

--- a/tests/git-branches.test.ts
+++ b/tests/git-branches.test.ts
@@ -1,0 +1,636 @@
+/**
+ * Issue #181: branch listing and branch CRUD on a project remote.
+ *
+ * The network legs (getRemoteInfo, clone, push) are simulated against a
+ * fixture; everything that decides behaviour — name validation, the existence
+ * pre-check, start-point resolution through a real `readObject`, the local
+ * `writeRef` a delete-push requires — runs for real against in-memory repos.
+ *
+ * That split is deliberate. The design's three sharpest edges are all in real
+ * isomorphic-git behaviour rather than in Stratum's own logic: a fetched head
+ * ref lands in `refs/remotes/origin/*` (which is why listing reads the
+ * advertisement instead of a clone), `push` resolves the LOCAL ref before it
+ * honours `delete`, and a non-forced push fast-forwards an existing branch
+ * rather than rejecting it. A suite that mocked isomorphic-git wholesale would
+ * go green against a design that does none of this correctly.
+ */
+import git, { type PromiseFsClient } from "isomorphic-git";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Shapes of the isomorphic-git calls this suite intercepts, and of what the
+ * harness records for each. Declared narrowly rather than as `any` so a
+ * signature change in the real library surfaces here as a type error instead of
+ * a silently mistyped assertion.
+ */
+interface RemoteInfoArgs {
+  url: string;
+}
+
+interface CloneArgs {
+  url: string;
+  ref: string;
+  depth?: number;
+  fs: PromiseFsClient;
+  dir: string;
+}
+
+interface PushArgs {
+  url: string;
+  ref: string;
+  remoteRef?: string;
+  delete?: boolean;
+  force?: boolean;
+  fs: PromiseFsClient;
+  dir: string;
+}
+
+interface CloneCapture {
+  url: string;
+  ref: string;
+  depth?: number;
+}
+
+interface PushCapture {
+  url: string;
+  ref: string;
+  remoteRef?: string;
+  delete: boolean;
+  force: boolean;
+  localOid: string;
+}
+
+interface RemoteFixture {
+  branch: string;
+  commits: Record<string, string>[];
+  /** Extra advertised refs beyond the default branch. */
+  heads?: Record<string, string>;
+  tags?: Record<string, string>;
+}
+
+const h = vi.hoisted(() => ({
+  servers: new Map<
+    string,
+    {
+      branch: string;
+      commits: Record<string, string>[];
+      heads?: Record<string, string>;
+      tags?: Record<string, string>;
+    }
+  >(),
+  pushes: [] as PushCapture[],
+  clones: [] as CloneCapture[],
+  /** How the next push fails, if at all: a remote rejection or a transport
+   * error. The two must not be reported the same way. */
+  pushFails: null as null | "rejected" | "network",
+}));
+
+vi.mock("isomorphic-git", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("isomorphic-git")>();
+  const real = actual.default;
+
+  async function seed(
+    fs: PromiseFsClient,
+    dir: string,
+    server: { branch: string; commits: Record<string, string>[] },
+  ) {
+    await real.init({ fs, dir, defaultBranch: server.branch });
+    const shas: string[] = [];
+    let t = 1700000000;
+    for (const files of server.commits) {
+      for (const [p, content] of Object.entries(files)) {
+        await fs.promises.writeFile(dir === "/" ? `/${p}` : `${dir}/${p}`, content);
+        await real.add({ fs, dir, filepath: p });
+      }
+      const author = { name: "Seed", email: "seed@test", timestamp: t++, timezoneOffset: 0 };
+      shas.push(
+        await real.commit({ fs, dir, message: `seed ${shas.length}`, author, committer: author }),
+      );
+    }
+    return shas;
+  }
+
+  /** Nest a flat `name -> oid` map the way getRemoteInfo nests advertised refs. */
+  function nest(flat: Record<string, string>): Record<string, unknown> {
+    const root: Record<string, unknown> = {};
+    for (const [name, oid] of Object.entries(flat)) {
+      const parts = name.split("/");
+      const last = parts.pop() as string;
+      let node = root;
+      for (const part of parts) {
+        node[part] = (node[part] as Record<string, unknown>) ?? {};
+        node = node[part] as Record<string, unknown>;
+      }
+      node[last] = oid;
+    }
+    return root;
+  }
+
+  const mocked = {
+    ...real,
+    __seed: seed,
+    getRemoteInfo: async (args: RemoteInfoArgs) => {
+      const server = h.servers.get(args.url);
+      if (!server) throw new Error(`NotFoundError: unknown remote ${args.url}`);
+      const fs = new (await import("../src/storage/memory-fs")).MemoryFS().toNodeFS();
+      const shas = await seed(fs, "/", server);
+      const tip = shas[shas.length - 1] as string;
+      return {
+        capabilities: [],
+        refs: {
+          heads: nest({ [server.branch]: tip, ...(server.heads ?? {}) }),
+          tags: nest(server.tags ?? {}),
+        },
+      };
+    },
+    clone: async (args: CloneArgs) => {
+      h.clones.push({ url: args.url, ref: args.ref, depth: args.depth });
+      const server = h.servers.get(args.url);
+      if (!server) throw new Error(`NotFoundError: unknown remote ${args.url}`);
+      // A real remote serves any ref it advertises, not just its default —
+      // which is what lets a delete clone the branch it is removing.
+      const advertisedHead = server.heads?.[args.ref];
+      if (args.ref !== server.branch && advertisedHead === undefined) {
+        throw new Error(`NotFoundError: Could not find ${args.ref}.`);
+      }
+      await seed(args.fs, args.dir, server);
+      if (advertisedHead !== undefined) {
+        await real.writeRef({
+          fs: args.fs,
+          dir: args.dir,
+          ref: `refs/heads/${args.ref}`,
+          value: advertisedHead,
+          force: true,
+        });
+      }
+    },
+    push: async (args: PushArgs) => {
+      h.pushes.push({
+        url: args.url,
+        ref: args.ref,
+        remoteRef: args.remoteRef,
+        delete: args.delete ?? false,
+        force: args.force ?? false,
+        // Resolve through the REAL ref store so a missing local ref fails the
+        // way `_push`'s `expand` would.
+        localOid: await real.resolveRef({ fs: args.fs, dir: args.dir, ref: args.ref }),
+      });
+      if (h.pushFails === "rejected") {
+        throw new actual.Errors.PushRejectedError("not-fast-forward");
+      }
+      if (h.pushFails === "network") throw new Error("fetch failed");
+      return { ok: true, error: null, refs: {} };
+    },
+  };
+  return { ...actual, default: mocked };
+});
+
+import {
+  MAX_BRANCHES,
+  createBranchRef,
+  deleteBranchRef,
+  isValidBranchName,
+  listRepoBranches,
+  resolveBranchRef,
+} from "../src/storage/git-ops";
+import { MemoryFS } from "../src/storage/memory-fs";
+import type { Logger } from "../src/utils/logger";
+
+const logger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  child: () => logger,
+} as unknown as Logger;
+
+type SeedFn = (
+  fs: PromiseFsClient,
+  dir: string,
+  server: { branch: string; commits: Record<string, string>[] },
+) => Promise<string[]>;
+// The mock module augments isomorphic-git with a seeding helper. Naming that
+// shape keeps the reach type-checked instead of casting through `any`.
+type SeededGit = typeof git & { __seed: SeedFn };
+const seed: SeedFn = (git as unknown as SeededGit).__seed;
+
+/**
+ * Reads one recorded call, failing with a clear message when the harness never
+ * captured it — a non-null assertion would instead report a confusing
+ * property-of-undefined error several lines later.
+ */
+function capture<T>(calls: T[], index: number): T {
+  const entry = calls[index];
+  if (entry === undefined) {
+    throw new Error(`expected a recorded call at index ${index}, saw ${calls.length}`);
+  }
+  return entry;
+}
+
+const REMOTE = "https://r/p.git";
+
+async function tipOf(server: RemoteFixture): Promise<string> {
+  const fs = new MemoryFS().toNodeFS();
+  const shas = await seed(fs, "/", server);
+  return shas[shas.length - 1] as string;
+}
+
+beforeEach(() => {
+  h.servers.clear();
+  h.pushes.length = 0;
+  h.clones.length = 0;
+  h.pushFails = null;
+});
+
+describe("isValidBranchName", () => {
+  it("accepts what git accepts, including names an allowlist would refuse", () => {
+    for (const name of ["main", "release/2.x", "feature(x)", "release@prod", "版本1"]) {
+      expect(isValidBranchName(name)).toBe(true);
+    }
+  });
+
+  it("rejects traversal, git's reserved syntax, and HEAD", () => {
+    for (const name of ["../heads/main", "a..b", "a~1", "a^1", "a:b", "a?b", "", "HEAD", "a b"]) {
+      expect(isValidBranchName(name)).toBe(false);
+    }
+  });
+});
+
+describe("listRepoBranches", () => {
+  it("lists every advertised head, including hierarchical names, sorted", async () => {
+    h.servers.set(REMOTE, {
+      branch: "main",
+      commits: [{ "a.txt": "1\n" }],
+      heads: { "release/2.x": "b".repeat(40), "zz-old": "c".repeat(40) },
+    });
+
+    const result = await listRepoBranches(REMOTE, "tok", logger, "main");
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.branches.map((b) => b.name)).toEqual(["main", "release/2.x", "zz-old"]);
+    expect(result.data.truncated).toBe(false);
+    expect(result.data.totalBranchCount).toBe(3);
+  });
+
+  it("reports the default branch's real tip", async () => {
+    const server: RemoteFixture = { branch: "trunk", commits: [{ "a.txt": "1\n" }] };
+    h.servers.set(REMOTE, server);
+
+    const result = await listRepoBranches(REMOTE, "tok", logger, "trunk");
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.branches[0]).toEqual({ name: "trunk", oid: await tipOf(server) });
+  });
+
+  it("truncates without ever dropping the default branch", async () => {
+    // A default branch that sorts last, so a naive head-of-list cap loses it.
+    const heads: Record<string, string> = {};
+    for (let i = 0; i < MAX_BRANCHES + 10; i++) {
+      heads[`aa-${String(i).padStart(4, "0")}`] = "d".repeat(40);
+    }
+    h.servers.set(REMOTE, { branch: "zzz-default", commits: [{ "a.txt": "1\n" }], heads });
+
+    const result = await listRepoBranches(REMOTE, "tok", logger, "zzz-default");
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.truncated).toBe(true);
+    expect(result.data.totalBranchCount).toBe(MAX_BRANCHES + 11);
+    expect(result.data.branches).toHaveLength(MAX_BRANCHES);
+    expect(result.data.branches.map((b) => b.name)).toContain("zzz-default");
+  });
+
+  it("surfaces an advertisement failure as a typed error rather than throwing", async () => {
+    const result = await listRepoBranches("https://r/missing.git", "tok", logger, "main");
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toMatchObject({ code: "EXTERNAL_SERVICE_ERROR" });
+  });
+});
+
+describe("resolveBranchRef", () => {
+  beforeEach(() => {
+    h.servers.set(REMOTE, {
+      branch: "main",
+      commits: [{ "a.txt": "1\n" }],
+      heads: { "release/2.x": "b".repeat(40), v1: "e".repeat(40) },
+      tags: { v1: "f".repeat(40) },
+    });
+  });
+
+  it("resolves a branch that exists", async () => {
+    const result = await resolveBranchRef(REMOTE, "tok", logger, "release/2.x");
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toEqual({ name: "release/2.x", oid: "b".repeat(40) });
+  });
+
+  it("reports an unknown ref rather than falling back to the default branch", async () => {
+    const result = await resolveBranchRef(REMOTE, "tok", logger, "nope");
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toEqual({ kind: "not-found", name: "nope" });
+  });
+
+  it("refuses a name that is both a branch and a tag instead of silently cloning the tag", async () => {
+    // isomorphic-git's refpaths checks refs/tags/<ref> BEFORE refs/heads/<ref>,
+    // so resolving this would serve the tag's tree under a branch URL.
+    const result = await resolveBranchRef(REMOTE, "tok", logger, "v1");
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toEqual({ kind: "ambiguous", name: "v1" });
+  });
+
+  it("rejects an invalid name before any network call", async () => {
+    const result = await resolveBranchRef("https://r/missing.git", "tok", logger, "../heads/main");
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toEqual({ kind: "invalid", name: "../heads/main" });
+  });
+});
+
+describe("createBranchRef", () => {
+  const server: RemoteFixture = {
+    branch: "main",
+    commits: [{ "a.txt": "1\n" }, { "b.txt": "2\n" }],
+  };
+
+  beforeEach(() => {
+    h.servers.set(REMOTE, { ...server });
+  });
+
+  it("creates a branch at the default branch tip and pushes it non-forced", async () => {
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "feature/x",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const tip = await tipOf(server);
+    expect(result.data).toEqual({ name: "feature/x", oid: tip });
+    expect(h.pushes).toHaveLength(1);
+    expect(capture(h.pushes, 0)).toMatchObject({
+      ref: "refs/heads/feature/x",
+      remoteRef: "refs/heads/feature/x",
+      force: false,
+      delete: false,
+      // The ref really exists in the local store the push was handed.
+      localOid: tip,
+    });
+  });
+
+  it("refuses an existing branch on the pre-check, without pushing", async () => {
+    h.servers.set(REMOTE, { ...server, heads: { "feature/x": "a".repeat(40) } });
+
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "feature/x",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toEqual({ kind: "exists", name: "feature/x" });
+    // The check is load-bearing: a non-forced push would have FAST-FORWARDED
+    // this branch and reported success, silently moving someone else's ref.
+    expect(h.pushes).toHaveLength(0);
+  });
+
+  it("reports a branch created between the pre-check and the push as a conflict", async () => {
+    h.pushFails = "rejected";
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "feature/x",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toEqual({ kind: "exists", name: "feature/x" });
+  });
+
+  it("does not report a transport failure as a name conflict", async () => {
+    h.pushFails = "network";
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "feature/x",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    // Telling a caller the name is taken would send them renaming a branch to
+    // fix a network problem.
+    expect(result.error).not.toMatchObject({ kind: "exists" });
+    expect(result.error).toMatchObject({ code: "EXTERNAL_SERVICE_ERROR" });
+  });
+
+  it("creates at a full sha that is a commit in the repository", async () => {
+    const fs = new MemoryFS().toNodeFS();
+    const shas = await seed(fs, "/", server);
+    const firstCommit = shas[0] as string;
+
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "v1-maintenance",
+      startPoint: firstCommit,
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.oid).toBe(firstCommit);
+  });
+
+  it("pushes a sha start point from the SAME full-history clone it verified it in", async () => {
+    const fs = new MemoryFS().toNodeFS();
+    const shas = await seed(fs, "/", server);
+    const firstCommit = shas[0] as string;
+
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "v1-maintenance",
+      startPoint: firstCommit,
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(true);
+
+    // Exactly one clone, and it carries full history. `git.push` walks the
+    // local object graph from an oid the remote does not already advertise, so
+    // verifying the sha against full history and then pushing from a separate
+    // SHALLOW clone would pass every check here and fail at the push — on
+    // precisely the old commits this option exists to branch from.
+    expect(h.clones).toHaveLength(1);
+    expect(capture(h.clones, 0).depth).toBeUndefined();
+    expect(capture(h.pushes, 0).localOid).toBe(firstCommit);
+  });
+
+  it("uses a cheap shallow clone when the start point is an advertised tip", async () => {
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "feature/y",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(true);
+    // The oid is already a ref tip on the remote, so the push sends a ref
+    // update and no objects — full history would be paid for nothing.
+    expect(h.clones).toHaveLength(1);
+    expect(capture(h.clones, 0).depth).toBe(50);
+  });
+
+  it("creates at another BRANCH's name without cloning to resolve it", async () => {
+    h.servers.set(REMOTE, { ...server, heads: { "release/2.x": "a".repeat(40) } });
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "from-branch",
+      startPoint: "release/2.x",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.oid).toBe("a".repeat(40));
+    // A branch tip is advertised by receive-pack, so the push needs no objects
+    // and a shallow clone is enough.
+    expect(capture(h.clones, 0).depth).toBe(50);
+  });
+
+  it("refuses a tag as a start point", async () => {
+    h.servers.set(REMOTE, { ...server, tags: { "v1.0": "a".repeat(40) } });
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "from-tag",
+      startPoint: "v1.0",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    // A tag can point at a blob, its peeled commit is not advertised by
+    // receive-pack, and it may sit outside both the default branch's history
+    // and the capped tag fetch a backup makes. Branch from the sha instead.
+    expect(result.error).toEqual({ kind: "bad-start-point", startPoint: "v1.0" });
+  });
+
+  it("refuses to create when the remote does not advertise the default branch", async () => {
+    h.servers.set(REMOTE, { branch: "main", commits: [{ "a.txt": "1\n" }] });
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "x",
+      defaultBranch: "trunk",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    // A named refusal, not the 502 a clone of a ref that is not there produces.
+    expect(result.error).toEqual({ kind: "no-default-branch", name: "trunk" });
+    expect(h.clones).toHaveLength(0);
+  });
+
+  it("refuses a name that collides with an existing branch's ref path", async () => {
+    h.servers.set(REMOTE, { ...server, heads: { "release/2.x": "a".repeat(40) } });
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "release",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    // Refs are files in a directory tree: `release` cannot be both a file and
+    // the directory holding `release/2.x`. Answered from the advertisement, so
+    // the caller gets the colliding name instead of an opaque 502 from the push.
+    expect(result.error).toEqual({
+      kind: "conflicts-with",
+      name: "release",
+      existing: "release/2.x",
+    });
+    expect(h.pushes).toHaveLength(0);
+  });
+
+  it("refuses an annotated tag as a start point even though its peel is advertised", async () => {
+    h.servers.set(REMOTE, {
+      ...server,
+      tags: { "v2.0": "1".repeat(40), "v2.0^{}": "2".repeat(40) },
+    });
+
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "from-annotated",
+      startPoint: "v2.0",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    // upload-pack advertises the peel; receive-pack does not. `git.push` would
+    // therefore fail to see that the remote already holds the commit and walk
+    // the local graph for it — which fails whenever it is outside the shallow
+    // window. Refused rather than half-supported.
+    expect(result.error).toEqual({ kind: "bad-start-point", startPoint: "v2.0" });
+  });
+
+  it("rejects a start point that is not in the repository", async () => {
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "ghost",
+      startPoint: "0".repeat(40),
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toEqual({ kind: "bad-start-point", startPoint: "0".repeat(40) });
+    expect(h.pushes).toHaveLength(0);
+  });
+
+  it("rejects a short sha rather than guessing at history it has not fetched", async () => {
+    const result = await createBranchRef(REMOTE, "tok", logger, {
+      name: "short",
+      startPoint: "abc1234",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toEqual({ kind: "bad-start-point", startPoint: "abc1234" });
+  });
+
+  it("rejects an invalid branch name before any network call", async () => {
+    const result = await createBranchRef("https://r/missing.git", "tok", logger, {
+      name: "../heads/main",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toEqual({ kind: "invalid-name", name: "../heads/main" });
+  });
+});
+
+describe("deleteBranchRef", () => {
+  const server: RemoteFixture = {
+    branch: "main",
+    commits: [{ "a.txt": "1\n" }],
+    heads: { stale: "a".repeat(40) },
+  };
+
+  beforeEach(() => {
+    h.servers.set(REMOTE, { ...server });
+  });
+
+  it("writes the local ref the delete-push requires, then deletes", async () => {
+    const result = await deleteBranchRef(REMOTE, "tok", logger, {
+      name: "stale",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(true);
+    expect(h.pushes).toHaveLength(1);
+    expect(capture(h.pushes, 0)).toMatchObject({
+      ref: "refs/heads/stale",
+      remoteRef: "refs/heads/stale",
+      delete: true,
+      // `_push` expands the LOCAL ref before honouring `delete`; without the
+      // writeRef above, this resolution throws NotFoundError.
+      localOid: "a".repeat(40),
+    });
+  });
+
+  it("refuses the default branch without consulting the remote", async () => {
+    const result = await deleteBranchRef("https://r/missing.git", "tok", logger, {
+      name: "main",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toEqual({ kind: "default-branch", name: "main" });
+  });
+
+  it("reports an unknown branch rather than pushing a no-op delete", async () => {
+    const result = await deleteBranchRef(REMOTE, "tok", logger, {
+      name: "never-existed",
+      defaultBranch: "main",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toEqual({ kind: "not-found", name: "never-existed" });
+    expect(h.pushes).toHaveLength(0);
+  });
+});

--- a/tests/git-ops-default-branch.test.ts
+++ b/tests/git-ops-default-branch.test.ts
@@ -490,6 +490,45 @@ describe("getDiffBetweenRepos", () => {
     expect(result.data.workspaceSha).toBe(wsTip);
   });
 
+  it("#274: returns the base commit the diff was computed against, pinned to that clone", async () => {
+    const baseServer: { branch: string; commits: Record<string, string>[] } = {
+      branch: "trunk",
+      commits: [{ "a.txt": "line1\n" }],
+    };
+    h.servers.set("https://r/base.git", baseServer);
+    h.servers.set("https://r/fork.git", {
+      branch: "trunk",
+      commits: [{ "a.txt": "line1\nline2\n" }],
+    });
+
+    const result = await getDiffBetweenRepos(
+      "https://r/base.git",
+      "btok",
+      "https://r/fork.git",
+      "wtok",
+      logger,
+      "trunk",
+    );
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const [baseTipAtDiffTime] = await precomputeShas({
+      branch: "trunk",
+      commits: [{ "a.txt": "line1\n" }],
+    });
+    expect(result.data.baseOid).toBe(baseTipAtDiffTime);
+
+    // The receiver's failure mode (#274): the default branch advances after the
+    // diff was generated. The base carried with the diff must still name the
+    // commit the hunks apply to, not whatever the branch has since become —
+    // applying them to the newer tree would produce a verdict for a combination
+    // no change ever proposed.
+    baseServer.commits.push({ "unrelated.txt": "landed after evaluation\n" });
+    const [, advancedTip] = await precomputeShas(baseServer);
+    expect(advancedTip).not.toBe(baseTipAtDiffTime);
+    expect(result.data.baseOid).toBe(baseTipAtDiffTime);
+  });
+
   it("errs when either side lacks the requested branch", async () => {
     h.servers.set("https://r/base.git", { branch: "trunk", commits: [{ "a.txt": "x\n" }] });
     h.servers.set("https://r/fork.git", { branch: "trunk", commits: [{ "a.txt": "x\n" }] });

--- a/tests/helpers/webhooks-d1.ts
+++ b/tests/helpers/webhooks-d1.ts
@@ -83,20 +83,14 @@ export function makeWebhooksD1(): {
             .filter((d) => d.webhook_id === bindings[0])
             .sort((a, b) => b.created_at.localeCompare(a.created_at))
             .slice(0, bindings[1] as number);
-        } else if (upper.includes("PROJECT_ID = ?")) {
-          // project_id-first with legacy name fallback: (project_id = ? OR (project_id IS NULL AND project = ?))
+        } else {
+          // listWebhooks scopes on project_id alone (#235) — there is no
+          // name-matching branch left to model.
           const projectId = bindings[0] as string;
-          const project = bindings[1] as string;
           const activeReq = upper.includes("ACTIVE = 1");
           results = webhooks.filter(
-            (w) =>
-              (w.project_id === projectId || (w.project_id === null && w.project === project)) &&
-              (!activeReq || w.active === 1),
+            (w) => w.project_id === projectId && (!activeReq || w.active === 1),
           );
-        } else if (upper.includes("AND ACTIVE = 1")) {
-          results = webhooks.filter((w) => w.project === bindings[0] && w.active === 1);
-        } else {
-          results = webhooks.filter((w) => w.project === bindings[0]);
         }
         return { results: results as T[], success: true, meta: {} };
       },

--- a/tests/namespace-routes.test.ts
+++ b/tests/namespace-routes.test.ts
@@ -86,6 +86,16 @@ vi.mock("../src/storage/git-ops", () => ({
     success: true,
     data: "mock-token",
   })),
+  // The repo view reads the remote's branch advertisement for its branch
+  // switcher (#181). This factory replaces the module wholesale, so an export
+  // it omits throws on first access rather than being undefined — a repo view
+  // that only ever advertised `main` is what these fixtures represent.
+  listRepoBranches: vi.fn(
+    async (_remote: string, _token: string, _logger: unknown, ref: string) => ({
+      success: true,
+      data: { branches: [{ name: ref, oid: "abc123" }], truncated: false, totalBranchCount: 1 },
+    }),
+  ),
 }));
 
 // Mock changes storage

--- a/tests/ui-route-sync-props.test.ts
+++ b/tests/ui-route-sync-props.test.ts
@@ -123,6 +123,22 @@ vi.mock("../src/storage/sync", async (importOriginal) => {
 // ---------------------------------------------------------------------------
 
 vi.mock("../src/storage/git-ops", () => ({
+  // The repo view mints one read token for ref resolution, the branch listing
+  // behind the switcher, and the clone fallback, so all three must be stubbed
+  // here or the page 500s before it reaches the props under test.
+  freshRepoToken: vi.fn(async () => ({ success: true, data: "mock-read-token" })),
+  listRepoBranches: vi.fn(async () => ({
+    success: true,
+    data: {
+      branches: [{ name: "main", oid: "abc1234" }],
+      truncated: false,
+      totalBranchCount: 1,
+    },
+  })),
+  resolveBranchRef: vi.fn(async () => ({
+    success: true,
+    data: { name: "main", oid: "abc1234" },
+  })),
   initAndPush: vi.fn(async () => ({ success: true, data: "sha_init" })),
   cloneRepo: vi.fn(async () => ({ fs: {}, dir: "/" })),
   commitAndPush: vi.fn(async () => "sha_commit"),

--- a/tests/webhooks-routes.test.ts
+++ b/tests/webhooks-routes.test.ts
@@ -96,10 +96,9 @@ describe("webhook management routes — project-id scoping (SA-1)", () => {
     );
 
     expect(res.status).toBe(200);
-    // The list must be scoped by the unique project id, not just the name.
-    expect(listWebhooks).toHaveBeenCalledWith(env.DB, expect.any(Object), "api", {
-      projectId: "proj_alice",
-    });
+    // The list must be scoped by the unique project id. The name is not passed
+    // at all (#235 step 3), so a name-scoped lookup is not expressible.
+    expect(listWebhooks).toHaveBeenCalledWith(env.DB, expect.any(Object), "proj_alice");
     const body = (await res.json()) as { webhooks: Array<Record<string, unknown>> };
     expect(body.webhooks).toHaveLength(1);
     expect(body.webhooks[0]).not.toHaveProperty("secret");
@@ -240,7 +239,7 @@ describe("webhook management routes — project-id scoping (SA-1)", () => {
     expect(res.headers.get("Cache-Control")).toBe("no-store");
   });
 
-  it("falls back to the name for a legacy webhook with no project_id", async () => {
+  it("#235: rejects a legacy webhook with no project_id instead of name-matching it", async () => {
     vi.mocked(getWebhook).mockResolvedValue({
       success: true,
       data: webhook({ id: "wh_legacy", projectId: undefined }),
@@ -255,8 +254,10 @@ describe("webhook management routes — project-id scoping (SA-1)", () => {
       env,
     );
 
-    // project.name === webhook.project ("api") → allowed for legacy rows.
-    expect(res.status).toBe(200);
-    expect(deleteWebhook).toHaveBeenCalled();
+    // The name fallback is gone: an unstamped row belongs to no project, so it
+    // is unreachable rather than reachable by whoever shares the name. The
+    // admin backfill exists to stamp these before they get here.
+    expect(res.status).toBe(404);
+    expect(deleteWebhook).not.toHaveBeenCalled();
   });
 });

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -31,6 +31,7 @@ function makeEvent(overrides: Partial<EventRecord> = {}): EventRecord {
     id: "evt_1",
     type: "change.merged",
     project: "my-project",
+    projectId: "proj_my_project",
     actorType: "user",
     actorId: "user_1",
     payload: { changeId: "chg_1", commit: "abc" },
@@ -46,6 +47,7 @@ describe("webhook storage", () => {
     const { db } = makeWebhooksD1();
     const result = await createWebhook(db, mockLogger, {
       project: "p",
+      projectId: "proj_p",
       url: "https://example.com/hook",
       createdBy: "user_1",
     });
@@ -74,10 +76,7 @@ describe("webhook storage", () => {
     });
 
     // Delivery for alice's project must only find alice's webhook.
-    const forAlice = await listWebhooks(db, mockLogger, "api", {
-      activeOnly: true,
-      projectId: "proj_alice",
-    });
+    const forAlice = await listWebhooks(db, mockLogger, "proj_alice", { activeOnly: true });
     expect(forAlice.success).toBe(true);
     if (!forAlice.success) return;
     expect(forAlice.data).toHaveLength(1);
@@ -98,19 +97,42 @@ describe("webhook storage", () => {
     };
 
     // Same id → owned.
-    expect(webhookBelongsToProject(base, { id: "proj_alice", name: "api" })).toBe(true);
+    expect(webhookBelongsToProject(base, { id: "proj_alice" })).toBe(true);
     // A different project that merely shares the name must NOT own it (the leak).
-    expect(webhookBelongsToProject(base, { id: "proj_bob", name: "api" })).toBe(false);
-    // Legacy row with no project_id falls back to the name.
+    expect(webhookBelongsToProject(base, { id: "proj_bob" })).toBe(false);
+    // #235 step 3: a legacy row with no project_id belongs to NO project — it is
+    // no longer name-matched into whichever tenant happens to share the name.
     const legacy: Webhook = { ...base, projectId: undefined };
-    expect(webhookBelongsToProject(legacy, { id: "proj_bob", name: "api" })).toBe(true);
-    expect(webhookBelongsToProject(legacy, { id: "proj_bob", name: "other" })).toBe(false);
+    expect(webhookBelongsToProject(legacy, { id: "proj_alice" })).toBe(false);
+    expect(webhookBelongsToProject(legacy, { id: "proj_bob" })).toBe(false);
+  });
+
+  it("#235: a legacy row with a NULL project_id is neither listed nor delivered to", async () => {
+    const { db, webhooks } = makeWebhooksD1();
+    // A row as the pre-migration-025 schema left it: named, but unstamped.
+    webhooks.push({
+      id: "wh_legacy",
+      project: "api",
+      project_id: null,
+      url: "https://legacy.example.com/hook",
+      secret: "stm_whsec_legacy",
+      events: "*",
+      active: 1,
+      created_by: "alice",
+      created_at: new Date().toISOString(),
+    });
+
+    const listed = await listWebhooks(db, mockLogger, "proj_api");
+    expect(listed.success).toBe(true);
+    if (!listed.success) return;
+    expect(listed.data).toHaveLength(0);
   });
 
   it("lists, toggles, and deletes webhooks", async () => {
     const { db, deliveries } = makeWebhooksD1();
     const created = await createWebhook(db, mockLogger, {
       project: "p",
+      projectId: "proj_p",
       url: "https://example.com/hook",
       createdBy: "user_1",
     });
@@ -119,12 +141,12 @@ describe("webhook storage", () => {
     const id = created.data.id;
 
     await setWebhookActive(db, mockLogger, id, false);
-    const activeOnly = await listWebhooks(db, mockLogger, "p", { activeOnly: true });
+    const activeOnly = await listWebhooks(db, mockLogger, "proj_p", { activeOnly: true });
     expect(activeOnly.success).toBe(true);
     if (!activeOnly.success) return;
     expect(activeOnly.data).toHaveLength(0);
 
-    const all = await listWebhooks(db, mockLogger, "p");
+    const all = await listWebhooks(db, mockLogger, "proj_p");
     expect(all.success).toBe(true);
     if (!all.success) return;
     expect(all.data).toHaveLength(1);
@@ -142,7 +164,7 @@ describe("webhook storage", () => {
       created_at: new Date().toISOString(),
     });
     await deleteWebhook(db, mockLogger, id);
-    const afterDelete = await listWebhooks(db, mockLogger, "p");
+    const afterDelete = await listWebhooks(db, mockLogger, "proj_p");
     expect(afterDelete.success).toBe(true);
     if (!afterDelete.success) return;
     expect(afterDelete.data).toHaveLength(0);
@@ -194,6 +216,7 @@ describe("deliverEventToWebhooks", () => {
     const { db, deliveries } = makeWebhooksD1();
     const created = await createWebhook(db, mockLogger, {
       project: "my-project",
+      projectId: "proj_my_project",
       url: "https://example.com/hook",
       events,
       createdBy: "user_1",
@@ -243,6 +266,41 @@ describe("deliverEventToWebhooks", () => {
     expect(deliveries[1]?.error).toContain("connection refused");
   });
 
+  it("#235: skips delivery entirely for an event carrying no project_id", async () => {
+    const { env, deliveries } = await setup();
+    fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+
+    // A legacy outbox row: named, but never stamped with the canonical id.
+    // Resolving it by name would deliver to whichever same-named project
+    // matched, across namespaces — so nothing is delivered at all.
+    await deliverEventToWebhooks(env, makeEvent({ projectId: undefined }), mockLogger);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(deliveries).toHaveLength(0);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "Skipping webhook delivery for an event with no project_id",
+      expect.objectContaining({ eventId: "evt_1", project: "my-project" }),
+    );
+  });
+
+  it("#235: does not deliver to a same-named project in another namespace", async () => {
+    const { db, deliveries } = makeWebhooksD1();
+    await createWebhook(db, mockLogger, {
+      project: "my-project",
+      projectId: "proj_other_tenant",
+      url: "https://other.example.com/hook",
+      createdBy: "bob",
+    });
+    const env = { DB: db } as unknown as Env;
+    fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+
+    // The event names the same project string but a different canonical id.
+    await deliverEventToWebhooks(env, makeEvent(), mockLogger);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(deliveries).toHaveLength(0);
+  });
+
   it("skips webhooks whose event filter does not match", async () => {
     const { env } = await setup("change.rejected");
     await deliverEventToWebhooks(env, makeEvent(), mockLogger);
@@ -273,11 +331,13 @@ describe("deliverEventToWebhooks", () => {
     const { db, deliveries } = makeWebhooksD1();
     await createWebhook(db, mockLogger, {
       project: "my-project",
+      projectId: "proj_my_project",
       url: "https://bad.example.com/hook",
       createdBy: "u",
     });
     await createWebhook(db, mockLogger, {
       project: "my-project",
+      projectId: "proj_my_project",
       url: "https://good.example.com/hook",
       createdBy: "u",
     });


### PR DESCRIPTION
## Summary

Three open issues, one commit each (plus a fourth carrying review fixes). They are independent — the commits are separable if you would rather land them apart.

### #181 — multi-branch support

PR #226 landed the default-branch hazard and explicitly left "branch CRUD / ref-scoped browsing / branch switcher" open. This closes that remainder.

**The premise had to be corrected first.** No path in the codebase puts a second `refs/heads/*` on a project repo: `importFromGitHub` imports a single branch, `restoreProjectRepo` pushed only the default branch and tags, every merge and sync targets the default branch, and the push gate refuses everything else. So this is not "the UI fails to show what `git clone` already shows" — there was nothing to show. **Branch creation is the enabling feature**; listing and ref-scoped browsing are what make it usable.

**Listing reads the ref advertisement, not a clone.** The obvious design — model `collectRepoBranches` on `collectRepoTags` and fetch each branch — does not work: isomorphic-git translates fetched head refs through the remote's refspec into `refs/remotes/origin/*`, so a clone's `refs/heads/` holds exactly one branch no matter how many were fetched. `git.getRemoteInfo` already carries every branch name and tip oid in two subrequests, which is all a listing needs. That also keeps `?ref=` validation off the clone path, where it would otherwise have cost ~400 subrequests per read against a ~1000 cap.

**Branch creation cannot introduce content.** The start point must resolve to an object the repository already holds — the default tip, another branch's tip, or a full 40-hex sha verified as a commit in a full-history clone. Tags are refused as start points: a tag can point at a blob, an annotated tag's peeled commit is advertised by upload-pack but not receive-pack (so `git.push` walks the local graph and fails outside the shallow window), and a tag may sit outside both the default branch's history and the `MAX_TAGS`-capped fetch a backup makes. This invariant is also what lets backup record refs only and leave `walkRepoObjects` untouched.

**Enforcement is one application-level check**, in `createBranchRef`. The push goes straight to the Artifacts remote with a minted write token and bypasses `src/routes/git-http.ts` entirely. That is deliberate and stated plainly in the code so no reader infers a defense in depth that is not there. The push gate itself is unchanged — pushing *content* to a non-default project ref over git stays refused.

Also included: `GET/POST/DELETE /api/projects/:ns/:slug/branches`, `?ref=` on `files`/`content`/`log` and on the UI repo and blob views, a `/branches` page, a no-JS `<form method="get">` branch switcher, and branch refs in backup and restore.

Explicit non-goals: changes or merges targeting a non-default branch, branch protection, branch rename, cross-branch compare, and `?ref=` accepting a tag or raw sha (a name that is both a branch and a tag is refused as ambiguous rather than resolved — `refpaths` checks `refs/tags/` *before* `refs/heads/`, so resolving it would serve the wrong tree under a URL that says otherwise).

### #235 — webhook tenant scoping, step 3

Steps 1–2 (the admin backfill and its `remainingNullRows` verification) landed in #268 and #287. `webhookBelongsToProject` and `listWebhooks` still matched `project_id = ? OR (project_id IS NULL AND project = ?)`, so a pre-migration-025 row could be read, mutated, and delivered to by a same-named project in another namespace.

Rather than delete the clause and leave the shape that produced it, `listWebhooks` now takes the project **id** in place of the name, so a name-scoped lookup is not expressible at the call site; `createWebhook`'s `projectId` is required for the same reason, so no new NULL row can undo the backfill. An unstamped legacy row belongs to no project — invisible to management, delivered to by nothing. The queue consumer drops an outbox row carrying no `project_id` with a WARN rather than resolving it by name.

### #274 — base commit in the webhook evaluator payload

The evaluator posted `{diff, policy}`, so a receiver could only apply the hunks to whatever the default branch was when the request landed. `getDiffBetweenRepos` already resolved the base tip — it needs it, because `readBlob` will not accept a ref name as an oid — and discarded it. It is now returned as `baseOid` and reaches the evaluator through a new optional `EvaluationContext`.

Deliberately the base from the diff's own clone at all three call sites: change creation resolves `baseSha` *before* the diff clone, and the re-evaluate route's `change.baseSha` records the base at creation, which is exactly the value that has gone stale by re-evaluation.

### Review round

Two adversarial reviews ran against the first three commits. The fourth commit fixes what they found. The one worth calling out: **restore authenticated its branch push as GitHub**, sending an Artifacts token verbatim instead of stripping its `?expires=` suffix — every restore carrying a branch would have failed, after main and the tags had already landed. It was invisible to the suite, which mocks `git.push` and never asserted the credential.

Also fixed: restore guards weaker than the request path they mirror (a non-commit tip, a ref-path collision aborting the whole restore, `HEAD` accepted as a branch name); backup silently recording fewer branches than the repo has; `DELETE` failing to find the name at all when the namespace arrived percent-encoded (Hono decodes params and paths differently, and this repo's own UI builds URLs the failing way); and four opaque 500/502s that are now named 4xx.

Four issues are **accepted rather than fixed**, recorded in `.claude/ship/TASKS.md`. The load-bearing one: the create pre-check is not a lock. `git.push` accepts a descendant oid without `force`, so two concurrent creates of the same name can let the second fast-forward the first. Closing it needs a compare-and-swap the transport does not offer, and the git-http gate already excludes every other writer of these refs.

## Related issues

Closes #181
Closes #235
Closes #274

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` — 2345 passed, 27 env-gated skips (unchanged from main), 0 failures
- [x] `npm run lint`

~90 new tests. The branch mechanics are tested against **real in-memory repos** rather than a wholly-mocked isomorphic-git, deliberately: the `refs/remotes` translation, `push({delete})`'s local-ref requirement, and the tag-before-branch `refpaths` order are all invisible to a mocked suite, and all three sank the first design. Three bugs of my own surfaced that way during implementation — pushing from a shallow clone after verifying the start point in a full-history one, branching from an annotated tag onto the tag object, and reporting a transport failure as a name conflict.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate — `openapi.yml`, the projects endpoint reference, and the BYO-CI contract in `docs/user-guide/ci-integration.md`
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change stays server-rendered with no client-side JavaScript — the branch switcher is a GET form

## Noted separately, not fixed here

PR #226's description claims it threaded the resolved default branch through "all ~26" hardcoded `ref: "main"` sites. `batchMergeWorkspaces` and `mergeStagedCommits` in `src/storage/git-ops.ts` still hardcode `main` (≈ lines 1204, 1229, 1275, 1284, 1399, 1406). That is a live bug for any project imported with a `master`/`trunk` default — batch merge targets a ref the repo does not have. It is a merge-path bug rather than multi-branch support, so it wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P11maBt5wGR783noPFLpqs

---
_Generated by [Claude Code](https://claude.ai/code/session_01P11maBt5wGR783noPFLpqs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added project branch listing, creation, and deletion.
  - Browse repositories, files, content, and commit history by branch with branch switching.
  - Repository backups now preserve eligible branches during snapshot and restore.
  - CI evaluation payloads include the exact source commit when available.

- **Bug Fixes**
  - Added clear handling for invalid, unknown, or ambiguous branch references.
  - Webhook delivery now uses canonical project identifiers, preventing cross-project or ambiguous deliveries.

- **Documentation**
  - Updated API and CI integration documentation for branch support and source-commit handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->