### PR TITLE
Make magic-link rate-limit admission atomic with a Durable Object (#283)

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -177,7 +177,6 @@ CREATE TABLE github_pr_mappings (
 
 ```text
 session:{sessionId} → { userId, expiresAt }
-rate_limit:magic_link:{emailHash} → { count, resetAt }
 sync_status:{namespace}:{slug} → { lastCheckedAt, hasUpdates, commitsBehind }
 eval_cache:{workspaceId}:{evaluatorId} → { result, cachedAt }
 ```
@@ -426,6 +425,35 @@ async function reportEvaluationToGitHub(env, change, project, evaluation): Promi
 _Evaluation performed by [Stratum](https://stratum.dev)_
 ```
 
+## Magic-Link Rate Limiter
+
+Durable Object holding one fixed-window send counter per subject — an
+address digest (`email:<sha256>`, 5 sends/hour) or a source IP
+(`ip:<addr>`, 20 sends/hour). A send is admitted only when it clears both.
+
+The counters lived in Workers KV until issue #283. That was a
+read-modify-write from the Worker, so concurrent sends read the same value
+and each wrote back `value + 1` — the caps bounded sequential traffic only.
+Inside a Durable Object the runtime's input gate holds other events while a
+storage operation is in flight, so the read and the write cannot interleave.
+
+Two subjects mean two objects, so the pair is reserved in sequence and the
+email reservation is refunded when the IP cap then refuses. A concurrent
+request can see the un-refunded count and be turned away; over-refusing
+briefly is the safe direction, and neither cap is ever exceeded. A single
+shared object would make the pair atomic but serialize every magic-link send
+on the platform behind one thread.
+
+**Storage errors fail open, deliberately.** A reservation that cannot be
+attempted — the binding is missing, or the object throws — admits the request
+and logs it. Failing closed would turn a transient storage fault into a total
+login outage, which is worse than the bounded over-sending a fault window
+allows. A reservation that *succeeds* and reports the cap still refuses: that
+is an answer, not a fault.
+
+Each object arms an alarm past the end of its window and erases itself on it,
+which is what `expirationTtl` did for the KV keys.
+
 ## Merge Queue
 
 Durable Object that serializes merge operations per repository.
@@ -501,7 +529,9 @@ Producer (API route) → Queue → Consumer Worker
 ```text
 POST /auth/email
   ↓
-Generate token → Store in KV (15 min TTL)
+Reserve against the per-email and per-IP caps (Durable Object)
+  ↓
+Generate token → Store in D1 (15 min TTL, single-use at verify)
   ↓
 Send email via Cloudflare Email
   ↓

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import type { Env, ImportJobMessage, MessageBatch, SyncJobMessage } from "./type
 import { CSS } from "./ui/styles";
 import { createLogger } from "./utils/logger";
 export { MergeQueue } from "./queue/merge-queue";
+export { MagicLinkRateLimiter } from "./queue/magic-link-limiter";
 export { RepoDO } from "./queue/repo-do";
 
 const app = new Hono<{ Bindings: Env }>();

--- a/src/queue/magic-link-limiter.ts
+++ b/src/queue/magic-link-limiter.ts
@@ -1,0 +1,118 @@
+import { DurableObject } from "cloudflare:workers";
+import type { Env } from "../types";
+
+/** The single storage key holding this bucket's window id and its count. */
+const BUCKET_KEY = "bucket";
+
+/**
+ * How long after a window closes the object waits before erasing itself. A
+ * counter is worthless once its window has rolled, but the grace period keeps a
+ * steadily-used bucket from thrashing delete/recreate against clock skew
+ * between the alarm and the next request.
+ */
+const CLEANUP_GRACE_MS = 60_000;
+
+interface Bucket {
+  /** `floor(epochSeconds / windowSeconds)` — the fixed window this count belongs to. */
+  window: number;
+  count: number;
+}
+
+export interface ReserveOutcome {
+  admitted: boolean;
+  /** The count after this call. Reported for logging; callers gate on `admitted`. */
+  count: number;
+}
+
+/**
+ * A serialized fixed-window counter, one instance per rate-limit subject (an
+ * email-address digest, or a source IP).
+ *
+ * This exists because the counter it replaces was a Workers KV
+ * read-modify-write: concurrent magic-link sends read the same value and each
+ * wrote back `value + 1`, so N simultaneous requests advanced the counter by
+ * one and the cap bounded sequential traffic only. A Durable Object closes that
+ * window — the runtime's input gate holds incoming events while a storage
+ * operation is in flight, so the read and the write below cannot interleave
+ * with another request against the same instance.
+ *
+ * Serialization is per instance, and an instance is per subject, so magic-link
+ * sends for different addresses (and from different IPs) still run in parallel.
+ *
+ * `limit` and `windowSeconds` are supplied by the caller rather than baked in
+ * here so the policy numbers stay next to the endpoint that enforces them.
+ * That is safe only because DO RPC is reachable from Worker code alone — no
+ * request can name its own limit. Do not expose this class over `fetch`.
+ */
+export class MagicLinkRateLimiter extends DurableObject<Env> {
+  /**
+   * Atomically admits or rejects one send against this subject's cap.
+   *
+   * @param limit - Maximum admissions per window
+   * @param windowSeconds - Fixed window length
+   * @param nowMs - Caller's clock, so a single request stamps both of its counters identically
+   * @returns Whether the send was admitted, and the resulting count
+   */
+  async reserve(limit: number, windowSeconds: number, nowMs: number): Promise<ReserveOutcome> {
+    // A malformed limit can only come from a bug in our own Worker, never from
+    // a request. Refusing (rather than throwing) keeps the failure out of the
+    // caller's catch block, which fails *open* — a throw here would turn a
+    // typo into a silently unlimited endpoint.
+    if (!isPositiveInteger(limit) || !isPositiveInteger(windowSeconds)) {
+      return { admitted: false, count: 0 };
+    }
+    const window = windowId(nowMs, windowSeconds);
+    const count = await this.currentCount(window);
+    if (count >= limit) return { admitted: false, count };
+    await this.ctx.storage.put<Bucket>(BUCKET_KEY, { window, count: count + 1 });
+    // Re-armed on every reserve so the erase always trails the live window.
+    await this.ctx.storage.setAlarm((window + 1) * windowSeconds * 1000 + CLEANUP_GRACE_MS);
+    return { admitted: true, count: count + 1 };
+  }
+
+  /**
+   * Returns one reservation to this subject's bucket.
+   *
+   * A send is admitted only when it clears *both* the per-email and the per-IP
+   * cap, and the two caps live in different instances — so the first reservation
+   * has to be given back when the second refuses. Between the two, a concurrent
+   * request can see the not-yet-refunded count and be rejected; that direction
+   * (over-refusing, briefly) is the safe one, and the caps are never exceeded.
+   *
+   * @param windowSeconds - Fixed window length, matching the `reserve` that took it
+   * @param nowMs - Caller's clock
+   */
+  async refund(windowSeconds: number, nowMs: number): Promise<void> {
+    if (!isPositiveInteger(windowSeconds)) return;
+    const window = windowId(nowMs, windowSeconds);
+    const bucket = await this.ctx.storage.get<Bucket>(BUCKET_KEY);
+    // A rolled window already discarded the reservation; a zero count means
+    // there is nothing to give back. Neither is worth clamping below zero.
+    if (bucket?.window !== window || bucket.count <= 0) return;
+    await this.ctx.storage.put<Bucket>(BUCKET_KEY, { window, count: bucket.count - 1 });
+  }
+
+  /**
+   * Erases the counter once its window has closed, so a subject seen once does
+   * not leave durable state behind forever. This is what `expirationTtl` did
+   * for the KV keys this replaces.
+   */
+  override async alarm(): Promise<void> {
+    await this.ctx.storage.deleteAll();
+  }
+
+  private async currentCount(window: number): Promise<number> {
+    const bucket = await this.ctx.storage.get<Bucket>(BUCKET_KEY);
+    // A bucket from an earlier window reads as zero rather than being deleted:
+    // the `put` below overwrites it, so the stale row costs nothing.
+    return bucket?.window === window ? bucket.count : 0;
+  }
+}
+
+function windowId(nowMs: number, windowSeconds: number): number {
+  return Math.floor(nowMs / 1000 / windowSeconds);
+}
+
+function isPositiveInteger(value: number): boolean {
+  return Number.isInteger(value) && value > 0;
+}

--- a/src/queue/magic-link-limiter.ts
+++ b/src/queue/magic-link-limiter.ts
@@ -1,7 +1,12 @@
 import { DurableObject } from "cloudflare:workers";
 import type { Env } from "../types";
 
-/** The single storage key holding this bucket's window id and its count. */
+/**
+ * One key holds both the window id and the count, rather than a key per window.
+ * That is what makes a rollover free: the next reserve overwrites the record
+ * instead of accumulating a row per hour that something would then have to
+ * sweep.
+ */
 const BUCKET_KEY = "bucket";
 
 /**

--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -4,7 +4,6 @@ import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { admitUser, betaGateEnabled, validateInviteCode } from "../beta/gate";
 import { getInviteCodesEmail, getMagicLinkEmail } from "../email/templates";
 import { enforceSameOrigin } from "../middleware/csrf";
-import type { ReserveOutcome } from "../queue/magic-link-limiter";
 import { recordAudit } from "../storage/audit";
 import { consumeMagicLink, createMagicLink } from "../storage/magic-links";
 import { createSession } from "../storage/sessions";
@@ -19,10 +18,10 @@ import { validateEmail } from "../utils/validation";
 const app = new Hono<{ Bindings: Env }>();
 
 // Rate limiting constants
-const MAGIC_LINK_RATE_LIMIT = 5; // max 5 requests per hour per email
+export const MAGIC_LINK_RATE_LIMIT = 5; // max 5 requests per hour per email
 // Per-IP cap so one client can't mail links to unlimited addresses (the
 // per-email limit alone leaves a mail-bombing / send-cost amplification vector).
-const MAGIC_LINK_IP_RATE_LIMIT = 20; // max 20 magic-link sends per hour per IP
+export const MAGIC_LINK_IP_RATE_LIMIT = 20; // max 20 magic-link sends per hour per IP
 const MAGIC_LINK_RATE_WINDOW = 60 * 60; // 1 hour in seconds
 
 // Generate a secure random token (32 bytes = 64 hex chars)
@@ -81,7 +80,7 @@ type ReserveResult = "admitted" | "blocked" | "unavailable";
  * @returns Whether the reservation was taken, refused, or could not be attempted
  */
 async function reserveSend(
-  namespace: DurableObjectNamespace | undefined,
+  namespace: Env["MAGIC_LINK_LIMITER"],
   name: string,
   limit: number,
   nowMs: number,
@@ -94,9 +93,7 @@ async function reserveSend(
     return "unavailable";
   }
   try {
-    const stub = namespace.get(namespace.idFromName(name)) as DurableObjectStub & {
-      reserve(limit: number, windowSeconds: number, nowMs: number): Promise<ReserveOutcome>;
-    };
+    const stub = namespace.get(namespace.idFromName(name));
     const outcome = await stub.reserve(limit, MAGIC_LINK_RATE_WINDOW, nowMs);
     return outcome.admitted ? "admitted" : "blocked";
   } catch (err) {
@@ -117,16 +114,14 @@ async function reserveSend(
  * @param logger - Request logger
  */
 async function refundSend(
-  namespace: DurableObjectNamespace | undefined,
+  namespace: Env["MAGIC_LINK_LIMITER"],
   name: string,
   nowMs: number,
   logger: Logger,
 ): Promise<void> {
   if (!namespace) return;
   try {
-    const stub = namespace.get(namespace.idFromName(name)) as DurableObjectStub & {
-      refund(windowSeconds: number, nowMs: number): Promise<void>;
-    };
+    const stub = namespace.get(namespace.idFromName(name));
     await stub.refund(MAGIC_LINK_RATE_WINDOW, nowMs);
   } catch (err) {
     logger.warn("Magic-link rate limit refund failed", { error: err });

--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -4,6 +4,7 @@ import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { admitUser, betaGateEnabled, validateInviteCode } from "../beta/gate";
 import { getInviteCodesEmail, getMagicLinkEmail } from "../email/templates";
 import { enforceSameOrigin } from "../middleware/csrf";
+import type { ReserveOutcome } from "../queue/magic-link-limiter";
 import { recordAudit } from "../storage/audit";
 import { consumeMagicLink, createMagicLink } from "../storage/magic-links";
 import { createSession } from "../storage/sessions";
@@ -32,7 +33,7 @@ function generateSecureToken(): string {
 }
 
 /**
- * Rate-limit bucket key for an email address, in the current hour window.
+ * Durable Object name for an email address's send counter.
  *
  * SHA-256 rather than hashEmail(): that helper is a 32-bit Java-style string
  * hash, and collisions in it are constructible rather than merely possible —
@@ -50,61 +51,143 @@ function generateSecureToken(): string {
  * Env is optional today. hashEmail() stays for log lines, where a short opaque
  * token is all that is wanted and a collision costs nothing.
  *
- * Changing the key shape resets in-flight hourly counters once, on deploy.
+ * The hour is no longer part of the name — the window now lives inside the
+ * object, which is what lets it erase itself on an alarm. Changing the name
+ * shape resets in-flight hourly counters once, on deploy.
  */
-async function getRateLimitKey(email: string): Promise<string> {
-  const hour = Math.floor(Date.now() / 1000 / MAGIC_LINK_RATE_WINDOW);
-  const emailHash = await hashToken(email);
-  return `magic_link_rate:${emailHash}:${hour}`;
+async function emailLimiterName(email: string): Promise<string> {
+  return `email:${await hashToken(email)}`;
 }
 
-function getIpRateLimitKey(ip: string): string {
-  const hour = Math.floor(Date.now() / 1000 / MAGIC_LINK_RATE_WINDOW);
-  return `magic_link_ip_rate:${ip}:${hour}`;
+/**
+ * Distinct prefix from the email buckets, so an IP literal can never be made to
+ * name an address's counter (or the reverse).
+ */
+function ipLimiterName(ip: string): string {
+  return `ip:${ip}`;
+}
+
+/** `unavailable` is a storage/binding failure, which is treated as an admission. */
+type ReserveResult = "admitted" | "blocked" | "unavailable";
+
+/**
+ * Takes one reservation from a subject's counter.
+ *
+ * @param namespace - The MagicLinkRateLimiter binding, absent in a deploy that predates it
+ * @param name - Subject name, from emailLimiterName/ipLimiterName
+ * @param limit - Cap for this subject, per window
+ * @param nowMs - One clock reading per request, so both counters land in the same window
+ * @param logger - Request logger
+ * @returns Whether the reservation was taken, refused, or could not be attempted
+ */
+async function reserveSend(
+  namespace: DurableObjectNamespace | undefined,
+  name: string,
+  limit: number,
+  nowMs: number,
+  logger: Logger,
+): Promise<ReserveResult> {
+  if (!namespace) {
+    // Only reachable on a deploy whose wrangler.toml predates the binding. Loud,
+    // because it means this endpoint is running with no cap at all.
+    logger.error("MAGIC_LINK_LIMITER is not bound; magic-link rate limiting is disabled");
+    return "unavailable";
+  }
+  try {
+    const stub = namespace.get(namespace.idFromName(name)) as DurableObjectStub & {
+      reserve(limit: number, windowSeconds: number, nowMs: number): Promise<ReserveOutcome>;
+    };
+    const outcome = await stub.reserve(limit, MAGIC_LINK_RATE_WINDOW, nowMs);
+    return outcome.admitted ? "admitted" : "blocked";
+  } catch (err) {
+    logger.warn("Magic-link rate limit reservation failed, allowing request", { error: err });
+    return "unavailable";
+  }
+}
+
+/**
+ * Gives back a reservation taken from a subject that then failed the other cap.
+ *
+ * Best-effort: a failure here leaks one count against the window, which
+ * over-counts the subject and can only refuse sends, never admit extra ones.
+ *
+ * @param namespace - The MagicLinkRateLimiter binding
+ * @param name - Subject name whose reservation is being returned
+ * @param nowMs - The same clock reading the reservation used
+ * @param logger - Request logger
+ */
+async function refundSend(
+  namespace: DurableObjectNamespace | undefined,
+  name: string,
+  nowMs: number,
+  logger: Logger,
+): Promise<void> {
+  if (!namespace) return;
+  try {
+    const stub = namespace.get(namespace.idFromName(name)) as DurableObjectStub & {
+      refund(windowSeconds: number, nowMs: number): Promise<void>;
+    };
+    await stub.refund(MAGIC_LINK_RATE_WINDOW, nowMs);
+  } catch (err) {
+    logger.warn("Magic-link rate limit refund failed", { error: err });
+  }
 }
 
 /**
  * Enforce both magic-link caps: per-email AND per-IP. The per-email limit alone
  * lets a single client mail links to unlimited addresses (one per email), so we
- * also bound sends per source IP. Reads fail open on a KV error (matching the
- * historical behavior — an auth path must not lock users out on a KV blip); both
- * caps re-apply on the next request once KV recovers. Returns `blocked`, plus a
- * `commit()` the caller invokes once it decides to actually send, which bumps
- * both counters together.
+ * also bound sends per source IP.
+ *
+ * This both decides *and* commits: a reservation is taken as part of the
+ * decision, so there is no window between "am I under the cap" and "count me".
+ * That is the whole point of issue #283 — the Workers KV counters this replaces
+ * read and wrote from the Worker, so N concurrent sends all read the same value
+ * and the cap only ever bound sequential traffic. Every call site already
+ * committed as its first statement after an unblocked check, so collapsing the
+ * two loses no caller flexibility.
+ *
+ * The two caps live in separate objects (one per email digest, one per IP),
+ * because a shared instance would serialize every magic-link send on the
+ * planet behind one thread. They are therefore reserved in sequence, and an
+ * email reservation is refunded when the IP cap then refuses. A concurrent
+ * request can observe the un-refunded count and be turned away; over-refusing
+ * for a few milliseconds is the safe direction, and neither cap is ever
+ * exceeded.
+ *
+ * **Storage-error policy: fail open, deliberately.** A reservation that cannot
+ * be attempted — the binding is missing, or the object throws — admits the
+ * request and logs. Failing closed would turn a transient storage fault into a
+ * total login outage, which is a worse failure than the bounded over-sending a
+ * fault-window bypass allows; both caps re-apply on the next request once
+ * storage recovers. This is the same policy the KV implementation had, restated
+ * here rather than changed silently.
+ *
+ * @param c - Request context, for the binding and the client IP
+ * @param email - The address a link would be sent to
+ * @param logger - Request logger
+ * @returns Whether the send is refused; when it is not, the send is already counted
  */
 async function checkMagicLinkRateLimits(
   c: Context<{ Bindings: Env }>,
   email: string,
   logger: Logger,
-): Promise<{ blocked: boolean; commit: () => Promise<void> }> {
-  const emailKey = await getRateLimitKey(email);
-  const ip = c.req.header("CF-Connecting-IP") ?? "unknown";
-  const ipKey = getIpRateLimitKey(ip);
-  let emailCount = 0;
-  let ipCount = 0;
-  try {
-    emailCount = Number.parseInt((await c.env.STATE.get(emailKey)) ?? "0");
-    ipCount = Number.parseInt((await c.env.STATE.get(ipKey)) ?? "0");
-  } catch (err) {
-    // Fail open means fail open for *both* caps. These are assigned in sequence,
-    // so a throw on the second read would otherwise leave a populated count from
-    // the first standing against a zero from the second — and an exhausted email
-    // bucket would block the request on a transient KV blip, which is precisely
-    // the lockout this contract exists to prevent. Reset both.
-    emailCount = 0;
-    ipCount = 0;
-    logger.warn("Failed to read magic-link rate limits, allowing request", { error: err });
+): Promise<{ blocked: boolean }> {
+  const namespace = c.env.MAGIC_LINK_LIMITER;
+  // One reading for both counters, so a request that straddles an hour boundary
+  // cannot land its two reservations in different windows.
+  const nowMs = Date.now();
+  const emailName = await emailLimiterName(email);
+  const ipName = ipLimiterName(c.req.header("CF-Connecting-IP") ?? "unknown");
+
+  const emailResult = await reserveSend(namespace, emailName, MAGIC_LINK_RATE_LIMIT, nowMs, logger);
+  if (emailResult === "blocked") return { blocked: true };
+
+  const ipResult = await reserveSend(namespace, ipName, MAGIC_LINK_IP_RATE_LIMIT, nowMs, logger);
+  if (ipResult === "blocked") {
+    if (emailResult === "admitted") await refundSend(namespace, emailName, nowMs, logger);
+    return { blocked: true };
   }
-  const blocked = emailCount >= MAGIC_LINK_RATE_LIMIT || ipCount >= MAGIC_LINK_IP_RATE_LIMIT;
-  const commit = async () => {
-    await c.env.STATE.put(emailKey, String(emailCount + 1), {
-      expirationTtl: MAGIC_LINK_RATE_WINDOW,
-    });
-    await c.env.STATE.put(ipKey, String(ipCount + 1), {
-      expirationTtl: MAGIC_LINK_RATE_WINDOW,
-    });
-  };
-  return { blocked, commit };
+  return { blocked: false };
 }
 
 const ERROR_MESSAGES: Record<string, string> = {
@@ -421,8 +504,6 @@ app.post("/send-signup", async (c) => {
   }
 
   try {
-    await rateLimit.commit();
-
     // Generate secure magic link token
     const token = generateSecureToken();
     // Store token in D1 (atomic single-use at verify time) with signup intent.
@@ -512,8 +593,6 @@ app.post("/send-login", async (c) => {
   }
 
   try {
-    await rateLimit.commit();
-
     if (existingUser.success) {
       // Generate secure magic link token
       const token = generateSecureToken();
@@ -601,8 +680,6 @@ app.post("/send", async (c) => {
   }
 
   try {
-    await rateLimit.commit();
-
     // Check if user exists to determine intent
     const existingUser = await getUserByEmail(c.env.DB, email, logger);
     const intent = existingUser.success ? "login" : "signup";

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,6 +135,9 @@ export interface Env {
   AI?: AiBinding;
   MERGE_QUEUE?: DurableObjectNamespace;
   REPO_DO?: DurableObjectNamespace;
+  /** Serialized magic-link send counters (issue #283). Optional only so tests
+   * can omit it; every deploy from this repo's wrangler.toml binds it. */
+  MAGIC_LINK_LIMITER?: DurableObjectNamespace;
   /** Content-addressed git object plane (ADR 004 Phase 2). */
   REPO_OBJECTS?: R2Bucket;
   /** Durable backup store (D1 dumps, KV identity, repo packs). Optional: when

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { MagicLinkRateLimiter } from "./queue/magic-link-limiter";
 import type { LoggerContext } from "./utils/logger";
 export type { LoggerContext };
 
@@ -136,8 +137,14 @@ export interface Env {
   MERGE_QUEUE?: DurableObjectNamespace;
   REPO_DO?: DurableObjectNamespace;
   /** Serialized magic-link send counters (issue #283). Optional only so tests
-   * can omit it; every deploy from this repo's wrangler.toml binds it. */
-  MAGIC_LINK_LIMITER?: DurableObjectNamespace;
+   * can omit it; every deploy from this repo's wrangler.toml binds it.
+   *
+   * Parameterised by the class so `.get()` returns a typed stub: the route then
+   * calls `reserve`/`refund` directly, and a signature change here becomes a
+   * compile error instead of surviving behind a hand-written cast. The import
+   * is type-only, so the cycle with magic-link-limiter.ts (which imports `Env`
+   * from here) is erased. */
+  MAGIC_LINK_LIMITER?: DurableObjectNamespace<MagicLinkRateLimiter>;
   /** Content-addressed git object plane (ADR 004 Phase 2). */
   REPO_OBJECTS?: R2Bucket;
   /** Durable backup store (D1 dumps, KV identity, repo packs). Optional: when

--- a/tests/auth-signup-login.test.ts
+++ b/tests/auth-signup-login.test.ts
@@ -1,12 +1,11 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { MagicLinkRateLimiter } from "../src/queue/magic-link-limiter";
 import { authRouter } from "../src/routes/auth";
 import { emailAuthRouter } from "../src/routes/email-auth";
 import type { Env, User } from "../src/types";
 import { NotFoundError } from "../src/utils/errors";
 import type { Logger } from "../src/utils/logger";
-import { makeFakeDurableObjects } from "./helpers/fake-durable-object";
+import { makeMagicLinkLimiters } from "./helpers/magic-link-limiter";
 
 // ============================================================================
 // Mocks
@@ -204,8 +203,8 @@ function makeKV(): KVNamespace {
  * A fresh limiter namespace per env, so each test starts from empty counters
  * the way a fresh KV store used to.
  */
-function makeLimiterNamespace(): DurableObjectNamespace {
-  return makeFakeDurableObjects((ctx) => new MagicLinkRateLimiter(ctx, {} as Env)).namespace;
+function makeLimiterNamespace(): NonNullable<Env["MAGIC_LINK_LIMITER"]> {
+  return makeMagicLinkLimiters().namespace;
 }
 
 function makeEnv(overrides?: Partial<Env>): Env {
@@ -708,7 +707,7 @@ describe("Auth Signup/Login Integration Tests", () => {
 
         for (const { faulty, email, ip } of cases) {
           const env = makeEnv();
-          const healthy = env.MAGIC_LINK_LIMITER as DurableObjectNamespace;
+          const healthy = makeLimiterNamespace();
           env.MAGIC_LINK_LIMITER = {
             idFromName: (name: string) => healthy.idFromName(name),
             get: (id: { toString(): string }) =>
@@ -718,7 +717,7 @@ describe("Auth Signup/Login Integration Tests", () => {
                     refund: () => Promise.reject(new Error("storage unavailable")),
                   }
                 : healthy.get(id as DurableObjectId),
-          } as unknown as DurableObjectNamespace;
+          } as unknown as NonNullable<Env["MAGIC_LINK_LIMITER"]>;
 
           // Well past both caps: nothing may refuse while a counter is faulty.
           for (let i = 0; i < 25; i++) {

--- a/tests/auth-signup-login.test.ts
+++ b/tests/auth-signup-login.test.ts
@@ -1,10 +1,12 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MagicLinkRateLimiter } from "../src/queue/magic-link-limiter";
 import { authRouter } from "../src/routes/auth";
 import { emailAuthRouter } from "../src/routes/email-auth";
 import type { Env, User } from "../src/types";
 import { NotFoundError } from "../src/utils/errors";
 import type { Logger } from "../src/utils/logger";
+import { makeFakeDurableObjects } from "./helpers/fake-durable-object";
 
 // ============================================================================
 // Mocks
@@ -198,10 +200,19 @@ function makeKV(): KVNamespace {
   } as unknown as KVNamespace;
 }
 
+/**
+ * A fresh limiter namespace per env, so each test starts from empty counters
+ * the way a fresh KV store used to.
+ */
+function makeLimiterNamespace(): DurableObjectNamespace {
+  return makeFakeDurableObjects((ctx) => new MagicLinkRateLimiter(ctx, {} as Env)).namespace;
+}
+
 function makeEnv(overrides?: Partial<Env>): Env {
   return {
     ARTIFACTS: {} as Env["ARTIFACTS"],
     STATE: makeKV(),
+    MAGIC_LINK_LIMITER: makeLimiterNamespace(),
     DB: {} as D1Database,
     EMAIL: {
       send: vi.fn().mockResolvedValue({ messageId: "test-message-id" }),
@@ -669,43 +680,60 @@ describe("Auth Signup/Login Integration Tests", () => {
       });
 
       /**
-       * The two reads are assigned in sequence, so a throw on the second one
-       * used to leave the first count standing. With the email bucket already
-       * exhausted that computed `blocked === true` — locking a user out of
-       * their own login on a transient KV blip, which is the exact failure the
-       * fail-open contract exists to prevent.
+       * Fail-open is the documented storage-error policy: a reservation that
+       * cannot be *attempted* admits the request, because failing closed would
+       * turn a transient storage fault into a total login outage.
+       *
+       * Note what this does not cover. A reservation that succeeds and reports
+       * the cap is a real answer, so an exhausted bucket still blocks — the KV
+       * counters this replaces admitted there too, but only because a throw on
+       * the second read reset the first read's count as well.
        */
-      it("fails open when the per-IP read throws after the email bucket is full", async () => {
-        const email = "failopen@example.com";
-        const env = makeEnv();
-        const realGet = env.STATE.get.bind(env.STATE);
-        // Exhaust the per-email bucket through the real path first.
-        for (let i = 0; i < 5; i++) {
-          await app.fetch(
-            request("/auth/email/send-signup", {
-              method: "POST",
-              body: createFormData({ email, username: `failopen${i}` }),
-            }),
-            env,
-          );
+      it("fails open when either counter's storage throws", async () => {
+        // Each case varies the OTHER dimension, so the healthy counter can
+        // never be the one that refuses and the assertion is about the faulty
+        // one alone.
+        const cases = [
+          {
+            faulty: "email:",
+            email: () => "failopen@example.com",
+            ip: (i: number) => `203.0.113.${i}`,
+          },
+          {
+            faulty: "ip:",
+            email: (i: number) => `failopen${i}@example.com`,
+            ip: () => "203.0.113.40",
+          },
+        ];
+
+        for (const { faulty, email, ip } of cases) {
+          const env = makeEnv();
+          const healthy = env.MAGIC_LINK_LIMITER as DurableObjectNamespace;
+          env.MAGIC_LINK_LIMITER = {
+            idFromName: (name: string) => healthy.idFromName(name),
+            get: (id: { toString(): string }) =>
+              id.toString().startsWith(faulty)
+                ? {
+                    reserve: () => Promise.reject(new Error("storage unavailable")),
+                    refund: () => Promise.reject(new Error("storage unavailable")),
+                  }
+                : healthy.get(id as DurableObjectId),
+          } as unknown as DurableObjectNamespace;
+
+          // Well past both caps: nothing may refuse while a counter is faulty.
+          for (let i = 0; i < 25; i++) {
+            const res = await app.fetch(
+              request("/auth/email/send-signup", {
+                method: "POST",
+                headers: { "CF-Connecting-IP": ip(i) },
+                body: createFormData({ email: email(i), username: `failopen${i}` }),
+              }),
+              env,
+            );
+            expect(res.status).toBe(302);
+            expect(res.headers.get("location")).not.toContain("error=rate_limited");
+          }
         }
-
-        // Now let the email read succeed and make only the per-IP read throw.
-        env.STATE.get = (async (key: string) => {
-          if (key.startsWith("magic_link_ip_rate:")) throw new Error("KV unavailable");
-          return realGet(key);
-        }) as typeof env.STATE.get;
-
-        const res = await app.fetch(
-          request("/auth/email/send-signup", {
-            method: "POST",
-            body: createFormData({ email, username: "failopen9" }),
-          }),
-          env,
-        );
-
-        expect(res.status).toBe(302);
-        expect(res.headers.get("location")).not.toContain("error=rate_limited");
       });
 
       // The per-email bucket keys on a digest of the address. It has to be

--- a/tests/helpers/fake-durable-object.ts
+++ b/tests/helpers/fake-durable-object.ts
@@ -1,0 +1,121 @@
+/**
+ * An in-memory stand-in for a DurableObjectNamespace.
+ *
+ * The interesting part is `gated`. workerd holds incoming events for an object
+ * while one of its storage operations is in flight (the "input gate"), which is
+ * exactly what makes a read-modify-write inside a Durable Object atomic. This
+ * helper models that with a per-instance promise chain, so a concurrency test
+ * run here reproduces the ordering guarantee production actually provides.
+ *
+ * Passing `gated: false` removes the guarantee, which is how a test can show
+ * that its concurrency assertion is not vacuous: the same assertion must fail
+ * against an ungated counter.
+ */
+export interface FakeDurableObjectStorage {
+  get<T>(key: string): Promise<T | undefined>;
+  put<T>(key: string, value: T): Promise<void>;
+  delete(key: string): Promise<boolean>;
+  deleteAll(): Promise<void>;
+  setAlarm(scheduledTime: number): Promise<void>;
+  getAlarm(): Promise<number | null>;
+}
+
+export interface FakeDurableObjects<T> {
+  namespace: DurableObjectNamespace;
+  /** Live instances, keyed by the name passed to `idFromName`. */
+  instances: Map<string, T>;
+  /**
+   * Each instance's storage, keyed the same way. Exposed here because the
+   * runtime's `ctx` is protected on the DurableObject base class, so a test
+   * cannot read it off the instance.
+   */
+  storages: Map<string, FakeDurableObjectStorage>;
+  /** Every RPC issued, as `"<name>.<method>"`, in call order. */
+  calls: string[];
+}
+
+function makeStorage(): FakeDurableObjectStorage {
+  const values = new Map<string, unknown>();
+  let alarm: number | null = null;
+  return {
+    // Every accessor is async so awaiting one yields the microtask queue —
+    // without that, an ungated read-modify-write would never interleave here
+    // and the harness self-check below could not fail.
+    get: async <T>(key: string) => values.get(key) as T | undefined,
+    put: async <T>(key: string, value: T) => {
+      values.set(key, value);
+    },
+    delete: async (key: string) => values.delete(key),
+    deleteAll: async () => {
+      values.clear();
+      alarm = null;
+    },
+    setAlarm: async (scheduledTime: number) => {
+      alarm = scheduledTime;
+    },
+    getAlarm: async () => alarm,
+  };
+}
+
+/**
+ * Builds a fake namespace whose stubs forward RPC to real instances of a
+ * Durable Object class.
+ *
+ * @param construct - Builds one instance around the supplied storage
+ * @param opts - `gated` (default true) models workerd's input gate
+ * @returns The namespace, its live instances, and a log of every RPC issued
+ */
+export function makeFakeDurableObjects<T extends object>(
+  construct: (ctx: DurableObjectState) => T,
+  opts: { gated?: boolean } = {},
+): FakeDurableObjects<T> {
+  const gated = opts.gated ?? true;
+  const instances = new Map<string, T>();
+  const storages = new Map<string, FakeDurableObjectStorage>();
+  const gates = new Map<string, Promise<unknown>>();
+  const calls: string[] = [];
+
+  function instanceFor(name: string): T {
+    const existing = instances.get(name);
+    if (existing) return existing;
+    const storage = makeStorage();
+    storages.set(name, storage);
+    const created = construct({ storage } as unknown as DurableObjectState);
+    instances.set(name, created);
+    return created;
+  }
+
+  const namespace = {
+    idFromName: (name: string) => ({ toString: () => name, name }),
+    get: (id: { toString(): string }) => {
+      const name = id.toString();
+      return new Proxy(
+        {},
+        {
+          get: (_target, method: string) => {
+            return async (...args: unknown[]) => {
+              calls.push(`${name}.${method}`);
+              const instance = instanceFor(name) as unknown as Record<
+                string,
+                (...a: unknown[]) => Promise<unknown>
+              >;
+              if (!gated) return instance[method]?.(...args);
+              // Serialize on the instance the way the runtime's input gate does.
+              // `.catch` keeps one rejected call from poisoning the chain, while
+              // the rejection still propagates to its own caller below.
+              const prior = gates.get(name) ?? Promise.resolve();
+              const next = prior.then(() => instance[method]?.(...args));
+              gates.set(
+                name,
+                next.catch(() => undefined),
+              );
+              return next;
+            };
+          },
+        },
+      ) as unknown as DurableObjectStub;
+    },
+  } as unknown as DurableObjectNamespace;
+
+  return { namespace, instances, storages, calls };
+}

--- a/tests/helpers/fake-durable-object.ts
+++ b/tests/helpers/fake-durable-object.ts
@@ -41,9 +41,17 @@ function makeStorage(): FakeDurableObjectStorage {
     // Every accessor is async so awaiting one yields the microtask queue —
     // without that, an ungated read-modify-write would never interleave here
     // and the harness self-check below could not fail.
-    get: async <T>(key: string) => values.get(key) as T | undefined,
+    //
+    // Both directions clone. Real DO storage serializes, so a caller cannot
+    // reach back into stored state through a reference it still holds; a Map of
+    // live objects would let a test mutate a bucket in place and pass where
+    // production would not.
+    get: async <T>(key: string) => {
+      const value = values.get(key);
+      return (value === undefined ? undefined : structuredClone(value)) as T | undefined;
+    },
     put: async <T>(key: string, value: T) => {
-      values.set(key, value);
+      values.set(key, structuredClone(value));
     },
     delete: async (key: string) => values.delete(key),
     deleteAll: async () => {
@@ -92,7 +100,13 @@ export function makeFakeDurableObjects<T extends object>(
       return new Proxy(
         {},
         {
-          get: (_target, method: string) => {
+          get: (_target, method) => {
+            // A Proxy that answers `.then` is a thenable: awaiting a stub (or
+            // resolving one inside a promise chain) would call it as a
+            // continuation and hang or resolve to the wrong thing. Symbols get
+            // the same treatment — Symbol.toPrimitive, util.inspect and friends
+            // are probes, not RPC.
+            if (typeof method !== "string" || method === "then") return undefined;
             return async (...args: unknown[]) => {
               calls.push(`${name}.${method}`);
               const instance = instanceFor(name) as unknown as Record<

--- a/tests/helpers/magic-link-limiter.ts
+++ b/tests/helpers/magic-link-limiter.ts
@@ -1,0 +1,31 @@
+import { MagicLinkRateLimiter } from "../../src/queue/magic-link-limiter";
+import type { Env } from "../../src/types";
+import { type FakeDurableObjectStorage, makeFakeDurableObjects } from "./fake-durable-object";
+
+export interface FakeMagicLinkLimiters {
+  /** Typed exactly as `Env` declares the binding, so no call site casts. */
+  namespace: NonNullable<Env["MAGIC_LINK_LIMITER"]>;
+  instances: Map<string, MagicLinkRateLimiter>;
+  storages: Map<string, FakeDurableObjectStorage>;
+  calls: string[];
+}
+
+/**
+ * A fake namespace backed by real {@link MagicLinkRateLimiter} instances.
+ *
+ * The one cast lives here rather than at each call site. `makeFakeDurableObjects`
+ * is generic and cannot know the RPC brand of whichever class it constructs, so
+ * something has to assert it; doing that once means a signature change in the
+ * Durable Object is a compile error in the tests instead of being absorbed by
+ * four separate hand-written stub types.
+ *
+ * @param opts - `gated` (default true) models workerd's input gate
+ * @returns The namespace plus the harness's instances, storages, and RPC log
+ */
+export function makeMagicLinkLimiters(opts: { gated?: boolean } = {}): FakeMagicLinkLimiters {
+  const fake = makeFakeDurableObjects((ctx) => new MagicLinkRateLimiter(ctx, {} as Env), opts);
+  return {
+    ...fake,
+    namespace: fake.namespace as unknown as NonNullable<Env["MAGIC_LINK_LIMITER"]>,
+  };
+}

--- a/tests/magic-link-admission.test.ts
+++ b/tests/magic-link-admission.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi } from "vitest";
+import { MagicLinkRateLimiter } from "../src/queue/magic-link-limiter";
+import { emailAuthRouter } from "../src/routes/email-auth";
+import type { Env } from "../src/types";
+import { NotFoundError } from "../src/utils/errors";
+import { makeFakeDurableObjects } from "./helpers/fake-durable-object";
+
+vi.mock("../src/storage/magic-links", () => ({
+  createMagicLink: vi.fn(async () => ({ success: true, data: undefined })),
+  consumeMagicLink: vi.fn(async () => ({ success: true, data: null })),
+}));
+
+vi.mock("../src/storage/users", () => ({
+  getUserByEmail: vi.fn(async () => ({ success: false, error: new NotFoundError("User", "x") })),
+  createUser: vi.fn(),
+  getUserByUsername: vi.fn(),
+  upsertGitHubUser: vi.fn(),
+  getUserByToken: vi.fn(),
+  getUser: vi.fn(),
+  linkGitHub: vi.fn(),
+}));
+
+const EMAIL_LIMIT = 5;
+const IP_LIMIT = 20;
+
+function makeHarness(opts: { namespace?: DurableObjectNamespace } = {}) {
+  const limiters = makeFakeDurableObjects((ctx) => new MagicLinkRateLimiter(ctx, {} as Env));
+  const send = vi.fn().mockResolvedValue({ messageId: "m" });
+  const env = {
+    ARTIFACTS: {} as Env["ARTIFACTS"],
+    STATE: {} as KVNamespace,
+    DB: {} as D1Database,
+    EMAIL: { send },
+    EMAIL_FROM_ADDRESS: "noreply@stratum.dev",
+    MAGIC_LINK_LIMITER: opts.namespace ?? limiters.namespace,
+  } as unknown as Env;
+  return { env, send, limiters };
+}
+
+function sendRequest(email: string, ip: string): Request {
+  const body = new FormData();
+  body.append("email", email);
+  return new Request("http://localhost/send", {
+    method: "POST",
+    body,
+    headers: { "CF-Connecting-IP": ip },
+  });
+}
+
+async function post(env: Env, email: string, ip: string): Promise<Response> {
+  return emailAuthRouter.fetch(sendRequest(email, ip), env);
+}
+
+function rateLimited(res: Response): boolean {
+  return res.headers.get("location")?.includes("error=rate_limited") ?? false;
+}
+
+describe("magic-link admission", () => {
+  it("admits at most the per-IP cap when requests from one IP race", async () => {
+    const { env, send } = makeHarness();
+
+    // 25 distinct addresses, so every per-email counter stays at 1 and the
+    // per-IP cap is the only thing that can refuse. All in flight at once —
+    // the read-to-write window the KV counters had is exactly here.
+    const responses = await Promise.all(
+      Array.from({ length: 25 }, (_, i) => post(env, `racer${i}@example.com`, "203.0.113.9")),
+    );
+
+    expect(responses.filter((r) => !rateLimited(r))).toHaveLength(IP_LIMIT);
+    expect(send).toHaveBeenCalledTimes(IP_LIMIT);
+  });
+
+  it("admits at most the per-email cap when requests for one address race", async () => {
+    const { env, send } = makeHarness();
+
+    // Distinct IPs, so the per-email cap is the only thing that can refuse.
+    const responses = await Promise.all(
+      Array.from({ length: 12 }, (_, i) => post(env, "victim@example.com", `198.51.100.${i}`)),
+    );
+
+    expect(responses.filter((r) => !rateLimited(r))).toHaveLength(EMAIL_LIMIT);
+    expect(send).toHaveBeenCalledTimes(EMAIL_LIMIT);
+  });
+
+  it("holds both caps when addresses and IPs race together", async () => {
+    const { env, send } = makeHarness();
+
+    // 8 addresses x 6 sends, all from one IP: each address would allow 5 (40
+    // total), the IP allows 20. The tighter cap has to win, exactly.
+    const requests = [];
+    for (let e = 0; e < 8; e++) {
+      for (let n = 0; n < 6; n++) requests.push(post(env, `mix${e}@example.com`, "203.0.113.10"));
+    }
+    const responses = await Promise.all(requests);
+
+    expect(responses.filter((r) => !rateLimited(r))).toHaveLength(IP_LIMIT);
+    expect(send).toHaveBeenCalledTimes(IP_LIMIT);
+  });
+
+  it("does not spend an IP reservation on a request the email cap refuses", async () => {
+    const { env, limiters } = makeHarness();
+    const ip = "203.0.113.11";
+
+    for (let i = 0; i < EMAIL_LIMIT; i++) await post(env, "spent@example.com", ip);
+    // Three more for the same address: all refused by the email cap, and none
+    // of them may consume the IP budget the other addresses still need.
+    for (let i = 0; i < 3; i++)
+      expect(rateLimited(await post(env, "spent@example.com", ip))).toBe(true);
+
+    const ipStorage = limiters.storages.get(`ip:${ip}`);
+    if (!ipStorage) throw new Error("ip limiter not created");
+    expect(await ipStorage.get("bucket")).toMatchObject({ count: EMAIL_LIMIT });
+  });
+
+  it("refunds the email reservation when the IP cap refuses the send", async () => {
+    const { env, limiters, send } = makeHarness();
+    const ip = "203.0.113.12";
+
+    // Burn the IP budget on addresses that are nowhere near their own cap.
+    for (let i = 0; i < IP_LIMIT; i++) await post(env, `filler${i}@example.com`, ip);
+    expect(send).toHaveBeenCalledTimes(IP_LIMIT);
+
+    // A fresh address now gets past its own cap and is stopped by the IP cap.
+    // Its email counter must come back to zero, or an IP-exhausted hour would
+    // silently eat the address's whole per-email budget too.
+    expect(rateLimited(await post(env, "unlucky@example.com", ip))).toBe(true);
+
+    const emailStorages = [...limiters.storages.entries()]
+      .filter(([name]) => name.startsWith("email:"))
+      .map(([, storage]) => storage);
+    const buckets = await Promise.all(
+      emailStorages.map(async (storage) => storage.get<{ count: number }>("bucket")),
+    );
+    // 20 fillers at 1 each, and the refunded address back at 0.
+    expect(buckets.filter((b) => b?.count === 1)).toHaveLength(IP_LIMIT);
+    expect(buckets.filter((b) => b?.count === 0)).toHaveLength(1);
+  });
+
+  it("issues exactly one reservation RPC per counter, with no separate read", async () => {
+    const { env, limiters } = makeHarness();
+
+    await post(env, "single@example.com", "203.0.113.13");
+
+    // The bug being fixed was a Worker-side read followed by a write. One RPC
+    // per counter is what keeps the decision inside the object's input gate.
+    expect(limiters.calls.filter((call) => call.endsWith(".reserve"))).toHaveLength(2);
+    expect(limiters.calls.filter((call) => call.endsWith(".refund"))).toHaveLength(0);
+    expect(limiters.calls.some((call) => call.startsWith("email:"))).toBe(true);
+    expect(limiters.calls.some((call) => call.startsWith("ip:"))).toBe(true);
+  });
+
+  it("fails open when the limiter binding is absent", async () => {
+    const { env, send } = makeHarness();
+    (env as { MAGIC_LINK_LIMITER?: DurableObjectNamespace }).MAGIC_LINK_LIMITER = undefined;
+
+    // Well past both caps. Failing closed here would be a total login outage on
+    // a self-hosted deploy whose config predates the binding.
+    for (let i = 0; i < IP_LIMIT + 5; i++) {
+      expect(rateLimited(await post(env, "nobinding@example.com", "203.0.113.14"))).toBe(false);
+    }
+    expect(send).toHaveBeenCalledTimes(IP_LIMIT + 5);
+  });
+
+  it("fails open when the limiter throws", async () => {
+    const throwing = {
+      idFromName: (name: string) => ({ toString: () => name }),
+      get: () => ({
+        reserve: () => Promise.reject(new Error("storage unavailable")),
+        refund: () => Promise.reject(new Error("storage unavailable")),
+      }),
+    } as unknown as DurableObjectNamespace;
+    const { env, send } = makeHarness({ namespace: throwing });
+
+    for (let i = 0; i < EMAIL_LIMIT + 3; i++) {
+      expect(rateLimited(await post(env, "outage@example.com", "203.0.113.15"))).toBe(false);
+    }
+    expect(send).toHaveBeenCalledTimes(EMAIL_LIMIT + 3);
+  });
+
+  it("separates the email and IP namespaces so an IP literal cannot name an address bucket", async () => {
+    const { env, limiters } = makeHarness();
+
+    await post(env, "ns@example.com", "203.0.113.16");
+
+    const names = [...limiters.instances.keys()];
+    expect(names.filter((n) => n.startsWith("email:"))).toHaveLength(1);
+    expect(names).toContain("ip:203.0.113.16");
+  });
+});

--- a/tests/magic-link-admission.test.ts
+++ b/tests/magic-link-admission.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { MagicLinkRateLimiter } from "../src/queue/magic-link-limiter";
-import { emailAuthRouter } from "../src/routes/email-auth";
+import {
+  MAGIC_LINK_IP_RATE_LIMIT,
+  MAGIC_LINK_RATE_LIMIT,
+  emailAuthRouter,
+} from "../src/routes/email-auth";
 import type { Env } from "../src/types";
 import { NotFoundError } from "../src/utils/errors";
-import { makeFakeDurableObjects } from "./helpers/fake-durable-object";
+import { makeMagicLinkLimiters } from "./helpers/magic-link-limiter";
 
 vi.mock("../src/storage/magic-links", () => ({
   createMagicLink: vi.fn(async () => ({ success: true, data: undefined })),
@@ -20,11 +23,13 @@ vi.mock("../src/storage/users", () => ({
   linkGitHub: vi.fn(),
 }));
 
-const EMAIL_LIMIT = 5;
-const IP_LIMIT = 20;
+// The production constants, not copies: a cap changed in one place and not the
+// other would otherwise leave these tests asserting a limit nothing enforces.
+const EMAIL_LIMIT = MAGIC_LINK_RATE_LIMIT;
+const IP_LIMIT = MAGIC_LINK_IP_RATE_LIMIT;
 
 function makeHarness(opts: { namespace?: DurableObjectNamespace } = {}) {
-  const limiters = makeFakeDurableObjects((ctx) => new MagicLinkRateLimiter(ctx, {} as Env));
+  const limiters = makeMagicLinkLimiters();
   const send = vi.fn().mockResolvedValue({ messageId: "m" });
   const env = {
     ARTIFACTS: {} as Env["ARTIFACTS"],

--- a/tests/magic-link-rate-limit.test.ts
+++ b/tests/magic-link-rate-limit.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { MagicLinkRateLimiter } from "../src/queue/magic-link-limiter";
+import type { Env } from "../src/types";
+import { makeFakeDurableObjects } from "./helpers/fake-durable-object";
+
+const WINDOW = 60 * 60;
+const HOUR_MS = WINDOW * 1000;
+
+function makeLimiters(opts: { gated?: boolean } = {}) {
+  return makeFakeDurableObjects((ctx) => new MagicLinkRateLimiter(ctx, {} as Env), opts);
+}
+
+/** RPC surface of the limiter, as the route sees it through a stub. */
+interface LimiterStub {
+  reserve(
+    limit: number,
+    windowSeconds: number,
+    nowMs: number,
+  ): Promise<{ admitted: boolean; count: number }>;
+  refund(windowSeconds: number, nowMs: number): Promise<void>;
+}
+
+function stubFor(namespace: DurableObjectNamespace, name: string): LimiterStub {
+  return namespace.get(namespace.idFromName(name)) as unknown as LimiterStub;
+}
+
+describe("MagicLinkRateLimiter", () => {
+  it("admits up to the limit and then refuses", async () => {
+    const { namespace } = makeLimiters();
+    const stub = stubFor(namespace, "email:a");
+    const now = Date.now();
+
+    const outcomes = [];
+    for (let i = 0; i < 7; i++) outcomes.push(await stub.reserve(5, WINDOW, now));
+
+    expect(outcomes.map((o) => o.admitted)).toEqual([true, true, true, true, true, false, false]);
+    expect(outcomes.map((o) => o.count)).toEqual([1, 2, 3, 4, 5, 5, 5]);
+  });
+
+  it("resets the counter when the window rolls", async () => {
+    const { namespace } = makeLimiters();
+    const stub = stubFor(namespace, "email:a");
+    const now = Date.now();
+
+    for (let i = 0; i < 5; i++) await stub.reserve(5, WINDOW, now);
+    expect((await stub.reserve(5, WINDOW, now)).admitted).toBe(false);
+
+    expect((await stub.reserve(5, WINDOW, now + HOUR_MS)).admitted).toBe(true);
+  });
+
+  it("gives a reservation back on refund", async () => {
+    const { namespace } = makeLimiters();
+    const stub = stubFor(namespace, "email:a");
+    const now = Date.now();
+
+    for (let i = 0; i < 5; i++) await stub.reserve(5, WINDOW, now);
+    expect((await stub.reserve(5, WINDOW, now)).admitted).toBe(false);
+
+    await stub.refund(WINDOW, now);
+    expect((await stub.reserve(5, WINDOW, now)).admitted).toBe(true);
+    // ...and only one was given back.
+    expect((await stub.reserve(5, WINDOW, now)).admitted).toBe(false);
+  });
+
+  it("ignores a refund whose window has already rolled", async () => {
+    const { namespace } = makeLimiters();
+    const stub = stubFor(namespace, "email:a");
+    const now = Date.now();
+
+    await stub.reserve(5, WINDOW, now);
+    // A refund stamped in the NEXT window must not decrement that window's
+    // (zero) count, which would otherwise carry a credit forward.
+    await stub.refund(WINDOW, now + HOUR_MS);
+
+    const next = await stub.reserve(5, WINDOW, now + HOUR_MS);
+    expect(next.count).toBe(1);
+  });
+
+  it("does not drive a counter below zero", async () => {
+    const { namespace } = makeLimiters();
+    const stub = stubFor(namespace, "email:a");
+    const now = Date.now();
+
+    await stub.refund(WINDOW, now);
+    await stub.refund(WINDOW, now);
+
+    expect((await stub.reserve(1, WINDOW, now)).count).toBe(1);
+    expect((await stub.reserve(1, WINDOW, now)).admitted).toBe(false);
+  });
+
+  it("refuses rather than throws on a malformed limit or window", async () => {
+    const { namespace } = makeLimiters();
+    const stub = stubFor(namespace, "email:a");
+    const now = Date.now();
+
+    // A throw would reach the caller's catch, which fails OPEN — so a bad
+    // constant has to refuse instead of turning the endpoint unlimited.
+    expect((await stub.reserve(0, WINDOW, now)).admitted).toBe(false);
+    expect((await stub.reserve(-1, WINDOW, now)).admitted).toBe(false);
+    expect((await stub.reserve(1.5, WINDOW, now)).admitted).toBe(false);
+    expect((await stub.reserve(Number.NaN, WINDOW, now)).admitted).toBe(false);
+    expect((await stub.reserve(5, 0, now)).admitted).toBe(false);
+  });
+
+  it("arms an alarm past the end of the live window and erases on it", async () => {
+    const { namespace, instances, storages } = makeLimiters();
+    const stub = stubFor(namespace, "email:a");
+    const now = Date.now();
+
+    await stub.reserve(5, WINDOW, now);
+    const instance = instances.get("email:a");
+    const storage = storages.get("email:a");
+    if (!instance || !storage) throw new Error("instance not created");
+
+    const alarm = await storage.getAlarm();
+    const windowEndMs = (Math.floor(now / 1000 / WINDOW) + 1) * HOUR_MS;
+    expect(alarm).toBeGreaterThan(windowEndMs);
+
+    await instance.alarm();
+    expect(await storage.getAlarm()).toBeNull();
+    // Storage erased, so the next window starts from nothing.
+    expect((await stub.reserve(5, WINDOW, now)).count).toBe(1);
+  });
+});
+
+describe("MagicLinkRateLimiter concurrency", () => {
+  it("holds the cap when 50 reservations run concurrently", async () => {
+    const { namespace } = makeLimiters();
+    const stub = stubFor(namespace, "ip:203.0.113.7");
+    const now = Date.now();
+
+    const outcomes = await Promise.all(
+      Array.from({ length: 50 }, () => stub.reserve(20, WINDOW, now)),
+    );
+
+    expect(outcomes.filter((o) => o.admitted)).toHaveLength(20);
+    // Counts are 1..20 with no repeats — no two admissions read the same value.
+    expect(
+      outcomes
+        .filter((o) => o.admitted)
+        .map((o) => o.count)
+        .sort((a, b) => a - b),
+    ).toEqual(Array.from({ length: 20 }, (_, i) => i + 1));
+  });
+
+  it("over-admits without the input gate, proving the assertion above is not vacuous", async () => {
+    // Same 50 concurrent reservations against an UNGATED instance: this is the
+    // Workers KV failure mode the Durable Object replaces. If this ever stops
+    // over-admitting, the harness has stopped modelling concurrency and the
+    // test above no longer proves anything.
+    const { namespace } = makeLimiters({ gated: false });
+    const stub = stubFor(namespace, "ip:203.0.113.7");
+    const now = Date.now();
+
+    const outcomes = await Promise.all(
+      Array.from({ length: 50 }, () => stub.reserve(20, WINDOW, now)),
+    );
+
+    expect(outcomes.filter((o) => o.admitted).length).toBeGreaterThan(20);
+  });
+});

--- a/tests/magic-link-rate-limit.test.ts
+++ b/tests/magic-link-rate-limit.test.ts
@@ -1,32 +1,25 @@
 import { describe, expect, it } from "vitest";
-import { MagicLinkRateLimiter } from "../src/queue/magic-link-limiter";
+import type { MagicLinkRateLimiter } from "../src/queue/magic-link-limiter";
 import type { Env } from "../src/types";
-import { makeFakeDurableObjects } from "./helpers/fake-durable-object";
+import { makeMagicLinkLimiters } from "./helpers/magic-link-limiter";
 
 const WINDOW = 60 * 60;
 const HOUR_MS = WINDOW * 1000;
 
-function makeLimiters(opts: { gated?: boolean } = {}) {
-  return makeFakeDurableObjects((ctx) => new MagicLinkRateLimiter(ctx, {} as Env), opts);
-}
+/**
+ * The limiter's RPC surface, derived from the class rather than restated, so a
+ * signature change there fails this suite instead of being absorbed by a
+ * hand-written interface that has quietly gone out of date.
+ */
+type LimiterStub = Pick<MagicLinkRateLimiter, "reserve" | "refund">;
 
-/** RPC surface of the limiter, as the route sees it through a stub. */
-interface LimiterStub {
-  reserve(
-    limit: number,
-    windowSeconds: number,
-    nowMs: number,
-  ): Promise<{ admitted: boolean; count: number }>;
-  refund(windowSeconds: number, nowMs: number): Promise<void>;
-}
-
-function stubFor(namespace: DurableObjectNamespace, name: string): LimiterStub {
-  return namespace.get(namespace.idFromName(name)) as unknown as LimiterStub;
+function stubFor(namespace: NonNullable<Env["MAGIC_LINK_LIMITER"]>, name: string): LimiterStub {
+  return namespace.get(namespace.idFromName(name));
 }
 
 describe("MagicLinkRateLimiter", () => {
   it("admits up to the limit and then refuses", async () => {
-    const { namespace } = makeLimiters();
+    const { namespace } = makeMagicLinkLimiters();
     const stub = stubFor(namespace, "email:a");
     const now = Date.now();
 
@@ -38,7 +31,7 @@ describe("MagicLinkRateLimiter", () => {
   });
 
   it("resets the counter when the window rolls", async () => {
-    const { namespace } = makeLimiters();
+    const { namespace } = makeMagicLinkLimiters();
     const stub = stubFor(namespace, "email:a");
     const now = Date.now();
 
@@ -49,7 +42,7 @@ describe("MagicLinkRateLimiter", () => {
   });
 
   it("gives a reservation back on refund", async () => {
-    const { namespace } = makeLimiters();
+    const { namespace } = makeMagicLinkLimiters();
     const stub = stubFor(namespace, "email:a");
     const now = Date.now();
 
@@ -63,7 +56,7 @@ describe("MagicLinkRateLimiter", () => {
   });
 
   it("ignores a refund whose window has already rolled", async () => {
-    const { namespace } = makeLimiters();
+    const { namespace } = makeMagicLinkLimiters();
     const stub = stubFor(namespace, "email:a");
     const now = Date.now();
 
@@ -77,7 +70,7 @@ describe("MagicLinkRateLimiter", () => {
   });
 
   it("does not drive a counter below zero", async () => {
-    const { namespace } = makeLimiters();
+    const { namespace } = makeMagicLinkLimiters();
     const stub = stubFor(namespace, "email:a");
     const now = Date.now();
 
@@ -89,7 +82,7 @@ describe("MagicLinkRateLimiter", () => {
   });
 
   it("refuses rather than throws on a malformed limit or window", async () => {
-    const { namespace } = makeLimiters();
+    const { namespace } = makeMagicLinkLimiters();
     const stub = stubFor(namespace, "email:a");
     const now = Date.now();
 
@@ -103,7 +96,7 @@ describe("MagicLinkRateLimiter", () => {
   });
 
   it("arms an alarm past the end of the live window and erases on it", async () => {
-    const { namespace, instances, storages } = makeLimiters();
+    const { namespace, instances, storages } = makeMagicLinkLimiters();
     const stub = stubFor(namespace, "email:a");
     const now = Date.now();
 
@@ -123,9 +116,43 @@ describe("MagicLinkRateLimiter", () => {
   });
 });
 
+describe("fake Durable Object harness", () => {
+  // The harness decides whether every test above means anything, so its two
+  // fidelity properties are pinned rather than assumed.
+
+  it("does not present a stub as a thenable", async () => {
+    const { namespace } = makeMagicLinkLimiters();
+    const stub = namespace.get(namespace.idFromName("email:a"));
+
+    // A Proxy that returns a function for `.then` is a thenable: awaiting it
+    // calls that as a continuation, so the await never settles to the stub.
+    expect((stub as unknown as { then?: unknown }).then).toBeUndefined();
+    await expect(Promise.resolve(stub)).resolves.toBe(stub);
+  });
+
+  it("isolates stored state from the caller's references", async () => {
+    const { namespace, storages } = makeMagicLinkLimiters();
+    const stub = namespace.get(namespace.idFromName("email:a"));
+    const now = Date.now();
+
+    await stub.reserve(5, WINDOW, now);
+    const storage = storages.get("email:a");
+    if (!storage) throw new Error("storage not created");
+
+    // Real DO storage serializes, so a handle a caller kept cannot reach back
+    // into the bucket. A Map of live objects would let this mutation stick and
+    // let a test pass against behaviour production does not have.
+    const read = await storage.get<{ window: number; count: number }>("bucket");
+    if (!read) throw new Error("bucket not written");
+    read.count = 999;
+
+    expect((await stub.reserve(5, WINDOW, now)).count).toBe(2);
+  });
+});
+
 describe("MagicLinkRateLimiter concurrency", () => {
   it("holds the cap when 50 reservations run concurrently", async () => {
-    const { namespace } = makeLimiters();
+    const { namespace } = makeMagicLinkLimiters();
     const stub = stubFor(namespace, "ip:203.0.113.7");
     const now = Date.now();
 
@@ -148,7 +175,7 @@ describe("MagicLinkRateLimiter concurrency", () => {
     // Workers KV failure mode the Durable Object replaces. If this ever stops
     // over-admitting, the harness has stopped modelling concurrency and the
     // test above no longer proves anything.
-    const { namespace } = makeLimiters({ gated: false });
+    const { namespace } = makeMagicLinkLimiters({ gated: false });
     const stub = stubFor(namespace, "ip:203.0.113.7");
     const now = Date.now();
 

--- a/tests/magic-link.test.ts
+++ b/tests/magic-link.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MagicLinkRateLimiter } from "../src/queue/magic-link-limiter";
 import { emailAuthRouter } from "../src/routes/email-auth";
 import type { Env } from "../src/types";
 import { NotFoundError } from "../src/utils/errors";
+import { makeFakeDurableObjects } from "./helpers/fake-durable-object";
 
 // Magic links now live in D1 with atomic consume; model that with an in-memory
 // store shared across the router's create/consume calls (single-use enforced by
@@ -60,6 +62,8 @@ function makeEnv(): Env {
   return {
     ARTIFACTS: {} as Env["ARTIFACTS"],
     STATE: makeKV(),
+    MAGIC_LINK_LIMITER: makeFakeDurableObjects((ctx) => new MagicLinkRateLimiter(ctx, {} as Env))
+      .namespace,
     DB: {} as D1Database,
     EMAIL: {
       send: vi.fn().mockResolvedValue({ messageId: "test-message-id" }),
@@ -189,16 +193,6 @@ describe("Magic Link Authentication", () => {
     });
 
     it("should enforce rate limiting", async () => {
-      const kvStore = new Map<string, string>();
-      env.STATE = {
-        get: vi.fn((key: string) => Promise.resolve(kvStore.get(key) ?? null)),
-        put: vi.fn((key: string, value: string) => {
-          kvStore.set(key, value);
-          return Promise.resolve();
-        }),
-        delete: vi.fn(),
-      } as unknown as KVNamespace;
-
       // Make 5 requests (the limit)
       for (let i = 0; i < 5; i++) {
         const formData = new FormData();

--- a/tests/magic-link.test.ts
+++ b/tests/magic-link.test.ts
@@ -1,9 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { MagicLinkRateLimiter } from "../src/queue/magic-link-limiter";
 import { emailAuthRouter } from "../src/routes/email-auth";
 import type { Env } from "../src/types";
 import { NotFoundError } from "../src/utils/errors";
-import { makeFakeDurableObjects } from "./helpers/fake-durable-object";
+import { makeMagicLinkLimiters } from "./helpers/magic-link-limiter";
 
 // Magic links now live in D1 with atomic consume; model that with an in-memory
 // store shared across the router's create/consume calls (single-use enforced by
@@ -62,8 +61,7 @@ function makeEnv(): Env {
   return {
     ARTIFACTS: {} as Env["ARTIFACTS"],
     STATE: makeKV(),
-    MAGIC_LINK_LIMITER: makeFakeDurableObjects((ctx) => new MagicLinkRateLimiter(ctx, {} as Env))
-      .namespace,
+    MAGIC_LINK_LIMITER: makeMagicLinkLimiters().namespace,
     DB: {} as D1Database,
     EMAIL: {
       send: vi.fn().mockResolvedValue({ messageId: "test-message-id" }),

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -29,6 +29,13 @@ new_classes = ["MergeQueue"]
 tag = "v2"
 new_sqlite_classes = ["RepoDO"]
 
+# MagicLinkRateLimiter: serialized magic-link send counters (issue #283). One
+# instance per subject (email digest / source IP); replaces the KV counters,
+# whose read-modify-write could not hold the cap under concurrency.
+[[migrations]]
+tag = "v3"
+new_sqlite_classes = ["MagicLinkRateLimiter"]
+
 # Observability - Workers Logs and Traces
 [observability]
 enabled = true
@@ -76,6 +83,11 @@ script_name = "stratum"
 [[durable_objects.bindings]]
 name = "REPO_DO"
 class_name = "RepoDO"
+script_name = "stratum"
+
+[[durable_objects.bindings]]
+name = "MAGIC_LINK_LIMITER"
+class_name = "MagicLinkRateLimiter"
 script_name = "stratum"
 
 [[queues.producers]]
@@ -200,6 +212,11 @@ name = "REPO_DO"
 class_name = "RepoDO"
 script_name = "stratum"
 
+[[env.production.durable_objects.bindings]]
+name = "MAGIC_LINK_LIMITER"
+class_name = "MagicLinkRateLimiter"
+script_name = "stratum"
+
 [[env.production.queues.producers]]
 binding = "EVENTS_QUEUE"
 queue = "stratum-events"
@@ -309,6 +326,11 @@ script_name = "stratum-staging"
 [[env.staging.durable_objects.bindings]]
 name = "REPO_DO"
 class_name = "RepoDO"
+script_name = "stratum-staging"
+
+[[env.staging.durable_objects.bindings]]
+name = "MAGIC_LINK_LIMITER"
+class_name = "MagicLinkRateLimiter"
 script_name = "stratum-staging"
 
 [[env.staging.r2_buckets]]


### PR DESCRIPTION
## Summary

The per-email (5/hour) and per-IP (20/hour) magic-link caps were Workers KV counters, read and written from the Worker:

```ts
emailCount = Number.parseInt((await c.env.STATE.get(emailKey)) ?? "0");
...
await c.env.STATE.put(emailKey, String(emailCount + 1), ...);
```

Concurrent sends read the same value and each wrote back `value + 1`, so N simultaneous requests advanced the counter by **one**. The caps bounded sequential traffic only — which is exactly what the originating review said they were: a scoped partial mitigation for mail-bombing and email-cost amplification.

Both counters move together to a `MagicLinkRateLimiter` Durable Object, one instance per subject (`email:<sha256>` or `ip:<addr>`). The runtime's input gate holds other events for an object while one of its storage operations is in flight, so the read and the write cannot interleave.

### The admission API now decides and commits in one step

`checkMagicLinkRateLimits()` stays the single call-site boundary the issue asked for, but the reservation *is* the decision — there is no longer a window between "am I under the cap" and "count me". This costs nothing at the call sites: all three already invoked `commit()` as the first statement after an unblocked check, with nothing in between that could change the outcome. `commit()` is gone.

### Why two objects, and what the refund is for

The two caps partition differently — per address and per source — so no single instance can hold both without becoming a global serialization point for every magic-link send on the platform. They are therefore reserved in sequence (email, then IP), and the email reservation is **refunded** when the IP cap then refuses.

Between the reservation and the refund, a concurrent request can observe the un-refunded count and be turned away. That direction — over-refusing, briefly — is the safe one, and **neither cap is ever exceeded**, which is the invariant that matters. A refund that itself fails leaks one count against the window, which can only refuse sends, never admit extra ones.

### Storage-error policy: fail open, stated rather than changed

The issue asked for this to be decided explicitly. It stays **fail open**: a reservation that cannot be *attempted* — the binding is absent, or the object throws — admits the request and logs it. Failing closed would turn a transient storage fault into a total login outage, which is a worse failure than the bounded over-sending a fault window allows; both caps re-apply on the next request once storage recovers.

Two things that are deliberately *not* covered by that:

- A reservation that **succeeds and reports the cap** still refuses. That is an answer, not a fault. The KV version admitted there too, but only as an accident: a throw on the second read reset the first read's count as well. The old "fails open when the per-IP read throws after the email bucket is full" test encoded that accident, and is replaced by one asserting the actual contract against both counters.
- A **malformed limit or window refuses** rather than throwing. A throw would reach the caller's `catch`, which fails open — turning a typo in a constant into a silently unlimited endpoint.

An absent `MAGIC_LINK_LIMITER` binding (only reachable on a self-hosted deploy whose `wrangler.toml` predates it) logs at ERROR, because it means the endpoint is running with no cap at all.

### Storage lifecycle

Each object arms an alarm past the end of its live window and `deleteAll()`s on it, which is what `expirationTtl` did for the KV keys — a subject seen once does not leave durable state behind. The hour is no longer part of the object name (it lives inside the object, which is what makes self-erasure possible), so in-flight hourly counters reset once on deploy.

## Related issues

Closes #283

## Type of change

- [x] Bug fix
- [x] Refactor / cleanup
- [x] Documentation

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` — 2251 passed, 27 env-gated skips, 0 failures
- [x] `npm run lint`

18 new tests. The concurrency tests run against a fake namespace that models workerd's input gate with a per-instance promise chain; storage accessors are async, so an *ungated* instance genuinely interleaves.

**One test asserts that the same 50 concurrent reservations OVER-admit against an ungated instance.** Without it the cap assertion could pass for the wrong reason — a harness that accidentally stopped modelling concurrency would make every concurrency test in the file vacuous, and nothing would say so. The route-level tests cover the issue's stated requirement directly: 25 concurrent sends from one IP admit exactly 20, 12 concurrent sends for one address admit exactly 5, and 8 addresses × 6 sends from one IP admit exactly 20 (the tighter cap winning). Also covered: an email-capped request does not spend IP budget, an IP-capped request gets its email reservation back, exactly one reservation RPC is issued per counter (no Worker-side read-then-write), and both fail-open paths.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate — the architecture doc's KV structure no longer lists the removed key, and a new section records the design and the fail-open policy
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript — no UI change

## Notes

**Not addressed here, on purpose:** the windows stay *fixed* rather than sliding. A fixed window permits a 2× burst across its boundary, but that is a property of the limit's shape, not of its atomicity, and changing it would change user-visible behaviour beyond what this issue asks for.

**Erasure:** a bucket is keyed by an unsalted SHA-256 of the address (as the object *name*; the stored value is only `{window, count}`) and erases itself within the hour. That matches the 1-hour KV TTL it replaces, so account deletion needs no new cascade — but it is worth knowing the property is the alarm, not a `purge()` RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P11maBt5wGR783noPFLpqs

---
_Generated by [Claude Code](https://claude.ai/code/session_01P11maBt5wGR783noPFLpqs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added more reliable magic-link request limits based on both email address and IP address.
  - Applied limits consistently across signup, login, and legacy magic-link sending flows.
  - Requests can continue during temporary rate-limiter storage failures.

- **Bug Fixes**
  - Improved concurrent request handling to prevent accidental over-admission.
  - Added refunds for email reservations when IP limits block a request.
  - Rate-limit windows now reset and clean up automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->