### PR TITLE
Deploy shared staging from main only, and guard the migration chain

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -115,6 +115,10 @@ jobs:
           # migrations. The default shallow fetch has no origin/main, and the
           # guard fails rather than skips in CI, so fetch the full history.
           fetch-depth: 0
+          # The guard only reads local objects (git show, git rev-parse) and
+          # nothing else here talks to a remote, so the job needs no token in
+          # .git/config — and this job uploads an artifact.
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -109,6 +109,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          # tests/wrangler-migration-chain.test.ts reads wrangler.toml at
+          # origin/main to prove this PR only appends Durable Object
+          # migrations. The default shallow fetch has no origin/main, and the
+          # guard fails rather than skips in CI, so fetch the full history.
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -155,187 +161,21 @@ jobs:
           CI: true
 
   # ========================================================================
-  # Staging Deployment
+  # No staging deployment here — on purpose.
   # ========================================================================
-  deploy-staging:
-    name: Deploy to Staging
-    needs: [integration-tests]
-    runs-on: ubuntu-latest
-    # Fork PRs are excluded: pull_request withholds secrets from forks, so the
-    # deploy can only fail there — and unreviewed fork code shouldn't reach the
-    # shared staging environment anyway. Jobs that need this one cascade to
-    # skipped on fork PRs. Never convert this workflow to pull_request_target.
-    if: >
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    concurrency:
-      group: deploy-staging-${{ github.head_ref }}
-      cancel-in-progress: true
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-    outputs:
-      staging_url: ${{ steps.deploy.outputs.url }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-
-      - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      # Staging binds its own -staging queues (see wrangler.toml); a deploy
-      # fails if a bound queue doesn't exist, so create them idempotently.
-      - name: Ensure Staging Queues Exist
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          for queue in stratum-events-staging stratum-imports-staging; do
-            if out=$(npx wrangler queues create "$queue" 2>&1); then
-              echo "✓ Created queue $queue"
-            elif echo "$out" | grep -qiE "already (exists|taken)|11009"; then
-              echo "✓ Queue $queue already exists"
-            else
-              echo "$out"
-              exit 1
-            fi
-          done
-
-      - name: Deploy to Cloudflare Staging
-        id: deploy
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          npx wrangler deploy --env=staging
-          SUBDOMAIN=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/subdomain" \
-            | jq -r '.result.subdomain')
-          URL="https://stratum-staging.$SUBDOMAIN.workers.dev"
-          echo "url=$URL" >> $GITHUB_OUTPUT
-          echo "Deployed to: $URL"
-
-      - name: Smoke test - Health endpoint
-        env:
-          STAGING_URL: ${{ steps.deploy.outputs.url }}
-        run: |
-          set -e
-          echo "→ Testing health endpoint: $STAGING_URL/health"
-          curl -sfS --retry 5 --retry-delay 5 "$STAGING_URL/health"
-          echo "✓ Health check passed"
-
-      - name: Smoke test - API endpoints
-        env:
-          STAGING_URL: ${{ steps.deploy.outputs.url }}
-        run: |
-          set -e
-          echo "→ Testing API availability"
-          curl -sfS "$STAGING_URL/api/projects" || true
-          echo "✓ API check completed"
-
-      - name: Comment PR with staging URL
-        if: success()
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
-        with:
-          # Ride out transient GitHub API 5xx (503 brownouts have failed
-          # otherwise-green runs on nothing but the status comment). A retried
-          # POST can rarely duplicate a status comment — accepted trade-off vs.
-          # red runs. Every non-transient 4xx is exempt; 429 stays retryable.
-          retries: 3
-          retry-exempt-status-codes: 400,401,402,403,404,405,406,407,409,410,411,412,413,414,415,416,417,418,421,422,423,424,426,428,431,451
-          script: |
-            const stagingUrl = '${{ steps.deploy.outputs.url }}';
-            const workflowRunUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
-
-            const body = `## 🚀 Staging Deployment Ready
-
-            **Preview URL:** ${stagingUrl}
-
-            ### Quick Links
-            - [Health Check](${stagingUrl}/health)
-            - [Home Page](${stagingUrl}/)
-            - [Workflow Run](${workflowRunUrl})
-
-            ### Testing Checklist
-            - [ ] Smoke tests pass
-            - [ ] Integration tests pass
-            - [ ] Manual testing completed
-
-            > This deployment will be updated automatically when new commits are pushed to this PR.
-            `;
-
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('Staging Deployment Ready')
-            );
-
-            if (botComment) {
-              // Update existing comment
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body
-              });
-            } else {
-              // Create new comment
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
-            }
-
-      - name: Run smoke tests against staging
-        env:
-          STAGING_URL: ${{ steps.deploy.outputs.url }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          set -e
-          echo "Running smoke tests against $STAGING_URL"
-          # Run vitest smoke tests with staging URL
-          npx vitest run tests/smoke/ --reporter=verbose || true
-
-      - name: Notify on deployment failure
-        if: failure()
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
-        with:
-          # Ride out transient GitHub API 5xx (503 brownouts have failed
-          # otherwise-green runs on nothing but the status comment). A retried
-          # POST can rarely duplicate a status comment — accepted trade-off vs.
-          # red runs. Every non-transient 4xx is exempt; 429 stays retryable.
-          retries: 3
-          retry-exempt-status-codes: 400,401,402,403,404,405,406,407,409,410,411,412,413,414,415,416,417,418,421,422,423,424,426,428,431,451
-          script: |
-            const workflowRunUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `## ❌ Staging Deployment Failed
-
-            The staging deployment failed for this PR.
-
-            [View Workflow Run](${workflowRunUrl})
-
-            Please check the logs and fix any issues before merging.`
-            });
+  # PRs used to run `wrangler deploy --env=staging`, which published the PR
+  # branch over the single shared stratum-staging Worker. Cloudflare records
+  # the last-applied Durable Object migration tag on the script itself, so a
+  # PR that added a migration left staging one tag ahead of main. Wrangler
+  # cannot find that tag in main's wrangler.toml, assumes it was deleted, and
+  # replays the whole chain from v1 — which fails on the already-populated
+  # MergeQueue class (API error 10074) and red-lines every subsequent push to
+  # main, and with it the production deploy that gates on staging.
+  #
+  # Per-PR environments live in pr-preview.yml: an isolated stratum-pr-<N>
+  # Worker with its own D1 and KV, torn down when the PR closes. The shared
+  # staging Worker is deployed from main only (ci.yml), which keeps its
+  # migration tag a function of main's wrangler.toml alone.
 
   # ========================================================================
   # PR Status Summary

--- a/docs/DEVELOPER_WORKFLOW.md
+++ b/docs/DEVELOPER_WORKFLOW.md
@@ -9,7 +9,7 @@ The Stratum project uses a PR-based workflow with per-PR preview environments, i
 Each PR gets its own isolated preview Worker. The shared staging and production
 environments are deployed only from `main`, after the PR merges.
 
-```
+```text
 ┌─────────────┐    ┌──────────────┐    ┌─────────────┐
 │   Create    │───▶│    Push      │───▶│   PR        │   per-PR, isolated
 │    PR       │    │   Commits    │    │   Preview   │   (torn down on close)
@@ -24,16 +24,10 @@ environments are deployed only from `main`, after the PR merges.
                                        merge to main
                                               │
                                               ▼
-                   ┌─────────────┐    ┌──────────────┐
-                   │   Staging   │───▶│  Production  │
-                   │   Deploy    │    │   Deploy     │
-                   └─────────────┘    └──────────────┘
-                                              │
-                                              ▼
-                                       ┌──────────────┐
-                                       │   Manual     │
-                                       │  Approval    │
-                                       └──────────────┘
+┌─────────────┐    ┌──────────────┐    ┌──────────────┐
+│   Staging   │───▶│    Manual    │───▶│  Production  │
+│   Deploy    │    │   Approval   │    │    Deploy    │
+└─────────────┘    └──────────────┘    └──────────────┘
 ```
 
 ## Creating a Pull Request
@@ -112,7 +106,7 @@ Every push to your PR branch will:
 
 Once your PR is open, you can access your changes at:
 
-```
+```text
 https://pr-<number>.staging.app.usestratum.dev
 ```
 
@@ -140,7 +134,7 @@ migration left staging one tag ahead of `main`. Wrangler could not find that tag
 in `main`'s `wrangler.toml`, assumed it had been deleted, and replayed the whole
 chain from `v1` — which fails on the already-populated `MergeQueue` class:
 
-```
+```text
 Cannot apply new-class migration to class 'MergeQueue' that is already
 depended on by existing Durable Objects [code: 10074]
 ```

--- a/docs/DEVELOPER_WORKFLOW.md
+++ b/docs/DEVELOPER_WORKFLOW.md
@@ -4,19 +4,36 @@ This document explains the new PR-based CI/CD workflow and how to use it effecti
 
 ## Overview
 
-The Stratum project now uses a comprehensive PR-based workflow with automatic staging deployments, integration tests, and manual production approvals.
+The Stratum project uses a PR-based workflow with per-PR preview environments, integration tests, and manual production approvals.
+
+Each PR gets its own isolated preview Worker. The shared staging and production
+environments are deployed only from `main`, after the PR merges.
 
 ```
-┌─────────────┐    ┌──────────────┐    ┌─────────────┐    ┌──────────────┐
-│   Create    │───▶│    Push      │───▶│   Staging   │───▶│  Production  │
-│    PR       │    │   Commits    │    │   Deploy    │    │   Deploy     │
-└─────────────┘    └──────────────┘    └─────────────┘    └──────────────┘
-                                              │                   │
-                                              ▼                   ▼
-                                       ┌──────────────┐    ┌──────────────┐
-                                       │  Automated   │    │   Manual     │
-                                       │    Tests     │    │  Approval    │
-                                       └──────────────┘    └──────────────┘
+┌─────────────┐    ┌──────────────┐    ┌─────────────┐
+│   Create    │───▶│    Push      │───▶│   PR        │   per-PR, isolated
+│    PR       │    │   Commits    │    │   Preview   │   (torn down on close)
+└─────────────┘    └──────────────┘    └─────────────┘
+                                              │
+                                              ▼
+                                       ┌──────────────┐
+                                       │  Automated   │
+                                       │    Tests     │
+                                       └──────────────┘
+                                              │
+                                       merge to main
+                                              │
+                                              ▼
+                   ┌─────────────┐    ┌──────────────┐
+                   │   Staging   │───▶│  Production  │
+                   │   Deploy    │    │   Deploy     │
+                   └─────────────┘    └──────────────┘
+                                              │
+                                              ▼
+                                       ┌──────────────┐
+                                       │   Manual     │
+                                       │  Approval    │
+                                       └──────────────┘
 ```
 
 ## Creating a Pull Request
@@ -68,13 +85,16 @@ When you create or update a PR, the following happens automatically:
 3. **Unit Tests** - Fast unit test suite
 4. **Integration Tests** - Integration test suite
 5. **Security Scan** - Secret detection and security checks
-6. **Staging Deployment** - Deploy to staging environment
+6. **Preview Environment** - Deploy an isolated preview Worker for this PR
+
+PRs do **not** deploy to the shared staging Worker. See
+[Why PRs don't deploy to staging](#why-prs-dont-deploy-to-staging).
 
 ### PR Comments
 
 The CI will automatically comment on your PR with:
 
-- ✅ Staging deployment URL
+- ✅ Preview environment URL
 - ✅ Test results summary
 - ✅ Links to workflow runs
 
@@ -83,38 +103,63 @@ The CI will automatically comment on your PR with:
 Every push to your PR branch will:
 
 1. Re-run all checks
-2. Update the staging deployment
+2. Update the preview environment
 3. Update the PR comment with new information
 
-## Staging Environment
+## Preview Environment
 
-### Accessing Staging
+### Accessing Your Preview
 
 Once your PR is open, you can access your changes at:
 
 ```
-https://stratum-staging.<subdomain>.workers.dev
+https://pr-<number>.staging.app.usestratum.dev
 ```
 
-The exact URL will be posted as a comment on your PR.
+The exact URL is posted as a comment on your PR. Each preview is a dedicated
+`stratum-pr-<number>` Worker with its own D1 database and KV namespace, and it is
+destroyed when the PR closes.
 
-### Testing on Staging
+### Testing on Your Preview
 
-1. **Manual Testing** - Use the staging URL to manually test your changes
+1. **Manual Testing** - Use the preview URL to manually test your changes
 2. **API Testing** - Test API endpoints with tools like curl or Postman
-3. **Integration Testing** - Run the smoke tests against staging:
+3. **Integration Testing** - Run the smoke tests against it:
 
 ```bash
-STAGING_URL=https://stratum-staging.<subdomain>.workers.dev \
+STAGING_URL=https://pr-<number>.staging.app.usestratum.dev \
   npm run test:smoke
 ```
 
-### Staging Database
+### Why PRs don't deploy to staging
 
-The staging environment uses a separate database:
+PR branches used to run `wrangler deploy --env=staging`, publishing over the
+single shared `stratum-staging` Worker. Cloudflare records the last-applied
+Durable Object migration tag **on the script itself**, so a PR that added a
+migration left staging one tag ahead of `main`. Wrangler could not find that tag
+in `main`'s `wrangler.toml`, assumed it had been deleted, and replayed the whole
+chain from `v1` — which fails on the already-populated `MergeQueue` class:
 
-- **Production**: `stratum` (D1 database)
-- **Staging**: `stratum-staging` (D1 database)
+```
+Cannot apply new-class migration to class 'MergeQueue' that is already
+depended on by existing Durable Objects [code: 10074]
+```
+
+That red-lined every push to `main`, and with it the production deploy that gates
+on staging. Deploying the shared environments from `main` only keeps their
+migration state a function of `main`'s `wrangler.toml` alone.
+
+`tests/wrangler-migration-chain.test.ts` guards the other half of the rule: a PR
+may append migrations but never remove, rename, reorder, or rewrite one that
+`main` already carries.
+
+### Databases
+
+| Environment | D1 database |
+|-------------|-------------|
+| Production | `stratum` |
+| Staging | `stratum-staging` |
+| PR preview | `stratum-pr-<number>` |
 
 Staging data is isolated from production and may be reset periodically.
 
@@ -128,7 +173,7 @@ Before a PR can be merged to `main`, all checks must pass:
 - ✅ Type check passed
 - ✅ Unit tests passed
 - ✅ Integration tests passed
-- ✅ Staging deployment successful
+- ✅ Preview environment deployed
 - ✅ Security scan passed
 
 ### Merge Process
@@ -210,6 +255,12 @@ STAGING_URL=https://... npm run test:smoke
 1. Check the workflow logs in GitHub Actions
 2. Verify your code compiles: `npm run typecheck`
 3. Check for environment-specific issues (wrangler.toml config)
+
+If the log carries `migration tag "vN", which was not found in your
+wrangler.toml file` followed by error 10074, the deployed script's Durable Object
+migration tag is ahead of the config being deployed. Reconcile the two — land the
+commit that defines the missing tag, rather than deleting tags from
+`wrangler.toml`, which only widens the gap.
 
 ### Tests Pass Locally but Fail in CI
 

--- a/docs/STAGING_SETUP.md
+++ b/docs/STAGING_SETUP.md
@@ -92,9 +92,14 @@ staging a tag ahead and blocks the `main` pipeline — see
 
 When you genuinely need to recover the environment out of band, deploy from a
 clean checkout of `main` so the configuration you publish matches what CI would
-publish:
+publish. Refuse to deploy if the worktree has any modified, staged, or untracked
+files — including changes to `wrangler.toml` or migrations:
 
 ```bash
+test -z "$(git status --porcelain)" || {
+  echo "Refusing staging deployment: use a clean worktree or fresh clone." >&2
+  exit 1
+}
 git fetch origin main && git checkout origin/main
 npx wrangler deploy --env=staging
 ```

--- a/docs/STAGING_SETUP.md
+++ b/docs/STAGING_SETUP.md
@@ -68,13 +68,22 @@ migrations_dir = "migrations"
 
 ### Automatic Deployment
 
-Staging is deployed from `main` only — every push to `main` deploys staging and
-then, after manual approval, production:
+Staging is deployed from `main` only, and not from every push to it: a push to
+`main` in `stratum-eng/stratum` deploys staging once the `test` job passes.
+Production then follows, gated on both the staging deploy and manual approval.
+Forks are skipped — they hold none of the secrets, so a deploy there could only
+fail, while the tests above still run and are still useful.
 
 ```yaml
 # .github/workflows/ci.yml
-- name: Deploy to Cloudflare Staging
-  run: npx wrangler deploy --env=staging
+deploy-staging:
+  needs: test
+  if: >
+    github.repository == 'stratum-eng/stratum' &&
+    github.event_name == 'push' && github.ref == 'refs/heads/main'
+  steps:
+    - name: Deploy to Cloudflare Staging
+      run: npx wrangler deploy --env=staging
 ```
 
 Pull requests get their own isolated `stratum-pr-<number>` Worker instead
@@ -96,6 +105,13 @@ publish. Refuse to deploy if the worktree has any modified, staged, or untracked
 files — including changes to `wrangler.toml` or migrations:
 
 ```bash
+# `origin` is whatever you configured it to be. Deploying a fork's main over
+# shared staging can advance its migration tag past canonical main, which is the
+# drift this whole procedure exists to avoid.
+git remote get-url origin | grep -qE '[/:]stratum-eng/stratum(\.git)?$' || {
+  echo "Refusing staging deployment: origin is not stratum-eng/stratum." >&2
+  exit 1
+}
 test -z "$(git status --porcelain)" || {
   echo "Refusing staging deployment: use a clean worktree or fresh clone." >&2
   exit 1

--- a/docs/STAGING_SETUP.md
+++ b/docs/STAGING_SETUP.md
@@ -100,8 +100,7 @@ test -z "$(git status --porcelain)" || {
   echo "Refusing staging deployment: use a clean worktree or fresh clone." >&2
   exit 1
 }
-git fetch origin main && git checkout origin/main
-npx wrangler deploy --env=staging
+git fetch origin main && git checkout origin/main && npx wrangler deploy --env=staging
 ```
 
 ### Local Development with Staging Services

--- a/docs/STAGING_SETUP.md
+++ b/docs/STAGING_SETUP.md
@@ -68,13 +68,18 @@ migrations_dir = "migrations"
 
 ### Automatic Deployment
 
-Staging is automatically deployed when you open or update a Pull Request:
+Staging is deployed from `main` only — every push to `main` deploys staging and
+then, after manual approval, production:
 
 ```yaml
-# .github/workflows/pr-checks.yml
+# .github/workflows/ci.yml
 - name: Deploy to Cloudflare Staging
   run: npx wrangler deploy --env=staging
 ```
+
+Pull requests get their own isolated `stratum-pr-<number>` Worker instead
+(`.github/workflows/pr-preview.yml`). They deliberately do not publish over this
+shared Worker — see [Why PRs don't deploy here](#why-prs-dont-deploy-here).
 
 ### Manual Deployment
 
@@ -303,29 +308,60 @@ If staging is processing production jobs:
 
 ## CI/CD Integration
 
-The staging environment is integrated into the PR workflow:
+Staging is deployed by the `main` pipeline, and gates the production deploy:
 
 ```yaml
-# .github/workflows/pr-checks.yml
+# .github/workflows/ci.yml
 jobs:
   deploy-staging:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
+      - name: Apply D1 Migrations (Staging)
+        run: npx wrangler d1 migrations apply stratum-staging --remote --env=staging
+
       - name: Deploy to Cloudflare Staging
         run: npx wrangler deploy --env=staging
 
-      - name: Smoke test
-        run: curl -sfS "$STAGING_URL/health"
+      - name: Smoke test - Health endpoint
+        run: curl -sfS "$STAGING_URL/api/health"
 
-      - name: Comment PR with staging URL
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              body: `🚀 Staging: ${process.env.STAGING_URL}`
-            });
+  deploy-production:
+    needs: [test, deploy-staging]
 ```
+
+### Why PRs don't deploy here
+
+PR branches used to run `wrangler deploy --env=staging`, publishing over this
+shared Worker. Cloudflare records the last-applied Durable Object migration tag
+**on the script itself**, not in `wrangler.toml`, so a PR that added a migration
+left staging one tag ahead of `main`. Wrangler could not find that tag in `main`'s
+config, assumed it had been deleted, and replayed the entire chain from `v1`:
+
+```
+▲ [WARNING] The published script stratum-staging has a migration tag "v3",
+  which was not found in your wrangler.toml file. [...] Applying all available
+  migrations to the script...
+✘ [ERROR] Cannot apply new-class migration to class 'MergeQueue' that is
+  already depended on by existing Durable Objects [code: 10074]
+```
+
+A tag cannot be un-applied from a deployed script, so this does not clear on a
+re-run: every push to `main` stayed red, and with it the production deploy that
+gates on staging.
+
+Two things keep it from recurring:
+
+1. Only `main` deploys to staging and production, so their migration tags are a
+   function of `main`'s `wrangler.toml` alone.
+2. `tests/wrangler-migration-chain.test.ts` fails any PR that removes, renames,
+   reorders, or rewrites a migration `main` already carries. Migrations may only
+   be appended.
+
+If staging and `main` do drift apart anyway (a manual `wrangler deploy
+--env=staging` from a laptop will do it), the fix is to land the config that
+defines the missing tag. Deleting tags from `wrangler.toml` to "match" only
+widens the gap. Recreating the Worker script is the last resort: it destroys the
+`RepoDO` ref authority and `MergeQueue` state for every staging project.
 
 ## Related Documentation
 

--- a/docs/STAGING_SETUP.md
+++ b/docs/STAGING_SETUP.md
@@ -81,16 +81,22 @@ Pull requests get their own isolated `stratum-pr-<number>` Worker instead
 (`.github/workflows/pr-preview.yml`). They deliberately do not publish over this
 shared Worker — see [Why PRs don't deploy here](#why-prs-dont-deploy-here).
 
-### Manual Deployment
+### Manual Deployment — emergency recovery only
 
-To deploy to staging manually:
+Deploying to this Worker by hand is **not** a normal workflow. It publishes
+whatever is in your working tree over the environment the whole team shares, and
+if that tree carries a Durable Object migration `main` does not have, it leaves
+staging a tag ahead and blocks the `main` pipeline — see
+[Why PRs don't deploy here](#why-prs-dont-deploy-here). Route changes through
+`main` and let `ci.yml` deploy them.
+
+When you genuinely need to recover the environment out of band, deploy from a
+clean checkout of `main` so the configuration you publish matches what CI would
+publish:
 
 ```bash
-# Deploy current branch to staging
+git fetch origin main && git checkout origin/main
 npx wrangler deploy --env=staging
-
-# Deploy with specific vars
-npx wrangler deploy --env=staging --var KEY=value
 ```
 
 ### Local Development with Staging Services
@@ -337,7 +343,7 @@ shared Worker. Cloudflare records the last-applied Durable Object migration tag
 left staging one tag ahead of `main`. Wrangler could not find that tag in `main`'s
 config, assumed it had been deleted, and replayed the entire chain from `v1`:
 
-```
+```text
 ▲ [WARNING] The published script stratum-staging has a migration tag "v3",
   which was not found in your wrangler.toml file. [...] Applying all available
   migrations to the script...

--- a/tests/node-child-process.d.ts
+++ b/tests/node-child-process.d.ts
@@ -1,0 +1,17 @@
+// Minimal ambient declarations for the Node surface the wrangler migration-chain
+// guard uses. The Workers tsconfig ships no @types/node on purpose — pulling it
+// in globally would let src/ reference Node APIs that don't exist in workerd — so
+// each test that reaches for a built-in declares just what it needs, the same way
+// tests/node-sqlite.d.ts does.
+declare module "node:child_process" {
+  export function execFileSync(
+    file: string,
+    args: readonly string[],
+    options: {
+      encoding?: "utf8";
+      stdio?: "ignore" | readonly ("ignore" | "pipe")[];
+    },
+  ): string;
+}
+
+declare const process: { env: Record<string, string | undefined> };

--- a/tests/wrangler-migration-chain.test.ts
+++ b/tests/wrangler-migration-chain.test.ts
@@ -66,7 +66,23 @@ function stripComment(line: string): string {
 
 function countChar(text: string, char: string): number {
   let count = 0;
-  for (const candidate of text) if (candidate === char) count++;
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < text.length; i++) {
+    const candidate = text[i];
+    if (quote === '"' && candidate === "\\") {
+      i++;
+      continue;
+    }
+    if (quote) {
+      if (candidate === quote) quote = null;
+      continue;
+    }
+    if (candidate === '"' || candidate === "'") {
+      quote = candidate;
+      continue;
+    }
+    if (candidate === char) count++;
+  }
   return count;
 }
 
@@ -256,10 +272,16 @@ tag = "not-a-migration"
     ).toThrow(/spans multiple lines/);
   });
 
-  it("accepts a single-line array containing brackets in a string", () => {
-    expect(parseMigrations('[[migrations]]\ntag = "v1"\nnew_classes = ["A[]"]\n')).toEqual([
-      { tag: "v1", fields: ['new_classes = ["A[]"]'] },
-    ]);
+  it("accepts a single-line array containing brackets in strings", () => {
+    expect(
+      parseMigrations('[[migrations]]\ntag = "v1"\nnew_classes = ["A[]", "A[", "A]"]\n'),
+    ).toEqual([{ tag: "v1", fields: ['new_classes = ["A[]", "A[", "A]"]'] }]);
+  });
+
+  it("refuses genuinely unbalanced brackets outside strings", () => {
+    expect(() => parseMigrations('[[migrations]]\ntag = "v1"\nnew_classes = ["A"]]\n')).toThrow(
+      /spans multiple lines/,
+    );
   });
 });
 

--- a/tests/wrangler-migration-chain.test.ts
+++ b/tests/wrangler-migration-chain.test.ts
@@ -64,6 +64,12 @@ function stripComment(line: string): string {
   return line;
 }
 
+function countChar(text: string, char: string): number {
+  let count = 0;
+  for (const candidate of text) if (candidate === char) count++;
+  return count;
+}
+
 /** Collapse whitespace runs so reformatting alone cannot trip the guard. */
 function normalize(line: string): string {
   return line.trim().replace(/\s+/g, " ");
@@ -96,6 +102,14 @@ function parseMigrations(toml: string): MigrationEntry[] {
     if (separator === -1) continue;
     const key = line.slice(0, separator).trim();
     const value = line.slice(separator + 1).trim();
+    // A value whose brackets don't balance on this line continues onto the
+    // next, where the parser would drop it — and a silently dropped field makes
+    // the comparison below pass for the wrong reason. Refuse to guess.
+    if (countChar(value, "[") !== countChar(value, "]")) {
+      throw new Error(
+        `[[migrations]] value for \`${key}\` spans multiple lines, which this guard cannot read. Keep migration values on one line so the append-only check can compare them.`,
+      );
+    }
     if (key === "tag") {
       current.tag = value.replace(/^["']|["']$/g, "");
     } else {
@@ -129,8 +143,9 @@ function findChainViolation(base: MigrationEntry[], head: MigrationEntry[]): str
   }
 
   if (head.length < base.length) {
+    const headTags = new Set(head.map((entry) => entry.tag));
     const dropped = base
-      .slice(head.length)
+      .filter((entry) => !headTags.has(entry.tag))
       .map((entry) => `"${entry.tag}"`)
       .join(", ");
     return `This branch removes migration(s) ${dropped} that are already on main. Those tags are recorded on the deployed staging and production scripts; dropping them makes wrangler replay the chain from the start and every deploy of those environments fails with error 10074. Add a follow-up migration instead of removing this one.`;
@@ -231,6 +246,21 @@ tag = "not-a-migration"
   it("returns nothing for a config with no migrations", () => {
     expect(parseMigrations('name = "stratum"\n')).toEqual([]);
   });
+
+  // A multi-line array used to be stored truncated as `new_sqlite_classes = [`,
+  // dropping the class names — so a rewritten class list compared equal to the
+  // original and the append-only check below passed for the wrong reason.
+  it("refuses a value that spans multiple lines rather than truncating it", () => {
+    expect(() =>
+      parseMigrations('[[migrations]]\ntag = "v2"\nnew_sqlite_classes = [\n  "RepoDO",\n]\n'),
+    ).toThrow(/spans multiple lines/);
+  });
+
+  it("accepts a single-line array containing brackets in a string", () => {
+    expect(parseMigrations('[[migrations]]\ntag = "v1"\nnew_classes = ["A[]"]\n')).toEqual([
+      { tag: "v1", fields: ['new_classes = ["A[]"]'] },
+    ]);
+  });
 });
 
 describe("findChainViolation", () => {
@@ -260,6 +290,14 @@ describe("findChainViolation", () => {
 
   it("rejects removing a deployed migration", () => {
     expect(findChainViolation([v1, v2, v3], [v1, v2])).toMatch(/removes migration\(s\) "v3"/);
+  });
+
+  // Naming the trailing entries of main rather than the missing ones accused
+  // "v3" here, which is still present.
+  it("names the migration that actually went missing, not the last one", () => {
+    const message = findChainViolation([v1, v2, v3], [v2, v3]);
+    expect(message).toMatch(/removes migration\(s\) "v1"/);
+    expect(message).not.toMatch(/"v3"/);
   });
 
   it("rejects renaming a deployed tag", () => {

--- a/tests/wrangler-migration-chain.test.ts
+++ b/tests/wrangler-migration-chain.test.ts
@@ -1,0 +1,322 @@
+/// <reference types="vite/client" />
+
+/**
+ * Guard: the Durable Object migration chain in wrangler.toml is append-only.
+ *
+ * Cloudflare records the last-applied migration tag on the deployed script, not
+ * in our config. Wrangler reads that tag, finds it in `[[migrations]]`, and
+ * sends only the migrations after it. When the tag is NOT in the list, wrangler
+ * assumes it was deleted and replays the chain from the top — which fails on any
+ * class that already has live objects:
+ *
+ *   ▲ [WARNING] The published script stratum-staging has a migration tag "v3",
+ *     which was not found in your wrangler.toml file. [...] Applying all
+ *     available migrations to the script...
+ *   ✘ [ERROR] Cannot apply new-class migration to class 'MergeQueue' that is
+ *     already depended on by existing Durable Objects [code: 10074]
+ *
+ * A tag cannot be un-applied from a deployed script, so this is not transient:
+ * every deploy of that environment stays broken until the config is put back.
+ * Reverting a merged migration, renaming a tag, or editing the classes of a tag
+ * that already shipped all produce it — and ci.yml gates the production deploy
+ * on staging, so a single revert takes down both.
+ *
+ * The rule that prevents all of it: the migration list may only ever grow at the
+ * end. This asserts that against main.
+ */
+
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+// Read via Vite's raw import rather than node:fs, so the guard type-checks under
+// the Workers tsconfig (the same trick tests/helpers/sqlite-d1.ts uses for SQL).
+import headToml from "../wrangler.toml?raw";
+
+/** One `[[migrations]]` entry: its tag, plus its remaining keys, normalized. */
+interface MigrationEntry {
+  tag: string;
+  /** `key = value` lines with comments and incidental whitespace removed. */
+  fields: string[];
+}
+
+/**
+ * Drop a trailing `#` comment, honouring quotes so a `#` inside a string value
+ * survives. TOML basic strings support backslash escapes and literal ('…')
+ * strings do not, which is why the escape is only consumed inside double quotes.
+ */
+function stripComment(line: string): string {
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (quote === '"' && char === "\\") {
+      i++;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === "#") return line.slice(0, i);
+  }
+  return line;
+}
+
+/** Collapse whitespace runs so reformatting alone cannot trip the guard. */
+function normalize(line: string): string {
+  return line.trim().replace(/\s+/g, " ");
+}
+
+/**
+ * Parse the top-level `[[migrations]]` entries out of a wrangler.toml, in file
+ * order. Per-environment `[[env.*.migrations]]` tables are deliberately not
+ * matched: this config declares migrations once at the top level and every
+ * environment inherits them.
+ */
+function parseMigrations(toml: string): MigrationEntry[] {
+  const entries: MigrationEntry[] = [];
+  let current: MigrationEntry | null = null;
+
+  for (const rawLine of toml.split("\n")) {
+    const line = normalize(stripComment(rawLine));
+    if (line === "") continue;
+
+    // Any table header closes the entry being filled; only ours opens one.
+    if (line.startsWith("[")) {
+      current = line === "[[migrations]]" ? { tag: "", fields: [] } : null;
+      if (current) entries.push(current);
+      continue;
+    }
+
+    if (!current) continue;
+
+    const separator = line.indexOf("=");
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    if (key === "tag") {
+      current.tag = value.replace(/^["']|["']$/g, "");
+    } else {
+      current.fields.push(`${key} = ${value}`);
+    }
+  }
+
+  return entries;
+}
+
+/** Order-insensitive rendering of an entry, for both comparison and messages. */
+function describeEntry(entry: MigrationEntry): string {
+  return [`tag = "${entry.tag}"`, ...[...entry.fields].sort()].join(", ");
+}
+
+/**
+ * Compare a candidate migration chain against the one already on main. Returns a
+ * human-readable problem, or null when the candidate is a clean append. Kept pure
+ * so the rule itself is unit-tested below without touching git.
+ */
+function findChainViolation(base: MigrationEntry[], head: MigrationEntry[]): string | null {
+  const seen = new Set<string>();
+  for (const entry of head) {
+    if (entry.tag === "") {
+      return "A [[migrations]] entry has no `tag`. Every migration needs one — the tag is the only thing Cloudflare records on the deployed script.";
+    }
+    if (seen.has(entry.tag)) {
+      return `Migration tag "${entry.tag}" appears more than once. Tags must be unique: wrangler matches the deployed script's tag by name and applies everything after the first match.`;
+    }
+    seen.add(entry.tag);
+  }
+
+  if (head.length < base.length) {
+    const dropped = base
+      .slice(head.length)
+      .map((entry) => `"${entry.tag}"`)
+      .join(", ");
+    return `This branch removes migration(s) ${dropped} that are already on main. Those tags are recorded on the deployed staging and production scripts; dropping them makes wrangler replay the chain from the start and every deploy of those environments fails with error 10074. Add a follow-up migration instead of removing this one.`;
+  }
+
+  for (let i = 0; i < base.length; i++) {
+    const before = base[i];
+    const after = head[i];
+    if (!before || !after) continue;
+    if (before.tag !== after.tag) {
+      return `Migration #${i + 1} is "${after.tag}" on this branch but "${before.tag}" on main. Tags are immutable once deployed — append a new one rather than renaming or reordering an existing one.`;
+    }
+    if (describeEntry(before) !== describeEntry(after)) {
+      return `Migration "${after.tag}" is already deployed but its definition changed.\n  on main:   ${describeEntry(before)}\n  on branch: ${describeEntry(after)}\nAn applied migration cannot be rewritten — environments that already ran it never see the edit, and fresh environments would diverge from them. Append a new migration instead.`;
+    }
+  }
+
+  return null;
+}
+
+function gitShowWranglerToml(ref: string): string | null {
+  try {
+    return execFileSync("git", ["show", `${ref}:wrangler.toml`], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** The nearest available trunk ref, or null in a checkout that has none. */
+function resolveBaseRef(): string | null {
+  for (const ref of ["origin/main", "main"]) {
+    try {
+      execFileSync("git", ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], {
+        stdio: "ignore",
+      });
+      return ref;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return null;
+}
+
+describe("parseMigrations", () => {
+  it("reads tags and fields in file order", () => {
+    expect(
+      parseMigrations(`
+name = "stratum"
+
+[[migrations]]
+tag = "v1"
+new_classes = ["MergeQueue"]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["RepoDO"]
+`),
+    ).toEqual([
+      { tag: "v1", fields: ['new_classes = ["MergeQueue"]'] },
+      { tag: "v2", fields: ['new_sqlite_classes = ["RepoDO"]'] },
+    ]);
+  });
+
+  it("ignores comments, blank lines, and incidental whitespace", () => {
+    expect(
+      parseMigrations(`
+# leading comment
+[[migrations]]
+tag   =   "v1"     # why this exists
+new_classes = ["MergeQueue"]
+`),
+    ).toEqual([{ tag: "v1", fields: ['new_classes = ["MergeQueue"]'] }]);
+  });
+
+  it("keeps a # that is inside a quoted value", () => {
+    expect(parseMigrations('[[migrations]]\ntag = "v#1"\n')).toEqual([{ tag: "v#1", fields: [] }]);
+  });
+
+  it("stops collecting at the next table header", () => {
+    expect(
+      parseMigrations(`
+[[migrations]]
+tag = "v1"
+
+[vars]
+tag = "not-a-migration"
+`),
+    ).toEqual([{ tag: "v1", fields: [] }]);
+  });
+
+  it("does not match per-environment migration tables", () => {
+    expect(parseMigrations('[[env.staging.migrations]]\ntag = "v9"\n')).toEqual([]);
+  });
+
+  it("returns nothing for a config with no migrations", () => {
+    expect(parseMigrations('name = "stratum"\n')).toEqual([]);
+  });
+});
+
+describe("findChainViolation", () => {
+  const v1: MigrationEntry = { tag: "v1", fields: ['new_classes = ["MergeQueue"]'] };
+  const v2: MigrationEntry = { tag: "v2", fields: ['new_sqlite_classes = ["RepoDO"]'] };
+  const v3: MigrationEntry = {
+    tag: "v3",
+    fields: ['new_sqlite_classes = ["MagicLinkRateLimiter"]'],
+  };
+
+  it("accepts an unchanged chain", () => {
+    expect(findChainViolation([v1, v2], [v1, v2])).toBeNull();
+  });
+
+  it("accepts appending a new migration", () => {
+    expect(findChainViolation([v1, v2], [v1, v2, v3])).toBeNull();
+  });
+
+  it("accepts field reordering within an already-deployed entry", () => {
+    expect(
+      findChainViolation(
+        [{ tag: "v1", fields: ["a = 1", "b = 2"] }],
+        [{ tag: "v1", fields: ["b = 2", "a = 1"] }],
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects removing a deployed migration", () => {
+    expect(findChainViolation([v1, v2, v3], [v1, v2])).toMatch(/removes migration\(s\) "v3"/);
+  });
+
+  it("rejects renaming a deployed tag", () => {
+    expect(findChainViolation([v1, v2], [v1, { ...v2, tag: "v2-repo" }])).toMatch(
+      /immutable once deployed/,
+    );
+  });
+
+  it("rejects reordering deployed migrations", () => {
+    expect(findChainViolation([v1, v2], [v2, v1])).toMatch(/but "v1" on main/);
+  });
+
+  it("rejects editing the classes of a deployed migration", () => {
+    expect(
+      findChainViolation([v1, v2], [v1, { tag: "v2", fields: ['new_sqlite_classes = ["Repo"]'] }]),
+    ).toMatch(/its definition changed/);
+  });
+
+  it("rejects inserting a migration ahead of a deployed one", () => {
+    expect(findChainViolation([v1, v2], [v1, v3, v2])).toMatch(/is "v3" on this branch/);
+  });
+
+  it("rejects a duplicate tag", () => {
+    expect(findChainViolation([v1], [v1, { ...v3, tag: "v1" }])).toMatch(/appears more than once/);
+  });
+
+  it("rejects a migration with no tag", () => {
+    expect(findChainViolation([], [{ tag: "", fields: [] }])).toMatch(/has no `tag`/);
+  });
+});
+
+describe("wrangler.toml migration chain vs. main", () => {
+  const baseRef = resolveBaseRef();
+
+  // Skipping is only defensible on a developer checkout with no trunk ref (a
+  // shallow clone, or a fork whose remote isn't named origin). In CI it is a
+  // real failure: a guard that quietly doesn't run is not a guard.
+  it.runIf(Boolean(process.env.CI))("can reach main to compare against", () => {
+    expect(
+      baseRef,
+      "Neither origin/main nor main is present. Check out with `fetch-depth: 0` so this guard can run.",
+    ).not.toBeNull();
+  });
+
+  it.skipIf(baseRef === null)("only ever appends Durable Object migrations", () => {
+    const baseToml = gitShowWranglerToml(baseRef as string);
+    expect(baseToml, `Could not read wrangler.toml at ${baseRef}`).not.toBeNull();
+
+    const base = parseMigrations(baseToml as string);
+    const head = parseMigrations(headToml);
+
+    // Both sides being empty would make the comparison vacuously green.
+    expect(
+      base.length,
+      "main declares no [[migrations]] — this guard would pass for the wrong reason",
+    ).toBeGreaterThan(0);
+
+    expect(findChainViolation(base, head)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Every push to `main` failed from 16:38 UTC on 2026-08-28 until #322 landed ([run 33206494593](https://github.com/stratum-eng/stratum/actions/runs/33206494593)):

```
▲ [WARNING] The published script stratum-staging has a migration tag "v3",
  which was not found in your wrangler.toml file. [...] Applying all
  available migrations to the script...
✘ [ERROR] Cannot apply new-class migration to class 'MergeQueue' that is
  already depended on by existing Durable Objects [code: 10074]
```

The `MergeQueue` error is the symptom. `pr-checks.yml` ran `wrangler deploy --env=staging` on **every** PR, publishing the PR branch over the single shared `stratum-staging` Worker. Cloudflare records the last-applied Durable Object migration tag **on the script**, not in our config, so #322 — which adds a third migration for `MagicLinkRateLimiter` and was still open at the time — left staging at `v3` while `main`'s `wrangler.toml` stopped at `v2`. Wrangler could not find `v3` in the config, assumed it had been deleted, and replayed the chain from `v1`, which fails on the already-populated `MergeQueue` class.

A tag cannot be un-applied from a deployed script, so it did not clear on a re-run: `main` stayed red, and with it the production deploy that gates on staging. The commit in the failing run was unrelated — any push would have failed identically.

#322 has since merged, which reconciled the two. This PR stops it recurring, in two parts.

### 1. PRs no longer deploy to the shared staging Worker

The `deploy-staging` job is removed from `pr-checks.yml` rather than re-pointed, because per-PR environments already exist and are healthy: `pr-preview.yml` gives each PR an isolated `stratum-pr-<N>` Worker with its own D1 and KV, torn down when the PR closes. The shared environments are now deployed from `main` alone (`ci.yml`), which makes their migration tag a function of `main`'s `wrangler.toml` and nothing else.

### 2. The migration chain is append-only

Isolation alone does not close the hole. The same failure reaches **production** the moment a merged migration is reverted — an ordinary thing to do, and `ci.yml` gates production on staging, so one revert takes down both.

`tests/wrangler-migration-chain.test.ts` adds the missing invariant: a branch may append migrations, but may not remove, rename, reorder, or rewrite one that `main` already carries. It compares `wrangler.toml` against `origin/main` (hence `fetch-depth: 0` on the test job) and **fails rather than skips** in CI when it cannot reach `main` — a guard that quietly does not run is not a guard.

It rides the existing `Unit Tests` job, so it is already inside the `PR Requirements` aggregate check.

## Related issues

None filed — this came out of triaging the failing run directly.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Other: CI/CD correctness

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` — 2279 passed, 27 env-gated skips, 0 failures
- [x] `npm run lint`

The guard's parser and rule are unit-tested against fixtures (17 cases): comment and whitespace handling, a `#` inside a quoted value, per-environment `[[env.*.migrations]]` tables correctly ignored, and every violation shape — removal, rename, reorder, mid-chain insertion, redefinition, duplicate tag, missing tag.

Beyond the fixtures, the guard was run against a reproduction of this exact regression: deleting the `v2` block from `wrangler.toml` makes it fail with

> This branch removes migration(s) "v2" that are already on main. Those tags are recorded on the deployed staging and production scripts; dropping them makes wrangler replay the chain from the start and every deploy of those environments fails with error 10074.

Rebased onto `main` after #322 merged and re-verified: the chain is now `v1, v2, v3` on both sides and the guard passes.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate — `docs/STAGING_SETUP.md` and `docs/DEVELOPER_WORKFLOW.md` both described PRs as deploying to staging; both now describe the per-PR preview environment, and each carries a section explaining why PRs stay off the shared Worker
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript — no UI change

## Notes

**Possible branch-protection follow-up:** if **"Deploy to Staging"** is a required status check on `main`, it needs removing from branch protection — the job no longer exists, so the check will never report. The `pr-status` job's `PR Requirements` aggregate never depended on it, which suggests it is not required, but I could not read protection settings to confirm.

**Two adjacent problems found while investigating, deliberately left alone:**

- `pr-checks.yml`'s `security-scan` job runs `git diff origin/main..HEAD` at the default shallow depth, where `origin/main` does not exist. With `continue-on-error: true`, the secret-in-diff check has likely never actually run.
- `wrangler.preview.toml` binds preview Workers to the **staging** Artifacts namespace, so PR previews share git object storage with staging — the same class of shared-state coupling this PR removes for the Worker script.

---
_Generated by [Claude Code](https://claude.ai/code/session_011JfBYHd2gURXXMNov8VT4N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pull requests now use isolated preview environments, preventing changes from overwriting shared staging.
  - Staging deploys from the main branch, with production releases requiring successful staging validation and approval.

- **Documentation**
  - Updated workflow and deployment guidance with preview access, testing instructions, migration troubleshooting, and recovery procedures.

- **Tests**
  - Added safeguards to detect invalid or inconsistent migration sequences before deployment.
  - Improved CI validation of deployment history and migration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->