### PR TITLE
Enterprise SSO (OIDC) + SCIM provisioning (#253)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,16 @@ npx wrangler secret put GOOGLE_CLIENT_SECRET
 npx wrangler secret put POSTHOG_API_KEY      # analytics (route patterns only, never paths)
 npx wrangler secret put GITHUB_TOKEN         # higher rate limits on GitHub import
 npx wrangler secret put GITHUB_WEBHOOK_SECRET  # inbound GitHub sync
+npx wrangler secret put SSO_ENCRYPTION_SECRET  # enables enterprise SSO/SCIM
 ```
 
 OAuth callback URLs are set in `[vars]` (`OAUTH_REDIRECT_URI`, `GOOGLE_REDIRECT_URI`) —
 point them at your own host and register the same URLs in your OAuth apps.
+
+With `SSO_ENCRYPTION_SECRET` set, an org admin configures one OIDC connection per
+organization (`PUT /api/orgs/:slug/sso`), proves domain ownership with a DNS TXT record,
+and users sign in at `/auth/sso`; IdPs can provision and deactivate users via SCIM 2.0 at
+`/scim/v2`. See [docs/api/authentication.md](docs/api/authentication.md).
 
 ### Database setup
 
@@ -271,7 +277,8 @@ outbound PR promotion) with conflict resolution · bulk import · queue-backed w
 resumable progress.
 
 **Identity and access**
-Magic-link email auth · GitHub OAuth · Google OAuth · API keys with rotation · agent
+Magic-link email auth · GitHub OAuth · Google OAuth · per-org enterprise SSO (OIDC) with
+DNS-verified email domains and SCIM 2.0 user provisioning · API keys with rotation · agent
 identities with short-lived tokens scoped to an owning user · organizations, teams, and
 role-based project access · CSRF protection · rate limiting.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,10 @@ single-tenant self-hosted usage.
       change at a time. Test N queued changes together and bisect on failure. (The
       server-side `changes/merge-batch` endpoint already does this for an explicit batch;
       this item is the queue doing it automatically.)
-- [ ] **SSO/SAML** — enterprise sign-in alongside magic-link, GitHub OAuth, and Google OAuth.
+- [ ] **SSO remainders** — per-org OIDC sign-in and SCIM 2.0 Users provisioning shipped
+      (#253; config via `/api/orgs/:slug/sso`, sign-in at `/auth/sso`). Still open: an SSO
+      enforcement toggle (magic-link still works for corporate emails), SAML (if a customer
+      requires it), SCIM Groups, and a management UI.
 - [ ] **Multi-tenancy and billing** — tenant isolation, usage metering, billing. Per-change
       cost tracking already exists and provides the metering foundation.
 - [ ] **Monitoring dashboard UI** — a UI over the existing `/api/admin/metrics` (queue

--- a/docs/CURRENT_CAPABILITIES.md
+++ b/docs/CURRENT_CAPABILITIES.md
@@ -1,8 +1,8 @@
 # Stratum Current Capabilities
 
-Last updated: 2026-08-25 — reflects completion of the master-plan feature roadmap
-(Phases 0–3 plus the code-level Phase 4 hardening items), plus the Git LFS
-limitation recorded below.
+Last updated: 2026-08-28 — reflects completion of the master-plan feature roadmap
+(Phases 0–3 plus the code-level Phase 4 hardening items), enterprise OIDC SSO +
+SCIM provisioning (#253), plus the Git LFS limitation recorded below.
 
 ## Core platform
 
@@ -44,8 +44,24 @@ limitation recorded below.
 
 ## Auth & security
 
-- Magic-link email auth, GitHub OAuth, Google OAuth (email-identity model), and
-  API keys; short-lived agent tokens scoped to an owning user.
+- Magic-link email auth, GitHub OAuth, Google OAuth, and API keys; short-lived
+  agent tokens scoped to an owning user. OAuth logins persist a stable
+  (issuer, subject) identity per provider — GitHub links to an existing
+  account only via a verified email.
+- Enterprise SSO: one OIDC connection per org, configured by an org
+  admin/owner via `PUT/GET/DELETE /api/orgs/:slug/sso` (plus
+  `verify-domains`, `enable`/`disable`, and `scim-token` sub-endpoints).
+  Email domains must be DNS-TXT-verified (checked over DoH) before enabling.
+  Users sign in at `/auth/sso` (org slug or work email) via authorization-code
+  + PKCE; verified-domain emails are JIT-provisioned into the org. Requires
+  the `SSO_ENCRYPTION_SECRET` secret (endpoints 501 without it). No
+  enforcement toggle yet: magic-link login still works for corporate emails.
+- SCIM 2.0 Users provisioning at `/scim/v2` (per-connection
+  `stratum_scim_*` bearer): Users CRUD with userName/externalId eq filters,
+  adopt-existing-account semantics, and reversible deactivation
+  (`users.disabled_at`) enforced at every credential path — API tokens, agent
+  tokens, session cookies, git smart-HTTP, and all login flows — with session
+  purge on deactivation. SCIM Groups are not implemented.
 - CSRF protection (Origin/Referer enforcement for session-cookie mutations),
   API key rotation, settings UI for key + agent token management.
 - Append-only audit trail for sensitive operations with an admin query API;
@@ -76,7 +92,9 @@ limitation recorded below.
   but evaluation itself has no queue worker yet.
 - Team permissions are org-wide; per-project team grants are not implemented.
 - Phase 4 operational items remain: load testing at 1000+ concurrent workspaces,
-  D1 hot/cold rotation, SSO/SAML, multi-tenancy/billing for Stratum Cloud.
+  D1 hot/cold rotation, multi-tenancy/billing for Stratum Cloud. OIDC SSO +
+  SCIM shipped; SAML, SCIM Groups, an SSO enforcement toggle, and an SSO
+  management UI (API only today) remain.
 - Durability is covered: D1 and KV identity back up to R2 daily and on demand,
   along with the reachable history of a rotating slice of repos (coverage rotates
   across runs under a per-run cap), with a tested restore path

--- a/docs/REMAINING_WORK.md
+++ b/docs/REMAINING_WORK.md
@@ -31,10 +31,22 @@ The merge queue Durable Object currently merges changes one at a time. Batch
 merging (test N queued changes together, bisect on failure) increases
 throughput when the queue is deep.
 
-### SSO/SAML
+### Enterprise SSO — remaining pieces
 
-Enterprise sign-in alongside the existing magic-link, GitHub OAuth, and Google
-OAuth options. Required for most paid team adoption.
+OIDC SSO and SCIM provisioning shipped (#253): per-org OIDC connections
+configured via `/api/orgs/:slug/sso` with DNS-TXT domain verification, sign-in
+at `/auth/sso` with JIT provisioning, and SCIM 2.0 Users at `/scim/v2` with
+reversible deactivation enforced at every credential path. See
+[CURRENT_CAPABILITIES.md](./CURRENT_CAPABILITIES.md) and
+[api/authentication.md](./api/authentication.md). Still open:
+
+- **SSO login enforcement toggle** — magic-link login still works for
+  corporate emails, so IdP MFA/conditional-access can be bypassed until an
+  org can require SSO. (Offboarding is still effective: disabled users fail
+  every login path.)
+- **SAML** — only if a customer requires it; OIDC covers the major IdPs.
+- **SCIM Groups** — group push / team mapping; only Users sync today.
+- **SSO management UI** — configuration is API-only today.
 
 ### Multi-tenancy and billing
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -15,6 +15,11 @@ For programmatic access:
 - **Agent tokens**: `stratum_agent_xxxxx` — short-lived, scoped to the owning
   user, and attributed to the agent in provenance. Agent tokens can never
   approve changes, on any surface.
+- **SCIM tokens**: `stratum_scim_xxxxx` — per-SSO-connection bearer accepted
+  only by the SCIM endpoints under `/scim/v2` (which accept no other
+  credential). Rotated by an org admin via
+  `POST /api/orgs/{slug}/sso/scim-token`; the plaintext is returned exactly
+  once.
 
 ```bash
 curl -H "Authorization: Bearer stratum_user_xxxxx" \
@@ -23,9 +28,10 @@ curl -H "Authorization: Bearer stratum_user_xxxxx" \
 
 ## Session cookies
 
-Signing in through the web UI (email magic link, GitHub OAuth, or Google
-OAuth) sets a `stratum_session` cookie, which authenticates browser requests
-to the same endpoints.
+Signing in through the web UI (email magic link, GitHub OAuth, Google OAuth,
+or single sign-on at `/auth/sso` for organizations with an enabled OIDC
+connection) sets a `stratum_session` cookie, which authenticates browser
+requests to the same endpoints.
 
 ## Anonymous access
 

--- a/docs/api/endpoints/organizations.md
+++ b/docs/api/endpoints/organizations.md
@@ -7,13 +7,14 @@
 `POST /api/orgs`
 
 ## SSO Connection (org admins/owner)
-`PUT /api/orgs/:slug/sso` — create or replace the org's OIDC connection
-`GET /api/orgs/:slug/sso` — read the connection (secrets redacted)
-`DELETE /api/orgs/:slug/sso` — delete the connection
-`POST /api/orgs/:slug/sso/verify-domains` — verify email domains via DNS TXT
-`POST /api/orgs/:slug/sso/enable` — enable (requires verified domains)
-`POST /api/orgs/:slug/sso/disable` — disable
-`POST /api/orgs/:slug/sso/scim-token` — rotate the SCIM bearer token
+
+- `PUT /api/orgs/:slug/sso` — create or replace the org's OIDC connection
+- `GET /api/orgs/:slug/sso` — read the connection (secrets redacted)
+- `DELETE /api/orgs/:slug/sso` — delete the connection
+- `POST /api/orgs/:slug/sso/verify-domains` — verify email domains via DNS TXT
+- `POST /api/orgs/:slug/sso/enable` — enable (requires verified domains)
+- `POST /api/orgs/:slug/sso/disable` — disable
+- `POST /api/orgs/:slug/sso/scim-token` — rotate the SCIM bearer token
 
 See the [OpenAPI specification](../openapi.yml) for full request/response
 shapes, and [Authentication](../authentication.md) for the SCIM token class.

--- a/docs/api/endpoints/organizations.md
+++ b/docs/api/endpoints/organizations.md
@@ -5,3 +5,15 @@
 
 ## Create Organization
 `POST /api/orgs`
+
+## SSO Connection (org admins/owner)
+`PUT /api/orgs/:slug/sso` — create or replace the org's OIDC connection
+`GET /api/orgs/:slug/sso` — read the connection (secrets redacted)
+`DELETE /api/orgs/:slug/sso` — delete the connection
+`POST /api/orgs/:slug/sso/verify-domains` — verify email domains via DNS TXT
+`POST /api/orgs/:slug/sso/enable` — enable (requires verified domains)
+`POST /api/orgs/:slug/sso/disable` — disable
+`POST /api/orgs/:slug/sso/scim-token` — rotate the SCIM bearer token
+
+See the [OpenAPI specification](../openapi.yml) for full request/response
+shapes, and [Authentication](../authentication.md) for the SCIM token class.

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -6,10 +6,12 @@ info:
 
     This specification is generated from the route code (`src/index.ts` and
     `src/routes/*.ts`) and covers every `/api/*` route, the root health check,
-    and the GitHub webhook receiver.
+    the GitHub webhook receiver, and the SCIM 2.0 provisioning endpoints under
+    `/scim/v2`.
 
     Not covered here:
-    - HTML page routes (`/`, `/p/*`, `/changes/*`, `/auth/*`, `/dev-login`, `/ui.css`, ...).
+    - HTML page routes (`/`, `/p/*`, `/changes/*`, `/auth/*` — including the
+      SSO sign-in flow at `/auth/sso/*` — `/dev-login`, `/ui.css`, ...).
     - The git smart-HTTP endpoints (`/@{namespace}/{slug}/info/refs`,
       `git-upload-pack`, `git-receive-pack`) — documented separately in
       `docs/adr/005`.
@@ -18,7 +20,9 @@ info:
     as a `Authorization: Bearer <token>` header. Browser requests may instead be
     authenticated by the `stratum_session` cookie. Read endpoints on projects
     with `visibility: public` also accept anonymous requests. Admin endpoints
-    additionally accept an `X-Admin-API-Key` header.
+    additionally accept an `X-Admin-API-Key` header. The `/scim/v2` endpoints
+    accept only a per-connection SCIM bearer token (`stratum_scim_*`) and no
+    other credential.
 
     Several form-friendly endpoints return a `302` redirect instead of JSON when
     the request body is form-encoded rather than `application/json`; this spec
@@ -53,6 +57,10 @@ tags:
     description: Outbound project webhooks
   - name: orgs
     description: Organizations, members, and teams
+  - name: sso
+    description: Per-org OIDC SSO connection administration (org admins/owners; 501 without SSO_ENCRYPTION_SECRET)
+  - name: scim
+    description: SCIM 2.0 Users provisioning (SCIM bearer token only)
   - name: users
     description: The authenticated user's account
   - name: agents
@@ -2377,6 +2385,236 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /api/orgs/{slug}/sso:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+    put:
+      operationId: upsertSsoConnection
+      tags: [sso]
+      summary: Create or replace the org's OIDC SSO connection (admins/owner only)
+      description: |
+        Endpoints are discovered from the issuer's OIDC discovery document. The
+        client secret is encrypted at rest and never echoed back. Changing the
+        connection resets domain verification. Like every `/sso` endpoint,
+        answers 501 when the server has no `SSO_ENCRYPTION_SECRET`; non-members
+        get the same 404 as a missing org.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [issuer, clientId, clientSecret, emailDomains]
+              properties:
+                issuer: { type: string, description: OIDC issuer URL }
+                clientId: { type: string }
+                clientSecret:
+                  type: string
+                  description: Accepted in request bodies only; never returned
+                emailDomains:
+                  type: array
+                  items: { type: string }
+                  description: Email domains this connection covers; each must pass DNS TXT verification before the connection can be enabled
+      responses:
+        "200":
+          description: Connection replaced
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SsoConnectionEnvelope" }
+        "201":
+          description: Connection created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SsoConnectionEnvelope" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "501":
+          $ref: "#/components/responses/SsoNotConfigured"
+    get:
+      operationId: getSsoConnection
+      tags: [sso]
+      summary: Get the org's SSO connection (admins/owner only)
+      responses:
+        "200":
+          description: Connection (secret ciphertext and SCIM token hash redacted)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SsoConnectionEnvelope" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "501":
+          $ref: "#/components/responses/SsoNotConfigured"
+    delete:
+      operationId: deleteSsoConnection
+      tags: [sso]
+      summary: Delete the org's SSO connection (admins/owner only)
+      description: Users this connection had deactivated via SCIM are re-enabled first, so deletion is a clean rollback rather than a lockout.
+      responses:
+        "200":
+          description: Connection deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+                  reenabledUserIds:
+                    type: array
+                    items: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "501":
+          $ref: "#/components/responses/SsoNotConfigured"
+
+  /api/orgs/{slug}/sso/verify-domains:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+    post:
+      operationId: verifySsoDomains
+      tags: [sso]
+      summary: Verify the connection's email domains via DNS (admins/owner only)
+      description: |
+        Checks (over DNS-over-HTTPS) that each domain publishes a TXT record
+        `stratum-sso-verify=<token>` at `_stratum-sso.<domain>`; the record
+        details are returned by `PUT`/`GET` under `domainVerification`. All
+        domains must pass in one call. Verified domains are globally unique
+        across connections.
+      responses:
+        "200":
+          description: All domains verified
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  verified: { type: boolean }
+                  domains:
+                    type: array
+                    items: { type: string }
+                  domainsVerifiedAt: { type: string, format: date-time }
+        "400":
+          description: TXT record missing or incorrect (code DOMAIN_VERIFICATION_FAILED, with failedDomains)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: A domain is already verified by another connection
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "501":
+          $ref: "#/components/responses/SsoNotConfigured"
+
+  /api/orgs/{slug}/sso/enable:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+    post:
+      operationId: enableSsoConnection
+      tags: [sso]
+      summary: Enable the connection for sign-in and SCIM (admins/owner only)
+      description: Requires verified domains; domain uniqueness is re-checked at enable time.
+      responses:
+        "200":
+          description: Enabled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled: { type: boolean }
+        "400":
+          description: Domains are not verified yet
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: A domain is already verified by another connection
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "501":
+          $ref: "#/components/responses/SsoNotConfigured"
+
+  /api/orgs/{slug}/sso/disable:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+    post:
+      operationId: disableSsoConnection
+      tags: [sso]
+      summary: Disable the connection (admins/owner only)
+      description: Stops SSO sign-in and SCIM for this connection without deleting its configuration.
+      responses:
+        "200":
+          description: Disabled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled: { type: boolean }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "501":
+          $ref: "#/components/responses/SsoNotConfigured"
+
+  /api/orgs/{slug}/sso/scim-token:
+    parameters:
+      - $ref: "#/components/parameters/OrgSlug"
+    post:
+      operationId: rotateScimToken
+      tags: [sso]
+      summary: Rotate the connection's SCIM bearer token (admins/owner only)
+      description: The plaintext token (`stratum_scim_*`) is returned exactly once; only its hash is stored. Rotation invalidates the previous token.
+      responses:
+        "200":
+          description: New SCIM token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  scimToken:
+                    type: string
+                    description: The `stratum_scim_*` bearer for `/scim/v2`
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "501":
+          $ref: "#/components/responses/SsoNotConfigured"
+
   /api/users/me:
     get:
       operationId: getMe
@@ -3124,6 +3362,252 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /scim/v2/ServiceProviderConfig:
+    get:
+      operationId: scimServiceProviderConfig
+      tags: [scim]
+      summary: SCIM service provider configuration
+      security:
+        - scimBearer: []
+      responses:
+        "200":
+          description: Supported SCIM features (PATCH supported; bulk, filter beyond eq, sort, and etags not)
+          content:
+            application/scim+json:
+              schema: { type: object }
+        "401":
+          $ref: "#/components/responses/ScimUnauthorized"
+
+  /scim/v2/ResourceTypes:
+    get:
+      operationId: scimResourceTypes
+      tags: [scim]
+      summary: SCIM resource types (Users only; no Groups)
+      security:
+        - scimBearer: []
+      responses:
+        "200":
+          description: Resource type list
+          content:
+            application/scim+json:
+              schema: { type: object }
+        "401":
+          $ref: "#/components/responses/ScimUnauthorized"
+
+  /scim/v2/Schemas:
+    get:
+      operationId: scimSchemas
+      tags: [scim]
+      summary: SCIM schemas (core User only)
+      security:
+        - scimBearer: []
+      responses:
+        "200":
+          description: Schema list
+          content:
+            application/scim+json:
+              schema: { type: object }
+        "401":
+          $ref: "#/components/responses/ScimUnauthorized"
+
+  /scim/v2/Users:
+    get:
+      operationId: scimListUsers
+      tags: [scim]
+      summary: List users in the connection's scope
+      security:
+        - scimBearer: []
+      parameters:
+        - name: filter
+          in: query
+          schema: { type: string }
+          description: Only `userName eq "..."` and `externalId eq "..."` are supported; any other filter answers 501
+        - name: startIndex
+          in: query
+          schema: { type: integer, minimum: 1, default: 1 }
+          description: 1-based start index
+        - name: count
+          in: query
+          schema: { type: integer, minimum: 0, maximum: 200, default: 100 }
+          description: Page size; 0 returns totalResults with no Resources
+      responses:
+        "200":
+          description: SCIM ListResponse of Users
+          content:
+            application/scim+json:
+              schema: { $ref: "#/components/schemas/ScimUserList" }
+        "401":
+          $ref: "#/components/responses/ScimUnauthorized"
+        "501":
+          description: Unsupported filter expression
+          content:
+            application/scim+json:
+              schema: { $ref: "#/components/schemas/ScimError" }
+    post:
+      operationId: scimCreateUser
+      tags: [scim]
+      summary: Provision a user
+      description: |
+        `userName` must be an email within the connection's verified domains.
+        If an account with that email already exists (and is not being
+        deleted), it is adopted into the connection's scope and answered with
+        200 instead of 201; otherwise a new account is created and added to
+        the org as a member.
+      security:
+        - scimBearer: []
+      requestBody:
+        required: true
+        content:
+          application/scim+json:
+            schema:
+              type: object
+              required: [userName]
+              properties:
+                userName: { type: string, description: Email address within the connection's verified domains }
+                externalId: { type: string }
+                active: { type: boolean, default: true }
+      responses:
+        "200":
+          description: Existing account adopted
+          content:
+            application/scim+json:
+              schema: { $ref: "#/components/schemas/ScimUser" }
+        "201":
+          description: User created
+          content:
+            application/scim+json:
+              schema: { $ref: "#/components/schemas/ScimUser" }
+        "400":
+          description: Invalid attribute (SCIM error body)
+          content:
+            application/scim+json:
+              schema: { $ref: "#/components/schemas/ScimError" }
+        "401":
+          $ref: "#/components/responses/ScimUnauthorized"
+        "409":
+          description: Conflicting account, already-provisioned user, or duplicate externalId
+          content:
+            application/scim+json:
+              schema: { $ref: "#/components/schemas/ScimError" }
+
+  /scim/v2/Users/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+        description: Stratum user id
+    get:
+      operationId: scimGetUser
+      tags: [scim]
+      summary: Get a user
+      security:
+        - scimBearer: []
+      responses:
+        "200":
+          description: User (`active` reflects the enforced account state)
+          content:
+            application/scim+json:
+              schema: { $ref: "#/components/schemas/ScimUser" }
+        "401":
+          $ref: "#/components/responses/ScimUnauthorized"
+        "404":
+          $ref: "#/components/responses/ScimNotFound"
+    put:
+      operationId: scimReplaceUser
+      tags: [scim]
+      summary: Replace a user
+      description: Only `active` and `externalId` are writable; `userName` cannot be changed (400 mutability). Deactivation (`active:false`) reversibly disables every credential the user holds and purges their sessions; reactivation restores the same credentials.
+      security:
+        - scimBearer: []
+      requestBody:
+        required: true
+        content:
+          application/scim+json:
+            schema:
+              type: object
+              properties:
+                userName: { type: string, description: Must equal the current value }
+                externalId: { type: [string, "null"] }
+                active: { type: boolean }
+      responses:
+        "200":
+          description: Updated user
+          content:
+            application/scim+json:
+              schema: { $ref: "#/components/schemas/ScimUser" }
+        "400":
+          description: Invalid attribute or userName change (SCIM error body)
+          content:
+            application/scim+json:
+              schema: { $ref: "#/components/schemas/ScimError" }
+        "401":
+          $ref: "#/components/responses/ScimUnauthorized"
+        "404":
+          $ref: "#/components/responses/ScimNotFound"
+        "409":
+          description: externalId already assigned to another user
+          content:
+            application/scim+json:
+              schema: { $ref: "#/components/schemas/ScimError" }
+    patch:
+      operationId: scimPatchUser
+      tags: [scim]
+      summary: Patch a user
+      description: Accepts `replace` operations on `active` and `externalId` (with or without a path). Replaces of unstored attributes (displayName, name.*, enterprise extension paths, ...) are ignored rather than errored, matching Okta/Entra profile syncs; non-replace operations are rejected.
+      security:
+        - scimBearer: []
+      requestBody:
+        required: true
+        content:
+          application/scim+json:
+            schema:
+              type: object
+              required: [Operations]
+              properties:
+                Operations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      op: { type: string, description: Only "replace" (case-insensitive) is supported }
+                      path: { type: string }
+                      value: {}
+      responses:
+        "200":
+          description: Updated user
+          content:
+            application/scim+json:
+              schema: { $ref: "#/components/schemas/ScimUser" }
+        "400":
+          description: Malformed operations (SCIM error body)
+          content:
+            application/scim+json:
+              schema: { $ref: "#/components/schemas/ScimError" }
+        "401":
+          $ref: "#/components/responses/ScimUnauthorized"
+        "404":
+          $ref: "#/components/responses/ScimNotFound"
+        "409":
+          description: externalId already assigned to another user
+          content:
+            application/scim+json:
+              schema: { $ref: "#/components/schemas/ScimError" }
+    delete:
+      operationId: scimDeleteUser
+      tags: [scim]
+      summary: Deactivate a user
+      description: Deactivates rather than erases (equivalent to `active:false`), so a later GET returns the resource with `active:false` and a misconfigured IdP cannot destroy data. Idempotent.
+      security:
+        - scimBearer: []
+      responses:
+        "204":
+          description: User deactivated
+        "401":
+          $ref: "#/components/responses/ScimUnauthorized"
+        "404":
+          $ref: "#/components/responses/ScimNotFound"
+
 components:
   securitySchemes:
     bearerAuth:
@@ -3135,6 +3619,14 @@ components:
       in: header
       name: X-Admin-API-Key
       description: Admin API key for administrator endpoints
+    scimBearer:
+      type: http
+      scheme: bearer
+      description: >
+        Per-connection SCIM token (`stratum_scim_*`), rotated via
+        `POST /api/orgs/{slug}/sso/scim-token`. The only credential the
+        `/scim/v2` endpoints accept — session cookies and user/agent tokens
+        are never honored there.
 
   parameters:
     Namespace:
@@ -3199,6 +3691,21 @@ components:
       content:
         application/json:
           schema: { $ref: "#/components/schemas/Error" }
+    SsoNotConfigured:
+      description: SSO is not configured on this server (no SSO_ENCRYPTION_SECRET)
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    ScimUnauthorized:
+      description: Missing/invalid SCIM bearer, or the connection is disabled, unverified, or deleted
+      content:
+        application/scim+json:
+          schema: { $ref: "#/components/schemas/ScimError" }
+    ScimNotFound:
+      description: User not found in the connection's scope
+      content:
+        application/scim+json:
+          schema: { $ref: "#/components/schemas/ScimError" }
 
   schemas:
     Error:
@@ -3213,7 +3720,109 @@ components:
           description: >
             Machine-readable code present on some errors (e.g. TARGET_DELETING,
             STALE_BASE, STALE_WORKSPACE, WORKSPACE_UNVERIFIABLE, MERGE_CONFLICT,
-            PROTECTION_BLOCKED, NOT_REDRIVABLE, GONE, INVALID_PATH)
+            PROTECTION_BLOCKED, NOT_REDRIVABLE, GONE, INVALID_PATH,
+            DOMAIN_VERIFICATION_FAILED)
+
+    SsoConnectionEnvelope:
+      type: object
+      properties:
+        connection:
+          type: object
+          description: Admin view of the connection — client secret ciphertext and SCIM token hash are never included
+          properties:
+            id: { type: string }
+            orgId: { type: string }
+            protocol: { type: string, enum: [oidc] }
+            issuer: { type: string }
+            clientId: { type: string }
+            authorizationEndpoint: { type: string }
+            tokenEndpoint: { type: string }
+            jwksUri: { type: string }
+            emailDomains:
+              type: array
+              items: { type: string }
+            domainsVerifiedAt:
+              type: [string, "null"]
+              format: date-time
+            enabled: { type: boolean }
+            scimTokenSet: { type: boolean }
+            createdAt: { type: string, format: date-time }
+            updatedAt: { type: string, format: date-time }
+        domainVerification:
+          type: [object, "null"]
+          description: The DNS TXT records to publish; null once domains are verified
+          properties:
+            token: { type: string }
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  domain: { type: string }
+                  name:
+                    type: string
+                    description: "`_stratum-sso.<domain>`"
+                  type: { type: string, enum: [TXT] }
+                  value:
+                    type: string
+                    description: "`stratum-sso-verify=<token>`"
+            instructions: { type: string }
+
+    ScimUser:
+      type: object
+      description: SCIM core User resource
+      properties:
+        schemas:
+          type: array
+          items: { type: string }
+        id: { type: string, description: Stratum user id }
+        userName: { type: string, description: The user's email address }
+        externalId: { type: string }
+        active:
+          type: boolean
+          description: Reflects users.disabled_at — the enforced account state
+        name:
+          type: object
+          properties:
+            formatted: { type: string }
+        emails:
+          type: array
+          items:
+            type: object
+            properties:
+              value: { type: string }
+              primary: { type: boolean }
+        meta:
+          type: object
+          properties:
+            resourceType: { type: string }
+            created: { type: string, format: date-time }
+            location: { type: string }
+
+    ScimUserList:
+      type: object
+      description: SCIM ListResponse envelope
+      properties:
+        schemas:
+          type: array
+          items: { type: string }
+        totalResults: { type: integer }
+        startIndex: { type: integer }
+        itemsPerPage: { type: integer }
+        Resources:
+          type: array
+          items: { $ref: "#/components/schemas/ScimUser" }
+
+    ScimError:
+      type: object
+      description: SCIM error envelope (urn:ietf:params:scim:api:messages:2.0:Error)
+      properties:
+        schemas:
+          type: array
+          items: { type: string }
+        status: { type: string }
+        detail: { type: string }
+        scimType: { type: string }
 
     Project:
       type: object

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -61,7 +61,10 @@ at all. You choose the level of buy-in, and you can start with layer mode.
 
 No. Email magic-link authentication is the recommended sign-in and has no
 external dependencies. GitHub OAuth (needed for GitHub sync) and Google OAuth
-are alternatives; all resolve to the same email-based identity.
+are alternatives, and organizations can configure enterprise SSO (OIDC) for
+sign-in at `/auth/sso`; all resolve to the same email-based account. Note that
+SSO does not yet lock out the other methods — magic-link sign-in still works
+for corporate emails until an enforcement toggle ships.
 
 ## What happens when an evaluation fails?
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -24,8 +24,11 @@ Sign in with any of:
 - **GitHub OAuth** at `/auth/github` — required later if you want bidirectional
   GitHub sync.
 - **Google OAuth** at `/auth/google`.
+- **Single sign-on (SSO)** at `/auth/sso` — if your organization has
+  configured OIDC SSO, enter your org's slug or your work email.
 
-All three resolve to the same email-identity account, so you can mix methods.
+All of these resolve to the same account (matched by verified email), so you
+can mix methods.
 
 ### Self-hosting
 

--- a/migrations/041_sso_scim.sql
+++ b/migrations/041_sso_scim.sql
@@ -89,6 +89,11 @@ CREATE INDEX IF NOT EXISTS idx_oidc_login_states_expires ON oidc_login_states(ex
 ALTER TABLE users ADD COLUMN disabled_at TEXT;
 
 -- Schema drift fix: src/github/client.ts already reads/writes these columns,
--- but no migration ever created them.
+-- but no migration ever created them. SQLite has no ADD COLUMN IF NOT EXISTS,
+-- so before applying in any environment where they might have been hot-fixed
+-- out of band, run `PRAGMA table_info(users)` and reconcile (drop the
+-- out-of-band columns or mark this migration applied). Production evidence
+-- says they don't exist: the reading code has silently error-caught since
+-- migration 007.
 ALTER TABLE users ADD COLUMN github_refresh_token TEXT;
 ALTER TABLE users ADD COLUMN github_token_expires_at INTEGER;

--- a/migrations/041_sso_scim.sql
+++ b/migrations/041_sso_scim.sql
@@ -1,0 +1,94 @@
+-- Enterprise SSO (OIDC) + SCIM deprovisioning data model (#253).
+--
+-- `identities` is the single model for ALL external identities: OIDC SSO
+-- logins, plus GitHub/Google OAuth (which today re-match by raw email string —
+-- an account-takeover vector for dormant accounts). A row is keyed by the
+-- stable (issuer, subject) pair so an email change at the provider can never
+-- detach or hijack an account. Invariant enforced in storage code (not SQL):
+-- at most one identity per (user_id, issuer).
+
+CREATE TABLE IF NOT EXISTS identities (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id),
+  provider TEXT NOT NULL CHECK(provider IN ('oidc','github','google')),
+  -- Non-empty CHECKs: an IdP omitting `sub` must never collapse all of its
+  -- users into a single ('issuer', '') row that re-points on every login.
+  issuer TEXT NOT NULL CHECK(length(issuer) > 0),
+  subject TEXT NOT NULL CHECK(length(subject) > 0),
+  email TEXT NOT NULL,
+  connection_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE (issuer, subject)
+);
+
+CREATE INDEX IF NOT EXISTS idx_identities_user ON identities(user_id);
+
+-- One OIDC connection per org (org_id UNIQUE). `protocol` exists so SAML can
+-- be added later without re-migrating; only 'oidc' ships. The client secret is
+-- stored AES-GCM-encrypted (keyed off SSO_ENCRYPTION_SECRET), the SCIM bearer
+-- token only as a SHA-256 hash. `email_domains` is a lowercased JSON array;
+-- a connection cannot be enabled until they are DNS-TXT-verified
+-- (domains_verified_at), because unverified domains + open org creation would
+-- be an account-takeover primitive.
+CREATE TABLE IF NOT EXISTS org_sso_connections (
+  id TEXT PRIMARY KEY,
+  org_id TEXT UNIQUE NOT NULL REFERENCES orgs(id),
+  protocol TEXT NOT NULL DEFAULT 'oidc' CHECK(protocol IN ('oidc')),
+  issuer TEXT NOT NULL,
+  client_id TEXT NOT NULL,
+  client_secret_ciphertext TEXT NOT NULL,
+  authorization_endpoint TEXT NOT NULL,
+  token_endpoint TEXT NOT NULL,
+  jwks_uri TEXT NOT NULL,
+  email_domains TEXT NOT NULL,
+  domains_verified_at TEXT,
+  scim_token_hash TEXT,
+  enabled INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+-- Managed-membership + SCIM resource mapping: a user is managed by a
+-- connection iff a row exists (created by SCIM provision/adopt or JIT login).
+-- SCIM resource id = user_id. `active = 0` records a SCIM deactivation so
+-- reactivation and cross-connection guards can reason about who disabled whom.
+CREATE TABLE IF NOT EXISTS scim_members (
+  connection_id TEXT NOT NULL REFERENCES org_sso_connections(id),
+  user_id TEXT NOT NULL REFERENCES users(id),
+  scim_external_id TEXT,
+  active INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (connection_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_scim_members_user ON scim_members(user_id);
+
+-- OIDC login state lives in D1 (not KV) for the same reason magic links moved
+-- in migration 031: consumption must be a single atomic conditional UPDATE so
+-- a state value can never be redeemed twice under a race. Rows are short-TTL
+-- and purged opportunistically + by the scheduled cron.
+-- `connection_id` is deliberately FK-free (like magic_links, 031): rows are
+-- ephemeral and purge-friendly, and a state for a just-deleted connection
+-- simply fails at consumption time.
+CREATE TABLE IF NOT EXISTS oidc_login_states (
+  state TEXT PRIMARY KEY,
+  connection_id TEXT NOT NULL,
+  nonce TEXT NOT NULL,
+  code_verifier TEXT NOT NULL,
+  redirect_to TEXT,
+  created_at TEXT NOT NULL,
+  expires_at INTEGER NOT NULL,
+  consumed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_oidc_login_states_expires ON oidc_login_states(expires_at);
+
+-- Reversible disable (SCIM deactivation), distinct from destructive
+-- `deleting_at` (migration 026): credentials are made inert by enforcement
+-- checks, not destroyed, so IdP unsuspend restores the account intact.
+ALTER TABLE users ADD COLUMN disabled_at TEXT;
+
+-- Schema drift fix: src/github/client.ts already reads/writes these columns,
+-- but no migration ever created them.
+ALTER TABLE users ADD COLUMN github_refresh_token TEXT;
+ALTER TABLE users ADD COLUMN github_token_expires_at INTEGER;

--- a/migrations/042_sso_domain_verification.sql
+++ b/migrations/042_sso_domain_verification.sql
@@ -1,0 +1,6 @@
+-- Per-connection DNS domain-verification token (#253 Task 4). Issued at
+-- connection create; an org admin proves domain ownership by publishing
+-- `stratum-sso-verify=<token>` as a TXT record at `_stratum-sso.<domain>`.
+-- The token survives email_domains edits (only domains_verified_at clears),
+-- so an admin never has to re-publish DNS after tweaking the domain list.
+ALTER TABLE org_sso_connections ADD COLUMN domain_verification_token TEXT;

--- a/migrations/043_scim_external_id_unique.sql
+++ b/migrations/043_scim_external_id_unique.sql
@@ -1,0 +1,12 @@
+-- SCIM externalId uniqueness per connection (#253 Task 6 review).
+--
+-- Okta pairs users during import by externalId; two users sharing one
+-- externalId on the same connection would break that pairing, so the pair is
+-- enforced UNIQUE at the schema level (storage maps the violation to a
+-- CONFLICT, the SCIM surface to 409 uniqueness). Partial index: NULL
+-- externalIds (rows adopted before the IdP assigned one) stay unconstrained,
+-- and the same externalId may exist on DIFFERENT connections — IdP namespaces
+-- are independent.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_scim_members_external_id
+  ON scim_members(connection_id, scim_external_id)
+  WHERE scim_external_id IS NOT NULL;

--- a/migrations/044_scim_token_hash_index.sql
+++ b/migrations/044_scim_token_hash_index.sql
@@ -1,0 +1,7 @@
+-- SCIM auth does a per-request lookup by token hash
+-- (getSsoConnectionByScimTokenHash); index the hashed column so that hot path
+-- never scans org_sso_connections. Partial: connections without a SCIM token
+-- (scim_token_hash NULL) can never authenticate and stay out of the index.
+CREATE INDEX IF NOT EXISTS idx_org_sso_connections_scim_token_hash
+  ON org_sso_connections(scim_token_hash)
+  WHERE scim_token_hash IS NOT NULL;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "diff": "^9.0.0",
         "hono": "^4.7.7",
         "isomorphic-git": "^1.27.1",
+        "jose": "6.2.10",
         "marked": "^15.0.12",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
@@ -28,6 +29,10 @@
         "typescript": "^5.8.3",
         "vitest": "^3.1.3",
         "wrangler": "^4.0.0"
+      },
+      "engines": {
+        "//": "node:sqlite is unflagged only from 22.13.0; tests/helpers/sqlite-d1.ts imports it.",
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3274,6 +3279,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "private": true,
   "license": "MIT",
   "description": "A code collaboration platform for the AI engineering era, built on Cloudflare Workers.",
-  "repository": { "type": "git", "url": "https://github.com/stratum-eng/stratum.git" },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stratum-eng/stratum.git"
+  },
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
@@ -29,6 +32,7 @@
     "diff": "^9.0.0",
     "hono": "^4.7.7",
     "isomorphic-git": "^1.27.1",
+    "jose": "6.2.10",
     "marked": "^15.0.12",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { restoreRouter } from "./routes/restore";
 import { reviewsRouter } from "./routes/reviews";
 import { sessionRouter } from "./routes/sessions";
 import { signupRouter } from "./routes/signup";
+import { ssoRouter } from "./routes/sso";
 import { syncRouter } from "./routes/sync";
 import { syncManagementRouter } from "./routes/sync-management";
 import { uiRouter } from "./routes/ui";
@@ -172,6 +173,9 @@ app.get("/ui/changes/:id", (c) => {
 });
 
 app.route("/auth", authRouter);
+// OIDC SSO login flow (picker, /:slug/start, /callback) — same global
+// middleware chain as the other auth routes.
+app.route("/auth/sso", ssoRouter);
 app.route("/auth/email", emailAuthRouter);
 app.route("/auth/login", loginRouter);
 app.route("/auth/signup", signupRouter);

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { orgsRouter } from "./routes/orgs";
 import { projectsRouter } from "./routes/projects";
 import { restoreRouter } from "./routes/restore";
 import { reviewsRouter } from "./routes/reviews";
+import { scimRouter } from "./routes/scim";
 import { sessionRouter } from "./routes/sessions";
 import { signupRouter } from "./routes/signup";
 import { ssoRouter } from "./routes/sso";
@@ -194,6 +195,9 @@ app.route("/api/orgs", orgSsoRouter);
 app.route("/api", syncRouter);
 app.route("/api", syncManagementRouter);
 app.route("/api/bulk-import", bulkImportRouter);
+// SCIM 2.0 Users (#253) — stratum_scim_* bearer only; every handler fails
+// closed unless authMiddleware resolved a SCIM connection.
+app.route("/scim/v2", scimRouter);
 app.route("/api/webhooks/github", githubWebhookRouter);
 // Git smart-HTTP proxy (clone/fetch). Mount before the UI catch-all so its
 // /@ns/slug/{info/refs,git-upload-pack,git-receive-pack} paths resolve here.

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,12 @@ app.get("/dev-login", async (c) => {
       userId = createResult.data.user.id;
       logger.info("Dev login: Created new user", { userId });
     } else {
+      // Parity with the real login flows: no session mint for a disabled or
+      // deleting account, even behind the localhost dev gate.
+      if (userResult.data.disabledAt || userResult.data.deletingAt) {
+        logger.warn("Dev login refused — account disabled", { userId: userResult.data.id });
+        return c.json({ error: "Account is disabled" }, 403);
+      }
       userId = userResult.data.id;
       logger.info("Dev login: Using existing user", { userId });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { healthRouter } from "./routes/health";
 import { issuesRouter } from "./routes/issues";
 import { loginRouter } from "./routes/login";
 import { metricsRouter } from "./routes/metrics";
+import { orgSsoRouter } from "./routes/org-sso";
 import { orgsRouter } from "./routes/orgs";
 import { projectsRouter } from "./routes/projects";
 import { restoreRouter } from "./routes/restore";
@@ -184,6 +185,8 @@ app.route("/api/agents", agentsRouter);
 app.route("/api", changesRouter);
 app.route("/api", reviewsRouter);
 app.route("/api/orgs", orgsRouter);
+// Org SSO admin API (/api/orgs/:slug/sso) — same authMiddleware chain as /api/orgs.
+app.route("/api/orgs", orgSsoRouter);
 app.route("/api", syncRouter);
 app.route("/api", syncManagementRouter);
 app.route("/api/bulk-import", bulkImportRouter);

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -76,8 +76,9 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
       // A soft-`deleting` account's credentials stop working immediately — the
       // deleting_at flag rides on the same user row (no second round-trip) and
       // we reject BEFORE setting any context so nothing downstream trusts it.
-      if (userResult.data.deletingAt) {
-        logger.warn("Auth rejected - user is deleting", {
+      // A disabled (SCIM-deprovisioned, reversible) account is equally inert.
+      if (userResult.data.deletingAt || userResult.data.disabledAt) {
+        logger.warn("Auth rejected - user is deleting or disabled", {
           path: c.req.path,
           userId: userResult.data.id,
         });
@@ -103,12 +104,12 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
         });
         return c.json({ error: "Invalid token" }, 401);
       }
-      // An agent inherits its owner's access, so a deleting owner's agent must
-      // stop working too — otherwise it's an authenticated write channel that
-      // re-creates rows the account cascade is erasing. Fail CLOSED on the
-      // owner lookup: an unresolved lookup or a deleting owner rejects the
-      // agent token. getUser can reject on a D1 error, so catch it rather
-      // than letting it propagate past this middleware.
+      // An agent inherits its owner's access, so a deleting or disabled
+      // owner's agent must stop working too — otherwise it's an authenticated
+      // write channel that outlives the account's access. Fail CLOSED on the
+      // owner lookup: an unresolved lookup or a deleting/disabled owner
+      // rejects the agent token. getUser can reject on a D1 error, so catch
+      // it rather than letting it propagate past this middleware.
       let ownerResult: Awaited<ReturnType<typeof getUser>>;
       try {
         ownerResult = await getUser(c.env.DB, agentResult.data.ownerId, logger);
@@ -119,8 +120,10 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
         });
         return c.json({ error: "Invalid token" }, 401);
       }
-      if (!ownerResult.success || ownerResult.data.deletingAt) {
-        logger.warn("Auth failed - agent owner is deleting", { path: c.req.path });
+      if (!ownerResult.success || ownerResult.data.deletingAt || ownerResult.data.disabledAt) {
+        logger.warn("Auth failed - agent owner is missing, deleting, or disabled", {
+          path: c.req.path,
+        });
         return c.json({ error: "Invalid token" }, 401);
       }
       c.set("agentId", agentResult.data.id);
@@ -150,12 +153,12 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
         logger.debug("Session expired, deleting", { userId });
         await deleteSession(c.env.DB, sessionId, userId, logger);
       } else {
-        // Fetch the user row FIRST so a soft-`deleting` account is rejected
-        // before any auth context is set (the deleting_at flag rides on the
+        // Fetch the user row FIRST so a soft-`deleting` or disabled account
+        // is rejected before any auth context is set (both flags ride on the
         // same row, so this is not an extra round-trip beyond the username
         // lookup this path already did). Fail CLOSED: an unresolved lookup
         // (missing row, or getUser rejecting on a D1 error) must not end up
-        // authenticated any more than a deleting account should.
+        // authenticated any more than a deleting or disabled account should.
         let userResult: Awaited<ReturnType<typeof getUser>>;
         try {
           userResult = await getUser(c.env.DB, sessionResult.data.userId, logger);
@@ -166,8 +169,8 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
           });
           return c.json({ error: "Unauthorized" }, 401);
         }
-        if (!userResult.success || userResult.data.deletingAt) {
-          logger.warn("Auth rejected - session user missing or deleting", { userId });
+        if (!userResult.success || userResult.data.deletingAt || userResult.data.disabledAt) {
+          logger.warn("Auth rejected - session user missing, deleting, or disabled", { userId });
           return c.json({ error: "Unauthorized" }, 401);
         }
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -160,7 +160,18 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
           path: c.req.path,
           tokenHint: sanitizeToken(token),
         });
-        return c.json({ error: "Invalid token" }, 401);
+        // A stratum_scim_ bearer identifies an IdP caller, so answer in the
+        // SCIM Error schema (RFC 7644 §3.12) rather than the repo's plain
+        // {error} JSON — this branch only; other token classes keep theirs.
+        return c.json(
+          {
+            schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+            status: "401",
+            detail: "Invalid token",
+          },
+          401,
+          { "Content-Type": "application/scim+json" },
+        );
       }
       c.set("scimConnectionId", connectionResult.data.id);
       c.set("authVia", "token");

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -3,8 +3,10 @@ import { getCookie } from "hono/cookie";
 import { isGitHttpPath } from "../routes/git-http";
 import { getAgentByToken } from "../storage/agents";
 import { deleteSession, getSession } from "../storage/sessions";
+import { getSsoConnectionByScimTokenHash } from "../storage/sso";
 import { getUser, getUserByToken } from "../storage/users";
 import type { Env } from "../types";
+import { hashToken } from "../utils/crypto";
 import { type Logger, createLogger } from "../utils/logger";
 
 declare module "hono" {
@@ -13,6 +15,13 @@ declare module "hono" {
     username: string;
     agentId?: string;
     agentOwnerId?: string;
+    /**
+     * Set ONLY for a valid `stratum_scim_*` bearer (an enabled,
+     * domain-verified connection). A SCIM caller is the org's IdP, not a
+     * user — userId is never set alongside this. The SCIM router re-loads
+     * the connection row per request, so only the id is carried here.
+     */
+    scimConnectionId?: string;
     /** How the caller authenticated — CSRF checks apply to "session" only. */
     authVia?: "token" | "session";
     logger: Logger;
@@ -132,6 +141,32 @@ export const authMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
       logger.debug("Auth success - agent", {
         agentId: agentResult.data.id,
         ownerId: agentResult.data.ownerId,
+      });
+      await next();
+      return;
+    }
+
+    if (token.startsWith("stratum_scim_")) {
+      // Only the token's hash is stored; the lookup itself enforces
+      // enabled=1 AND verified domains, so a rotated, disabled, or
+      // unverified connection's token 401s exactly like any invalid token.
+      const connectionResult = await getSsoConnectionByScimTokenHash(
+        c.env.DB,
+        logger,
+        await hashToken(token),
+      );
+      if (!connectionResult.success) {
+        logger.warn("Auth failed - invalid SCIM token", {
+          path: c.req.path,
+          tokenHint: sanitizeToken(token),
+        });
+        return c.json({ error: "Invalid token" }, 401);
+      }
+      c.set("scimConnectionId", connectionResult.data.id);
+      c.set("authVia", "token");
+      logger.debug("Auth success - SCIM connection", {
+        connectionId: connectionResult.data.id,
+        orgId: connectionResult.data.orgId,
       });
       await next();
       return;

--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -9,6 +9,18 @@ export interface RateLimitOptions {
   requestsPerMinute?: number;
 }
 
+// SCIM sync traffic is bursty by nature: an Okta first import runs ~3
+// requests per user (userName-filtered GET, POST/PATCH, verify GET) plus
+// paging, back-to-back, so the global per-minute bucket would 429 mid-sync
+// and the IdP would mark users as failed. SCIM therefore gets its own
+// PER-CONNECTION fixed window: 3000 requests/hour gives a ~1000-user first
+// sync headroom in a single burst while still bounding a runaway client. The
+// hourly window keeps Retry-After bounded to at most an hour, and the fixed
+// window matches the existing limiter's shape. Keyed on the connection (not
+// user/IP) — one tenant's sync cannot starve another's.
+const SCIM_REQUESTS_PER_HOUR = 3000;
+const SCIM_WINDOW_SECONDS = 3600;
+
 export interface ImportRateLimitOptions {
   /** Maximum imports per user per time window (default: 1) */
   importsPerWindow?: number;
@@ -51,6 +63,49 @@ export function rateLimitMiddleware(opts?: RateLimitOptions): MiddlewareHandler<
     // metered WRITE and must NOT be exempt — otherwise writes bypass the limiter
     // entirely. Exempt only upload-pack RPCs and the upload-pack ref advertise.
     if (isGitHttpPath(c.req.path) && isExemptGitRead(c.req.path, c.req.query("service"))) {
+      await next();
+      return;
+    }
+
+    // A SCIM caller (set only for a valid stratum_scim_* bearer) bypasses the
+    // per-user/IP bucketing for its own per-connection window — see
+    // SCIM_REQUESTS_PER_HOUR for the sizing rationale.
+    const scimConnectionId = c.get("scimConnectionId");
+    if (scimConnectionId) {
+      const windowBucket = Math.floor(Date.now() / (SCIM_WINDOW_SECONDS * 1000));
+      const key = `ratelimit:scim:${scimConnectionId}:${windowBucket}`;
+      const resetSeconds = (windowBucket + 1) * SCIM_WINDOW_SECONDS;
+      const scimRetryAfter = resetSeconds - Math.floor(Date.now() / 1000);
+
+      try {
+        const raw = await c.env.STATE.get(key);
+        const count = raw !== null ? Number.parseInt(raw, 10) : 0;
+        if (count >= SCIM_REQUESTS_PER_HOUR) {
+          logger.warn("SCIM rate limit exceeded", {
+            connectionId: scimConnectionId,
+            path: c.req.path,
+            count,
+          });
+          return c.json({ error: "Too many requests" }, 429, {
+            "Retry-After": String(scimRetryAfter),
+            "X-RateLimit-Limit": String(SCIM_REQUESTS_PER_HOUR),
+            "X-RateLimit-Remaining": "0",
+          });
+        }
+        await c.env.STATE.put(key, String(count + 1), {
+          expirationTtl: SCIM_WINDOW_SECONDS * 2,
+        });
+        c.header("X-RateLimit-Limit", String(SCIM_REQUESTS_PER_HOUR));
+        c.header("X-RateLimit-Remaining", String(SCIM_REQUESTS_PER_HOUR - count - 1));
+        c.header("X-RateLimit-Reset", String(resetSeconds));
+      } catch (err) {
+        // KV unavailable — allow the request, matching the global limiter.
+        logger.warn("SCIM rate limit check failed - allowing request", {
+          error: err instanceof Error ? err.message : String(err),
+          path: c.req.path,
+        });
+      }
+
       await next();
       return;
     }

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -193,20 +193,42 @@ app.get("/github/callback", async (c) => {
   const emailPrefix = primaryEmail.split("@")[0];
   logger.info("Upserting GitHub user", { githubId: githubUser.id, emailPrefix });
 
+  const byGithub = await getUserByGitHubId(c.env.DB, String(githubUser.id), logger);
+  const byPrimaryEmail = await getUserByEmail(c.env.DB, primaryEmail, logger);
+
   // Closed beta: OAuth is login-only. A brand-new account (no match by GitHub id
   // or email) must be created through the invite-gated magic-link flow first.
   if (betaGateEnabled(c.env)) {
-    const byGithub = await getUserByGitHubId(c.env.DB, String(githubUser.id), logger);
     // Match an existing account only by a *verified* email — never the unverified
     // fallback used for primaryEmail, which could be attacker-controlled and let
     // someone slip past the gate by claiming a beta user's address.
     const verifiedEmail =
       emails.find((e) => e.primary && e.verified)?.email ?? emails.find((e) => e.verified)?.email;
-    const byEmail = verifiedEmail ? await getUserByEmail(c.env.DB, verifiedEmail, logger) : null;
+    const byEmail =
+      verifiedEmail === primaryEmail
+        ? byPrimaryEmail
+        : verifiedEmail
+          ? await getUserByEmail(c.env.DB, verifiedEmail, logger)
+          : null;
     if (!byGithub.success && !byEmail?.success) {
       logger.warn("Blocked GitHub signup — closed beta", { githubId: githubUser.id });
       return c.redirect("/auth/signup?error=invite_required");
     }
+  }
+
+  // A disabled (or deleting) account must not sign in — and the refusal must
+  // come BEFORE upsertGitHubUser, which would otherwise link github_id onto
+  // the frozen row and hand it a working login credential at re-enable time.
+  // Check the same account upsertGitHubUser would match: by GitHub id, else by
+  // primaryEmail.
+  const existingAccount = byGithub.success
+    ? byGithub.data
+    : byPrimaryEmail.success
+      ? byPrimaryEmail.data
+      : null;
+  if (existingAccount && (existingAccount.disabledAt || existingAccount.deletingAt)) {
+    logger.warn("Blocked GitHub sign-in — account disabled", { userId: existingAccount.id });
+    return c.redirect("/auth/login?error=account_disabled");
   }
 
   const userResult = await upsertGitHubUser(
@@ -225,6 +247,7 @@ app.get("/github/callback", async (c) => {
   }
 
   const user = userResult.data;
+
   const sessionLogger = logger.child({ userId: user.id });
 
   const sessionResult = await createSession(c.env.DB, user.id, sessionLogger);
@@ -375,6 +398,13 @@ app.get("/google/callback", async (c) => {
   const existing = await getUserByEmail(c.env.DB, googleUser.email, logger);
   let userId: string;
   if (existing.success) {
+    // A disabled (or deleting) account must not sign in: refuse BEFORE minting
+    // a session, so no stratum_session cookie and no session.created audit row
+    // exist for it.
+    if (existing.data.disabledAt || existing.data.deletingAt) {
+      logger.warn("Blocked Google sign-in — account disabled", { userId: existing.data.id });
+      return c.redirect("/auth/login?error=account_disabled");
+    }
     userId = existing.data.id;
   } else {
     // Closed beta: OAuth is login-only — new accounts require an invite code.

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -2,9 +2,19 @@ import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { betaGateEnabled } from "../beta/gate";
 import { recordAudit } from "../storage/audit";
+import { getIdentityByIssuerSubject, upsertIdentity } from "../storage/identities";
 import { createSession, deleteSession, getSession } from "../storage/sessions";
-import { createUser, getUserByEmail, getUserByGitHubId, upsertGitHubUser } from "../storage/users";
+import {
+  createUser,
+  getUser,
+  getUserByEmail,
+  getUserByGitHubId,
+  upsertGitHubUser,
+} from "../storage/users";
 import type { Env } from "../types";
+import { constantTimeEqual } from "../utils/crypto";
+import { NotFoundError } from "../utils/errors";
+import type { Logger } from "../utils/logger";
 import { createLogger } from "../utils/logger";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -12,14 +22,38 @@ const app = new Hono<{ Bindings: Env }>();
 const OAUTH_STATE_COOKIE = "stratum_oauth_state";
 const OAUTH_STATE_TTL_SECONDS = 600;
 
-/** Constant-time string equality — OAuth state values are attacker-influenced. */
-function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) {
-    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+// Canonical issuer values for the identities table (see src/storage/identities.ts).
+// RESERVED: the OIDC connection-registration flow (org SSO) must reject these
+// issuers — an org-supplied connection claiming either could re-point rows in
+// the GitHub/Google identity namespace via upsertIdentity's ON CONFLICT.
+const GITHUB_ISSUER = "https://github.com";
+const GOOGLE_ISSUER = "https://accounts.google.com";
+
+/**
+ * Record the external identity for a completed OAuth sign-in. Non-fatal by
+ * design: identity rows are forward-provisioning for SSO (backfilled lazily at
+ * login), while GitHub login is still keyed off users.github_id and Google
+ * falls back to email match — so a storage blip here must not lock anyone out.
+ * The next successful login retries the upsert.
+ */
+async function recordOAuthIdentity(
+  db: D1Database,
+  logger: Logger,
+  input: {
+    userId: string;
+    provider: "github" | "google";
+    issuer: string;
+    subject: string;
+    email: string;
+  },
+): Promise<void> {
+  const result = await upsertIdentity(db, logger, input);
+  if (!result.success) {
+    logger.error("Failed to upsert OAuth identity; continuing login", result.error, {
+      provider: input.provider,
+      userId: input.userId,
+    });
   }
-  return diff === 0;
 }
 
 /**
@@ -52,7 +86,7 @@ async function consumeOAuthState(
   state: string,
 ): Promise<boolean> {
   const cookieState = getCookie(c, OAUTH_STATE_COOKIE);
-  if (!cookieState || !timingSafeEqual(cookieState, state)) {
+  if (!cookieState || !constantTimeEqual(cookieState, state)) {
     return false;
   }
   deleteCookie(c, OAUTH_STATE_COOKIE, { path: "/auth" });
@@ -108,7 +142,7 @@ app.get("/github/callback", async (c) => {
     return c.json({ error: "GitHub OAuth is not configured" }, 501);
   }
 
-  const { code, state, next } = c.req.query();
+  const { code, state } = c.req.query();
 
   if (!state) {
     logger.warn("Missing state parameter");
@@ -178,14 +212,35 @@ app.get("/github/callback", async (c) => {
   }
 
   const githubUser = await userRes.json<{ id: number; login: string }>();
-  const emails = await emailsRes.json<{ email: string; primary: boolean; verified: boolean }[]>();
+  const emailsBody = await emailsRes.json<unknown>();
+  // A 200 with a non-array body (proxy error page, API drift) must not throw —
+  // the empty list already has correct semantics on every path below.
+  const emails = (Array.isArray(emailsBody) ? emailsBody : []) as {
+    email: string;
+    primary: boolean;
+    verified: boolean;
+  }[];
 
-  const primaryEmail =
-    emails.find((e) => e.primary && e.verified)?.email ??
-    emails.find((e) => e.verified)?.email ??
-    emails[0]?.email;
+  // A returning linked user's credential is the GitHub account id itself, so
+  // resolve by github_id before any email requirement applies.
+  const byGithub = await getUserByGitHubId(c.env.DB, String(githubUser.id), logger);
 
-  if (!primaryEmail) {
+  // Email match and account creation trust GitHub emails only when GitHub has
+  // verified them — an unverified address is attacker-claimable and would let
+  // someone link onto (or squat) another person's account. Lowercased so the
+  // match hits accounts stored via the magic-link flow, which normalizes.
+  const verifiedEmail = (
+    emails.find((e) => e.primary && e.verified)?.email ?? emails.find((e) => e.verified)?.email
+  )
+    ?.trim()
+    .toLowerCase();
+
+  let primaryEmail: string;
+  if (verifiedEmail) {
+    primaryEmail = verifiedEmail;
+  } else if (byGithub.success) {
+    primaryEmail = byGithub.data.email;
+  } else {
     logger.warn("No verified email found on GitHub account", { githubId: githubUser.id });
     return c.json({ error: "No verified email found on GitHub account" }, 422);
   }
@@ -193,27 +248,13 @@ app.get("/github/callback", async (c) => {
   const emailPrefix = primaryEmail.split("@")[0];
   logger.info("Upserting GitHub user", { githubId: githubUser.id, emailPrefix });
 
-  const byGithub = await getUserByGitHubId(c.env.DB, String(githubUser.id), logger);
   const byPrimaryEmail = await getUserByEmail(c.env.DB, primaryEmail, logger);
 
   // Closed beta: OAuth is login-only. A brand-new account (no match by GitHub id
-  // or email) must be created through the invite-gated magic-link flow first.
-  if (betaGateEnabled(c.env)) {
-    // Match an existing account only by a *verified* email — never the unverified
-    // fallback used for primaryEmail, which could be attacker-controlled and let
-    // someone slip past the gate by claiming a beta user's address.
-    const verifiedEmail =
-      emails.find((e) => e.primary && e.verified)?.email ?? emails.find((e) => e.verified)?.email;
-    const byEmail =
-      verifiedEmail === primaryEmail
-        ? byPrimaryEmail
-        : verifiedEmail
-          ? await getUserByEmail(c.env.DB, verifiedEmail, logger)
-          : null;
-    if (!byGithub.success && !byEmail?.success) {
-      logger.warn("Blocked GitHub signup — closed beta", { githubId: githubUser.id });
-      return c.redirect("/auth/signup?error=invite_required");
-    }
+  // or verified email) must be created through the invite-gated magic-link flow.
+  if (betaGateEnabled(c.env) && !byGithub.success && !byPrimaryEmail.success) {
+    logger.warn("Blocked GitHub signup — closed beta", { githubId: githubUser.id });
+    return c.redirect("/auth/signup?error=invite_required");
   }
 
   // A disabled (or deleting) account must not sign in — and the refusal must
@@ -250,6 +291,14 @@ app.get("/github/callback", async (c) => {
 
   const sessionLogger = logger.child({ userId: user.id });
 
+  await recordOAuthIdentity(c.env.DB, sessionLogger, {
+    userId: user.id,
+    provider: "github",
+    issuer: GITHUB_ISSUER,
+    subject: String(githubUser.id),
+    email: primaryEmail,
+  });
+
   const sessionResult = await createSession(c.env.DB, user.id, sessionLogger);
   if (sessionResult.success) {
     await recordAudit(c.env.DB, sessionLogger, {
@@ -275,19 +324,7 @@ app.get("/github/callback", async (c) => {
 
   sessionLogger.info("GitHub OAuth successful, session created");
 
-  let redirectTo = "/";
-  if (next && typeof next === "string") {
-    try {
-      const url = new URL(next, "http://localhost");
-      if (url.hostname === "localhost" || url.hostname === "") {
-        redirectTo = url.pathname + url.search;
-      }
-    } catch {
-      // invalid next param — fall back to /
-    }
-  }
-
-  return c.redirect(redirectTo);
+  return c.redirect("/");
 });
 
 app.get("/google", async (c) => {
@@ -382,43 +419,110 @@ app.get("/google/callback", async (c) => {
   }
 
   const googleUser = await userRes.json<{
-    sub: string;
+    sub?: string;
     email?: string;
     email_verified?: boolean;
   }>();
 
-  if (!googleUser.email || googleUser.email_verified !== true) {
-    logger.warn("Google account has no verified email");
-    return c.json({ error: "No verified email on Google account" }, 422);
+  if (!googleUser.sub) {
+    logger.error("Google userinfo response missing sub");
+    return c.json({ error: "Failed to fetch Google user data" }, 502);
   }
 
-  // Google identity maps onto the email-based account model: an existing
-  // account with this email is reused, otherwise one is created — the same
-  // semantics as magic-link sign-in.
-  const existing = await getUserByEmail(c.env.DB, googleUser.email, logger);
+  // Lowercased so matching hits accounts stored via the magic-link flow, which
+  // normalizes; identities.email is normalized the same way in storage.
+  const googleEmail = googleUser.email?.trim().toLowerCase();
+
+  // Resolve by the stable (issuer, sub) pair first — the identity persisted at
+  // a prior login. The sub, not the email, is the credential for a returning
+  // linked user (mirroring github_id-first above), so the verified-email
+  // requirement applies only to the email-match/create paths below. Only
+  // NotFound falls through to email matching; a storage failure fails the
+  // login closed, because falling through could email-match (or JIT-create) a
+  // duplicate account for an already-linked subject.
+  const identityLookup = await getIdentityByIssuerSubject(
+    c.env.DB,
+    logger,
+    GOOGLE_ISSUER,
+    googleUser.sub,
+  );
+  if (!identityLookup.success && !(identityLookup.error instanceof NotFoundError)) {
+    logger.error("Google identity lookup failed", identityLookup.error);
+    return c.json({ error: "Failed to sign in" }, 500);
+  }
+
   let userId: string;
-  if (existing.success) {
+  let identityEmail: string;
+  if (identityLookup.success) {
+    // An identity row must point at a live user (account deletion cascades
+    // through deleteIdentitiesForUser) — treat a dangling row as an error, not
+    // as license to fall through and mint a duplicate account.
+    const identityUser = await getUser(c.env.DB, identityLookup.data.userId, logger);
+    if (!identityUser.success) {
+      logger.error("Google identity points at a missing user", identityUser.error, {
+        identityId: identityLookup.data.id,
+      });
+      return c.json({ error: "Failed to sign in" }, 500);
+    }
     // A disabled (or deleting) account must not sign in: refuse BEFORE minting
     // a session, so no stratum_session cookie and no session.created audit row
     // exist for it.
-    if (existing.data.disabledAt || existing.data.deletingAt) {
-      logger.warn("Blocked Google sign-in — account disabled", { userId: existing.data.id });
+    if (identityUser.data.disabledAt || identityUser.data.deletingAt) {
+      logger.warn("Blocked Google sign-in — account disabled", { userId: identityUser.data.id });
       return c.redirect("/auth/login?error=account_disabled");
     }
-    userId = existing.data.id;
+    userId = identityUser.data.id;
+    // Refresh the identity email only from a verified claim; otherwise keep
+    // the account's stored email.
+    identityEmail =
+      googleEmail && googleUser.email_verified === true ? googleEmail : identityUser.data.email;
   } else {
-    // Closed beta: OAuth is login-only — new accounts require an invite code.
-    if (betaGateEnabled(c.env)) {
-      logger.warn("Blocked Google signup — closed beta");
-      return c.redirect("/auth/signup?error=invite_required");
+    // Email match and account creation trust the Google email only when
+    // verified — an unverified address is attacker-claimable.
+    if (!googleEmail || googleUser.email_verified !== true) {
+      logger.warn("Google account has no verified email");
+      return c.json({ error: "No verified email on Google account" }, 422);
     }
-    const createdResult = await createUser(c.env.DB, googleUser.email, logger);
-    if (!createdResult.success) {
-      logger.error("Failed to create user from Google sign-in", createdResult.error);
-      return c.json({ error: "Failed to create user" }, 500);
+    identityEmail = googleEmail;
+    // Unlinked Google identity maps onto the email-based account model: an
+    // existing account with this (verified) email is reused, otherwise one is
+    // created — the same semantics as magic-link sign-in.
+    const existing = await getUserByEmail(c.env.DB, googleEmail, logger);
+    if (existing.success) {
+      if (existing.data.disabledAt || existing.data.deletingAt) {
+        logger.warn("Blocked Google sign-in — account disabled", { userId: existing.data.id });
+        return c.redirect("/auth/login?error=account_disabled");
+      }
+      userId = existing.data.id;
+    } else {
+      // Closed beta: OAuth is login-only — new accounts require an invite code.
+      if (betaGateEnabled(c.env)) {
+        logger.warn("Blocked Google signup — closed beta");
+        return c.redirect("/auth/signup?error=invite_required");
+      }
+      const createdResult = await createUser(c.env.DB, googleEmail, logger);
+      if (createdResult.success) {
+        userId = createdResult.data.user.id;
+      } else {
+        // Two concurrent first logins race on users.email UNIQUE; the loser's
+        // account exists now — sign it in instead of surfacing a raw 500.
+        const raced = await getUserByEmail(c.env.DB, googleEmail, logger);
+        if (!raced.success || raced.data.disabledAt || raced.data.deletingAt) {
+          logger.error("Failed to create user from Google sign-in", createdResult.error);
+          return c.json({ error: "Failed to create user" }, 500);
+        }
+        userId = raced.data.id;
+      }
     }
-    userId = createdResult.data.user.id;
   }
+
+  await recordOAuthIdentity(c.env.DB, logger.child({ userId }), {
+    userId,
+    provider: "google",
+    issuer: GOOGLE_ISSUER,
+    subject: googleUser.sub,
+    email: identityEmail,
+  });
 
   const sessionLogger = logger.child({ userId });
   const sessionResult = await createSession(c.env.DB, userId, sessionLogger);

--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -382,12 +382,15 @@ app.post("/send-login", async (c) => {
   }
 
   try {
-    // A disabled account gets the same enumeration-safe `login_link_sent`
-    // response as an unknown one, but no mail: a link would only lead to a
-    // hard `account_disabled` rejection at verify time, and refusing loudly
-    // here would leak which addresses have (disabled) accounts.
-    if (existingUser.success && existingUser.data.disabledAt) {
-      logger.info("Login requested for disabled account; skipping send", { emailHash });
+    // A disabled or deleting account gets the same enumeration-safe
+    // `login_link_sent` response as an unknown one, but no mail: a link would
+    // only lead to a hard `account_disabled` rejection at verify time, and
+    // refusing loudly here would leak which addresses have (disabled or
+    // mid-erasure) accounts.
+    if (existingUser.success && (existingUser.data.disabledAt || existingUser.data.deletingAt)) {
+      logger.info("Login requested for disabled or deleting account; skipping send", {
+        emailHash,
+      });
       return emailAuthRedirect(c, "success", "login_link_sent", "/auth/login");
     }
 
@@ -481,10 +484,13 @@ app.post("/send", async (c) => {
     // Check if user exists to determine intent
     const existingUser = await getUserByEmail(c.env.DB, email, logger);
 
-    // Same silent refusal as /send-login: a disabled account gets the uniform
-    // success response but no mail (a link could only fail at verify time).
-    if (existingUser.success && existingUser.data.disabledAt) {
-      logger.info("Legacy magic link requested for disabled account; skipping send", { emailHash });
+    // Same silent refusal as /send-login: a disabled or deleting account gets
+    // the uniform success response but no mail (a link could only fail at
+    // verify time).
+    if (existingUser.success && (existingUser.data.disabledAt || existingUser.data.deletingAt)) {
+      logger.info("Legacy magic link requested for disabled or deleting account; skipping send", {
+        emailHash,
+      });
       return emailAuthRedirect(c, "success", "email_sent");
     }
 

--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -382,6 +382,15 @@ app.post("/send-login", async (c) => {
   }
 
   try {
+    // A disabled account gets the same enumeration-safe `login_link_sent`
+    // response as an unknown one, but no mail: a link would only lead to a
+    // hard `account_disabled` rejection at verify time, and refusing loudly
+    // here would leak which addresses have (disabled) accounts.
+    if (existingUser.success && existingUser.data.disabledAt) {
+      logger.info("Login requested for disabled account; skipping send", { emailHash });
+      return emailAuthRedirect(c, "success", "login_link_sent", "/auth/login");
+    }
+
     if (existingUser.success) {
       // Generate secure magic link token
       const token = generateSecureToken();
@@ -471,6 +480,14 @@ app.post("/send", async (c) => {
   try {
     // Check if user exists to determine intent
     const existingUser = await getUserByEmail(c.env.DB, email, logger);
+
+    // Same silent refusal as /send-login: a disabled account gets the uniform
+    // success response but no mail (a link could only fail at verify time).
+    if (existingUser.success && existingUser.data.disabledAt) {
+      logger.info("Legacy magic link requested for disabled account; skipping send", { emailHash });
+      return emailAuthRedirect(c, "success", "email_sent");
+    }
+
     const intent = existingUser.success ? "login" : "signup";
     let username: string | undefined;
     if (!existingUser.success) {
@@ -615,7 +632,12 @@ app.post("/verify", async (c) => {
       const existingUserByEmail = await getUserByEmail(c.env.DB, email, logger);
       if (existingUserByEmail.success) {
         logger.warn("Email already exists during signup verification", { emailHash });
-        // User already exists, treat as login
+        // User already exists, treat as login — which a disabled (or deleting)
+        // account must not slip through (no session mint, no audit row).
+        if (existingUserByEmail.data.disabledAt || existingUserByEmail.data.deletingAt) {
+          logger.warn("Rejected signup-as-login for disabled account", { emailHash });
+          return emailAuthRedirect(c, "error", "account_disabled", "/auth/login");
+        }
         const userId = existingUserByEmail.data.id;
         return await createSessionAndRedirect(c, userId, emailHash, rememberMe, logger);
       }
@@ -665,6 +687,18 @@ app.post("/verify", async (c) => {
       if (!existingUser.success) {
         logger.warn("Email not found during login verification", { emailHash });
         return emailAuthRedirect(c, "error", "email_not_found", "/auth/login");
+      }
+
+      // A disabled (or deleting) account is hard-rejected here, BEFORE any
+      // session mint — send-login is enumeration-safe, so this is where the
+      // clear refusal lands (e.g. a link minted before the account was
+      // disabled).
+      if (existingUser.data.disabledAt || existingUser.data.deletingAt) {
+        logger.warn("Rejected login for disabled account", {
+          emailHash,
+          userId: existingUser.data.id,
+        });
+        return emailAuthRedirect(c, "error", "account_disabled", "/auth/login");
       }
 
       const userId = existingUser.data.id;

--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -1,6 +1,6 @@
 import type { Context } from "hono";
 import { Hono } from "hono";
-import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { setCookie } from "hono/cookie";
 import { admitUser, betaGateEnabled, validateInviteCode } from "../beta/gate";
 import { getInviteCodesEmail, getMagicLinkEmail } from "../email/templates";
 import { enforceSameOrigin } from "../middleware/csrf";
@@ -800,23 +800,7 @@ async function createSessionAndRedirect(
 
   sessionLogger.info("Session created, redirecting user");
 
-  // Validate redirect to prevent open redirects - only allow same-origin relative paths
-  const rawRedirect = getCookie(c, "redirect_after_login") ?? "";
-  let redirectTo = defaultRedirect;
-  try {
-    const candidate = new URL(rawRedirect, new URL(c.req.url).origin);
-    if (
-      candidate.origin === new URL(c.req.url).origin &&
-      /^\/[^/\\]/.test(rawRedirect) // disallow //, /\, etc.
-    ) {
-      redirectTo = candidate.pathname + candidate.search + candidate.hash;
-    }
-  } catch {
-    // ignore, use defaultRedirect
-  }
-  deleteCookie(c, "redirect_after_login", { path: "/" });
-
-  return c.redirect(redirectTo);
+  return c.redirect(defaultRedirect);
 }
 
 export { app as emailAuthRouter };

--- a/src/routes/git-http.ts
+++ b/src/routes/git-http.ts
@@ -164,20 +164,21 @@ async function authenticate(
 
   if (token.startsWith("stratum_user_")) {
     const result = await getUserByToken(c.env.DB, token, logger);
-    // A soft-deleting account's credentials stop working immediately over git
-    // too — the HTTP middleware rejects it, but git smart-HTTP owns its own auth
-    // and must apply the same gate, or an erasure-requested user keeps clone/push
-    // access until the cascade lands.
-    if (!result.success || result.data.deletingAt) return null;
+    // A soft-deleting or disabled account's credentials stop working
+    // immediately over git too — the HTTP middleware rejects them, but git
+    // smart-HTTP owns its own auth and must apply the same gate, or a
+    // deprovisioned user keeps clone/push access to private code.
+    if (!result.success || result.data.deletingAt || result.data.disabledAt) return null;
     return { userId: result.data.id };
   }
   const result = await getAgentByToken(c.env.DB, token, logger);
   if (!result.success) return null;
-  // An agent inherits its owner's access, so a deleting owner's agent must stop
-  // working too — otherwise it's an authenticated git write channel that outlives
-  // the account it belongs to. Fail CLOSED on the owner lookup: an unresolved or
-  // deleting owner yields no identity. getUser can reject on a D1 error, which
-  // would otherwise escape authenticate's documented no-500 contract, so catch it.
+  // An agent inherits its owner's access, so a deleting or disabled owner's
+  // agent must stop working too — otherwise it's an authenticated git write
+  // channel that outlives the account's access. Fail CLOSED on the owner
+  // lookup: an unresolved, deleting, or disabled owner yields no identity.
+  // getUser can reject on a D1 error, which would otherwise escape
+  // authenticate's documented no-500 contract, so catch it.
   let owner: Awaited<ReturnType<typeof getUser>>;
   try {
     owner = await getUser(c.env.DB, result.data.ownerId, logger);
@@ -188,7 +189,7 @@ async function authenticate(
     });
     return null;
   }
-  if (!owner.success || owner.data.deletingAt) return null;
+  if (!owner.success || owner.data.deletingAt || owner.data.disabledAt) return null;
   return { agentId: result.data.id, agentOwnerId: result.data.ownerId };
 }
 

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -470,6 +470,10 @@ app.get("/", (c) => {
                   Continue with Google
                 </a>
 
+                <a href="/auth/sso" class="btn btn-github" style={{ marginTop: "0.5rem" }}>
+                  Single sign-on (SSO)
+                </a>
+
                 <div class="auth-footer">
                   <p class="auth-footer-text">
                     Don't have an account? <a href="/auth/signup">Sign up</a>

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -16,6 +16,10 @@ const ERROR_MESSAGES: Record<string, string> = {
     "Email authentication is not fully configured. Please contact the administrator.",
   send_failed: "Failed to send email. Please try again later.",
   rate_limited: "Too many requests. Please try again in an hour.",
+  // Every login flow (magic link, GitHub, Google) refuses a disabled account
+  // with this code before minting a session.
+  account_disabled:
+    "This account has been disabled. Contact your organization's administrator to restore access.",
 };
 
 const SUCCESS_MESSAGES: Record<string, string> = {

--- a/src/routes/org-sso.ts
+++ b/src/routes/org-sso.ts
@@ -1,0 +1,448 @@
+import { type Context, Hono } from "hono";
+import {
+  checkDomainTxtRecord,
+  verificationRecordName,
+  verificationTxtValue,
+} from "../services/domain-verification";
+import { discoverOidcConfiguration } from "../services/oidc-discovery";
+import { recordAudit } from "../storage/audit";
+import { type Org, getOrgBySlug, isOrgAdmin, isOrgMember } from "../storage/orgs";
+import {
+  type SsoConnection,
+  deleteSsoConnection,
+  findVerifiedDomainConflicts,
+  getSsoConnectionByOrgId,
+  listDeactivatedScimUserIds,
+  normalizeEmailDomains,
+  rotateScimToken,
+  setSsoConnectionEnabled,
+  setSsoDomainsVerified,
+  upsertSsoConnection,
+} from "../storage/sso";
+import { enableUser } from "../storage/users";
+import type { Env } from "../types";
+import { SSO_SECRET_SALT, encryptToken } from "../utils/crypto";
+import { ConflictError, ValidationError } from "../utils/errors";
+import { type Logger, createLogger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
+import { appError, badRequest, forbidden, notFound, ok } from "../utils/response";
+
+/**
+ * Org SSO admin API (#253 Task 4), mounted under /api/orgs/:slug/sso behind
+ * authMiddleware. Every endpoint is gated on org admin (role 'admin' OR the
+ * orgs.owner_id column — no code path ever writes an 'owner' role, and the
+ * owner's member row may have been removed). The client secret is accepted in
+ * request bodies only and never echoed; the SCIM token plaintext is shown
+ * exactly once at rotation.
+ */
+
+const app = new Hono<{ Bindings: Env }>();
+
+// Config bodies are a handful of short strings plus a small domain list.
+const MAX_SSO_BODY_BYTES = 64 * 1024;
+
+interface OrgAdminContext {
+  org: Org;
+  userId: string;
+  logger: Logger;
+}
+
+type SsoHandlerContext = Context<{ Bindings: Env }>;
+
+/**
+ * Shared gate: 501 without SSO_ENCRYPTION_SECRET, then org-admin authz.
+ * Non-members get the same 404 as a missing org (no existence leak);
+ * members without admin get 403.
+ */
+async function requireOrgAdmin(c: SsoHandlerContext): Promise<OrgAdminContext | Response> {
+  if (!c.env.SSO_ENCRYPTION_SECRET) {
+    return c.json({ error: "SSO is not configured on this server" }, 501);
+  }
+
+  const userId = c.get("userId");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const slug = c.req.param("slug") ?? "";
+  const logger = createLogger({ path: c.req.path, userId, slug });
+
+  const orgResult = await getOrgBySlug(c.env.DB, logger, slug);
+  if (!orgResult.success) {
+    logger.warn("Org not found for SSO admin request", { slug });
+    return notFound("Org", slug);
+  }
+  const org = orgResult.data;
+
+  const adminResult = await isOrgAdmin(c.env.DB, logger, org.id, userId);
+  const isAdmin = (adminResult.success && adminResult.data) || org.ownerId === userId;
+  if (!isAdmin) {
+    const memberResult = await isOrgMember(c.env.DB, logger, org.id, userId);
+    if (memberResult.success && memberResult.data) {
+      logger.warn("Non-admin member denied SSO admin access", { orgId: org.id, userId });
+      return forbidden("Forbidden");
+    }
+    // Fail closed: non-members and membership-lookup errors both get the
+    // missing-org 404.
+    logger.debug("SSO admin access denied (non-member or lookup failure)", { orgId: org.id });
+    return notFound("Org", slug);
+  }
+
+  return { org, userId, logger };
+}
+
+/** Admin-facing view: everything except the secret ciphertext and SCIM hash. */
+function redactConnection(connection: SsoConnection) {
+  return {
+    id: connection.id,
+    orgId: connection.orgId,
+    protocol: connection.protocol,
+    issuer: connection.issuer,
+    clientId: connection.clientId,
+    authorizationEndpoint: connection.authorizationEndpoint,
+    tokenEndpoint: connection.tokenEndpoint,
+    jwksUri: connection.jwksUri,
+    emailDomains: connection.emailDomains,
+    domainsVerifiedAt: connection.domainsVerifiedAt,
+    enabled: connection.enabled,
+    scimTokenSet: connection.scimTokenHash !== null,
+    createdAt: connection.createdAt,
+    updatedAt: connection.updatedAt,
+  };
+}
+
+/** The DNS records an admin must publish, retrievable any time before verification. */
+function domainVerificationInfo(connection: SsoConnection) {
+  const token = connection.domainVerificationToken;
+  if (!token) return null;
+  return {
+    token,
+    records: connection.emailDomains.map((domain) => ({
+      domain,
+      name: verificationRecordName(domain),
+      type: "TXT" as const,
+      value: verificationTxtValue(token),
+    })),
+    instructions:
+      "Publish each TXT record at the name shown, then call POST /verify-domains. " +
+      "All listed domains must verify before the connection can be enabled.",
+  };
+}
+
+app.put("/:slug/sso", async (c) => {
+  const ctx = await requireOrgAdmin(c);
+  if (ctx instanceof Response) return ctx;
+  const { org, userId, logger } = ctx;
+
+  let body: {
+    issuer?: unknown;
+    clientId?: unknown;
+    clientSecret?: unknown;
+    emailDomains?: unknown;
+  };
+  // Malformed JSON must be a 400, not a rethrow into the global 500 handler;
+  // the empty-object fallback fails the required-field checks below.
+  const parsed = await readJsonWithLimit<typeof body>(c, MAX_SSO_BODY_BYTES, logger).catch(
+    () => ({}),
+  );
+  if (parsed instanceof Response) return parsed;
+  body = parsed;
+
+  if (typeof body.issuer !== "string" || !body.issuer.trim()) {
+    return badRequest("issuer is required");
+  }
+  if (typeof body.clientId !== "string" || !body.clientId.trim()) {
+    return badRequest("clientId is required");
+  }
+  if (typeof body.clientSecret !== "string" || !body.clientSecret) {
+    return badRequest("clientSecret is required");
+  }
+  if (!Array.isArray(body.emailDomains) || !body.emailDomains.every((d) => typeof d === "string")) {
+    return badRequest("emailDomains must be an array of strings");
+  }
+
+  const domainsResult = normalizeEmailDomains(body.emailDomains);
+  if (!domainsResult.success) return appError(domainsResult.error);
+  const emailDomains = domainsResult.data;
+
+  const issuer = body.issuer.trim();
+  const discoveryResult = await discoverOidcConfiguration(issuer, logger);
+  if (!discoveryResult.success) return appError(discoveryResult.error);
+  const endpoints = discoveryResult.data;
+
+  // c.env.SSO_ENCRYPTION_SECRET is set — requireOrgAdmin 501s otherwise.
+  const secret = c.env.SSO_ENCRYPTION_SECRET as string;
+  const ciphertext = await encryptToken(body.clientSecret, secret, SSO_SECRET_SALT);
+
+  const upsertResult = await upsertSsoConnection(c.env.DB, logger, {
+    orgId: org.id,
+    issuer,
+    clientId: body.clientId.trim(),
+    clientSecretCiphertext: ciphertext,
+    authorizationEndpoint: endpoints.authorizationEndpoint,
+    tokenEndpoint: endpoints.tokenEndpoint,
+    jwksUri: endpoints.jwksUri,
+    emailDomains,
+  });
+  if (!upsertResult.success) return appError(upsertResult.error);
+  const { connection, created } = upsertResult.data;
+
+  await recordAudit(c.env.DB, logger, {
+    action: created ? "sso.connection.created" : "sso.connection.updated",
+    actorType: "user",
+    actorId: userId,
+    subject: org.id,
+    detail: { connectionId: connection.id, issuer, emailDomains },
+  });
+
+  return ok(
+    {
+      connection: redactConnection(connection),
+      domainVerification: domainVerificationInfo(connection),
+    },
+    created ? 201 : 200,
+  );
+});
+
+app.get("/:slug/sso", async (c) => {
+  const ctx = await requireOrgAdmin(c);
+  if (ctx instanceof Response) return ctx;
+  const { org, logger } = ctx;
+
+  const connectionResult = await getSsoConnectionByOrgId(c.env.DB, logger, org.id);
+  if (!connectionResult.success) return appError(connectionResult.error);
+  const connection = connectionResult.data;
+
+  return ok({
+    connection: redactConnection(connection),
+    domainVerification: domainVerificationInfo(connection),
+  });
+});
+
+app.delete("/:slug/sso", async (c) => {
+  const ctx = await requireOrgAdmin(c);
+  if (ctx instanceof Response) return ctx;
+  const { org, userId, logger } = ctx;
+
+  const connectionResult = await getSsoConnectionByOrgId(c.env.DB, logger, org.id);
+  if (!connectionResult.success) return appError(connectionResult.error);
+  const connection = connectionResult.data;
+
+  // Deleting a connection is a clean rollback, never a permanent lockout:
+  // users this connection deactivated via SCIM get their accounts back first.
+  const deactivatedResult = await listDeactivatedScimUserIds(c.env.DB, logger, connection.id);
+  if (!deactivatedResult.success) return appError(deactivatedResult.error);
+
+  const reenabledUserIds: string[] = [];
+  for (const targetUserId of deactivatedResult.data) {
+    const enableResult = await enableUser(c.env.DB, targetUserId, logger);
+    if (!enableResult.success) {
+      logger.error(
+        "Failed to re-enable SCIM-disabled user during connection deletion",
+        enableResult.error,
+        { connectionId: connection.id, targetUserId },
+      );
+      return appError(enableResult.error);
+    }
+    reenabledUserIds.push(targetUserId);
+    await recordAudit(c.env.DB, logger, {
+      action: "user.enabled",
+      actorType: "user",
+      actorId: userId,
+      subject: targetUserId,
+      detail: { via: "sso.connection.deleted", connectionId: connection.id },
+    });
+  }
+
+  const deleteResult = await deleteSsoConnection(c.env.DB, logger, connection.id);
+  if (!deleteResult.success) return appError(deleteResult.error);
+
+  await recordAudit(c.env.DB, logger, {
+    action: "sso.connection.deleted",
+    actorType: "user",
+    actorId: userId,
+    subject: org.id,
+    detail: { connectionId: connection.id, reenabledUserIds },
+  });
+
+  return ok({ deleted: true, reenabledUserIds });
+});
+
+app.post("/:slug/sso/verify-domains", async (c) => {
+  const ctx = await requireOrgAdmin(c);
+  if (ctx instanceof Response) return ctx;
+  const { org, userId, logger } = ctx;
+
+  const connectionResult = await getSsoConnectionByOrgId(c.env.DB, logger, org.id);
+  if (!connectionResult.success) return appError(connectionResult.error);
+  const connection = connectionResult.data;
+
+  if (!connection.domainVerificationToken) {
+    return appError(new ValidationError("Connection has no domain verification token"));
+  }
+
+  // A malformed stored email_domains list parses to [] — the DoH loop below
+  // would then be vacuous and stamp a verification that checked nothing.
+  if (connection.emailDomains.length === 0) {
+    return appError(new ValidationError("Connection has no email domains to verify"));
+  }
+
+  // Verified domains are globally unique across connections. Two connections
+  // concurrently verifying the same domain can both pass this check and both
+  // stamp, after which both 409 at enable time — bounded (it requires both
+  // orgs to control the domain's DNS, effectively impossible) and accepted;
+  // recovery is editing one connection's domain list, which clears its
+  // verification.
+  const conflictsResult = await findVerifiedDomainConflicts(
+    c.env.DB,
+    logger,
+    connection.emailDomains,
+    connection.id,
+  );
+  if (!conflictsResult.success) return appError(conflictsResult.error);
+  if (conflictsResult.data.length > 0) {
+    return appError(
+      new ConflictError(
+        `Domains already verified by another connection: ${conflictsResult.data.join(", ")}`,
+      ),
+    );
+  }
+
+  const failedDomains: string[] = [];
+  for (const domain of connection.emailDomains) {
+    const checkResult = await checkDomainTxtRecord(
+      domain,
+      connection.domainVerificationToken,
+      logger,
+    );
+    if (!checkResult.success) return appError(checkResult.error);
+    if (!checkResult.data) failedDomains.push(domain);
+  }
+  if (failedDomains.length > 0) {
+    return c.json(
+      {
+        error: "Domain verification failed: TXT record missing or incorrect",
+        code: "DOMAIN_VERIFICATION_FAILED",
+        failedDomains,
+      },
+      400,
+    );
+  }
+
+  // Stamp conditionally on the exact list the DoH checks ran against; a
+  // concurrent PUT that edited the domains mid-verification surfaces as a 409.
+  const verifyResult = await setSsoDomainsVerified(
+    c.env.DB,
+    logger,
+    connection.id,
+    connection.emailDomains,
+  );
+  if (!verifyResult.success) return appError(verifyResult.error);
+
+  await recordAudit(c.env.DB, logger, {
+    action: "sso.domain.verified",
+    actorType: "user",
+    actorId: userId,
+    subject: org.id,
+    detail: { connectionId: connection.id, domains: connection.emailDomains },
+  });
+
+  return ok({
+    verified: true,
+    domains: connection.emailDomains,
+    domainsVerifiedAt: verifyResult.data,
+  });
+});
+
+app.post("/:slug/sso/enable", async (c) => {
+  const ctx = await requireOrgAdmin(c);
+  if (ctx instanceof Response) return ctx;
+  const { org, userId, logger } = ctx;
+
+  const connectionResult = await getSsoConnectionByOrgId(c.env.DB, logger, org.id);
+  if (!connectionResult.success) return appError(connectionResult.error);
+  const connection = connectionResult.data;
+
+  if (!connection.domainsVerifiedAt) {
+    return appError(
+      new ValidationError("Connection cannot be enabled until its domains are verified"),
+    );
+  }
+
+  // Re-check global uniqueness at enable time: a competing connection may
+  // have verified an overlapping domain since this one verified.
+  const conflictsResult = await findVerifiedDomainConflicts(
+    c.env.DB,
+    logger,
+    connection.emailDomains,
+    connection.id,
+  );
+  if (!conflictsResult.success) return appError(conflictsResult.error);
+  if (conflictsResult.data.length > 0) {
+    return appError(
+      new ConflictError(
+        `Domains already verified by another connection: ${conflictsResult.data.join(", ")}`,
+      ),
+    );
+  }
+
+  const enableResult = await setSsoConnectionEnabled(c.env.DB, logger, connection.id, true);
+  if (!enableResult.success) return appError(enableResult.error);
+
+  await recordAudit(c.env.DB, logger, {
+    action: "sso.connection.updated",
+    actorType: "user",
+    actorId: userId,
+    subject: org.id,
+    detail: { connectionId: connection.id, enabled: true },
+  });
+
+  return ok({ enabled: true });
+});
+
+app.post("/:slug/sso/disable", async (c) => {
+  const ctx = await requireOrgAdmin(c);
+  if (ctx instanceof Response) return ctx;
+  const { org, userId, logger } = ctx;
+
+  const connectionResult = await getSsoConnectionByOrgId(c.env.DB, logger, org.id);
+  if (!connectionResult.success) return appError(connectionResult.error);
+  const connection = connectionResult.data;
+
+  const disableResult = await setSsoConnectionEnabled(c.env.DB, logger, connection.id, false);
+  if (!disableResult.success) return appError(disableResult.error);
+
+  await recordAudit(c.env.DB, logger, {
+    action: "sso.connection.updated",
+    actorType: "user",
+    actorId: userId,
+    subject: org.id,
+    detail: { connectionId: connection.id, enabled: false },
+  });
+
+  return ok({ enabled: false });
+});
+
+app.post("/:slug/sso/scim-token", async (c) => {
+  const ctx = await requireOrgAdmin(c);
+  if (ctx instanceof Response) return ctx;
+  const { org, userId, logger } = ctx;
+
+  const connectionResult = await getSsoConnectionByOrgId(c.env.DB, logger, org.id);
+  if (!connectionResult.success) return appError(connectionResult.error);
+  const connection = connectionResult.data;
+
+  const rotateResult = await rotateScimToken(c.env.DB, logger, connection.id);
+  if (!rotateResult.success) return appError(rotateResult.error);
+
+  await recordAudit(c.env.DB, logger, {
+    action: "sso.scim_token.rotated",
+    actorType: "user",
+    actorId: userId,
+    subject: org.id,
+    detail: { connectionId: connection.id },
+  });
+
+  // Plaintext is returned exactly once; only the hash is stored.
+  return ok({ scimToken: rotateResult.data });
+});
+
+export { app as orgSsoRouter };

--- a/src/routes/org-sso.ts
+++ b/src/routes/org-sso.ts
@@ -12,14 +12,13 @@ import {
   deleteSsoConnection,
   findVerifiedDomainConflicts,
   getSsoConnectionByOrgId,
-  listDeactivatedScimUserIds,
   normalizeEmailDomains,
+  reenableUsersForConnectionRemoval,
   rotateScimToken,
   setSsoConnectionEnabled,
   setSsoDomainsVerified,
   upsertSsoConnection,
 } from "../storage/sso";
-import { enableUser } from "../storage/users";
 import type { Env } from "../types";
 import { SSO_SECRET_SALT, encryptToken } from "../utils/crypto";
 import { ConflictError, ValidationError } from "../utils/errors";
@@ -163,10 +162,12 @@ app.put("/:slug/sso", async (c) => {
   if (!domainsResult.success) return appError(domainsResult.error);
   const emailDomains = domainsResult.data;
 
-  const issuer = body.issuer.trim();
-  const discoveryResult = await discoverOidcConfiguration(issuer, logger);
+  const discoveryResult = await discoverOidcConfiguration(body.issuer.trim(), logger);
   if (!discoveryResult.success) return appError(discoveryResult.error);
   const endpoints = discoveryResult.data;
+  // Store the discovery module's canonical (trailing-slash-normalized) issuer,
+  // not the admin's raw input, so id_token `iss` comparisons stay exact.
+  const issuer = endpoints.issuer;
 
   // c.env.SSO_ENCRYPTION_SECRET is set — requireOrgAdmin 501s otherwise.
   const secret = c.env.SSO_ENCRYPTION_SECRET as string;
@@ -228,29 +229,10 @@ app.delete("/:slug/sso", async (c) => {
 
   // Deleting a connection is a clean rollback, never a permanent lockout:
   // users this connection deactivated via SCIM get their accounts back first.
-  const deactivatedResult = await listDeactivatedScimUserIds(c.env.DB, logger, connection.id);
-  if (!deactivatedResult.success) return appError(deactivatedResult.error);
-
-  const reenabledUserIds: string[] = [];
-  for (const targetUserId of deactivatedResult.data) {
-    const enableResult = await enableUser(c.env.DB, targetUserId, logger);
-    if (!enableResult.success) {
-      logger.error(
-        "Failed to re-enable SCIM-disabled user during connection deletion",
-        enableResult.error,
-        { connectionId: connection.id, targetUserId },
-      );
-      return appError(enableResult.error);
-    }
-    reenabledUserIds.push(targetUserId);
-    await recordAudit(c.env.DB, logger, {
-      action: "user.enabled",
-      actorType: "user",
-      actorId: userId,
-      subject: targetUserId,
-      detail: { via: "sso.connection.deleted", connectionId: connection.id },
-    });
-  }
+  // Set-based; the storage helper carries the cross-connection vote guard.
+  const reenableResult = await reenableUsersForConnectionRemoval(c.env.DB, logger, connection.id);
+  if (!reenableResult.success) return appError(reenableResult.error);
+  const reenabledUserIds = reenableResult.data;
 
   const deleteResult = await deleteSsoConnection(c.env.DB, logger, connection.id);
   if (!deleteResult.success) return appError(deleteResult.error);

--- a/src/routes/scim.ts
+++ b/src/routes/scim.ts
@@ -1,0 +1,757 @@
+import { type Context, Hono } from "hono";
+import { deriveUsernameBase, findAvailableUsername } from "../services/sso-usernames";
+import { recordAudit } from "../storage/audit";
+import { ensureOrgMember } from "../storage/orgs";
+import {
+  type ScimScopedUser,
+  type SsoConnection,
+  deprovisionUser,
+  ensureScimMember,
+  getScimMember,
+  getScimScopedUser,
+  getSsoConnectionById,
+  listScimScopedUsers,
+  reactivateUser,
+  setScimMemberExternalId,
+} from "../storage/sso";
+import { createUser, getUserByEmail } from "../storage/users";
+import type { Env } from "../types";
+import { type Logger, createLogger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
+
+/**
+ * SCIM 2.0 Users endpoints (#253 Task 6), mounted at /scim/v2. Auth is a
+ * `stratum_scim_*` bearer resolved by authMiddleware to a scimConnectionId —
+ * every handler here FAILS CLOSED unless that var is set: a session cookie or
+ * user/agent bearer is never honored on this surface, because SCIM writes are
+ * org-lifecycle operations authorized by the connection's token alone.
+ *
+ * Deviations from RFC 7644, chosen for real IdP behavior (Okta/Entra):
+ * - DELETE deactivates instead of erasing; a later GET returns the resource
+ *   with active:false. (Okta's lifecycle uses PATCH active:false; a DELETE
+ *   that destroyed data would make an IdP misconfiguration unrecoverable.)
+ * - PATCH ignores replaces of attributes we don't store (displayName, name.*,
+ *   enterprise-extension paths, ...) instead of erroring: Okta and Entra send
+ *   them on every profile sync, and a 4xx would mark the whole user as failed.
+ *   Only structurally invalid operations (non-replace ops, malformed values)
+ *   are rejected.
+ */
+
+const app = new Hono<{ Bindings: Env }>();
+
+const USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+const LIST_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
+const ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";
+const SCIM_CONTENT_TYPE = "application/scim+json";
+// SCIM payloads are one user each; Entra's PATCH envelopes are the largest.
+const MAX_SCIM_BODY_BYTES = 256 * 1024;
+const DEFAULT_PAGE_COUNT = 100;
+const MAX_PAGE_COUNT = 200;
+
+type ScimContext = Context<{ Bindings: Env }>;
+
+function scimJson(body: Record<string, unknown>, status = 200): Response {
+  // The explicit Content-Type in init survives Response.json's default.
+  return Response.json(body, {
+    status,
+    headers: { "Content-Type": SCIM_CONTENT_TYPE },
+  });
+}
+
+function scimError(status: number, detail: string, scimType?: string): Response {
+  const body: Record<string, unknown> = {
+    schemas: [ERROR_SCHEMA],
+    status: String(status),
+    detail,
+  };
+  if (scimType) body.scimType = scimType;
+  return scimJson(body, status);
+}
+
+interface ScimRequestContext {
+  connection: SsoConnection;
+  logger: Logger;
+}
+
+/**
+ * Fail-closed gate + connection load. The connection row is re-read per
+ * request (authMiddleware stores only ids) — a connection deleted or disabled
+ * mid-flight 401s rather than operating on stale scope.
+ */
+async function requireScimConnection(c: ScimContext): Promise<ScimRequestContext | Response> {
+  const connectionId = c.get("scimConnectionId");
+  if (!connectionId) {
+    return scimError(401, "SCIM requests must authenticate with a SCIM bearer token");
+  }
+  const logger = createLogger({
+    path: c.req.path,
+    method: c.req.method,
+    connectionId,
+  });
+  const connectionResult = await getSsoConnectionById(c.env.DB, logger, connectionId);
+  if (
+    !connectionResult.success ||
+    !connectionResult.data.enabled ||
+    connectionResult.data.domainsVerifiedAt === null
+  ) {
+    logger.warn("SCIM connection no longer usable");
+    return scimError(401, "SCIM connection is no longer available");
+  }
+  return { connection: connectionResult.data, logger };
+}
+
+function userLocation(c: ScimContext, userId: string): string {
+  return `${new URL(c.req.url).origin}/scim/v2/Users/${userId}`;
+}
+
+/** `active` reflects users.disabled_at — the enforced truth — not the IdP's last write. */
+function userResource(c: ScimContext, user: ScimScopedUser): Record<string, unknown> {
+  const resource: Record<string, unknown> = {
+    schemas: [USER_SCHEMA],
+    id: user.userId,
+    userName: user.email,
+    active: user.disabledAt === null,
+    name: { formatted: user.username },
+    emails: [{ value: user.email, primary: true }],
+    meta: {
+      resourceType: "User",
+      created: user.createdAt,
+      location: userLocation(c, user.userId),
+    },
+  };
+  if (user.externalId !== null) resource.externalId = user.externalId;
+  return resource;
+}
+
+async function readScimBody(
+  c: ScimContext,
+  logger: Logger,
+): Promise<Record<string, unknown> | Response> {
+  const body = await readJsonWithLimit<unknown>(c, MAX_SCIM_BODY_BYTES, logger).catch(() => null);
+  if (body instanceof Response) {
+    // readJsonWithLimit's 413 is the repo's plain {error, code} shape; this
+    // surface answers in the SCIM Error schema.
+    if (body.status === 413) return scimError(413, "Request body too large");
+    return body;
+  }
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return scimError(400, "Request body must be a JSON object", "invalidSyntax");
+  }
+  return body as Record<string, unknown>;
+}
+
+/**
+ * Coerce a SCIM `active` value. Entra sends string booleans ("True"/"False");
+ * Okta sends real booleans. Returns undefined for anything else so the caller
+ * can 400 with invalidValue.
+ */
+function coerceActive(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true") return true;
+    if (normalized === "false") return false;
+  }
+  return undefined;
+}
+
+// Exactly the two filter forms Okta/Entra send during provisioning:
+// `userName eq "value"` / `externalId eq "value"` (attribute and operator
+// case-insensitive, value double-quoted). Anything else is unsupported.
+const FILTER_PATTERN = /^\s*(userName|externalId)\s+eq\s+"([^"]*)"\s*$/i;
+
+function parseFilter(raw: string): { attribute: "username" | "externalid"; value: string } | null {
+  const match = FILTER_PATTERN.exec(raw);
+  if (!match) return null;
+  return {
+    attribute: (match[1] ?? "").toLowerCase() as "username" | "externalid",
+    value: match[2] ?? "",
+  };
+}
+
+function parsePositiveInt(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Apply an `active` transition through the enforced lifecycle. The skip is
+ * PER-DIRECTION: a transition is skipped only when the desired direction is
+ * already FULLY applied (deactivate: disabled AND this connection's vote is
+ * active=0; activate: enabled AND this connection's vote is not active=0) —
+ * so an idempotent full-sync PUT/PATCH doesn't re-run (and re-audit) a
+ * completed transition, while a half-applied drift state (e.g. a partial
+ * deprovision failure) or a missing deactivation vote on an account another
+ * connection disabled still triggers the transition that repairs it.
+ * Transitions themselves are idempotent, so over-calling is safe.
+ */
+async function applyActiveTransition(
+  db: D1Database,
+  logger: Logger,
+  connectionId: string,
+  user: ScimScopedUser,
+  desiredActive: boolean,
+): Promise<Response | null> {
+  const skip = desiredActive
+    ? user.disabledAt === null && user.scimActive !== false
+    : user.disabledAt !== null && user.scimActive === false;
+  if (skip) return null;
+  const result = desiredActive
+    ? await reactivateUser(db, logger, connectionId, user.userId)
+    : await deprovisionUser(db, logger, connectionId, user.userId);
+  if (!result.success) {
+    return scimError(500, desiredActive ? "Failed to activate user" : "Failed to deactivate user");
+  }
+  return null;
+}
+
+/** Set externalId (adopting the user into management if needed). */
+async function applyExternalId(
+  db: D1Database,
+  logger: Logger,
+  connectionId: string,
+  userId: string,
+  externalId: string | null,
+): Promise<Response | null> {
+  const ensureResult = await ensureScimMember(db, logger, connectionId, userId);
+  if (!ensureResult.success) return scimError(500, "Failed to update user");
+  const setResult = await setScimMemberExternalId(db, logger, connectionId, userId, externalId);
+  if (!setResult.success) {
+    if (setResult.error.code === "CONFLICT") {
+      return scimError(409, "externalId is already assigned to another user", "uniqueness");
+    }
+    return scimError(500, "Failed to update user");
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Discovery endpoints — static, but still auth-gated (they reveal nothing
+// secret; the gate is uniformity: NOTHING under /scim/v2 answers without the
+// connection's token).
+// ---------------------------------------------------------------------------
+
+app.get("/ServiceProviderConfig", async (c) => {
+  const ctx = await requireScimConnection(c);
+  if (ctx instanceof Response) return ctx;
+  const origin = new URL(c.req.url).origin;
+  return scimJson({
+    schemas: ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
+    documentationUri: `${origin}/docs`,
+    patch: { supported: true },
+    bulk: { supported: false, maxOperations: 0, maxPayloadSize: 0 },
+    filter: { supported: true, maxResults: MAX_PAGE_COUNT },
+    changePassword: { supported: false },
+    sort: { supported: false },
+    etag: { supported: false },
+    authenticationSchemes: [
+      {
+        type: "oauthbearertoken",
+        name: "OAuth Bearer Token",
+        description: "Authorization: Bearer <SCIM token issued by the org's Stratum admin>",
+        primary: true,
+      },
+    ],
+    meta: {
+      resourceType: "ServiceProviderConfig",
+      location: `${origin}/scim/v2/ServiceProviderConfig`,
+    },
+  });
+});
+
+app.get("/ResourceTypes", async (c) => {
+  const ctx = await requireScimConnection(c);
+  if (ctx instanceof Response) return ctx;
+  const origin = new URL(c.req.url).origin;
+  return scimJson({
+    schemas: [LIST_SCHEMA],
+    totalResults: 1,
+    startIndex: 1,
+    itemsPerPage: 1,
+    Resources: [
+      {
+        schemas: ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+        id: "User",
+        name: "User",
+        endpoint: "/Users",
+        description: "Stratum user account",
+        schema: USER_SCHEMA,
+        meta: { resourceType: "ResourceType", location: `${origin}/scim/v2/ResourceTypes/User` },
+      },
+    ],
+  });
+});
+
+app.get("/Schemas", async (c) => {
+  const ctx = await requireScimConnection(c);
+  if (ctx instanceof Response) return ctx;
+  const origin = new URL(c.req.url).origin;
+  return scimJson({
+    schemas: [LIST_SCHEMA],
+    totalResults: 1,
+    startIndex: 1,
+    itemsPerPage: 1,
+    Resources: [
+      {
+        id: USER_SCHEMA,
+        name: "User",
+        description: "Stratum user account",
+        attributes: [
+          {
+            name: "userName",
+            type: "string",
+            multiValued: false,
+            required: true,
+            caseExact: false,
+            mutability: "immutable",
+            returned: "default",
+            uniqueness: "server",
+            description: "The user's email address",
+          },
+          {
+            name: "active",
+            type: "boolean",
+            multiValued: false,
+            required: false,
+            mutability: "readWrite",
+            returned: "default",
+            description: "Whether the account's credentials work",
+          },
+          {
+            name: "name",
+            type: "complex",
+            multiValued: false,
+            required: false,
+            mutability: "readOnly",
+            returned: "default",
+            subAttributes: [
+              {
+                name: "formatted",
+                type: "string",
+                multiValued: false,
+                required: false,
+                mutability: "readOnly",
+                returned: "default",
+              },
+            ],
+          },
+          {
+            name: "emails",
+            type: "complex",
+            multiValued: true,
+            required: false,
+            mutability: "readOnly",
+            returned: "default",
+            subAttributes: [
+              {
+                name: "value",
+                type: "string",
+                multiValued: false,
+                required: false,
+                mutability: "readOnly",
+                returned: "default",
+              },
+              {
+                name: "primary",
+                type: "boolean",
+                multiValued: false,
+                required: false,
+                mutability: "readOnly",
+                returned: "default",
+              },
+            ],
+          },
+        ],
+        meta: {
+          resourceType: "Schema",
+          location: `${origin}/scim/v2/Schemas/${USER_SCHEMA}`,
+        },
+      },
+    ],
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Users
+// ---------------------------------------------------------------------------
+
+app.get("/Users", async (c) => {
+  const ctx = await requireScimConnection(c);
+  if (ctx instanceof Response) return ctx;
+  const { connection, logger } = ctx;
+
+  const listResult = await listScimScopedUsers(c.env.DB, logger, connection);
+  if (!listResult.success) return scimError(500, "Failed to list users");
+  let users = listResult.data;
+
+  const rawFilter = c.req.query("filter");
+  if (rawFilter !== undefined) {
+    const filter = parseFilter(rawFilter);
+    if (!filter) {
+      // RFC 7644 §3.4.2.2: an unsupported filter is 501, not an empty list —
+      // an empty 200 would make the IdP believe the user does not exist.
+      return scimError(501, "Only 'userName eq \"...\"' and 'externalId eq \"...\"' are supported");
+    }
+    users = users.filter((user) =>
+      filter.attribute === "username"
+        ? user.email === filter.value.trim().toLowerCase()
+        : user.externalId === filter.value,
+    );
+  }
+
+  const startIndex = Math.max(parsePositiveInt(c.req.query("startIndex")) ?? 1, 1);
+  // RFC 7644 §3.4.2.4: count=0 (and any negative value, treated as 0) returns
+  // totalResults with no Resources.
+  const count = Math.min(
+    Math.max(parsePositiveInt(c.req.query("count")) ?? DEFAULT_PAGE_COUNT, 0),
+    MAX_PAGE_COUNT,
+  );
+  const page = count === 0 ? [] : users.slice(startIndex - 1, startIndex - 1 + count);
+
+  return scimJson({
+    schemas: [LIST_SCHEMA],
+    totalResults: users.length,
+    startIndex,
+    itemsPerPage: page.length,
+    Resources: page.map((user) => userResource(c, user)),
+  });
+});
+
+app.get("/Users/:id", async (c) => {
+  const ctx = await requireScimConnection(c);
+  if (ctx instanceof Response) return ctx;
+  const { connection, logger } = ctx;
+
+  const userResult = await getScimScopedUser(c.env.DB, logger, connection, c.req.param("id"));
+  if (!userResult.success) {
+    if (userResult.error.code === "NOT_FOUND") return scimError(404, "User not found");
+    return scimError(500, "Failed to get user");
+  }
+  return scimJson(userResource(c, userResult.data));
+});
+
+app.post("/Users", async (c) => {
+  const ctx = await requireScimConnection(c);
+  if (ctx instanceof Response) return ctx;
+  const { connection, logger } = ctx;
+
+  const body = await readScimBody(c, logger);
+  if (body instanceof Response) return body;
+
+  const rawUserName = body.userName;
+  if (typeof rawUserName !== "string" || rawUserName.trim().length === 0) {
+    return scimError(400, "userName is required", "invalidValue");
+  }
+  const email = rawUserName.trim().toLowerCase();
+  const domain = email.includes("@") ? (email.split("@").pop() ?? "") : "";
+  if (!connection.emailDomains.includes(domain)) {
+    return scimError(
+      400,
+      "userName must be an email address within the connection's verified domains",
+      "invalidValue",
+    );
+  }
+
+  const externalId = typeof body.externalId === "string" ? body.externalId : undefined;
+  const active = body.active === undefined ? true : coerceActive(body.active);
+  if (active === undefined) {
+    return scimError(400, "active must be a boolean", "invalidValue");
+  }
+
+  const existing = await getUserByEmail(c.env.DB, email, logger);
+  let userId: string;
+  let adopted: boolean;
+  if (existing.success) {
+    // A soft-deleting account still owns the email; it cannot be adopted and
+    // the email cannot be reissued mid-erasure.
+    if (existing.data.deletingAt) {
+      return scimError(409, "A conflicting account already exists", "uniqueness");
+    }
+    const memberResult = await getScimMember(c.env.DB, logger, connection.id, existing.data.id);
+    if (!memberResult.success) return scimError(500, "Failed to provision user");
+    if (memberResult.data !== null) {
+      return scimError(409, "User is already provisioned for this connection", "uniqueness");
+    }
+    userId = existing.data.id;
+    adopted = true;
+  } else {
+    // The beta gate is deliberately bypassed here (as in OIDC JIT): SCIM
+    // provisioning is authorized by the connection's DNS-verified email
+    // domain, a stronger gate than a referral code.
+    const base = deriveUsernameBase(email);
+    const created = await createUser(
+      c.env.DB,
+      email,
+      logger,
+      await findAvailableUsername(c.env.DB, logger, base),
+    );
+    if (created.success) {
+      userId = created.data.user.id;
+      adopted = false;
+    } else {
+      // The insert may have lost the EMAIL race: a concurrent OIDC JIT login
+      // or duplicate POST created the account after the existence check above.
+      // If the user exists now, fall into the adopt path instead of erroring.
+      const raced = await getUserByEmail(c.env.DB, email, logger);
+      if (raced.success) {
+        if (raced.data.deletingAt) {
+          return scimError(409, "A conflicting account already exists", "uniqueness");
+        }
+        userId = raced.data.id;
+        adopted = true;
+      } else {
+        // Otherwise a concurrent claim won the USERNAME race; re-derive once.
+        const retried = await createUser(
+          c.env.DB,
+          email,
+          logger,
+          await findAvailableUsername(c.env.DB, logger, base),
+        );
+        if (!retried.success) return scimError(500, "Failed to provision user");
+        userId = retried.data.user.id;
+        adopted = false;
+      }
+    }
+  }
+
+  // ensureOrgMember, never addOrgMember: adopting an org owner/admin into
+  // SCIM management must not demote their existing role.
+  const orgResult = await ensureOrgMember(c.env.DB, logger, connection.orgId, userId, "member");
+  if (!orgResult.success) return scimError(500, "Failed to provision user");
+  const memberResult = await ensureScimMember(c.env.DB, logger, connection.id, userId);
+  if (!memberResult.success) return scimError(500, "Failed to provision user");
+  if (externalId !== undefined) {
+    const setResult = await setScimMemberExternalId(
+      c.env.DB,
+      logger,
+      connection.id,
+      userId,
+      externalId,
+    );
+    if (!setResult.success) {
+      if (setResult.error.code === "CONFLICT") {
+        return scimError(409, "externalId is already assigned to another user", "uniqueness");
+      }
+      return scimError(500, "Failed to provision user");
+    }
+  }
+  if (!active) {
+    const deprovisionResult = await deprovisionUser(c.env.DB, logger, connection.id, userId);
+    if (!deprovisionResult.success) return scimError(500, "Failed to provision user");
+  }
+
+  await recordAudit(c.env.DB, logger, {
+    action: "scim.user.provisioned",
+    actorType: "system",
+    subject: userId,
+    detail: { via: "scim", connectionId: connection.id, adopted },
+  });
+
+  const provisioned = await getScimScopedUser(c.env.DB, logger, connection, userId);
+  if (!provisioned.success) return scimError(500, "Failed to provision user");
+  return scimJson(userResource(c, provisioned.data), adopted ? 200 : 201);
+});
+
+app.put("/Users/:id", async (c) => {
+  const ctx = await requireScimConnection(c);
+  if (ctx instanceof Response) return ctx;
+  const { connection, logger } = ctx;
+
+  const userResult = await getScimScopedUser(c.env.DB, logger, connection, c.req.param("id"));
+  if (!userResult.success) {
+    if (userResult.error.code === "NOT_FOUND") return scimError(404, "User not found");
+    return scimError(500, "Failed to get user");
+  }
+  const user = userResult.data;
+
+  // Any successful write verb adopts: after a 2xx the IdP believes it manages
+  // this user, so even a no-op PUT must create the scim_members row —
+  // otherwise the user could silently fall out of the connection's scope.
+  const adoptResult = await ensureScimMember(c.env.DB, logger, connection.id, user.userId);
+  if (!adoptResult.success) return scimError(500, "Failed to update user");
+
+  const body = await readScimBody(c, logger);
+  if (body instanceof Response) return body;
+
+  // users.email is UNIQUE and load-bearing (login, git identity, audit trail);
+  // silently ignoring a rename would leave the IdP believing it succeeded and
+  // desync every future userName-filtered lookup — so reject loudly instead.
+  if (typeof body.userName === "string" && body.userName.trim().toLowerCase() !== user.email) {
+    return scimError(400, "userName cannot be changed", "mutability");
+  }
+
+  if (body.externalId !== undefined) {
+    if (typeof body.externalId !== "string" && body.externalId !== null) {
+      return scimError(400, "externalId must be a string", "invalidValue");
+    }
+    if (body.externalId !== user.externalId) {
+      const failure = await applyExternalId(
+        c.env.DB,
+        logger,
+        connection.id,
+        user.userId,
+        body.externalId,
+      );
+      if (failure) return failure;
+      await recordAudit(c.env.DB, logger, {
+        action: "scim.user.updated",
+        actorType: "system",
+        subject: user.userId,
+        detail: { via: "scim", connectionId: connection.id, externalId: body.externalId },
+      });
+    }
+  }
+
+  if (body.active !== undefined) {
+    const desiredActive = coerceActive(body.active);
+    if (desiredActive === undefined) {
+      return scimError(400, "active must be a boolean", "invalidValue");
+    }
+    const failure = await applyActiveTransition(
+      c.env.DB,
+      logger,
+      connection.id,
+      user,
+      desiredActive,
+    );
+    if (failure) return failure;
+  }
+
+  const updated = await getScimScopedUser(c.env.DB, logger, connection, user.userId);
+  if (!updated.success) return scimError(500, "Failed to get user");
+  return scimJson(userResource(c, updated.data));
+});
+
+app.patch("/Users/:id", async (c) => {
+  const ctx = await requireScimConnection(c);
+  if (ctx instanceof Response) return ctx;
+  const { connection, logger } = ctx;
+
+  const userResult = await getScimScopedUser(c.env.DB, logger, connection, c.req.param("id"));
+  if (!userResult.success) {
+    if (userResult.error.code === "NOT_FOUND") return scimError(404, "User not found");
+    return scimError(500, "Failed to get user");
+  }
+  const user = userResult.data;
+
+  // Adopt on any successful write verb — see the PUT handler's rationale.
+  const adoptResult = await ensureScimMember(c.env.DB, logger, connection.id, user.userId);
+  if (!adoptResult.success) return scimError(500, "Failed to update user");
+
+  const body = await readScimBody(c, logger);
+  if (body instanceof Response) return body;
+  const operations = body.Operations;
+  if (!Array.isArray(operations)) {
+    return scimError(400, "Operations must be an array", "invalidSyntax");
+  }
+
+  let desiredActive: boolean | undefined;
+  let externalIdUpdate: string | null | undefined;
+
+  for (const operation of operations) {
+    if (operation === null || typeof operation !== "object" || Array.isArray(operation)) {
+      return scimError(400, "Each operation must be an object", "invalidSyntax");
+    }
+    const op = operation as Record<string, unknown>;
+    // Entra capitalizes op names ("Replace"); compare case-insensitively.
+    if (typeof op.op !== "string" || op.op.toLowerCase() !== "replace") {
+      return scimError(400, `Unsupported PATCH operation '${String(op.op)}'`, "invalidPath");
+    }
+    const path = typeof op.path === "string" ? op.path.trim().toLowerCase() : undefined;
+
+    if (path === undefined) {
+      // No-path replace: the value object carries the attributes.
+      if (op.value === null || typeof op.value !== "object" || Array.isArray(op.value)) {
+        return scimError(400, "replace without a path requires an object value", "invalidValue");
+      }
+      for (const [key, value] of Object.entries(op.value as Record<string, unknown>)) {
+        const attribute = key.toLowerCase();
+        if (attribute === "active") {
+          const coerced = coerceActive(value);
+          if (coerced === undefined) {
+            return scimError(400, "active must be a boolean", "invalidValue");
+          }
+          desiredActive = coerced;
+        } else if (attribute === "externalid") {
+          if (typeof value !== "string" && value !== null) {
+            return scimError(400, "externalId must be a string", "invalidValue");
+          }
+          externalIdUpdate = value;
+        }
+        // Unknown attributes ignored — see the unknown-path policy above.
+      }
+    } else if (path === "active") {
+      const coerced = coerceActive(op.value);
+      if (coerced === undefined) {
+        return scimError(400, "active must be a boolean", "invalidValue");
+      }
+      desiredActive = coerced;
+    } else if (path === "externalid") {
+      if (typeof op.value !== "string" && op.value !== null) {
+        return scimError(400, "externalId must be a string", "invalidValue");
+      }
+      externalIdUpdate = op.value;
+    }
+    // else: unknown-path replace (displayName, name.givenName, enterprise
+    // extension paths, ...) — ignored, not errored; see module doc.
+  }
+
+  if (externalIdUpdate !== undefined && externalIdUpdate !== user.externalId) {
+    const failure = await applyExternalId(
+      c.env.DB,
+      logger,
+      connection.id,
+      user.userId,
+      externalIdUpdate,
+    );
+    if (failure) return failure;
+    await recordAudit(c.env.DB, logger, {
+      action: "scim.user.updated",
+      actorType: "system",
+      subject: user.userId,
+      detail: { via: "scim", connectionId: connection.id, externalId: externalIdUpdate },
+    });
+  }
+  if (desiredActive !== undefined) {
+    const failure = await applyActiveTransition(
+      c.env.DB,
+      logger,
+      connection.id,
+      user,
+      desiredActive,
+    );
+    if (failure) return failure;
+  }
+
+  const updated = await getScimScopedUser(c.env.DB, logger, connection, user.userId);
+  if (!updated.success) return scimError(500, "Failed to get user");
+  return scimJson(userResource(c, updated.data));
+});
+
+app.delete("/Users/:id", async (c) => {
+  const ctx = await requireScimConnection(c);
+  if (ctx instanceof Response) return ctx;
+  const { connection, logger } = ctx;
+
+  const userResult = await getScimScopedUser(c.env.DB, logger, connection, c.req.param("id"));
+  if (!userResult.success) {
+    if (userResult.error.code === "NOT_FOUND") return scimError(404, "User not found");
+    return scimError(500, "Failed to get user");
+  }
+
+  // DELETE deactivates rather than erases (see module doc): identical to
+  // active:false, so a later GET shows the resource with active:false. Same
+  // direction-aware skip as applyActiveTransition: a fully deactivated user
+  // (disabled AND this connection's vote recorded) is a retried DELETE —
+  // still 204, without re-running (and re-auditing) the deprovision.
+  const user = userResult.data;
+  const fullyDeactivated = user.disabledAt !== null && user.scimActive === false;
+  if (!fullyDeactivated) {
+    const deprovisionResult = await deprovisionUser(c.env.DB, logger, connection.id, user.userId);
+    if (!deprovisionResult.success) return scimError(500, "Failed to deactivate user");
+  }
+  return new Response(null, { status: 204 });
+});
+
+export { app as scimRouter };

--- a/src/routes/scim.ts
+++ b/src/routes/scim.ts
@@ -30,11 +30,12 @@ import { readJsonWithLimit } from "../utils/request-body";
  * - DELETE deactivates instead of erasing; a later GET returns the resource
  *   with active:false. (Okta's lifecycle uses PATCH active:false; a DELETE
  *   that destroyed data would make an IdP misconfiguration unrecoverable.)
- * - PATCH ignores replaces of attributes we don't store (displayName, name.*,
+ * - PATCH ignores ops on attributes we don't store (displayName, name.*,
  *   enterprise-extension paths, ...) instead of erroring: Okta and Entra send
  *   them on every profile sync, and a 4xx would mark the whole user as failed.
- *   Only structurally invalid operations (non-replace ops, malformed values)
- *   are rejected.
+ *   Stored attributes accept replace AND add (Entra sends Add on link; RFC
+ *   7644 add-on-existing-attribute replaces); only remove ops on stored
+ *   attributes and malformed values are rejected.
  */
 
 const app = new Hono<{ Bindings: Env }>();
@@ -50,11 +51,15 @@ const MAX_PAGE_COUNT = 200;
 
 type ScimContext = Context<{ Bindings: Env }>;
 
-function scimJson(body: Record<string, unknown>, status = 200): Response {
+function scimJson(
+  body: Record<string, unknown>,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
   // The explicit Content-Type in init survives Response.json's default.
   return Response.json(body, {
     status,
-    headers: { "Content-Type": SCIM_CONTENT_TYPE },
+    headers: { "Content-Type": SCIM_CONTENT_TYPE, ...headers },
   });
 }
 
@@ -462,6 +467,9 @@ app.post("/Users", async (c) => {
   const existing = await getUserByEmail(c.env.DB, email, logger);
   let userId: string;
   let adopted: boolean;
+  // Set when the payload asks for active:true but the account is currently
+  // deactivated for this connection — a retried POST must repair that.
+  let needsReactivation = false;
   if (existing.success) {
     // A soft-deleting account still owns the email; it cannot be adopted and
     // the email cannot be reissued mid-erasure.
@@ -471,7 +479,21 @@ app.post("/Users", async (c) => {
     const memberResult = await getScimMember(c.env.DB, logger, connection.id, existing.data.id);
     if (!memberResult.success) return scimError(500, "Failed to provision user");
     if (memberResult.data !== null) {
-      return scimError(409, "User is already provisioned for this connection", "uniqueness");
+      // An already-managed user is not automatically a conflict: a retried
+      // POST after a partial provision must finish the job — IdPs stop
+      // retrying on 409 and would strand the account in whatever state the
+      // failed step never reached. Only a mismatched externalId against a
+      // non-null stored one is a genuine uniqueness conflict; otherwise
+      // converge and let the normal flow re-apply the remaining steps.
+      if (
+        externalId !== undefined &&
+        memberResult.data.externalId !== null &&
+        memberResult.data.externalId !== externalId
+      ) {
+        return scimError(409, "User is already provisioned for this connection", "uniqueness");
+      }
+      needsReactivation =
+        existing.data.disabledAt !== undefined || memberResult.data.active === false;
     }
     userId = existing.data.id;
     adopted = true;
@@ -539,6 +561,12 @@ app.post("/Users", async (c) => {
   if (!active) {
     const deprovisionResult = await deprovisionUser(c.env.DB, logger, connection.id, userId);
     if (!deprovisionResult.success) return scimError(500, "Failed to provision user");
+  } else if (needsReactivation) {
+    // Convergence applies BOTH active directions: idempotent, and carries the
+    // cross-connection guard, so a repaired retry cannot override another
+    // connection's standing deactivation.
+    const reactivateResult = await reactivateUser(c.env.DB, logger, connection.id, userId);
+    if (!reactivateResult.success) return scimError(500, "Failed to provision user");
   }
 
   await recordAudit(c.env.DB, logger, {
@@ -550,7 +578,12 @@ app.post("/Users", async (c) => {
 
   const provisioned = await getScimScopedUser(c.env.DB, logger, connection, userId);
   if (!provisioned.success) return scimError(500, "Failed to provision user");
-  return scimJson(userResource(c, provisioned.data), adopted ? 200 : 201);
+  // RFC 7644 §3.3: creation answers 201 with a Location header — including
+  // adoption/convergence, where "created" means "now managed here"; Okta and
+  // Entra key off the 201 + Location pair.
+  return scimJson(userResource(c, provisioned.data), 201, {
+    Location: userLocation(c, provisioned.data.userId),
+  });
 });
 
 app.put("/Users/:id", async (c) => {
@@ -565,12 +598,6 @@ app.put("/Users/:id", async (c) => {
   }
   const user = userResult.data;
 
-  // Any successful write verb adopts: after a 2xx the IdP believes it manages
-  // this user, so even a no-op PUT must create the scim_members row —
-  // otherwise the user could silently fall out of the connection's scope.
-  const adoptResult = await ensureScimMember(c.env.DB, logger, connection.id, user.userId);
-  if (!adoptResult.success) return scimError(500, "Failed to update user");
-
   const body = await readScimBody(c, logger);
   if (body instanceof Response) return body;
 
@@ -580,6 +607,14 @@ app.put("/Users/:id", async (c) => {
   if (typeof body.userName === "string" && body.userName.trim().toLowerCase() !== user.email) {
     return scimError(400, "userName cannot be changed", "mutability");
   }
+
+  // Any successful write verb adopts: after a 2xx the IdP believes it manages
+  // this user, so even a no-op PUT must create the scim_members row —
+  // otherwise the user could silently fall out of the connection's scope.
+  // Adoption runs AFTER body parsing and structural validation: a 400 must
+  // not adopt.
+  const adoptResult = await ensureScimMember(c.env.DB, logger, connection.id, user.userId);
+  if (!adoptResult.success) return scimError(500, "Failed to update user");
 
   if (body.externalId !== undefined) {
     if (typeof body.externalId !== "string" && body.externalId !== null) {
@@ -635,10 +670,6 @@ app.patch("/Users/:id", async (c) => {
   }
   const user = userResult.data;
 
-  // Adopt on any successful write verb — see the PUT handler's rationale.
-  const adoptResult = await ensureScimMember(c.env.DB, logger, connection.id, user.userId);
-  if (!adoptResult.success) return scimError(500, "Failed to update user");
-
   const body = await readScimBody(c, logger);
   if (body instanceof Response) return body;
   const operations = body.Operations;
@@ -654,16 +685,31 @@ app.patch("/Users/:id", async (c) => {
       return scimError(400, "Each operation must be an object", "invalidSyntax");
     }
     const op = operation as Record<string, unknown>;
-    // Entra capitalizes op names ("Replace"); compare case-insensitively.
-    if (typeof op.op !== "string" || op.op.toLowerCase() !== "replace") {
+    if (typeof op.op !== "string") {
       return scimError(400, `Unsupported PATCH operation '${String(op.op)}'`, "invalidPath");
     }
+    // Entra capitalizes op names ("Replace", "Add"); compare case-insensitively.
+    const opName = op.op.toLowerCase();
     const path = typeof op.path === "string" ? op.path.trim().toLowerCase() : undefined;
 
+    // Resolve the path FIRST: an op on an attribute we don't store
+    // (displayName, name.givenName, enterprise extension paths, ...) is
+    // ignored regardless of op type — Okta/Entra profile syncs send them on
+    // every update, and a 4xx would mark the whole user as failed.
+    if (path !== undefined && path !== "active" && path !== "externalid") {
+      continue;
+    }
+    // On stored paths: RFC 7644 §3.5.2.1 says add on an existing single-valued
+    // attribute replaces it (Entra sends Add on initial link), so add and
+    // replace are equivalent here; remove (and anything else) is invalid.
+    if (opName !== "replace" && opName !== "add") {
+      return scimError(400, `Unsupported PATCH operation '${String(op.op)}'`, "invalidPath");
+    }
+
     if (path === undefined) {
-      // No-path replace: the value object carries the attributes.
+      // No-path op: the value object carries the attributes.
       if (op.value === null || typeof op.value !== "object" || Array.isArray(op.value)) {
-        return scimError(400, "replace without a path requires an object value", "invalidValue");
+        return scimError(400, `${opName} without a path requires an object value`, "invalidValue");
       }
       for (const [key, value] of Object.entries(op.value as Record<string, unknown>)) {
         const attribute = key.toLowerCase();
@@ -687,15 +733,18 @@ app.patch("/Users/:id", async (c) => {
         return scimError(400, "active must be a boolean", "invalidValue");
       }
       desiredActive = coerced;
-    } else if (path === "externalid") {
+    } else {
       if (typeof op.value !== "string" && op.value !== null) {
         return scimError(400, "externalId must be a string", "invalidValue");
       }
       externalIdUpdate = op.value;
     }
-    // else: unknown-path replace (displayName, name.givenName, enterprise
-    // extension paths, ...) — ignored, not errored; see module doc.
   }
+
+  // Adopt on any successful write verb — see the PUT handler's rationale.
+  // Adoption runs AFTER the Operations validation above: a 400 must not adopt.
+  const adoptResult = await ensureScimMember(c.env.DB, logger, connection.id, user.userId);
+  if (!adoptResult.success) return scimError(500, "Failed to update user");
 
   if (externalIdUpdate !== undefined && externalIdUpdate !== user.externalId) {
     const failure = await applyExternalId(

--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -493,6 +493,10 @@ app.get("/", (c) => {
                   Continue with Google
                 </a>
 
+                <a href="/auth/sso" class="github-btn" style={{ marginTop: "0.5rem" }}>
+                  Single sign-on (SSO)
+                </a>
+
                 <div class="auth-footer">
                   Already have an account? <a href="/auth/login">Sign in</a>
                 </div>

--- a/src/routes/sso.tsx
+++ b/src/routes/sso.tsx
@@ -1,0 +1,981 @@
+import { type Context, Hono } from "hono";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import { readBodyCapped } from "../services/oidc-discovery";
+import { recordAudit } from "../storage/audit";
+import { getIdentityByIssuerSubject, upsertIdentity } from "../storage/identities";
+import { ensureOrgMember, getOrg, getOrgBySlug } from "../storage/orgs";
+import { createSession } from "../storage/sessions";
+import {
+  OIDC_STATE_TTL_SECONDS,
+  type OidcLoginState,
+  type SsoConnection,
+  consumeOidcLoginState,
+  createOidcLoginState,
+  ensureScimMember,
+  getSsoConnectionById,
+  getSsoConnectionByOrgSlug,
+  getSsoConnectionByVerifiedDomain,
+  purgeExpiredOidcStates,
+} from "../storage/sso";
+import { createUser, getUser, getUserByEmail, getUserByUsername } from "../storage/users";
+import { type Env, MAX_NAMESPACE_LENGTH, type User } from "../types";
+import { SSO_SECRET_SALT, constantTimeEqual, decryptToken } from "../utils/crypto";
+import { NotFoundError } from "../utils/errors";
+import { type Logger, createLogger } from "../utils/logger";
+import { validateUsername } from "../utils/username-validation";
+
+/**
+ * OIDC single sign-on login flow (#253 Task 5), mounted at /auth/sso.
+ * The picker resolves an org slug or work-email domain to a connection, /start
+ * begins the authorization-code + PKCE flow, and /callback verifies the
+ * id_token (jose, RS256/ES256 only) and signs the user in — linking, adopting,
+ * or JIT-creating the account under the connection's verified email domains.
+ */
+
+const app = new Hono<{ Bindings: Env }>();
+
+const SSO_STATE_COOKIE = "stratum_sso_state";
+const SSO_STATE_COOKIE_PATH = "/auth/sso";
+// Starts are cheap (one D1 insert + a redirect), but each mints a state row —
+// bound them per source IP like magic-link sends are.
+const SSO_START_IP_RATE_LIMIT = 30;
+const SSO_START_RATE_WINDOW_SECONDS = 60 * 60;
+const TOKEN_EXCHANGE_TIMEOUT_MS = 10_000;
+const MAX_TOKEN_RESPONSE_BYTES = 64 * 1024;
+const SESSION_COOKIE_MAX_AGE_SECONDS = 2592000;
+// Asymmetric signatures only: accepting HS256 would let anyone holding the
+// (shared) client secret forge id_tokens.
+const ID_TOKEN_ALGORITHMS = ["RS256", "ES256"];
+const ID_TOKEN_CLOCK_TOLERANCE_SECONDS = 60;
+// JIT usernames: bounded probe for a free numeric-suffixed name before
+// falling back to a random one.
+const MAX_USERNAME_SUFFIX_ATTEMPTS = 10;
+
+// Codes the /callback redirects back to the picker page with. Raw IdP error
+// strings are never reflected — they map to the generic idp_error.
+const ERROR_MESSAGES: Record<string, string> = {
+  idp_error: "The identity provider returned an error. Please try signing in again.",
+  invalid_state: "Sign-in session is invalid or has expired. Please try again.",
+  no_email: "Your identity provider did not share an email address. Contact your administrator.",
+  unverified_email:
+    "Your email address is not verified with your identity provider. Contact your administrator.",
+  domain_not_allowed:
+    "Your email domain is not registered for this organization's single sign-on. " +
+    "Guest accounts cannot sign in here — contact your administrator.",
+  account_disabled:
+    "This account has been disabled. Contact your organization's administrator to restore access.",
+  rate_limited: "Too many sign-in attempts. Please try again in an hour.",
+  sso_failed: "Single sign-on failed. Please try again or contact your administrator.",
+};
+
+const NO_CONNECTION_MESSAGE = "No SSO configuration found for that organization or email domain.";
+
+type SsoContext = Context<{ Bindings: Env }>;
+
+function requestLogger(c: SsoContext): Logger {
+  return createLogger({
+    requestId: crypto.randomUUID(),
+    path: c.req.path,
+    method: c.req.method,
+  });
+}
+
+/** All /auth/sso endpoints require the server-wide SSO secret, like org-sso.ts. */
+function ssoUnconfigured(c: SsoContext): Response | null {
+  if (!c.env.SSO_ENCRYPTION_SECRET) {
+    return c.json({ error: "SSO is not configured on this server" }, 501);
+  }
+  return null;
+}
+
+function randomHex(byteLength: number): string {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function base64url(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/** RFC 7636 code_verifier: 32 random bytes base64url-encoded (43 chars). */
+function makeCodeVerifier(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return base64url(bytes);
+}
+
+async function codeChallengeS256(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return base64url(new Uint8Array(digest));
+}
+
+/**
+ * A safe post-login destination is a same-origin absolute path: it must start
+ * with "/" but not "//" or "/\" (both of which browsers treat as
+ * scheme-relative, i.e. an open redirect). C0 controls and DEL are rejected
+ * outright — browsers strip ASCII tab/newline before parsing a Location per
+ * the WHATWG URL spec, so "/\t/evil.com" would navigate to "//evil.com".
+ * Anything else is treated as absent.
+ */
+function validateRedirectTo(raw: string | undefined | null): string | null {
+  if (!raw || !raw.startsWith("/")) return null;
+  if (raw.startsWith("//") || raw.startsWith("/\\")) return null;
+  for (let i = 0; i < raw.length; i++) {
+    const code = raw.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) return null;
+  }
+  return raw;
+}
+
+function loginUsable(connection: SsoConnection): boolean {
+  return connection.enabled && connection.domainsVerifiedAt !== null;
+}
+
+/**
+ * Per-IP hourly cap on /start, mirroring checkMagicLinkRateLimits: reads fail
+ * open (an auth path must not lock users out on a KV blip) and the counter is
+ * committed only once the request is actually going to redirect to the IdP.
+ */
+async function checkSsoStartRateLimit(
+  c: SsoContext,
+  logger: Logger,
+): Promise<{ blocked: boolean; commit: () => Promise<void> }> {
+  const ip = c.req.header("CF-Connecting-IP") ?? "unknown";
+  const hour = Math.floor(Date.now() / 1000 / SSO_START_RATE_WINDOW_SECONDS);
+  const key = `sso_start_ip_rate:${ip}:${hour}`;
+  let count = 0;
+  try {
+    count = Number.parseInt((await c.env.STATE.get(key)) ?? "0");
+  } catch (err) {
+    count = 0;
+    logger.warn("Failed to read SSO start rate limit, allowing request", { error: err });
+  }
+  const blocked = count >= SSO_START_IP_RATE_LIMIT;
+  const commit = async () => {
+    try {
+      await c.env.STATE.put(key, String(count + 1), {
+        expirationTtl: SSO_START_RATE_WINDOW_SECONDS,
+      });
+    } catch (err) {
+      logger.warn("Failed to commit SSO start rate limit", { error: err });
+    }
+  };
+  return { blocked, commit };
+}
+
+function ssoErrorRedirect(c: SsoContext, code: keyof typeof ERROR_MESSAGES): Response {
+  return c.redirect(`/auth/sso?error=${code}`);
+}
+
+interface PickerPageOptions {
+  error?: string;
+  identifier?: string;
+  redirectTo?: string | null;
+  status?: 200 | 404 | 429;
+}
+
+/** The SSO picker page, styled to match src/routes/login.tsx (shared /ui.css tokens). */
+function renderPickerPage(
+  c: SsoContext,
+  opts: PickerPageOptions = {},
+): Response | Promise<Response> {
+  const { error, identifier = "", redirectTo = null, status = 200 } = opts;
+  return c.html(
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Single Sign-On — Stratum</title>
+        <link
+          rel="icon"
+          href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='6'%20fill='%230d0d0d'/%3E%3Ctext%20x='16'%20y='23'%20font-family='monospace'%20font-size='20'%20font-weight='700'%20fill='%237ca9f7'%20text-anchor='middle'%3ES%3C/text%3E%3C/svg%3E"
+        />
+        <link rel="stylesheet" href="/ui.css" />
+        <style>{`
+          /* Color tokens come from the shared stylesheet (/ui.css). */
+
+          .auth-page {
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            background: var(--bg-primary);
+          }
+
+          .auth-container {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 2rem 1rem;
+          }
+
+          .auth-card {
+            width: 100%;
+            max-width: 400px;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 2rem;
+          }
+
+          .auth-header {
+            text-align: center;
+            margin-bottom: 1.5rem;
+          }
+
+          .auth-title {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 0.5rem;
+          }
+
+          .auth-subtitle {
+            font-size: 0.9rem;
+            color: var(--text-secondary);
+            line-height: 1.5;
+          }
+
+          .alert {
+            padding: 0.875rem 1rem;
+            border-radius: 6px;
+            margin-bottom: 1rem;
+            font-size: 0.9rem;
+            line-height: 1.5;
+          }
+
+          .alert-error {
+            background: var(--error-bg);
+            border: 1px solid var(--error-border);
+            color: var(--error-text);
+          }
+
+          .form-group {
+            margin-bottom: 1.25rem;
+          }
+
+          .form-label {
+            display: block;
+            font-size: 0.85rem;
+            font-weight: 500;
+            color: var(--text-secondary);
+            margin-bottom: 0.5rem;
+          }
+
+          .form-input {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            background: var(--bg-primary);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            color: var(--text-primary);
+            font-family: inherit;
+            font-size: 1rem;
+            transition: border-color 0.15s, box-shadow 0.15s;
+          }
+
+          .form-input:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(26, 58, 110, 0.3);
+          }
+
+          .form-input::placeholder {
+            color: var(--text-tertiary);
+          }
+
+          .btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            padding: 0.75rem 1rem;
+            background: var(--accent);
+            border: 1px solid var(--accent);
+            border-radius: 6px;
+            color: white;
+            font-family: inherit;
+            font-size: 1rem;
+            font-weight: 500;
+            cursor: pointer;
+            transition: background-color 0.15s, border-color 0.15s, opacity 0.15s;
+            text-decoration: none;
+          }
+
+          .btn:hover {
+            background: var(--accent-hover);
+            border-color: var(--accent-hover);
+            text-decoration: none;
+          }
+
+          .btn:focus {
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(26, 58, 110, 0.3);
+          }
+
+          .auth-help {
+            margin-top: 1rem;
+            font-size: 0.85rem;
+            color: var(--text-tertiary);
+            text-align: center;
+            line-height: 1.5;
+          }
+
+          .auth-footer {
+            margin-top: 1.5rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border);
+            text-align: center;
+          }
+
+          .auth-footer-text {
+            font-size: 0.9rem;
+            color: var(--text-secondary);
+          }
+
+          .auth-footer a {
+            color: var(--accent-text);
+            font-weight: 500;
+          }
+
+          .auth-footer a:hover {
+            color: var(--accent-text-hover);
+            text-decoration: underline;
+          }
+
+          @media (max-width: 480px) {
+            .auth-card {
+              padding: 1.5rem;
+            }
+
+            .auth-title {
+              font-size: 1.25rem;
+            }
+          }
+        `}</style>
+      </head>
+      <body class="auth-page">
+        <nav class="nav">
+          <a class="nav-brand" href="/">
+            stratum
+          </a>
+        </nav>
+        <main class="auth-container">
+          <div class="auth-card">
+            <div class="auth-header">
+              <h1 class="auth-title">Single sign-on</h1>
+              <p class="auth-subtitle">
+                Sign in with your organization's identity provider. Enter your organization name or
+                your work email address.
+              </p>
+            </div>
+
+            {error && <div class="alert alert-error">{error}</div>}
+
+            <form action="/auth/sso" method="get">
+              <div class="form-group">
+                <label class="form-label" for="identifier">
+                  Organization or work email
+                </label>
+                <input
+                  class="form-input"
+                  type="text"
+                  id="identifier"
+                  name="identifier"
+                  placeholder="acme or you@acme.com"
+                  value={identifier}
+                  required
+                  autoComplete="email"
+                />
+              </div>
+              {redirectTo && <input type="hidden" name="redirect_to" value={redirectTo} />}
+              <button type="submit" class="btn">
+                Continue
+              </button>
+            </form>
+
+            <div class="auth-help">
+              Your organization's administrator sets up single sign-on. If you're not sure whether
+              your organization uses it, ask your administrator.
+            </div>
+
+            <div class="auth-footer">
+              <p class="auth-footer-text">
+                Prefer email? <a href="/auth/login">Sign in with a magic link</a>
+              </p>
+            </div>
+          </div>
+        </main>
+      </body>
+    </html>,
+    status,
+  );
+}
+
+// GET /auth/sso — picker: resolve an org slug or work-email domain to a
+// connection and bounce to its /start. Accepted disclosure: this reveals
+// whether a domain has SSO configured (industry-standard discovery behavior).
+app.get("/", async (c) => {
+  const unconfigured = ssoUnconfigured(c);
+  if (unconfigured) return unconfigured;
+
+  const logger = requestLogger(c);
+  const errorCode = c.req.query("error");
+  const redirectTo = validateRedirectTo(c.req.query("redirect_to"));
+  const identifier = (c.req.query("identifier") ?? "").trim().toLowerCase();
+
+  if (!identifier) {
+    const error =
+      errorCode !== undefined ? (ERROR_MESSAGES[errorCode] ?? "Sign-in failed.") : undefined;
+    return renderPickerPage(c, { error, redirectTo });
+  }
+
+  // Slug first for bare identifiers (falling back to treating the input as a
+  // domain); an email routes by its domain. Misses and lookup failures render
+  // the same generic message (fail closed, no oracle beyond configured-or-not).
+  let connection: SsoConnection | null = null;
+  if (!identifier.includes("@")) {
+    const bySlug = await getSsoConnectionByOrgSlug(c.env.DB, logger, identifier);
+    if (bySlug.success && loginUsable(bySlug.data)) connection = bySlug.data;
+  }
+  if (!connection) {
+    const domain = identifier.split("@").pop() ?? "";
+    const byDomain = await getSsoConnectionByVerifiedDomain(c.env.DB, logger, domain);
+    if (byDomain.success) connection = byDomain.data;
+  }
+
+  if (!connection) {
+    return renderPickerPage(c, { error: NO_CONNECTION_MESSAGE, identifier, redirectTo });
+  }
+
+  const orgResult = await getOrg(c.env.DB, logger, connection.orgId);
+  if (!orgResult.success) {
+    logger.error("SSO connection points at a missing org", orgResult.error, {
+      connectionId: connection.id,
+    });
+    return renderPickerPage(c, { error: NO_CONNECTION_MESSAGE, identifier, redirectTo });
+  }
+
+  const params = new URLSearchParams();
+  if (redirectTo) params.set("redirect_to", redirectTo);
+  const query = params.toString();
+  return c.redirect(`/auth/sso/${orgResult.data.slug}/start${query ? `?${query}` : ""}`);
+});
+
+// GET /auth/sso/:slug/start — begin the authorization-code + PKCE flow.
+app.get("/:slug/start", async (c) => {
+  const unconfigured = ssoUnconfigured(c);
+  if (unconfigured) return unconfigured;
+
+  const logger = requestLogger(c);
+  const slug = c.req.param("slug");
+
+  const connectionResult = await getSsoConnectionByOrgSlug(c.env.DB, logger, slug);
+  if (!connectionResult.success || !loginUsable(connectionResult.data)) {
+    // Same generic message for unknown slug, disabled, and unverified — a
+    // probe learns only "not usable for login".
+    logger.warn("SSO start for unusable connection", { slug });
+    return renderPickerPage(c, { error: NO_CONNECTION_MESSAGE, status: 404 });
+  }
+  const connection = connectionResult.data;
+
+  const rateLimit = await checkSsoStartRateLimit(c, logger);
+  if (rateLimit.blocked) {
+    logger.warn("SSO start rate limit exceeded", { slug });
+    return renderPickerPage(c, { error: ERROR_MESSAGES.rate_limited, status: 429 });
+  }
+
+  // Opportunistic cleanup — best-effort, never blocks the login.
+  await purgeExpiredOidcStates(c.env.DB, logger);
+
+  const redirectTo = validateRedirectTo(c.req.query("redirect_to"));
+  const nonce = randomHex(32);
+  const codeVerifier = makeCodeVerifier();
+  const codeChallenge = await codeChallengeS256(codeVerifier);
+
+  const stateResult = await createOidcLoginState(c.env.DB, logger, {
+    connectionId: connection.id,
+    nonce,
+    codeVerifier,
+    redirectTo,
+  });
+  if (!stateResult.success) {
+    logger.error("Failed to persist OIDC login state", stateResult.error, { slug });
+    return c.json({ error: "Failed to start sign-in" }, 500);
+  }
+  const state = stateResult.data;
+
+  await rateLimit.commit();
+
+  // Browser-binding cookie: the callback's state must match it (constant-time)
+  // — the D1 row's atomic consumption handles replay, the cookie handles
+  // login-CSRF / session fixation (same double-submit binding as auth.ts).
+  setCookie(c, SSO_STATE_COOKIE, state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "Lax",
+    maxAge: OIDC_STATE_TTL_SECONDS,
+    path: SSO_STATE_COOKIE_PATH,
+  });
+
+  // One canonical callback for all connections, derived from the request
+  // origin so start and callback always agree.
+  const redirectUri = `${new URL(c.req.url).origin}/auth/sso/callback`;
+  const authorizeUrl = new URL(connection.authorizationEndpoint);
+  authorizeUrl.searchParams.set("response_type", "code");
+  authorizeUrl.searchParams.set("client_id", connection.clientId);
+  authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+  authorizeUrl.searchParams.set("scope", "openid email profile");
+  authorizeUrl.searchParams.set("state", state);
+  authorizeUrl.searchParams.set("nonce", nonce);
+  authorizeUrl.searchParams.set("code_challenge", codeChallenge);
+  authorizeUrl.searchParams.set("code_challenge_method", "S256");
+
+  logger.info("Redirecting to IdP authorization endpoint", {
+    connectionId: connection.id,
+    orgId: connection.orgId,
+  });
+  return c.redirect(authorizeUrl.toString());
+});
+
+interface IdTokenClaims {
+  subject: string;
+  email: string;
+}
+
+type ClaimRefusal = "no_email" | "unverified_email" | "domain_not_allowed" | "sso_failed";
+
+/**
+ * Apply the PRD email-claim rules to a verified id_token payload: `sub` and
+ * `email` required; `email_verified` present as boolean false OR string
+ * "false" (Entra emits string booleans) → reject; the (normalized) email's
+ * domain must be one of the connection's verified domains — IdP guests
+ * outside those domains are refused.
+ */
+function extractClaims(
+  payload: Record<string, unknown>,
+  connection: SsoConnection,
+  logger: Logger,
+): { claims: IdTokenClaims } | { refusal: ClaimRefusal } {
+  const subject = payload.sub;
+  if (typeof subject !== "string" || subject.length === 0) {
+    logger.warn("id_token missing sub claim", { connectionId: connection.id });
+    return { refusal: "sso_failed" };
+  }
+  const rawEmail = payload.email;
+  if (typeof rawEmail !== "string" || rawEmail.trim().length === 0) {
+    logger.warn("id_token missing email claim", { connectionId: connection.id });
+    return { refusal: "no_email" };
+  }
+  const emailVerified = payload.email_verified;
+  if (emailVerified === false || emailVerified === "false") {
+    logger.warn("id_token email is unverified", { connectionId: connection.id });
+    return { refusal: "unverified_email" };
+  }
+  const email = rawEmail.trim().toLowerCase();
+  const domain = email.split("@").pop() ?? "";
+  if (!connection.emailDomains.includes(domain)) {
+    logger.warn("id_token email outside verified domains", { connectionId: connection.id });
+    return { refusal: "domain_not_allowed" };
+  }
+  return { claims: { subject, email } };
+}
+
+/** Exchange the authorization code (client_secret_post + PKCE); null on any failure. */
+async function exchangeCodeForIdToken(
+  connection: SsoConnection,
+  clientSecret: string,
+  code: string,
+  codeVerifier: string,
+  redirectUri: string,
+  logger: Logger,
+): Promise<string | null> {
+  let res: Response;
+  try {
+    res = await fetch(connection.tokenEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+        client_id: connection.clientId,
+        client_secret: clientSecret,
+        code_verifier: codeVerifier,
+      }),
+      signal: AbortSignal.timeout(TOKEN_EXCHANGE_TIMEOUT_MS),
+    });
+  } catch {
+    logger.warn("OIDC token exchange request failed", { connectionId: connection.id });
+    return null;
+  }
+  if (!res.ok) {
+    logger.warn("OIDC token exchange returned non-OK status", {
+      connectionId: connection.id,
+      status: res.status,
+    });
+    return null;
+  }
+  const body = await readBodyCapped(res, MAX_TOKEN_RESPONSE_BYTES);
+  if (body === null) {
+    logger.warn("OIDC token response exceeded size cap", { connectionId: connection.id });
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (parsed === null || typeof parsed !== "object") return null;
+    const idToken = (parsed as Record<string, unknown>).id_token;
+    return typeof idToken === "string" && idToken.length > 0 ? idToken : null;
+  } catch {
+    logger.warn("OIDC token response is not valid JSON", { connectionId: connection.id });
+    return null;
+  }
+}
+
+/**
+ * Derive a JIT username from the email local part via the exact pipeline
+ * signup uses (see createUser), falling back to a random name when the local
+ * part cannot produce a valid one.
+ */
+function deriveUsernameBase(email: string): string {
+  const candidate = (email.split("@")[0] ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^[-0-9]+/, "")
+    .replace(/-+$/, "")
+    // Truncate long local parts to the username cap (re-trimming so the cut
+    // cannot leave a trailing hyphen) rather than failing max-length
+    // validation and falling to the random fallback.
+    .slice(0, MAX_NAMESPACE_LENGTH)
+    .replace(/-+$/, "");
+  const validation = validateUsername(candidate);
+  return validation.success ? validation.data : `sso-${randomHex(3)}`;
+}
+
+/**
+ * Find a free username: the base, then numeric suffixes, then a random
+ * fallback. Usernames and org slugs share one namespace (user and org pages
+ * live under the same URL prefix), so a name is taken when EITHER exists.
+ */
+async function findAvailableUsername(
+  db: D1Database,
+  logger: Logger,
+  base: string,
+): Promise<string> {
+  for (let attempt = 0; attempt < MAX_USERNAME_SUFFIX_ATTEMPTS; attempt++) {
+    const suffix = attempt === 0 ? "" : `-${attempt + 1}`;
+    // Keep base + suffix within the username cap; re-trim so a truncation
+    // can't leave a trailing hyphen.
+    const truncated = base.slice(0, MAX_NAMESPACE_LENGTH - suffix.length).replace(/-+$/, "");
+    const candidate = `${truncated}${suffix}`;
+    const userTaken = (await getUserByUsername(db, candidate, logger)).success;
+    if (userTaken) continue;
+    const slugTaken = (await getOrgBySlug(db, logger, candidate)).success;
+    if (!slugTaken) return candidate;
+  }
+  return `sso-${randomHex(4)}`;
+}
+
+type ResolutionFailure =
+  | { kind: "redirect"; code: keyof typeof ERROR_MESSAGES }
+  | { kind: "server_error" };
+
+type ResolutionResult = { userId: string } | ResolutionFailure;
+
+function isDisabled(user: User): boolean {
+  return Boolean(user.disabledAt || user.deletingAt);
+}
+
+/**
+ * PRD identity resolution: (1) (issuer, sub) identity → sign in; (2) existing
+ * user by verified-domain email → adopt (org membership + scim_members +
+ * identity link); (3) JIT create. Disabled/deleting accounts are refused on
+ * every branch BEFORE any membership or session write. Storage failures fail
+ * the login closed — falling through could provision a duplicate account.
+ */
+async function resolveSsoUser(
+  db: D1Database,
+  logger: Logger,
+  connection: SsoConnection,
+  claims: IdTokenClaims,
+): Promise<ResolutionResult> {
+  const identityLookup = await getIdentityByIssuerSubject(
+    db,
+    logger,
+    connection.issuer,
+    claims.subject,
+  );
+  if (identityLookup.success) {
+    const userResult = await getUser(db, identityLookup.data.userId, logger);
+    if (!userResult.success) {
+      logger.error("SSO identity points at a missing user", userResult.error, {
+        identityId: identityLookup.data.id,
+      });
+      return { kind: "server_error" };
+    }
+    if (isDisabled(userResult.data)) {
+      logger.warn("Blocked SSO sign-in — account disabled", { userId: userResult.data.id });
+      return { kind: "redirect", code: "account_disabled" };
+    }
+    // For this connection, a sub-match signs in only: membership and the
+    // scim_members row were established at adopt/JIT time and are SCIM's to
+    // manage from then on. But when the identity was established via a
+    // DIFFERENT connection (one IdP issuer serving several orgs, each with
+    // its own verified domains — extractClaims already enforced this org's),
+    // this org's membership was never written: establish it now. The identity
+    // row keeps its original connection_id.
+    if (identityLookup.data.connectionId !== connection.id) {
+      const userId = userResult.data.id;
+      const memberResult = await ensureOrgMember(db, logger, connection.orgId, userId, "member");
+      if (!memberResult.success) {
+        logger.error("Failed to add SSO user to org", memberResult.error, { userId });
+        return { kind: "server_error" };
+      }
+      const scimResult = await ensureScimMember(db, logger, connection.id, userId);
+      if (!scimResult.success) return { kind: "server_error" };
+    }
+    return { userId: userResult.data.id };
+  }
+  if (!(identityLookup.error instanceof NotFoundError)) {
+    logger.error("SSO identity lookup failed", identityLookup.error);
+    return { kind: "server_error" };
+  }
+
+  const byEmail = await getUserByEmail(db, claims.email, logger);
+  let userId: string;
+  if (byEmail.success) {
+    if (isDisabled(byEmail.data)) {
+      logger.warn("Blocked SSO sign-in — account disabled", { userId: byEmail.data.id });
+      return { kind: "redirect", code: "account_disabled" };
+    }
+    userId = byEmail.data.id;
+    logger.info("Adopting existing account into SSO", { userId, orgId: connection.orgId });
+  } else {
+    // JIT creation deliberately bypasses the beta gate: the verified email
+    // domain (DNS-proven org ownership) substitutes for an invite code.
+    const base = deriveUsernameBase(claims.email);
+    let username = await findAvailableUsername(db, logger, base);
+    let created = await createUser(db, claims.email, logger, username);
+    if (!created.success) {
+      // A concurrent first login (or username claim) can win the UNIQUE race;
+      // re-derive and retry exactly once before failing.
+      username = await findAvailableUsername(db, logger, base);
+      created = await createUser(db, claims.email, logger, username);
+    }
+    if (!created.success) {
+      // The email UNIQUE race: the racing login created the account — adopt it.
+      // Residual: a username-UNIQUE loss on both attempts (double random-suffix
+      // collision) lands here too and 500s; the user's retry succeeds.
+      const raced = await getUserByEmail(db, claims.email, logger);
+      if (!raced.success || isDisabled(raced.data)) {
+        logger.error("Failed to JIT-create SSO user", created.error);
+        return { kind: "server_error" };
+      }
+      userId = raced.data.id;
+    } else {
+      userId = created.data.user.id;
+      logger.info("JIT-created SSO user", { userId, orgId: connection.orgId });
+    }
+  }
+
+  // ensureOrgMember, never addOrgMember: adopting an org owner/admin into SSO
+  // must not demote their existing role to 'member'.
+  const memberResult = await ensureOrgMember(db, logger, connection.orgId, userId, "member");
+  if (!memberResult.success) {
+    logger.error("Failed to add SSO user to org", memberResult.error, { userId });
+    return { kind: "server_error" };
+  }
+  const scimResult = await ensureScimMember(db, logger, connection.id, userId);
+  if (!scimResult.success) return { kind: "server_error" };
+
+  const identityResult = await upsertIdentity(db, logger, {
+    userId,
+    provider: "oidc",
+    issuer: connection.issuer,
+    subject: claims.subject,
+    email: claims.email,
+    connectionId: connection.id,
+  });
+  if (!identityResult.success) {
+    // Fail closed (unlike the best-effort OAuth backfill): for SSO the
+    // identity row IS the credential, and a Conflict here means the pair was
+    // concurrently linked to another account.
+    logger.error("Failed to link SSO identity", identityResult.error, { userId });
+    return { kind: "server_error" };
+  }
+
+  return { userId };
+}
+
+// GET /auth/sso/callback — the single redirect URI for all connections.
+app.get("/callback", async (c) => {
+  const unconfigured = ssoUnconfigured(c);
+  if (unconfigured) return unconfigured;
+
+  const logger = requestLogger(c);
+  const query = c.req.query();
+
+  if (query.error) {
+    // Never reflect raw IdP strings into HTML; log them truncated instead.
+    logger.warn("IdP returned an error on callback", {
+      error: String(query.error).slice(0, 100),
+      description: String(query.error_description ?? "").slice(0, 200),
+    });
+    return ssoErrorRedirect(c, "idp_error");
+  }
+
+  const state = query.state;
+  if (!state) {
+    logger.warn("SSO callback missing state parameter");
+    return ssoErrorRedirect(c, "invalid_state");
+  }
+
+  const cookieState = getCookie(c, SSO_STATE_COOKIE);
+  deleteCookie(c, SSO_STATE_COOKIE, { path: SSO_STATE_COOKIE_PATH });
+  if (!cookieState || !constantTimeEqual(cookieState, state)) {
+    logger.warn("SSO callback state not bound to this browser", {
+      statePrefix: state.slice(0, 8),
+    });
+    return ssoErrorRedirect(c, "invalid_state");
+  }
+
+  // Atomic single-use: exactly one callback per state wins, even under a race.
+  const consumed = await consumeOidcLoginState(c.env.DB, logger, state);
+  if (!consumed.success) {
+    logger.error("Failed to consume SSO login state", consumed.error);
+    return c.json({ error: "Failed to sign in" }, 500);
+  }
+  const loginState: OidcLoginState | null = consumed.data;
+  if (!loginState) {
+    logger.warn("SSO state unknown, expired, or replayed", { statePrefix: state.slice(0, 8) });
+    return ssoErrorRedirect(c, "invalid_state");
+  }
+
+  const code = query.code;
+  if (!code) {
+    logger.warn("SSO callback missing code parameter");
+    return ssoErrorRedirect(c, "sso_failed");
+  }
+
+  const connectionResult = await getSsoConnectionById(c.env.DB, logger, loginState.connectionId);
+  if (!connectionResult.success) {
+    if (connectionResult.error instanceof NotFoundError) {
+      logger.warn("SSO connection deleted mid-login", { connectionId: loginState.connectionId });
+      return ssoErrorRedirect(c, "sso_failed");
+    }
+    return c.json({ error: "Failed to sign in" }, 500);
+  }
+  const connection = connectionResult.data;
+  // Re-check at callback time: an admin may have disabled the connection (or
+  // its verification may have been cleared) after /start issued the state.
+  if (!loginUsable(connection)) {
+    logger.warn("SSO connection no longer usable at callback", { connectionId: connection.id });
+    return ssoErrorRedirect(c, "sso_failed");
+  }
+
+  // ssoUnconfigured guarantees the secret is set.
+  const encryptionSecret = c.env.SSO_ENCRYPTION_SECRET as string;
+  const clientSecret = await decryptToken(
+    connection.clientSecretCiphertext,
+    encryptionSecret,
+    SSO_SECRET_SALT,
+  );
+  if (clientSecret === null) {
+    logger.error("Failed to decrypt SSO client secret", undefined, {
+      connectionId: connection.id,
+    });
+    return c.json({ error: "Failed to sign in" }, 500);
+  }
+
+  const redirectUri = `${new URL(c.req.url).origin}/auth/sso/callback`;
+  const idToken = await exchangeCodeForIdToken(
+    connection,
+    clientSecret,
+    code,
+    loginState.codeVerifier,
+    redirectUri,
+    logger,
+  );
+  if (idToken === null) return ssoErrorRedirect(c, "sso_failed");
+
+  // JWKS is fetched per login in practice (Workers isolates are ephemeral;
+  // jose's in-isolate cache is best-effort) — accepted latency cost.
+  let payload: Record<string, unknown>;
+  try {
+    const jwks = createRemoteJWKSet(new URL(connection.jwksUri));
+    const verified = await jwtVerify(idToken, jwks, {
+      issuer: connection.issuer,
+      audience: connection.clientId,
+      algorithms: ID_TOKEN_ALGORITHMS,
+      clockTolerance: ID_TOKEN_CLOCK_TOLERANCE_SECONDS,
+    });
+    payload = verified.payload;
+  } catch (err) {
+    logger.warn("id_token verification failed", {
+      connectionId: connection.id,
+      reason: err instanceof Error ? err.message.slice(0, 200) : "unknown",
+    });
+    return ssoErrorRedirect(c, "sso_failed");
+  }
+
+  // Multi-audience tokens require azp per OIDC Core §3.1.3.7. jose only
+  // checks that our client_id is AMONG the audiences — pin azp so a token
+  // minted for a different party in the same audience list is refused.
+  if (Array.isArray(payload.aud) && payload.azp !== connection.clientId) {
+    logger.warn("id_token azp missing or mismatched on multi-audience token", {
+      connectionId: connection.id,
+    });
+    return ssoErrorRedirect(c, "sso_failed");
+  }
+
+  if (typeof payload.nonce !== "string" || payload.nonce !== loginState.nonce) {
+    logger.warn("id_token nonce mismatch", { connectionId: connection.id });
+    return ssoErrorRedirect(c, "invalid_state");
+  }
+
+  const extraction = extractClaims(payload, connection, logger);
+  if ("refusal" in extraction) return ssoErrorRedirect(c, extraction.refusal);
+
+  const resolution = await resolveSsoUser(c.env.DB, logger, connection, extraction.claims);
+  if ("kind" in resolution) {
+    if (resolution.kind === "redirect") return ssoErrorRedirect(c, resolution.code);
+    return c.json({ error: "Failed to sign in" }, 500);
+  }
+  const { userId } = resolution;
+
+  const sessionLogger = logger.child({ userId });
+  const sessionResult = await createSession(c.env.DB, userId, sessionLogger);
+  if (!sessionResult.success) {
+    sessionLogger.error("Failed to create session");
+    return c.json({ error: "Failed to create session" }, 500);
+  }
+  await recordAudit(c.env.DB, sessionLogger, {
+    action: "session.created",
+    actorType: "user",
+    actorId: userId,
+    detail: { method: "oidc", orgId: connection.orgId },
+  });
+
+  setCookie(c, "stratum_session", sessionResult.data.id, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "Lax",
+    maxAge: SESSION_COOKIE_MAX_AGE_SECONDS,
+    path: "/",
+  });
+
+  sessionLogger.info("OIDC SSO sign-in successful", { orgId: connection.orgId });
+  // Re-validate on read: the stored value went through validateRedirectTo at
+  // /start, but a DB value must not be trusted as a redirect target.
+  return c.redirect(validateRedirectTo(loginState.redirectTo) ?? "/");
+});
+
+export { app as ssoRouter };

--- a/src/routes/sso.tsx
+++ b/src/routes/sso.tsx
@@ -2,9 +2,10 @@ import { type Context, Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { createRemoteJWKSet, jwtVerify } from "jose";
 import { readBodyCapped } from "../services/oidc-discovery";
+import { deriveUsernameBase, findAvailableUsername, randomHex } from "../services/sso-usernames";
 import { recordAudit } from "../storage/audit";
 import { getIdentityByIssuerSubject, upsertIdentity } from "../storage/identities";
-import { ensureOrgMember, getOrg, getOrgBySlug } from "../storage/orgs";
+import { ensureOrgMember, getOrg } from "../storage/orgs";
 import { createSession } from "../storage/sessions";
 import {
   OIDC_STATE_TTL_SECONDS,
@@ -18,12 +19,11 @@ import {
   getSsoConnectionByVerifiedDomain,
   purgeExpiredOidcStates,
 } from "../storage/sso";
-import { createUser, getUser, getUserByEmail, getUserByUsername } from "../storage/users";
-import { type Env, MAX_NAMESPACE_LENGTH, type User } from "../types";
+import { createUser, getUser, getUserByEmail } from "../storage/users";
+import type { Env, User } from "../types";
 import { SSO_SECRET_SALT, constantTimeEqual, decryptToken } from "../utils/crypto";
 import { NotFoundError } from "../utils/errors";
 import { type Logger, createLogger } from "../utils/logger";
-import { validateUsername } from "../utils/username-validation";
 
 /**
  * OIDC single sign-on login flow (#253 Task 5), mounted at /auth/sso.
@@ -48,9 +48,6 @@ const SESSION_COOKIE_MAX_AGE_SECONDS = 2592000;
 // (shared) client secret forge id_tokens.
 const ID_TOKEN_ALGORITHMS = ["RS256", "ES256"];
 const ID_TOKEN_CLOCK_TOLERANCE_SECONDS = 60;
-// JIT usernames: bounded probe for a free numeric-suffixed name before
-// falling back to a random one.
-const MAX_USERNAME_SUFFIX_ATTEMPTS = 10;
 
 // Codes the /callback redirects back to the picker page with. Raw IdP error
 // strings are never reflected — they map to the generic idp_error.
@@ -87,14 +84,6 @@ function ssoUnconfigured(c: SsoContext): Response | null {
     return c.json({ error: "SSO is not configured on this server" }, 501);
   }
   return null;
-}
-
-function randomHex(byteLength: number): string {
-  const bytes = new Uint8Array(byteLength);
-  crypto.getRandomValues(bytes);
-  return Array.from(bytes)
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
 }
 
 function base64url(bytes: Uint8Array): string {
@@ -637,51 +626,6 @@ async function exchangeCodeForIdToken(
     logger.warn("OIDC token response is not valid JSON", { connectionId: connection.id });
     return null;
   }
-}
-
-/**
- * Derive a JIT username from the email local part via the exact pipeline
- * signup uses (see createUser), falling back to a random name when the local
- * part cannot produce a valid one.
- */
-function deriveUsernameBase(email: string): string {
-  const candidate = (email.split("@")[0] ?? "")
-    .toLowerCase()
-    .replace(/[^a-z0-9-]/g, "")
-    .replace(/-+/g, "-")
-    .replace(/^[-0-9]+/, "")
-    .replace(/-+$/, "")
-    // Truncate long local parts to the username cap (re-trimming so the cut
-    // cannot leave a trailing hyphen) rather than failing max-length
-    // validation and falling to the random fallback.
-    .slice(0, MAX_NAMESPACE_LENGTH)
-    .replace(/-+$/, "");
-  const validation = validateUsername(candidate);
-  return validation.success ? validation.data : `sso-${randomHex(3)}`;
-}
-
-/**
- * Find a free username: the base, then numeric suffixes, then a random
- * fallback. Usernames and org slugs share one namespace (user and org pages
- * live under the same URL prefix), so a name is taken when EITHER exists.
- */
-async function findAvailableUsername(
-  db: D1Database,
-  logger: Logger,
-  base: string,
-): Promise<string> {
-  for (let attempt = 0; attempt < MAX_USERNAME_SUFFIX_ATTEMPTS; attempt++) {
-    const suffix = attempt === 0 ? "" : `-${attempt + 1}`;
-    // Keep base + suffix within the username cap; re-trim so a truncation
-    // can't leave a trailing hyphen.
-    const truncated = base.slice(0, MAX_NAMESPACE_LENGTH - suffix.length).replace(/-+$/, "");
-    const candidate = `${truncated}${suffix}`;
-    const userTaken = (await getUserByUsername(db, candidate, logger)).success;
-    if (userTaken) continue;
-    const slugTaken = (await getOrgBySlug(db, logger, candidate)).success;
-    if (!slugTaken) return candidate;
-  }
-  return `sso-${randomHex(4)}`;
 }
 
 type ResolutionFailure =

--- a/src/routes/sso.tsx
+++ b/src/routes/sso.tsx
@@ -128,9 +128,11 @@ function loginUsable(connection: SsoConnection): boolean {
 }
 
 /**
- * Per-IP hourly cap on /start, mirroring checkMagicLinkRateLimits: reads fail
- * open (an auth path must not lock users out on a KV blip) and the counter is
- * committed only once the request is actually going to redirect to the IdP.
+ * Per-IP hourly cap on /start: reads fail open (an auth path must not lock
+ * users out on a KV blip) and the counter is committed only once the request
+ * is actually going to redirect to the IdP. KV read-then-write is best-effort
+ * under concurrency; unlike magic-link sends (#283) a /start admits no email,
+ * so an atomic Durable Object counter isn't warranted here.
  */
 async function checkSsoStartRateLimit(
   c: SsoContext,
@@ -437,7 +439,7 @@ app.get("/", async (c) => {
   if (!connection) {
     const domain = identifier.split("@").pop() ?? "";
     const byDomain = await getSsoConnectionByVerifiedDomain(c.env.DB, logger, domain);
-    if (byDomain.success) connection = byDomain.data;
+    if (byDomain.success && loginUsable(byDomain.data)) connection = byDomain.data;
   }
 
   if (!connection) {

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -3,6 +3,7 @@ import { sweepDeletionJobs } from "./queue/deletion-runner";
 import { sweepStaleEvents } from "./queue/event-consumer";
 import { runTtlSweep } from "./queue/ttl-sweep";
 import { syncAllProjects } from "./routes/sync";
+import { purgeExpiredOidcStates } from "./storage/sso";
 import type { Env } from "./types";
 import type { Logger } from "./utils/logger";
 
@@ -11,7 +12,8 @@ export type ScheduledJob =
   | "deletion-sweep"
   | "backup"
   | "ttl-sweep"
-  | "project-sync";
+  | "project-sync"
+  | "oidc-state-purge";
 
 /**
  * Cron → jobs routing. Backup runs on its OWN trigger (`0 4 * * *`), isolated
@@ -27,7 +29,7 @@ export function jobsForCron(cron: string): ScheduledJob[] {
     case "0 4 * * *":
       return ["backup"];
     case "0 6 * * *":
-      return ["ttl-sweep", "project-sync"];
+      return ["ttl-sweep", "project-sync", "oidc-state-purge"];
     default:
       return [];
   }
@@ -41,6 +43,7 @@ const JOB_RUNNERS: JobRunners = {
   backup: (env, logger) => runBackup(env, logger, new Date().toISOString()),
   "ttl-sweep": (env, logger) => runTtlSweep(env, logger),
   "project-sync": (env) => syncAllProjects(env),
+  "oidc-state-purge": (env, logger) => purgeExpiredOidcStates(env.DB, logger),
 };
 
 /**

--- a/src/services/domain-verification.ts
+++ b/src/services/domain-verification.ts
@@ -1,0 +1,102 @@
+import { type AppError, ExternalServiceError } from "../utils/errors";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+
+/**
+ * DNS TXT domain verification via DNS-over-HTTPS (Cloudflare's JSON API).
+ * An admin proves ownership of an email domain by publishing
+ * `stratum-sso-verify=<token>` as a TXT record at `_stratum-sso.<domain>`.
+ * Admin-time only (never on the login path), so the external DoH dependency
+ * is acceptable.
+ */
+
+const DOH_ENDPOINT = "https://cloudflare-dns.com/dns-query";
+const DOH_TIMEOUT_MS = 10_000;
+const TXT_RECORD_TYPE = 16;
+
+export function verificationRecordName(domain: string): string {
+  return `_stratum-sso.${domain}`;
+}
+
+export function verificationTxtValue(token: string): string {
+  return `stratum-sso-verify=${token}`;
+}
+
+interface DohAnswer {
+  type?: number;
+  data?: string;
+}
+
+/**
+ * Check whether `_stratum-sso.<domain>` publishes a TXT record containing
+ * `stratum-sso-verify=<token>`. `ok(false)` means the lookup worked but the
+ * record is absent/wrong; `err` means the lookup itself failed (the caller
+ * must not treat that as "not verified yet" silently — it is retryable).
+ */
+export async function checkDomainTxtRecord(
+  domain: string,
+  token: string,
+  logger: Logger,
+): Promise<Result<boolean, AppError>> {
+  const name = verificationRecordName(domain);
+  const url = `${DOH_ENDPOINT}?name=${encodeURIComponent(name)}&type=TXT`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { Accept: "application/dns-json" },
+      signal: AbortSignal.timeout(DOH_TIMEOUT_MS),
+    });
+  } catch (error) {
+    logger.warn("DoH TXT lookup failed", { domain });
+    return err(
+      new ExternalServiceError(
+        "dns-over-https",
+        "TXT lookup request failed",
+        error instanceof Error ? error : undefined,
+      ),
+    );
+  }
+
+  if (!res.ok) {
+    logger.warn("DoH TXT lookup returned non-OK status", { domain, status: res.status });
+    return err(new ExternalServiceError("dns-over-https", `TXT lookup returned ${res.status}`));
+  }
+
+  let answers: DohAnswer[];
+  let status: unknown;
+  try {
+    const parsed = (await res.json()) as { Status?: unknown; Answer?: DohAnswer[] };
+    status = parsed.Status;
+    answers = Array.isArray(parsed.Answer) ? parsed.Answer : [];
+  } catch {
+    return err(new ExternalServiceError("dns-over-https", "TXT lookup returned invalid JSON"));
+  }
+
+  // Only NOERROR (0) and NXDOMAIN (3) are authoritative answers about the
+  // record's presence. Anything else — SERVFAIL (2, incl. DNSSEC-bogus),
+  // REFUSED (5), … — is a resolver failure and must surface as retryable, not
+  // as "TXT record missing".
+  if (status !== 0 && status !== 3) {
+    logger.warn("DoH TXT lookup returned non-authoritative DNS status", { domain, status });
+    return err(
+      new ExternalServiceError(
+        "dns-over-https",
+        `TXT lookup returned DNS status ${String(status)}`,
+      ),
+    );
+  }
+
+  const expected = verificationTxtValue(token);
+  // DoH JSON quotes TXT data (possibly in multiple quoted chunks); strip the
+  // quotes, then require the record to equal the expected value exactly.
+  const found = answers.some(
+    (answer) =>
+      answer.type === TXT_RECORD_TYPE &&
+      typeof answer.data === "string" &&
+      answer.data.replaceAll('"', "") === expected,
+  );
+
+  logger.info("DoH TXT verification checked", { domain, found });
+  return ok(found);
+}

--- a/src/services/oidc-discovery.ts
+++ b/src/services/oidc-discovery.ts
@@ -1,0 +1,219 @@
+import { type AppError, ExternalServiceError, ValidationError } from "../utils/errors";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+
+/**
+ * OIDC discovery (`/.well-known/openid-configuration`) with SSRF hardening.
+ *
+ * The issuer is org-admin-supplied and the discovery document is fetched
+ * server-side, so both the issuer URL and every endpoint the document names
+ * are attacker-suppliable. Each must independently pass host validation
+ * (https, public non-IP hostname) before anything is stored — a hostile IdP
+ * must not be able to point login-time token/JWKS fetches at internal hosts.
+ */
+
+/**
+ * Issuers reserved for the existing OAuth flows. An org connection claiming
+ * one could mint `identities` rows in the GitHub/Google namespace and re-point
+ * OAuth-linked accounts, so they are rejected outright.
+ */
+export const RESERVED_ISSUERS = ["https://github.com", "https://accounts.google.com"] as const;
+
+export interface OidcEndpoints {
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  jwksUri: string;
+}
+
+const DISCOVERY_TIMEOUT_MS = 10_000;
+const MAX_DISCOVERY_BYTES = 64 * 1024;
+
+// Suffixes that resolve inside private/reserved namespaces regardless of DNS.
+const PRIVATE_HOSTNAME_SUFFIXES = [
+  ".localhost",
+  ".local",
+  ".internal",
+  ".home.arpa",
+  ".in-addr.arpa",
+  ".ip6.arpa",
+];
+
+function isIpLiteral(hostname: string): boolean {
+  // URL.hostname renders IPv6 literals bracketed ("[::1]"); a colon can only
+  // appear in an IPv6 literal.
+  if (hostname.startsWith("[") || hostname.includes(":")) return true;
+  return /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname);
+}
+
+/**
+ * Validate that a URL is a safe outbound-fetch target: https, no embedded
+ * credentials, and a public multi-label hostname (no IP literals, localhost,
+ * or private/reserved suffixes — single-label names catch bare internal
+ * hostnames like `metadata`).
+ */
+export function validateOidcUrl(rawUrl: string, field: string): ValidationError | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return new ValidationError(`${field} must be a valid URL`, { field });
+  }
+  if (url.protocol !== "https:") {
+    return new ValidationError(`${field} must use https`, { field });
+  }
+  if (url.username !== "" || url.password !== "") {
+    return new ValidationError(`${field} must not embed credentials`, { field });
+  }
+  // WHATWG URL preserves a trailing dot on named hosts ("localhost." !==
+  // "localhost"), which would dodge every check below — strip it once here so
+  // the whole function sees the canonical name.
+  const hostname = url.hostname.toLowerCase().replace(/\.$/, "");
+  if (hostname === "localhost" || isIpLiteral(hostname)) {
+    return new ValidationError(`${field} must not target a local or IP-literal host`, { field });
+  }
+  if (PRIVATE_HOSTNAME_SUFFIXES.some((suffix) => hostname.endsWith(suffix))) {
+    return new ValidationError(`${field} must not target a private/reserved hostname`, { field });
+  }
+  if (!hostname.includes(".")) {
+    return new ValidationError(`${field} hostname must be a public multi-label name`, { field });
+  }
+  return null;
+}
+
+/** Validate an issuer for connection creation (host rules + reserved-issuer check). */
+export function validateIssuer(issuer: string): ValidationError | null {
+  const urlError = validateOidcUrl(issuer, "issuer");
+  if (urlError) return urlError;
+
+  const url = new URL(issuer);
+  if (url.search !== "" || url.hash !== "") {
+    return new ValidationError("issuer must not contain a query or fragment", { field: "issuer" });
+  }
+
+  const normalized = issuer.replace(/\/+$/, "").toLowerCase();
+  if ((RESERVED_ISSUERS as readonly string[]).includes(normalized)) {
+    return new ValidationError("issuer is reserved for built-in OAuth providers", {
+      field: "issuer",
+    });
+  }
+  return null;
+}
+
+async function readBodyCapped(res: Response, maxBytes: number): Promise<string | null> {
+  const reader = res.body?.getReader();
+  if (!reader) {
+    const text = await res.text();
+    return new TextEncoder().encode(text).byteLength > maxBytes ? null : text;
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+  const combined = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(combined);
+}
+
+/**
+ * Fetch and validate `<issuer>/.well-known/openid-configuration`.
+ *
+ * The document's `issuer` must exactly equal the supplied issuer (RFC 8414
+ * §3.3 — a mismatch means a confused-deputy or hosting-provider takeover),
+ * and all three endpoints must pass the same host validation as the issuer.
+ */
+export async function discoverOidcConfiguration(
+  issuer: string,
+  logger: Logger,
+): Promise<Result<OidcEndpoints, AppError>> {
+  const issuerError = validateIssuer(issuer);
+  if (issuerError) return err(issuerError);
+
+  const discoveryUrl = `${issuer.replace(/\/+$/, "")}/.well-known/openid-configuration`;
+  logger.info("Fetching OIDC discovery document", { issuer });
+
+  let res: Response;
+  try {
+    res = await fetch(discoveryUrl, {
+      headers: { Accept: "application/json" },
+      // A redirect could re-point the fetch at a host that never passed
+      // validation; discovery documents live at their canonical URL.
+      redirect: "error",
+      signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+    });
+  } catch (error) {
+    logger.warn("OIDC discovery fetch failed", { issuer });
+    return err(
+      new ExternalServiceError(
+        "oidc-discovery",
+        "discovery request failed",
+        error instanceof Error ? error : undefined,
+      ),
+    );
+  }
+
+  if (!res.ok) {
+    logger.warn("OIDC discovery returned non-OK status", { issuer, status: res.status });
+    return err(new ExternalServiceError("oidc-discovery", `discovery returned ${res.status}`));
+  }
+
+  const contentType = res.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    return err(new ValidationError("discovery document is not application/json"));
+  }
+
+  const body = await readBodyCapped(res, MAX_DISCOVERY_BYTES);
+  if (body === null) {
+    return err(new ValidationError("discovery document exceeds size limit"));
+  }
+
+  let doc: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return err(new ValidationError("discovery document is not a JSON object"));
+    }
+    doc = parsed as Record<string, unknown>;
+  } catch {
+    return err(new ValidationError("discovery document is not valid JSON"));
+  }
+
+  if (doc.issuer !== issuer) {
+    logger.warn("OIDC discovery issuer mismatch", { issuer });
+    return err(new ValidationError("discovery document issuer does not match the supplied issuer"));
+  }
+
+  const endpoints: OidcEndpoints = {
+    authorizationEndpoint: "",
+    tokenEndpoint: "",
+    jwksUri: "",
+  };
+  const fields: Array<[keyof OidcEndpoints, string]> = [
+    ["authorizationEndpoint", "authorization_endpoint"],
+    ["tokenEndpoint", "token_endpoint"],
+    ["jwksUri", "jwks_uri"],
+  ];
+  for (const [key, docField] of fields) {
+    const value = doc[docField];
+    if (typeof value !== "string" || value.length === 0) {
+      return err(new ValidationError(`discovery document is missing ${docField}`));
+    }
+    const endpointError = validateOidcUrl(value, docField);
+    if (endpointError) return err(endpointError);
+    endpoints[key] = value;
+  }
+
+  logger.info("OIDC discovery succeeded", { issuer });
+  return ok(endpoints);
+}

--- a/src/services/oidc-discovery.ts
+++ b/src/services/oidc-discovery.ts
@@ -99,7 +99,12 @@ export function validateIssuer(issuer: string): ValidationError | null {
   return null;
 }
 
-async function readBodyCapped(res: Response, maxBytes: number): Promise<string | null> {
+/**
+ * Read a response body up to `maxBytes`; null when the cap is exceeded. Shared
+ * by discovery and the OIDC login token exchange — both fetch org-admin-
+ * supplied endpoints, so an unbounded body must never be buffered.
+ */
+export async function readBodyCapped(res: Response, maxBytes: number): Promise<string | null> {
   const reader = res.body?.getReader();
   if (!reader) {
     const text = await res.text();

--- a/src/services/oidc-discovery.ts
+++ b/src/services/oidc-discovery.ts
@@ -20,6 +20,8 @@ import { type Result, err, ok } from "../utils/result";
 export const RESERVED_ISSUERS = ["https://github.com", "https://accounts.google.com"] as const;
 
 export interface OidcEndpoints {
+  /** The canonical (trailing-slash-normalized) issuer callers should store. */
+  issuer: string;
   authorizationEndpoint: string;
   tokenEndpoint: string;
   jwksUri: string;
@@ -145,8 +147,12 @@ export async function discoverOidcConfiguration(
   const issuerError = validateIssuer(issuer);
   if (issuerError) return err(issuerError);
 
-  const discoveryUrl = `${issuer.replace(/\/+$/, "")}/.well-known/openid-configuration`;
-  logger.info("Fetching OIDC discovery document", { issuer });
+  // Normalize once and use the normalized form everywhere — the discovery URL,
+  // the RFC 8414 issuer equality check, and the returned (stored) issuer — so
+  // a trailing-slash input cannot desync any of the three.
+  const normalizedIssuer = issuer.replace(/\/+$/, "");
+  const discoveryUrl = `${normalizedIssuer}/.well-known/openid-configuration`;
+  logger.info("Fetching OIDC discovery document", { issuer: normalizedIssuer });
 
   let res: Response;
   try {
@@ -194,12 +200,13 @@ export async function discoverOidcConfiguration(
     return err(new ValidationError("discovery document is not valid JSON"));
   }
 
-  if (doc.issuer !== issuer) {
-    logger.warn("OIDC discovery issuer mismatch", { issuer });
+  if (doc.issuer !== normalizedIssuer) {
+    logger.warn("OIDC discovery issuer mismatch", { issuer: normalizedIssuer });
     return err(new ValidationError("discovery document issuer does not match the supplied issuer"));
   }
 
   const endpoints: OidcEndpoints = {
+    issuer: normalizedIssuer,
     authorizationEndpoint: "",
     tokenEndpoint: "",
     jwksUri: "",

--- a/src/services/sso-usernames.ts
+++ b/src/services/sso-usernames.ts
@@ -1,0 +1,70 @@
+import { getOrgBySlug } from "../storage/orgs";
+import { getUserByUsername } from "../storage/users";
+import { MAX_NAMESPACE_LENGTH } from "../types";
+import type { Logger } from "../utils/logger";
+import { validateUsername } from "../utils/username-validation";
+
+/**
+ * Username derivation for provisioned accounts, shared by the OIDC JIT login
+ * path (src/routes/sso.tsx) and SCIM provisioning (src/routes/scim.ts) so both
+ * produce identical names for the same email — a user provisioned by SCIM and
+ * one JIT-created at first login must not diverge.
+ */
+
+// Bounded probe for a free numeric-suffixed name before falling back to a
+// random one.
+const MAX_USERNAME_SUFFIX_ATTEMPTS = 10;
+
+/** CSPRNG hex string of `byteLength` bytes (also used by routes/sso.tsx). */
+export function randomHex(byteLength: number): string {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Derive a username from the email local part via the exact pipeline signup
+ * uses (see createUser), falling back to a random name when the local part
+ * cannot produce a valid one.
+ */
+export function deriveUsernameBase(email: string): string {
+  const candidate = (email.split("@")[0] ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^[-0-9]+/, "")
+    .replace(/-+$/, "")
+    // Truncate long local parts to the username cap (re-trimming so the cut
+    // cannot leave a trailing hyphen) rather than failing max-length
+    // validation and falling to the random fallback.
+    .slice(0, MAX_NAMESPACE_LENGTH)
+    .replace(/-+$/, "");
+  const validation = validateUsername(candidate);
+  return validation.success ? validation.data : `sso-${randomHex(3)}`;
+}
+
+/**
+ * Find a free username: the base, then numeric suffixes, then a random
+ * fallback. Usernames and org slugs share one namespace (user and org pages
+ * live under the same URL prefix), so a name is taken when EITHER exists.
+ */
+export async function findAvailableUsername(
+  db: D1Database,
+  logger: Logger,
+  base: string,
+): Promise<string> {
+  for (let attempt = 0; attempt < MAX_USERNAME_SUFFIX_ATTEMPTS; attempt++) {
+    const suffix = attempt === 0 ? "" : `-${attempt + 1}`;
+    // Keep base + suffix within the username cap; re-trim so a truncation
+    // can't leave a trailing hyphen.
+    const truncated = base.slice(0, MAX_NAMESPACE_LENGTH - suffix.length).replace(/-+$/, "");
+    const candidate = `${truncated}${suffix}`;
+    const userTaken = (await getUserByUsername(db, candidate, logger)).success;
+    if (userTaken) continue;
+    const slugTaken = (await getOrgBySlug(db, logger, candidate)).success;
+    if (!slugTaken) return candidate;
+  }
+  return `sso-${randomHex(4)}`;
+}

--- a/src/storage/audit.ts
+++ b/src/storage/audit.ts
@@ -28,7 +28,11 @@ export type AuditAction =
   | "sso.connection.updated"
   | "sso.connection.deleted"
   | "sso.domain.verified"
-  | "sso.scim_token.rotated";
+  | "sso.scim_token.rotated"
+  | "scim.user.provisioned"
+  | "scim.user.updated"
+  | "scim.user.deactivated"
+  | "scim.user.reactivated";
 
 export interface AuditEntry {
   id: string;

--- a/src/storage/audit.ts
+++ b/src/storage/audit.ts
@@ -21,7 +21,9 @@ export type AuditAction =
   | "deletion.completed"
   | "deletion.incomplete"
   | "deletion.redrive"
-  | "webhook.project_id_backfilled";
+  | "webhook.project_id_backfilled"
+  | "user.disabled"
+  | "user.enabled";
 
 export interface AuditEntry {
   id: string;

--- a/src/storage/audit.ts
+++ b/src/storage/audit.ts
@@ -23,7 +23,12 @@ export type AuditAction =
   | "deletion.redrive"
   | "webhook.project_id_backfilled"
   | "user.disabled"
-  | "user.enabled";
+  | "user.enabled"
+  | "sso.connection.created"
+  | "sso.connection.updated"
+  | "sso.connection.deleted"
+  | "sso.domain.verified"
+  | "sso.scim_token.rotated";
 
 export interface AuditEntry {
   id: string;

--- a/src/storage/d1-backup.ts
+++ b/src/storage/d1-backup.ts
@@ -15,6 +15,11 @@ export const BACKUP_TABLES: readonly string[] = [
   "teams",
   "org_members",
   "team_members",
+  // SSO/SCIM (migration 041): identities references users; scim_members
+  // references org_sso_connections, which references orgs — so this order.
+  "identities",
+  "org_sso_connections",
+  "scim_members",
   "sessions",
   "import_jobs",
   "changes",
@@ -49,6 +54,9 @@ export const BACKUP_EXCLUDED_TABLES: readonly string[] = [
   // Ephemeral, single-use, short-TTL login tokens (stored hashed). They expire
   // in minutes, so a backup would only ever hold dead rows — nothing to restore.
   "magic_links",
+  // Same story for OIDC login state (migration 041): single-use, 10-minute-TTL
+  // rows consumed at callback time; a backup would only ever hold dead rows.
+  "oidc_login_states",
   // The backup orchestrator's own per-repo rotation cursor. It describes backup
   // progress, not user data; restoring it into a fresh DB would be meaningless.
   "backup_state",

--- a/src/storage/deletion.ts
+++ b/src/storage/deletion.ts
@@ -7,8 +7,8 @@ import { findActiveJobForTarget } from "./deletion-jobs";
 import { artifactsRepoNameFromRemote } from "./git-ops";
 import { deleteIdentitiesForUser } from "./identities";
 import { deleteAllUserSessions } from "./sessions";
+import { reenableUsersForConnectionRemoval } from "./sso";
 import { listProjects } from "./state";
-import { enableUser } from "./users";
 
 /**
  * Shared tombstone for anonymized cross-project contributions. A single
@@ -751,28 +751,34 @@ async function resolveOrgOwnership(
     .run();
   // Removing a connection is a clean rollback, never a permanent lockout:
   // users its SCIM deactivated (possibly no longer org members) get their
-  // accounts back before the mapping rows vanish — mirrors the re-enable pass
-  // in DELETE /api/orgs/:slug/sso (src/routes/org-sso.ts). The erased user is
-  // excluded: their account is being deleted anyway.
-  const deactivated = await db
-    .prepare(
-      "SELECT user_id, connection_id FROM scim_members WHERE active = 0 AND user_id != ? " +
-        "AND connection_id IN (SELECT id FROM org_sso_connections WHERE org_id = ?)",
-    )
-    .bind(userId, org.id)
-    .all<{ user_id: string; connection_id: string }>();
-  for (const row of deactivated.results) {
-    const enabled = await enableUser(db, row.user_id, logger);
-    if (!enabled.success) {
-      residuals.push(`org:${org.id}:scim-reenable:${row.user_id}`);
-      continue;
-    }
-    await recordAudit(db, logger, {
-      action: "user.enabled",
-      actorType: "system",
-      subject: row.user_id,
-      detail: { via: "org.deleted", orgId: org.id, connectionId: row.connection_id },
+  // accounts back before the mapping rows vanish — the same set-based helper
+  // (with the cross-connection vote guard) as DELETE /api/orgs/:slug/sso
+  // (src/routes/org-sso.ts). The erased user is excluded: their account is
+  // being deleted anyway. org_id is UNIQUE, so the org has at most one
+  // connection.
+  const connectionRow = await db
+    .prepare("SELECT id FROM org_sso_connections WHERE org_id = ?")
+    .bind(org.id)
+    .first<{ id: string }>();
+  if (connectionRow) {
+    const reenabled = await reenableUsersForConnectionRemoval(db, logger, connectionRow.id, {
+      excludeUserId: userId,
     });
+    if (!reenabled.success) {
+      residuals.push(`org:${org.id}:scim-reenable-batch`);
+    } else {
+      await recordAudit(db, logger, {
+        action: "sso.connection.deleted",
+        actorType: "system",
+        subject: org.id,
+        detail: {
+          via: "org.deleted",
+          orgId: org.id,
+          connectionId: connectionRow.id,
+          reenabledUserIds: reenabled.data,
+        },
+      });
+    }
   }
   await db
     .prepare(

--- a/src/storage/deletion.ts
+++ b/src/storage/deletion.ts
@@ -2,11 +2,13 @@ import type { Env, ProjectEntry, WorkspaceEntry } from "../types";
 import { type AppError, toAppError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
 import { type Result, err, ok } from "../utils/result";
+import { recordAudit } from "./audit";
 import { findActiveJobForTarget } from "./deletion-jobs";
 import { artifactsRepoNameFromRemote } from "./git-ops";
 import { deleteIdentitiesForUser } from "./identities";
 import { deleteAllUserSessions } from "./sessions";
 import { listProjects } from "./state";
+import { enableUser } from "./users";
 
 /**
  * Shared tombstone for anonymized cross-project contributions. A single
@@ -747,6 +749,31 @@ async function resolveOrgOwnership(
     )
     .bind(org.id)
     .run();
+  // Removing a connection is a clean rollback, never a permanent lockout:
+  // users its SCIM deactivated (possibly no longer org members) get their
+  // accounts back before the mapping rows vanish — mirrors the re-enable pass
+  // in DELETE /api/orgs/:slug/sso (src/routes/org-sso.ts). The erased user is
+  // excluded: their account is being deleted anyway.
+  const deactivated = await db
+    .prepare(
+      "SELECT user_id, connection_id FROM scim_members WHERE active = 0 AND user_id != ? " +
+        "AND connection_id IN (SELECT id FROM org_sso_connections WHERE org_id = ?)",
+    )
+    .bind(userId, org.id)
+    .all<{ user_id: string; connection_id: string }>();
+  for (const row of deactivated.results) {
+    const enabled = await enableUser(db, row.user_id, logger);
+    if (!enabled.success) {
+      residuals.push(`org:${org.id}:scim-reenable:${row.user_id}`);
+      continue;
+    }
+    await recordAudit(db, logger, {
+      action: "user.enabled",
+      actorType: "system",
+      subject: row.user_id,
+      detail: { via: "org.deleted", orgId: org.id, connectionId: row.connection_id },
+    });
+  }
   await db
     .prepare(
       "DELETE FROM scim_members WHERE connection_id IN (SELECT id FROM org_sso_connections WHERE org_id = ?)",

--- a/src/storage/deletion.ts
+++ b/src/storage/deletion.ts
@@ -4,6 +4,7 @@ import type { Logger } from "../utils/logger";
 import { type Result, err, ok } from "../utils/result";
 import { findActiveJobForTarget } from "./deletion-jobs";
 import { artifactsRepoNameFromRemote } from "./git-ops";
+import { deleteIdentitiesForUser } from "./identities";
 import { deleteAllUserSessions } from "./sessions";
 import { listProjects } from "./state";
 
@@ -718,7 +719,7 @@ async function resolveOrgOwnership(
   }
 
   // No other members: the org is empty. Cascade its owned projects, then delete
-  // the org and any residual membership/team rows so no orphan survives.
+  // the org and any residual membership/team/SSO rows so no orphan survives.
   logger.info("Deleting empty org during account erasure", { orgId: org.id });
   const projectsResult = await listProjects(env.STATE, logger);
   if (projectsResult.success) {
@@ -735,6 +736,24 @@ async function resolveOrgOwnership(
     .bind(org.id)
     .run();
   await db.prepare("DELETE FROM teams WHERE org_id = ?").bind(org.id).run();
+  // SSO children before the org row: scim_members hangs off the connection, so
+  // it must go first or the connection delete would orphan its member mappings.
+  // identities.connection_id is a soft reference (no FK) that can belong to
+  // JIT-provisioned users who are no longer org members — null it, don't leave
+  // it dangling at a deleted connection id.
+  await db
+    .prepare(
+      "UPDATE identities SET connection_id = NULL WHERE connection_id IN (SELECT id FROM org_sso_connections WHERE org_id = ?)",
+    )
+    .bind(org.id)
+    .run();
+  await db
+    .prepare(
+      "DELETE FROM scim_members WHERE connection_id IN (SELECT id FROM org_sso_connections WHERE org_id = ?)",
+    )
+    .bind(org.id)
+    .run();
+  await db.prepare("DELETE FROM org_sso_connections WHERE org_id = ?").bind(org.id).run();
   await db.prepare("DELETE FROM orgs WHERE id = ?").bind(org.id).run();
 }
 
@@ -769,7 +788,7 @@ async function cascadeOwnedProject(
  * GDPR-grade account erasure. Order is load-bearing:
  *   1. delete owned projects (so only cross-project rows remain to anonymize),
  *   2. anonymize the remainder,
- *   3. drop agents / sessions / memberships,
+ *   3. drop agents / sessions / memberships / identities / SCIM mappings,
  *   4. resolve sole-owner orgs (promote or delete — never blocks),
  *   5. delete the users row LAST (frees email/username/token_hash/github_id
  *      uniques only once everything else is gone).
@@ -799,12 +818,17 @@ export async function deleteAccountCascade(
     const anonymized = await anonymizeUserContributions(db, userId, logger);
     if (!anonymized.success) residuals.push(`account:anonymize:${anonymized.error.code}`);
 
-    // 3) Agents, sessions, memberships.
+    // 3) Agents, sessions, memberships, external identities. Identity and SCIM
+    //    rows must go before the users row so a future signup by the same IdP
+    //    subject is neither blocked nor hijacked by a dangling mapping.
     await db.prepare("DELETE FROM agents WHERE owner_id = ?").bind(userId).run();
     const sessions = await deleteAllUserSessions(db, userId, logger);
     if (!sessions.success) residuals.push(`account:sessions:${sessions.error.code}`);
     await db.prepare("DELETE FROM org_members WHERE user_id = ?").bind(userId).run();
     await db.prepare("DELETE FROM team_members WHERE user_id = ?").bind(userId).run();
+    const identities = await deleteIdentitiesForUser(db, logger, userId);
+    if (!identities.success) residuals.push(`account:identities:${identities.error.code}`);
+    await db.prepare("DELETE FROM scim_members WHERE user_id = ?").bind(userId).run();
 
     // 4) Sole-owner org fallback (after membership rows are gone so an empty org
     //    is correctly detected). Never blocks erasure.

--- a/src/storage/identities.ts
+++ b/src/storage/identities.ts
@@ -1,0 +1,238 @@
+import { AppError, ConflictError, NotFoundError, ValidationError } from "../utils/errors";
+import { newId } from "../utils/ids";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+
+// External identities (migration 041): one row per (issuer, subject), the
+// stable pair an IdP guarantees for a user. Two invariants:
+//   1. (issuer, subject) is globally unique — enforced by the schema.
+//   2. At most one identity per (user_id, issuer) — enforced here (SQL can't
+//      express it without blocking legitimate subject rotation), so a user can
+//      hold identities from many issuers but never two subjects at one issuer.
+
+export type IdentityProvider = "oidc" | "github" | "google";
+
+export interface Identity {
+  id: string;
+  userId: string;
+  provider: IdentityProvider;
+  issuer: string;
+  subject: string;
+  email: string;
+  connectionId: string | null;
+  createdAt: string;
+}
+
+export interface UpsertIdentityInput {
+  userId: string;
+  provider: IdentityProvider;
+  issuer: string;
+  subject: string;
+  email: string;
+  connectionId?: string | null;
+}
+
+interface IdentityRow {
+  id: string;
+  user_id: string;
+  provider: IdentityProvider;
+  issuer: string;
+  subject: string;
+  email: string;
+  connection_id: string | null;
+  created_at: string;
+}
+
+// IdP claims are semi-hostile input once org admins can register arbitrary
+// issuers; a cap keeps a multi-MB claim from becoming a multi-MB D1 row.
+const MAX_IDENTITY_FIELD_LENGTH = 1024;
+
+function validateIdentityField(name: string, value: string): ValidationError | null {
+  if (value.trim().length === 0) {
+    return new ValidationError(`Identity ${name} must be non-empty`, { field: name });
+  }
+  if (value.length > MAX_IDENTITY_FIELD_LENGTH) {
+    return new ValidationError(`Identity ${name} exceeds ${MAX_IDENTITY_FIELD_LENGTH} chars`, {
+      field: name,
+    });
+  }
+  return null;
+}
+
+function rowToIdentity(row: IdentityRow): Identity {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    provider: row.provider,
+    issuer: row.issuer,
+    subject: row.subject,
+    email: row.email,
+    connectionId: row.connection_id,
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * Link an external identity to a user, replacing any prior state that would
+ * violate either invariant: the user's previous subject at this issuer is
+ * removed (subject rotation), and an existing (issuer, subject) row is
+ * re-pointed at this user (the row's email/connection refresh on every login).
+ * Both statements run in one atomic batch so a crash can't leave the user with
+ * two identities at one issuer.
+ */
+export async function upsertIdentity(
+  db: D1Database,
+  logger: Logger,
+  input: UpsertIdentityInput,
+): Promise<Result<Identity, AppError>> {
+  const { userId, provider, issuer, subject } = input;
+  logger.debug("Upserting identity", { userId, provider, issuer });
+
+  for (const [name, value] of [
+    ["issuer", issuer],
+    ["subject", subject],
+    ["email", input.email],
+  ] as const) {
+    const invalid = validateIdentityField(name, value);
+    if (invalid) return err(invalid);
+  }
+  // Domain checks and email-matching downstream compare lowercased (the repo
+  // convention for emails); issuer/subject stay byte-exact per OIDC.
+  const email = input.email.trim().toLowerCase();
+
+  try {
+    const id = newId("idn");
+    const createdAt = new Date().toISOString();
+    const connectionId = input.connectionId ?? null;
+
+    // Best-effort pre-read, for the forensic re-point warning below only —
+    // correctness never depends on it.
+    const prior = await db
+      .prepare("SELECT user_id FROM identities WHERE issuer = ? AND subject = ?")
+      .bind(issuer, subject)
+      .first<{ user_id: string }>();
+
+    await db.batch([
+      db
+        .prepare("DELETE FROM identities WHERE user_id = ? AND issuer = ? AND subject != ?")
+        .bind(userId, issuer, subject),
+      db
+        .prepare(
+          `INSERT INTO identities (id, user_id, provider, issuer, subject, email, connection_id, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT (issuer, subject) DO UPDATE SET
+             user_id = excluded.user_id,
+             provider = excluded.provider,
+             email = excluded.email,
+             connection_id = excluded.connection_id,
+             created_at = CASE
+               WHEN identities.user_id = excluded.user_id THEN identities.created_at
+               ELSE excluded.created_at
+             END`,
+        )
+        .bind(id, userId, provider, issuer, subject, email, connectionId, createdAt),
+    ]);
+
+    // Re-read: on conflict the stored row keeps its original id. The ownership
+    // assertion closes the read-after-batch race — if a concurrent upsert
+    // re-pointed the pair to another user in the window, fail rather than hand
+    // the caller an identity it would mint a session for.
+    const row = await db
+      .prepare("SELECT * FROM identities WHERE issuer = ? AND subject = ?")
+      .bind(issuer, subject)
+      .first<IdentityRow>();
+    if (!row) {
+      return err(
+        new AppError(`Identity missing after upsert for issuer '${issuer}'`, "STORAGE_ERROR", 500),
+      );
+    }
+    if (row.user_id !== userId) {
+      logger.error("Identity re-pointed concurrently during upsert", undefined, {
+        issuer,
+        expectedUserId: userId,
+        actualUserId: row.user_id,
+      });
+      return err(new ConflictError("Identity was linked to another account concurrently"));
+    }
+
+    if (prior && prior.user_id !== userId) {
+      // The breadcrumb for account-takeover forensics: an (issuer, subject)
+      // changing owners is legitimate only in rare flows (subject reuse at the
+      // IdP); the normal login path signs in the existing owner instead.
+      logger.warn("Identity re-pointed from another user", {
+        issuer,
+        provider,
+        previousUserId: prior.user_id,
+        userId,
+      });
+    }
+
+    logger.info("Identity upserted", { userId, provider, issuer, identityId: row.id });
+    return ok(rowToIdentity(row));
+  } catch (error) {
+    logger.error("Failed to upsert identity", error instanceof Error ? error : undefined, {
+      userId,
+      provider,
+      issuer,
+    });
+    return err(new AppError("Failed to upsert identity", "STORAGE_ERROR", 500, { userId }));
+  }
+}
+
+export async function getIdentityByIssuerSubject(
+  db: D1Database,
+  logger: Logger,
+  issuer: string,
+  subject: string,
+): Promise<Result<Identity, NotFoundError | AppError>> {
+  logger.debug("Querying identity by issuer/subject", { issuer });
+
+  try {
+    const row = await db
+      .prepare("SELECT * FROM identities WHERE issuer = ? AND subject = ?")
+      .bind(issuer, subject)
+      .first<IdentityRow>();
+
+    if (!row) {
+      logger.debug("Identity not found", { issuer });
+      return err(new NotFoundError("Identity", `${issuer}#subject`));
+    }
+
+    logger.debug("Identity found", { issuer, identityId: row.id, userId: row.user_id });
+    return ok(rowToIdentity(row));
+  } catch (error) {
+    // Never mask a DB failure as NotFound: the SSO resolution chain falls
+    // through NotFound into email-matching/JIT-creation, so a transient error
+    // here must fail the login closed, not provision a duplicate account.
+    logger.error("Failed to get identity", error instanceof Error ? error : undefined, { issuer });
+    return err(new AppError("Failed to get identity", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
+ * Remove every identity for a user (account deletion cascade), so a future
+ * signup by the same IdP subject is neither blocked nor hijacked.
+ */
+export async function deleteIdentitiesForUser(
+  db: D1Database,
+  logger: Logger,
+  userId: string,
+): Promise<Result<number, AppError>> {
+  logger.debug("Deleting identities for user", { userId });
+
+  try {
+    const result = await db.prepare("DELETE FROM identities WHERE user_id = ?").bind(userId).run();
+    const deletedCount = result.meta?.changes ?? 0;
+    logger.info("Identities deleted for user", { userId, deletedCount });
+    return ok(deletedCount);
+  } catch (error) {
+    logger.error(
+      "Failed to delete identities for user",
+      error instanceof Error ? error : undefined,
+      {
+        userId,
+      },
+    );
+    return err(new AppError("Failed to delete identities", "STORAGE_ERROR", 500, { userId }));
+  }
+}

--- a/src/storage/orgs.ts
+++ b/src/storage/orgs.ts
@@ -173,6 +173,42 @@ export async function addOrgMember(
   }
 }
 
+/**
+ * Add a user to an org only if they are not already a member (`ON CONFLICT DO
+ * NOTHING`). Exists for the SSO adopt/JIT login path: unlike `addOrgMember`,
+ * which overwrites the stored role on conflict, a sign-in must never downgrade
+ * an existing owner/admin to the default role.
+ */
+export async function ensureOrgMember(
+  db: D1Database,
+  logger: Logger,
+  orgId: string,
+  userId: string,
+  role: "member" | "admin" = "member",
+): Promise<Result<void, Error>> {
+  logger.info("Ensuring org member", { orgId, userId, role });
+
+  try {
+    const joinedAt = new Date().toISOString();
+    await db
+      .prepare(
+        "INSERT INTO org_members (org_id, user_id, role, joined_at) VALUES (?, ?, ?, ?) ON CONFLICT (org_id, user_id) DO NOTHING",
+      )
+      .bind(orgId, userId, role, joinedAt)
+      .run();
+
+    logger.info("Org member ensured", { orgId, userId, role });
+    return ok(undefined);
+  } catch (error) {
+    logger.error("Failed to ensure org member", error instanceof Error ? error : undefined, {
+      orgId,
+      userId,
+      role,
+    });
+    return err(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
 export async function removeOrgMember(
   db: D1Database,
   logger: Logger,

--- a/src/storage/sso.ts
+++ b/src/storage/sso.ts
@@ -762,28 +762,49 @@ export async function purgeExpiredOidcStates(
 }
 
 /**
- * Users this connection deactivated via SCIM (`scim_members.active = 0`) —
- * the set connection deletion must re-enable so removing a connection is a
- * clean rollback, never a permanent lockout.
+ * Re-enable the users a connection deactivated via SCIM
+ * (`scim_members.active = 0`), for connection removal: deleting a connection
+ * is a clean rollback, never a permanent lockout. The NOT-IN subquery is the
+ * cross-connection vote guard — removing one connection must not resurrect a
+ * user ANOTHER connection still deactivates (mirrors `reactivateUser`'s
+ * guard), and doing it set-based in one UPDATE bounds the D1 query count on
+ * large connections. `excludeUserId` skips a user whose account is being
+ * erased anyway. Returns the re-enabled user ids.
  */
-export async function listDeactivatedScimUserIds(
+export async function reenableUsersForConnectionRemoval(
   db: D1Database,
   logger: Logger,
   connectionId: string,
+  opts: { excludeUserId?: string } = {},
 ): Promise<Result<string[], AppError>> {
   try {
-    const { results } = await db
-      .prepare("SELECT user_id FROM scim_members WHERE connection_id = ? AND active = 0")
-      .bind(connectionId)
-      .all<{ user_id: string }>();
-    return ok(results.map((row) => row.user_id));
+    const excludeClause = opts.excludeUserId === undefined ? "" : "AND id != ?";
+    const stmt = db.prepare(
+      `UPDATE users SET disabled_at = NULL
+       WHERE disabled_at IS NOT NULL
+         AND id IN (SELECT user_id FROM scim_members WHERE connection_id = ? AND active = 0)
+         AND id NOT IN (SELECT user_id FROM scim_members WHERE connection_id != ? AND active = 0)
+         ${excludeClause}
+       RETURNING id`,
+    );
+    const bound =
+      opts.excludeUserId === undefined
+        ? stmt.bind(connectionId, connectionId)
+        : stmt.bind(connectionId, connectionId, opts.excludeUserId);
+    const { results } = await bound.all<{ id: string }>();
+    const reenabledUserIds = results.map((row) => row.id);
+    logger.info("Re-enabled SCIM-disabled users for connection removal", {
+      connectionId,
+      reenabled: reenabledUserIds.length,
+    });
+    return ok(reenabledUserIds);
   } catch (error) {
     logger.error(
-      "Failed to list deactivated SCIM users",
+      "Failed to re-enable SCIM-disabled users",
       error instanceof Error ? error : undefined,
       { connectionId },
     );
-    return err(new AppError("Failed to list deactivated SCIM users", "STORAGE_ERROR", 500));
+    return err(new AppError("Failed to re-enable SCIM-disabled users", "STORAGE_ERROR", 500));
   }
 }
 

--- a/src/storage/sso.ts
+++ b/src/storage/sso.ts
@@ -1,0 +1,605 @@
+import { generateApiKey, hashToken } from "../utils/crypto";
+import { AppError, ConflictError, NotFoundError, ValidationError } from "../utils/errors";
+import { newId } from "../utils/ids";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+
+/**
+ * Org SSO connections (migration 041 + 042): one OIDC connection per org.
+ * The client secret arrives here already encrypted (AES-GCM under the SSO
+ * salt) and the SCIM bearer token is stored only as a SHA-256 hash — this
+ * module never sees or logs either plaintext.
+ */
+
+export interface SsoConnection {
+  id: string;
+  orgId: string;
+  protocol: "oidc";
+  issuer: string;
+  clientId: string;
+  clientSecretCiphertext: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  jwksUri: string;
+  emailDomains: string[];
+  domainsVerifiedAt: string | null;
+  domainVerificationToken: string | null;
+  scimTokenHash: string | null;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpsertSsoConnectionInput {
+  orgId: string;
+  issuer: string;
+  clientId: string;
+  clientSecretCiphertext: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  jwksUri: string;
+  /** Already normalized via `normalizeEmailDomains`. */
+  emailDomains: string[];
+}
+
+interface SsoConnectionRow {
+  id: string;
+  org_id: string;
+  protocol: "oidc";
+  issuer: string;
+  client_id: string;
+  client_secret_ciphertext: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  jwks_uri: string;
+  email_domains: string;
+  domains_verified_at: string | null;
+  domain_verification_token: string | null;
+  scim_token_hash: string | null;
+  enabled: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Public/shared mailbox providers that no org can claim as an SSO email
+ * domain. Defense in depth: DNS TXT verification would fail for these anyway,
+ * but rejecting them at create time gives an honest error instead of an
+ * unverifiable connection.
+ */
+export const PUBLIC_EMAIL_DOMAINS = [
+  "gmail.com",
+  "googlemail.com",
+  "outlook.com",
+  "hotmail.com",
+  "live.com",
+  "yahoo.com",
+  "icloud.com",
+  "me.com",
+  "aol.com",
+  "proton.me",
+  "protonmail.com",
+  "gmx.com",
+  "mail.com",
+  "zoho.com",
+  "yandex.com",
+] as const;
+
+const MAX_EMAIL_DOMAINS = 20;
+// The DoH verification query name is `_stratum-sso.<domain>` — 13 extra octets
+// on top of the domain — so the domain itself must fit in 253 - 13 = 240.
+const MAX_DOMAIN_LENGTH = 240;
+const MAX_DOMAIN_LABEL_LENGTH = 63;
+// Lowercased hostname with at least two labels; no leading/trailing hyphens.
+const DOMAIN_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+
+function rowToConnection(row: SsoConnectionRow): SsoConnection {
+  let emailDomains: string[] = [];
+  try {
+    const parsed: unknown = JSON.parse(row.email_domains);
+    if (Array.isArray(parsed)) {
+      emailDomains = parsed.filter((d): d is string => typeof d === "string");
+    }
+  } catch {
+    // A malformed stored array yields no domains — the connection simply
+    // resolves nothing rather than crashing every lookup.
+  }
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    protocol: row.protocol,
+    issuer: row.issuer,
+    clientId: row.client_id,
+    clientSecretCiphertext: row.client_secret_ciphertext,
+    authorizationEndpoint: row.authorization_endpoint,
+    tokenEndpoint: row.token_endpoint,
+    jwksUri: row.jwks_uri,
+    emailDomains,
+    domainsVerifiedAt: row.domains_verified_at,
+    domainVerificationToken: row.domain_verification_token,
+    scimTokenHash: row.scim_token_hash,
+    enabled: row.enabled === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * Lowercase, trim, dedupe, and validate a list of email domains; rejects
+ * public mailbox providers and malformed hostnames.
+ */
+export function normalizeEmailDomains(domains: string[]): Result<string[], ValidationError> {
+  if (domains.length === 0) {
+    return err(new ValidationError("emailDomains must contain at least one domain"));
+  }
+  if (domains.length > MAX_EMAIL_DOMAINS) {
+    return err(new ValidationError(`emailDomains cannot exceed ${MAX_EMAIL_DOMAINS} entries`));
+  }
+  const normalized: string[] = [];
+  for (const raw of domains) {
+    const domain = raw.trim().toLowerCase();
+    if (
+      domain.length === 0 ||
+      domain.length > MAX_DOMAIN_LENGTH ||
+      !DOMAIN_PATTERN.test(domain) ||
+      domain.split(".").some((label) => label.length > MAX_DOMAIN_LABEL_LENGTH)
+    ) {
+      return err(new ValidationError(`'${raw}' is not a valid email domain`));
+    }
+    if ((PUBLIC_EMAIL_DOMAINS as readonly string[]).includes(domain)) {
+      return err(
+        new ValidationError(`'${domain}' is a public email provider and cannot be claimed`),
+      );
+    }
+    if (!normalized.includes(domain)) normalized.push(domain);
+  }
+  return ok(normalized);
+}
+
+function randomHexToken(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function sameDomains(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((domain, i) => domain === sortedB[i]);
+}
+
+/**
+ * Create the org's connection, or replace it wholesale (PUT semantics).
+ * On replace, the domain verification token, SCIM token hash, and — when the
+ * domain list is unchanged — verification/enabled state all survive. An edited
+ * domain list clears `domains_verified_at` and disables the connection (an
+ * unverified connection must never stay enabled); the token stays, so the
+ * admin's published DNS records remain valid for re-verification.
+ */
+export async function upsertSsoConnection(
+  db: D1Database,
+  logger: Logger,
+  input: UpsertSsoConnectionInput,
+): Promise<Result<{ connection: SsoConnection; created: boolean }, AppError>> {
+  logger.info("Upserting SSO connection", { orgId: input.orgId, issuer: input.issuer });
+
+  try {
+    const now = new Date().toISOString();
+    const emailDomainsJson = JSON.stringify(input.emailDomains);
+
+    const existingResult = await getSsoConnectionByOrgId(db, logger, input.orgId);
+    if (!existingResult.success && !(existingResult.error instanceof NotFoundError)) {
+      return err(existingResult.error);
+    }
+
+    if (existingResult.success) {
+      const existing = existingResult.data;
+      const domainsUnchanged = sameDomains(existing.emailDomains, input.emailDomains);
+      const domainsVerifiedAt = domainsUnchanged ? existing.domainsVerifiedAt : null;
+      const enabled = domainsUnchanged && existing.enabled ? 1 : 0;
+      // Rows created before migration 042 have no verification token; generate
+      // one on replace so verify-domains has a recovery path short of a
+      // destructive DELETE.
+      const domainVerificationToken = existing.domainVerificationToken ?? randomHexToken();
+
+      await db
+        .prepare(
+          `UPDATE org_sso_connections
+           SET issuer = ?, client_id = ?, client_secret_ciphertext = ?,
+               authorization_endpoint = ?, token_endpoint = ?, jwks_uri = ?,
+               email_domains = ?, domains_verified_at = ?, domain_verification_token = ?,
+               enabled = ?, updated_at = ?
+           WHERE id = ?`,
+        )
+        .bind(
+          input.issuer,
+          input.clientId,
+          input.clientSecretCiphertext,
+          input.authorizationEndpoint,
+          input.tokenEndpoint,
+          input.jwksUri,
+          emailDomainsJson,
+          domainsVerifiedAt,
+          domainVerificationToken,
+          enabled,
+          now,
+          existing.id,
+        )
+        .run();
+
+      logger.info("SSO connection replaced", {
+        orgId: input.orgId,
+        connectionId: existing.id,
+        domainsUnchanged,
+      });
+      return ok({
+        connection: {
+          ...existing,
+          issuer: input.issuer,
+          clientId: input.clientId,
+          clientSecretCiphertext: input.clientSecretCiphertext,
+          authorizationEndpoint: input.authorizationEndpoint,
+          tokenEndpoint: input.tokenEndpoint,
+          jwksUri: input.jwksUri,
+          emailDomains: input.emailDomains,
+          domainsVerifiedAt,
+          domainVerificationToken,
+          enabled: enabled === 1,
+          updatedAt: now,
+        },
+        created: false,
+      });
+    }
+
+    const id = newId("ssoc");
+    const verificationToken = randomHexToken();
+    await db
+      .prepare(
+        `INSERT INTO org_sso_connections (
+           id, org_id, protocol, issuer, client_id, client_secret_ciphertext,
+           authorization_endpoint, token_endpoint, jwks_uri, email_domains,
+           domains_verified_at, domain_verification_token, scim_token_hash,
+           enabled, created_at, updated_at
+         ) VALUES (?, ?, 'oidc', ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, 0, ?, ?)`,
+      )
+      .bind(
+        id,
+        input.orgId,
+        input.issuer,
+        input.clientId,
+        input.clientSecretCiphertext,
+        input.authorizationEndpoint,
+        input.tokenEndpoint,
+        input.jwksUri,
+        emailDomainsJson,
+        verificationToken,
+        now,
+        now,
+      )
+      .run();
+
+    logger.info("SSO connection created", { orgId: input.orgId, connectionId: id });
+    return ok({
+      connection: {
+        id,
+        orgId: input.orgId,
+        protocol: "oidc",
+        issuer: input.issuer,
+        clientId: input.clientId,
+        clientSecretCiphertext: input.clientSecretCiphertext,
+        authorizationEndpoint: input.authorizationEndpoint,
+        tokenEndpoint: input.tokenEndpoint,
+        jwksUri: input.jwksUri,
+        emailDomains: input.emailDomains,
+        domainsVerifiedAt: null,
+        domainVerificationToken: verificationToken,
+        scimTokenHash: null,
+        enabled: false,
+        createdAt: now,
+        updatedAt: now,
+      },
+      created: true,
+    });
+  } catch (error) {
+    logger.error("Failed to upsert SSO connection", error instanceof Error ? error : undefined, {
+      orgId: input.orgId,
+    });
+    return err(new AppError("Failed to upsert SSO connection", "STORAGE_ERROR", 500));
+  }
+}
+
+export async function getSsoConnectionByOrgId(
+  db: D1Database,
+  logger: Logger,
+  orgId: string,
+): Promise<Result<SsoConnection, NotFoundError | AppError>> {
+  try {
+    const row = await db
+      .prepare("SELECT * FROM org_sso_connections WHERE org_id = ?")
+      .bind(orgId)
+      .first<SsoConnectionRow>();
+    if (!row) return err(new NotFoundError("SSO connection", orgId));
+    return ok(rowToConnection(row));
+  } catch (error) {
+    logger.error("Failed to get SSO connection", error instanceof Error ? error : undefined, {
+      orgId,
+    });
+    return err(new AppError("Failed to get SSO connection", "STORAGE_ERROR", 500));
+  }
+}
+
+export async function getSsoConnectionById(
+  db: D1Database,
+  logger: Logger,
+  connectionId: string,
+): Promise<Result<SsoConnection, NotFoundError | AppError>> {
+  try {
+    const row = await db
+      .prepare("SELECT * FROM org_sso_connections WHERE id = ?")
+      .bind(connectionId)
+      .first<SsoConnectionRow>();
+    if (!row) return err(new NotFoundError("SSO connection", connectionId));
+    return ok(rowToConnection(row));
+  } catch (error) {
+    logger.error("Failed to get SSO connection", error instanceof Error ? error : undefined, {
+      connectionId,
+    });
+    return err(new AppError("Failed to get SSO connection", "STORAGE_ERROR", 500));
+  }
+}
+
+export async function getSsoConnectionByOrgSlug(
+  db: D1Database,
+  logger: Logger,
+  slug: string,
+): Promise<Result<SsoConnection, NotFoundError | AppError>> {
+  try {
+    const row = await db
+      .prepare(
+        `SELECT c.* FROM org_sso_connections c
+         JOIN orgs o ON o.id = c.org_id
+         WHERE o.slug = ?`,
+      )
+      .bind(slug)
+      .first<SsoConnectionRow>();
+    if (!row) return err(new NotFoundError("SSO connection", slug));
+    return ok(rowToConnection(row));
+  } catch (error) {
+    logger.error(
+      "Failed to get SSO connection by slug",
+      error instanceof Error ? error : undefined,
+      { slug },
+    );
+    return err(new AppError("Failed to get SSO connection", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
+ * Resolve a connection by a VERIFIED email domain. Only connections with
+ * `domains_verified_at` set are considered — an unverified claim must never
+ * route logins. `requireEnabled` additionally restricts to enabled
+ * connections (the login path needs that; admin tooling may not).
+ *
+ * Full table scan + JSON parse: fine at the one-connection-per-org scale.
+ */
+export async function getSsoConnectionByVerifiedDomain(
+  db: D1Database,
+  logger: Logger,
+  domain: string,
+  opts: { requireEnabled?: boolean } = {},
+): Promise<Result<SsoConnection, NotFoundError | AppError>> {
+  const requireEnabled = opts.requireEnabled ?? true;
+  const needle = domain.trim().toLowerCase();
+  try {
+    const { results } = await db
+      .prepare(
+        `SELECT * FROM org_sso_connections
+         WHERE domains_verified_at IS NOT NULL ${requireEnabled ? "AND enabled = 1" : ""}`,
+      )
+      .all<SsoConnectionRow>();
+
+    for (const row of results) {
+      const connection = rowToConnection(row);
+      if (connection.emailDomains.includes(needle)) {
+        return ok(connection);
+      }
+    }
+    return err(new NotFoundError("SSO connection", needle));
+  } catch (error) {
+    logger.error(
+      "Failed to resolve SSO connection by domain",
+      error instanceof Error ? error : undefined,
+      { domain: needle },
+    );
+    return err(new AppError("Failed to resolve SSO connection", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
+ * Domains from `domains` already verified by ANOTHER connection. Verified
+ * domains are globally unique across connections; callers reject with a
+ * conflict when this returns a non-empty list (checked at verify AND enable
+ * time, so a stale unverified claim can't sneak through later).
+ */
+export async function findVerifiedDomainConflicts(
+  db: D1Database,
+  logger: Logger,
+  domains: string[],
+  excludeConnectionId: string,
+): Promise<Result<string[], AppError>> {
+  try {
+    const { results } = await db
+      .prepare(
+        "SELECT * FROM org_sso_connections WHERE domains_verified_at IS NOT NULL AND id != ?",
+      )
+      .bind(excludeConnectionId)
+      .all<SsoConnectionRow>();
+
+    const claimed = new Set<string>();
+    for (const row of results) {
+      for (const domain of rowToConnection(row).emailDomains) claimed.add(domain);
+    }
+    return ok(domains.filter((domain) => claimed.has(domain)));
+  } catch (error) {
+    logger.error(
+      "Failed to check verified-domain uniqueness",
+      error instanceof Error ? error : undefined,
+    );
+    return err(new AppError("Failed to check domain uniqueness", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
+ * Mark the connection's domains verified (all of them — verification is
+ * all-or-nothing). `checkedDomains` must be the exact list the DNS checks ran
+ * against: the stamp is conditional on the stored `email_domains` still
+ * matching it (same JSON serialization `upsertSsoConnection` writes), so a
+ * concurrent PUT that edits the list mid-verification gets a CONFLICT instead
+ * of a verification stamp for a never-checked list.
+ */
+export async function setSsoDomainsVerified(
+  db: D1Database,
+  logger: Logger,
+  connectionId: string,
+  checkedDomains: string[],
+): Promise<Result<string, AppError>> {
+  const verifiedAt = new Date().toISOString();
+  try {
+    const result = await db
+      .prepare(
+        "UPDATE org_sso_connections SET domains_verified_at = ?, updated_at = ? WHERE id = ? AND email_domains = ?",
+      )
+      .bind(verifiedAt, verifiedAt, connectionId, JSON.stringify(checkedDomains))
+      .run();
+    if ((result.meta?.changes ?? 0) === 0) {
+      const exists = await getSsoConnectionById(db, logger, connectionId);
+      if (!exists.success) return err(exists.error);
+      return err(new ConflictError("connection changed during verification; retry"));
+    }
+    logger.info("SSO domains verified", { connectionId });
+    return ok(verifiedAt);
+  } catch (error) {
+    logger.error("Failed to mark domains verified", error instanceof Error ? error : undefined, {
+      connectionId,
+    });
+    return err(new AppError("Failed to mark domains verified", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
+ * Toggle `enabled`. Enabling requires verified domains — enforced in SQL so a
+ * verify/enable race cannot enable an unverified connection.
+ */
+export async function setSsoConnectionEnabled(
+  db: D1Database,
+  logger: Logger,
+  connectionId: string,
+  enabled: boolean,
+): Promise<Result<void, AppError>> {
+  const now = new Date().toISOString();
+  try {
+    const guard = enabled ? "AND domains_verified_at IS NOT NULL" : "";
+    const result = await db
+      .prepare(`UPDATE org_sso_connections SET enabled = ?, updated_at = ? WHERE id = ? ${guard}`)
+      .bind(enabled ? 1 : 0, now, connectionId)
+      .run();
+    if ((result.meta?.changes ?? 0) === 0) {
+      const exists = await getSsoConnectionById(db, logger, connectionId);
+      if (!exists.success) return err(exists.error);
+      return err(
+        new ValidationError("Connection cannot be enabled until its domains are verified"),
+      );
+    }
+    logger.info("SSO connection toggled", { connectionId, enabled });
+    return ok(undefined);
+  } catch (error) {
+    logger.error("Failed to toggle SSO connection", error instanceof Error ? error : undefined, {
+      connectionId,
+    });
+    return err(new AppError("Failed to toggle SSO connection", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
+ * Generate (or rotate) the connection's SCIM bearer token. Only the SHA-256
+ * hash is stored; the plaintext is returned exactly once for the caller to
+ * show and is never logged.
+ */
+export async function rotateScimToken(
+  db: D1Database,
+  logger: Logger,
+  connectionId: string,
+): Promise<Result<string, AppError>> {
+  try {
+    const plaintext = await generateApiKey("stratum_scim");
+    const tokenHash = await hashToken(plaintext);
+    const result = await db
+      .prepare("UPDATE org_sso_connections SET scim_token_hash = ?, updated_at = ? WHERE id = ?")
+      .bind(tokenHash, new Date().toISOString(), connectionId)
+      .run();
+    if ((result.meta?.changes ?? 0) === 0) {
+      return err(new NotFoundError("SSO connection", connectionId));
+    }
+    logger.info("SCIM token rotated", { connectionId });
+    return ok(plaintext);
+  } catch (error) {
+    logger.error("Failed to rotate SCIM token", error instanceof Error ? error : undefined, {
+      connectionId,
+    });
+    return err(new AppError("Failed to rotate SCIM token", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
+ * Users this connection deactivated via SCIM (`scim_members.active = 0`) —
+ * the set connection deletion must re-enable so removing a connection is a
+ * clean rollback, never a permanent lockout.
+ */
+export async function listDeactivatedScimUserIds(
+  db: D1Database,
+  logger: Logger,
+  connectionId: string,
+): Promise<Result<string[], AppError>> {
+  try {
+    const { results } = await db
+      .prepare("SELECT user_id FROM scim_members WHERE connection_id = ? AND active = 0")
+      .bind(connectionId)
+      .all<{ user_id: string }>();
+    return ok(results.map((row) => row.user_id));
+  } catch (error) {
+    logger.error(
+      "Failed to list deactivated SCIM users",
+      error instanceof Error ? error : undefined,
+      { connectionId },
+    );
+    return err(new AppError("Failed to list deactivated SCIM users", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
+ * Delete the connection and its managed-membership rows atomically. Managed
+ * users become ordinary org members; re-enabling the ones this connection
+ * disabled is the caller's job (it needs per-user audit context).
+ */
+export async function deleteSsoConnection(
+  db: D1Database,
+  logger: Logger,
+  connectionId: string,
+): Promise<Result<void, AppError>> {
+  try {
+    await db.batch([
+      db.prepare("DELETE FROM scim_members WHERE connection_id = ?").bind(connectionId),
+      db.prepare("DELETE FROM org_sso_connections WHERE id = ?").bind(connectionId),
+    ]);
+    logger.info("SSO connection deleted", { connectionId });
+    return ok(undefined);
+  } catch (error) {
+    logger.error("Failed to delete SSO connection", error instanceof Error ? error : undefined, {
+      connectionId,
+    });
+    return err(new AppError("Failed to delete SSO connection", "STORAGE_ERROR", 500));
+  }
+}

--- a/src/storage/sso.ts
+++ b/src/storage/sso.ts
@@ -3,6 +3,10 @@ import { AppError, ConflictError, NotFoundError, ValidationError } from "../util
 import { newId } from "../utils/ids";
 import type { Logger } from "../utils/logger";
 import { type Result, err, ok } from "../utils/result";
+import { listAgents } from "./agents";
+import { recordAudit } from "./audit";
+import { deleteAllUserSessions } from "./sessions";
+import { disableUser, enableUser } from "./users";
 
 /**
  * Org SSO connections (migration 041 + 042): one OIDC connection per org.
@@ -554,6 +558,38 @@ export async function rotateScimToken(
 }
 
 /**
+ * Resolve the connection a SCIM bearer token belongs to. Only ENABLED
+ * connections with VERIFIED domains authenticate: a disabled connection's
+ * token must stop working immediately, and an unverified one must never
+ * manage accounts (verification is the trust anchor for the whole SCIM
+ * surface). Callers pass the token's SHA-256 hash — the plaintext never
+ * reaches storage.
+ */
+export async function getSsoConnectionByScimTokenHash(
+  db: D1Database,
+  logger: Logger,
+  tokenHash: string,
+): Promise<Result<SsoConnection, NotFoundError | AppError>> {
+  try {
+    const row = await db
+      .prepare(
+        `SELECT * FROM org_sso_connections
+         WHERE scim_token_hash = ? AND enabled = 1 AND domains_verified_at IS NOT NULL`,
+      )
+      .bind(tokenHash)
+      .first<SsoConnectionRow>();
+    if (!row) return err(new NotFoundError("SSO connection", "by-scim-token"));
+    return ok(rowToConnection(row));
+  } catch (error) {
+    logger.error(
+      "Failed to resolve SSO connection by SCIM token",
+      error instanceof Error ? error : undefined,
+    );
+    return err(new AppError("Failed to resolve SSO connection", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
  * Mark a user managed by a connection (idempotent). Used at OIDC login when an
  * existing account is adopted or JIT-created; SCIM later updates the same row.
  * INSERT OR IGNORE so a re-login never resets `active` or `scim_external_id`
@@ -774,4 +810,320 @@ export async function deleteSsoConnection(
     });
     return err(new AppError("Failed to delete SSO connection", "STORAGE_ERROR", 500));
   }
+}
+
+// ---------------------------------------------------------------------------
+// SCIM Users scope + lifecycle (#253 Task 6)
+// ---------------------------------------------------------------------------
+
+/** A connection's SCIM member row (or its absence — visible-for-adoption). */
+export interface ScimMember {
+  externalId: string | null;
+  active: boolean;
+}
+
+/**
+ * One user as this connection's SCIM surface sees them. `managed` is whether a
+ * scim_members row exists; `scimActive` is that row's flag (null when
+ * unmanaged). `active` in the SCIM resource is derived from `disabledAt` —
+ * the enforced truth — not from `scimActive`.
+ */
+export interface ScimScopedUser {
+  userId: string;
+  email: string;
+  username: string;
+  createdAt: string;
+  disabledAt: string | null;
+  externalId: string | null;
+  managed: boolean;
+  scimActive: boolean | null;
+}
+
+interface ScimScopedUserRow {
+  id: string;
+  email: string;
+  username: string;
+  created_at: string;
+  disabled_at: string | null;
+  scim_external_id: string | null;
+  scim_active: number | null;
+}
+
+function rowToScimScopedUser(row: ScimScopedUserRow): ScimScopedUser {
+  return {
+    userId: row.id,
+    email: row.email,
+    username: row.username,
+    createdAt: row.created_at,
+    disabledAt: row.disabled_at,
+    externalId: row.scim_external_id,
+    managed: row.scim_active !== null,
+    scimActive: row.scim_active === null ? null : row.scim_active === 1,
+  };
+}
+
+function inScimScope(connection: SsoConnection, user: ScimScopedUser): boolean {
+  if (user.managed) return true;
+  const domain = user.email.split("@").pop() ?? "";
+  return connection.emailDomains.includes(domain);
+}
+
+/**
+ * Candidate rows for the connection's SCIM scope: every user with a
+ * scim_members row for this connection, plus every member of the connection's
+ * org (the JS-side domain filter narrows those to the verified email domains —
+ * "visible for adoption"). Soft-deleting users are excluded outright: deletion
+ * dominates disable, and a mid-erasure account must not resurface to the IdP
+ * or accept a reactivation.
+ */
+async function queryScimScope(
+  db: D1Database,
+  connection: SsoConnection,
+  userId?: string,
+): Promise<ScimScopedUser[]> {
+  const userClause = userId === undefined ? "" : "AND u.id = ?";
+  const stmt = db.prepare(
+    `SELECT u.id, u.email, u.username, u.created_at, u.disabled_at,
+            sm.scim_external_id, sm.active AS scim_active
+     FROM users u
+     LEFT JOIN scim_members sm ON sm.user_id = u.id AND sm.connection_id = ?
+     WHERE u.deleting_at IS NULL ${userClause}
+       AND (sm.user_id IS NOT NULL
+            OR EXISTS (SELECT 1 FROM org_members om WHERE om.org_id = ? AND om.user_id = u.id))
+     ORDER BY u.created_at, u.id`,
+  );
+  // Positional binds follow the placeholders' textual order: join, optional
+  // user pin, org membership probe.
+  const bound =
+    userId === undefined
+      ? stmt.bind(connection.id, connection.orgId)
+      : stmt.bind(connection.id, userId, connection.orgId);
+  const { results } = await bound.all<ScimScopedUserRow>();
+  return results.map(rowToScimScopedUser).filter((user) => inScimScope(connection, user));
+}
+
+export async function listScimScopedUsers(
+  db: D1Database,
+  logger: Logger,
+  connection: SsoConnection,
+): Promise<Result<ScimScopedUser[], AppError>> {
+  try {
+    return ok(await queryScimScope(db, connection));
+  } catch (error) {
+    logger.error("Failed to list SCIM-scoped users", error instanceof Error ? error : undefined, {
+      connectionId: connection.id,
+    });
+    return err(new AppError("Failed to list SCIM users", "STORAGE_ERROR", 500));
+  }
+}
+
+export async function getScimScopedUser(
+  db: D1Database,
+  logger: Logger,
+  connection: SsoConnection,
+  userId: string,
+): Promise<Result<ScimScopedUser, NotFoundError | AppError>> {
+  try {
+    const users = await queryScimScope(db, connection, userId);
+    const user = users[0];
+    if (!user) return err(new NotFoundError("User", userId));
+    return ok(user);
+  } catch (error) {
+    logger.error("Failed to get SCIM-scoped user", error instanceof Error ? error : undefined, {
+      connectionId: connection.id,
+      userId,
+    });
+    return err(new AppError("Failed to get SCIM user", "STORAGE_ERROR", 500));
+  }
+}
+
+/** The connection's scim_members row for a user, or null when unmanaged. */
+export async function getScimMember(
+  db: D1Database,
+  logger: Logger,
+  connectionId: string,
+  userId: string,
+): Promise<Result<ScimMember | null, AppError>> {
+  try {
+    const row = await db
+      .prepare(
+        "SELECT scim_external_id, active FROM scim_members WHERE connection_id = ? AND user_id = ?",
+      )
+      .bind(connectionId, userId)
+      .first<{ scim_external_id: string | null; active: number }>();
+    if (!row) return ok(null);
+    return ok({ externalId: row.scim_external_id, active: row.active === 1 });
+  } catch (error) {
+    logger.error("Failed to get scim_members row", error instanceof Error ? error : undefined, {
+      connectionId,
+      userId,
+    });
+    return err(new AppError("Failed to get managed membership", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
+ * Set (or clear, with null) the IdP's externalId on the connection's
+ * membership row. The row must already exist — callers ensureScimMember first.
+ * An externalId already assigned to ANOTHER user on the same connection
+ * violates the migration-043 unique index and returns a ConflictError.
+ */
+export async function setScimMemberExternalId(
+  db: D1Database,
+  logger: Logger,
+  connectionId: string,
+  userId: string,
+  externalId: string | null,
+): Promise<Result<void, ConflictError | AppError>> {
+  try {
+    await db
+      .prepare(
+        "UPDATE scim_members SET scim_external_id = ? WHERE connection_id = ? AND user_id = ?",
+      )
+      .bind(externalId, connectionId, userId)
+      .run();
+    return ok(undefined);
+  } catch (error) {
+    if (error instanceof Error && /UNIQUE constraint failed/i.test(error.message)) {
+      logger.warn("SCIM externalId already assigned on this connection", { connectionId, userId });
+      return err(new ConflictError("externalId is already assigned to another user"));
+    }
+    logger.error("Failed to set SCIM externalId", error instanceof Error ? error : undefined, {
+      connectionId,
+      userId,
+    });
+    return err(new AppError("Failed to set SCIM externalId", "STORAGE_ERROR", 500));
+  }
+}
+
+/** Upsert the connection's membership row with the given active flag. */
+async function upsertScimMemberActive(
+  db: D1Database,
+  connectionId: string,
+  userId: string,
+  active: boolean,
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO scim_members (connection_id, user_id, active, created_at) VALUES (?, ?, ?, ?)
+       ON CONFLICT (connection_id, user_id) DO UPDATE SET active = excluded.active`,
+    )
+    .bind(connectionId, userId, active ? 1 : 0, new Date().toISOString())
+    .run();
+}
+
+/**
+ * SCIM deactivation: record who disabled whom (scim_members.active = 0), set
+ * the enforced flag (users.disabled_at), then purge sessions. Any storage
+ * failure fails the whole request — deprovision must never report success
+ * while sessions survive — but the ordering guarantees the enforced flag
+ * holds even when the session purge fails (the middleware then rejects the
+ * surviving sessions anyway). Idempotent: rerunning changes nothing. Audits
+ * are best-effort per the recordAudit contract; agentIds enumerate the
+ * credentials made inert by the flag.
+ */
+export async function deprovisionUser(
+  db: D1Database,
+  logger: Logger,
+  connectionId: string,
+  userId: string,
+): Promise<Result<{ disabledAt: string }, AppError>> {
+  try {
+    await upsertScimMemberActive(db, connectionId, userId, false);
+  } catch (error) {
+    logger.error("Failed to record SCIM deactivation", error instanceof Error ? error : undefined, {
+      connectionId,
+      userId,
+    });
+    return err(new AppError("Failed to record SCIM deactivation", "STORAGE_ERROR", 500));
+  }
+
+  const disableResult = await disableUser(db, userId, logger);
+  if (!disableResult.success) return err(disableResult.error);
+
+  const purgeResult = await deleteAllUserSessions(db, userId, logger);
+  if (!purgeResult.success) return err(purgeResult.error);
+
+  // Audit detail only — a lookup failure must not fail a completed deprovision.
+  const agentsResult = await listAgents(db, userId, logger);
+  const agentIds = agentsResult.success ? agentsResult.data.map((agent) => agent.id) : [];
+  const detail = { via: "scim", connectionId, agentIds };
+  await recordAudit(db, logger, {
+    action: "scim.user.deactivated",
+    actorType: "system",
+    subject: userId,
+    detail,
+  });
+  await recordAudit(db, logger, {
+    action: "user.disabled",
+    actorType: "system",
+    subject: userId,
+    detail,
+  });
+
+  logger.info("SCIM user deprovisioned", { connectionId, userId });
+  return ok({ disabledAt: disableResult.data });
+}
+
+/**
+ * SCIM reactivation: mark this connection's membership active again, and clear
+ * users.disabled_at only when NO other connection still holds an active
+ * deactivation for the user — one IdP unsuspending an account must not undo
+ * another IdP's suspension. Idempotent. A failed guard read fails CLOSED (the
+ * account stays disabled) rather than enabling on unknown state.
+ */
+export async function reactivateUser(
+  db: D1Database,
+  logger: Logger,
+  connectionId: string,
+  userId: string,
+): Promise<Result<{ enabled: boolean }, AppError>> {
+  try {
+    await upsertScimMemberActive(db, connectionId, userId, true);
+  } catch (error) {
+    logger.error("Failed to record SCIM reactivation", error instanceof Error ? error : undefined, {
+      connectionId,
+      userId,
+    });
+    return err(new AppError("Failed to record SCIM reactivation", "STORAGE_ERROR", 500));
+  }
+
+  let blocked: boolean;
+  try {
+    const row = await db
+      .prepare("SELECT COUNT(*) AS n FROM scim_members WHERE user_id = ? AND active = 0")
+      .bind(userId)
+      .first<{ n: number }>();
+    blocked = (row?.n ?? 0) > 0;
+  } catch (error) {
+    logger.error("Failed to check reactivation guard", error instanceof Error ? error : undefined, {
+      connectionId,
+      userId,
+    });
+    return err(new AppError("Failed to check reactivation guard", "STORAGE_ERROR", 500));
+  }
+
+  if (!blocked) {
+    const enableResult = await enableUser(db, userId, logger);
+    if (!enableResult.success) return err(enableResult.error);
+  }
+
+  const detail = { via: "scim", connectionId };
+  await recordAudit(db, logger, {
+    action: "scim.user.reactivated",
+    actorType: "system",
+    subject: userId,
+    detail,
+  });
+  if (!blocked) {
+    await recordAudit(db, logger, {
+      action: "user.enabled",
+      actorType: "system",
+      subject: userId,
+      detail,
+    });
+  }
+
+  logger.info("SCIM user reactivated", { connectionId, userId, enabled: !blocked });
+  return ok({ enabled: !blocked });
 }

--- a/src/storage/sso.ts
+++ b/src/storage/sso.ts
@@ -554,6 +554,178 @@ export async function rotateScimToken(
 }
 
 /**
+ * Mark a user managed by a connection (idempotent). Used at OIDC login when an
+ * existing account is adopted or JIT-created; SCIM later updates the same row.
+ * INSERT OR IGNORE so a re-login never resets `active` or `scim_external_id`
+ * that SCIM has since written.
+ */
+export async function ensureScimMember(
+  db: D1Database,
+  logger: Logger,
+  connectionId: string,
+  userId: string,
+): Promise<Result<void, AppError>> {
+  try {
+    await db
+      .prepare(
+        "INSERT OR IGNORE INTO scim_members (connection_id, user_id, active, created_at) VALUES (?, ?, 1, ?)",
+      )
+      .bind(connectionId, userId, new Date().toISOString())
+      .run();
+    return ok(undefined);
+  } catch (error) {
+    logger.error("Failed to ensure scim_members row", error instanceof Error ? error : undefined, {
+      connectionId,
+      userId,
+    });
+    return err(new AppError("Failed to record managed membership", "STORAGE_ERROR", 500));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OIDC login states (migration 041): short-lived per-login rows whose atomic
+// consumption is the replay guard for the authorization-code callback.
+// ---------------------------------------------------------------------------
+
+/**
+ * Single source of truth for the login-state lifetime: the row expiry written
+ * here AND the browser-binding cookie's maxAge in routes/sso.tsx must agree,
+ * so the route imports this rather than declaring its own copy.
+ */
+export const OIDC_STATE_TTL_SECONDS = 600;
+
+export interface OidcLoginState {
+  state: string;
+  connectionId: string;
+  nonce: string;
+  codeVerifier: string;
+  redirectTo: string | null;
+}
+
+interface OidcLoginStateRow {
+  state: string;
+  connection_id: string;
+  nonce: string;
+  code_verifier: string;
+  redirect_to: string | null;
+}
+
+export interface CreateOidcLoginStateInput {
+  connectionId: string;
+  nonce: string;
+  codeVerifier: string;
+  redirectTo: string | null;
+}
+
+function randomHex32Bytes(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Persist a login state row (10-minute TTL); returns the generated `state`. */
+export async function createOidcLoginState(
+  db: D1Database,
+  logger: Logger,
+  input: CreateOidcLoginStateInput,
+): Promise<Result<string, AppError>> {
+  try {
+    const state = randomHex32Bytes();
+    const now = Math.floor(Date.now() / 1000);
+    await db
+      .prepare(
+        `INSERT INTO oidc_login_states (state, connection_id, nonce, code_verifier, redirect_to, created_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        state,
+        input.connectionId,
+        input.nonce,
+        input.codeVerifier,
+        input.redirectTo,
+        new Date().toISOString(),
+        now + OIDC_STATE_TTL_SECONDS,
+      )
+      .run();
+    return ok(state);
+  } catch (error) {
+    logger.error("Failed to create OIDC login state", error instanceof Error ? error : undefined, {
+      connectionId: input.connectionId,
+    });
+    return err(new AppError("Failed to create OIDC login state", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
+ * Atomically consume a login state: exactly ONE caller succeeds even under
+ * concurrent callbacks, because the guard is a single conditional UPDATE
+ * (`consumed_at IS NULL AND not expired`) whose affected-row count is the
+ * winner signal — the same pattern as consumeMagicLink. Returns null when the
+ * state is unknown, already consumed, or expired.
+ */
+export async function consumeOidcLoginState(
+  db: D1Database,
+  logger: Logger,
+  state: string,
+): Promise<Result<OidcLoginState | null, AppError>> {
+  try {
+    const now = Math.floor(Date.now() / 1000);
+    const update = await db
+      .prepare(
+        "UPDATE oidc_login_states SET consumed_at = ? WHERE state = ? AND consumed_at IS NULL AND expires_at > ?",
+      )
+      .bind(new Date().toISOString(), state, now)
+      .run();
+    if (update.meta.changes !== 1) return ok(null);
+
+    const row = await db
+      .prepare(
+        "SELECT state, connection_id, nonce, code_verifier, redirect_to FROM oidc_login_states WHERE state = ?",
+      )
+      .bind(state)
+      .first<OidcLoginStateRow>();
+    if (!row) return ok(null);
+
+    return ok({
+      state: row.state,
+      connectionId: row.connection_id,
+      nonce: row.nonce,
+      codeVerifier: row.code_verifier,
+      redirectTo: row.redirect_to,
+    });
+  } catch (error) {
+    logger.error("Failed to consume OIDC login state", error instanceof Error ? error : undefined);
+    return err(new AppError("Failed to consume OIDC login state", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
+ * Delete expired state rows. Called opportunistically from the start route and
+ * from the daily cron; consumed-but-unexpired rows keep their tombstone until
+ * expiry so a replayed state stays distinguishable from an unknown one.
+ */
+export async function purgeExpiredOidcStates(
+  db: D1Database,
+  logger: Logger,
+): Promise<Result<number, AppError>> {
+  try {
+    const now = Math.floor(Date.now() / 1000);
+    const result = await db
+      .prepare("DELETE FROM oidc_login_states WHERE expires_at < ?")
+      .bind(now)
+      .run();
+    const purged = result.meta?.changes ?? 0;
+    if (purged > 0) logger.debug("Purged expired OIDC login states", { purged });
+    return ok(purged);
+  } catch (error) {
+    logger.error("Failed to purge OIDC login states", error instanceof Error ? error : undefined);
+    return err(new AppError("Failed to purge OIDC login states", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
  * Users this connection deactivated via SCIM (`scim_members.active = 0`) —
  * the set connection deletion must re-enable so removing a connection is a
  * clean rollback, never a permanent lockout.

--- a/src/storage/users.ts
+++ b/src/storage/users.ts
@@ -22,6 +22,9 @@ interface UserRow {
   // Added in migration 026; NULL on live accounts. `SELECT *` already fetches
   // it, so the auth hot path gets `deletingAt` without a second round-trip.
   deleting_at: string | null;
+  // Added in migration 041; NULL on enabled accounts. Rides on the same row as
+  // deleting_at so the auth hot path sees it for free.
+  disabled_at: string | null;
 }
 
 function rowToUser(row: UserRow): User {
@@ -34,8 +37,10 @@ function rowToUser(row: UserRow): User {
   };
   if (row.github_id !== null) user.githubId = row.github_id;
   if (row.github_username !== null) user.githubUsername = row.github_username;
-  // `deleting_at` may be absent when a stub/legacy read omits the column.
+  // `deleting_at`/`disabled_at` may be absent when a stub/legacy read omits
+  // the columns.
   if (row.deleting_at != null) user.deletingAt = row.deleting_at;
+  if (row.disabled_at != null) user.disabledAt = row.disabled_at;
   return user;
 }
 
@@ -183,6 +188,70 @@ export async function markUserDeleting(
       userId,
     });
     return err(new AppError("Failed to mark user deleting", "STORAGE_ERROR", 500, { userId }));
+  }
+}
+
+/**
+ * Reversibly disable an account (sets users.disabled_at = now). Every
+ * credential path — auth middleware, git smart-HTTP, and the login flows —
+ * rejects while the flag is set; `enableUser` restores the same credentials.
+ * Idempotent: re-disabling keeps the earliest timestamp, so repeated SCIM
+ * deprovision requests don't rewrite when the account was actually disabled.
+ */
+export async function disableUser(
+  db: D1Database,
+  userId: string,
+  logger: Logger,
+): Promise<Result<string, AppError>> {
+  const now = new Date().toISOString();
+  try {
+    // RETURNING so the caller gets the STORED timestamp: on an idempotent
+    // re-disable, COALESCE keeps the earlier one, and an audit/SCIM response
+    // built from this value must not misreport when disablement happened.
+    const row = await db
+      .prepare(
+        "UPDATE users SET disabled_at = COALESCE(disabled_at, ?) WHERE id = ? RETURNING disabled_at",
+      )
+      .bind(now, userId)
+      .first<{ disabled_at: string }>();
+    if (!row) {
+      return err(new AppError(`User '${userId}' not found`, "NOT_FOUND", 404, { userId }));
+    }
+    logger.info("User disabled", { userId });
+    return ok(row.disabled_at);
+  } catch (error) {
+    logger.error("Failed to disable user", error instanceof Error ? error : undefined, {
+      userId,
+    });
+    return err(new AppError("Failed to disable user", "STORAGE_ERROR", 500, { userId }));
+  }
+}
+
+/**
+ * Re-enable a disabled account (clears users.disabled_at). The user's existing
+ * credentials — tokens, agents, sessions that survived — work again. Idempotent
+ * on an already-enabled account.
+ */
+export async function enableUser(
+  db: D1Database,
+  userId: string,
+  logger: Logger,
+): Promise<Result<void, AppError>> {
+  try {
+    const result = await db
+      .prepare("UPDATE users SET disabled_at = NULL WHERE id = ?")
+      .bind(userId)
+      .run();
+    if ((result.meta?.changes ?? 0) === 0) {
+      return err(new AppError(`User '${userId}' not found`, "NOT_FOUND", 404, { userId }));
+    }
+    logger.info("User enabled", { userId });
+    return ok(undefined);
+  } catch (error) {
+    logger.error("Failed to enable user", error instanceof Error ? error : undefined, {
+      userId,
+    });
+    return err(new AppError("Failed to enable user", "STORAGE_ERROR", 500, { userId }));
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -392,6 +392,13 @@ export interface User {
    * Absent/null on live accounts. See PRD "Grace window".
    */
   deletingAt?: string;
+  /**
+   * When set (ISO timestamp), the account is disabled — reversibly, unlike the
+   * destructive `deletingAt`. All credentials are inert while set (auth,
+   * git smart-HTTP, and every login flow reject); `enableUser` clears it and
+   * the same credentials work again. Set by SCIM deprovisioning.
+   */
+  disabledAt?: string;
 }
 
 export interface Session {

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,10 @@ export interface Env {
   BETA_GATE?: string;
   REFERRAL_SERVICE_URL?: string;
   REFERRAL_SERVICE_SECRET?: string;
+  /** Encrypts org SSO client secrets at rest (PBKDF2 + AES-GCM, SSO-specific
+   * salt). Unset → the whole SSO surface (admin API, login) returns 501. Kept
+   * separate from the GitHub token secret for blast-radius isolation. */
+  SSO_ENCRYPTION_SECRET?: string;
   ANALYTICS?: AnalyticsEngineDataset;
   SANDBOX?: SandboxBinding;
   AI?: AiBinding;

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -55,9 +55,21 @@ export async function generateApiKey(prefix: string): Promise<string> {
 }
 
 /**
- * Derive encryption key from environment secret using PBKDF2
+ * The historical hardcoded salt. It predates any second use of the AES-GCM
+ * helpers, so it stays the default: every existing GitHub-token ciphertext was
+ * produced under it and must keep decrypting byte-for-byte.
  */
-async function getEncryptionKey(secret: string): Promise<CryptoKey> {
+const GITHUB_TOKEN_SALT = "stratum-github-token-salt";
+
+/** PBKDF2 salt for SSO client-secret encryption (keyed off SSO_ENCRYPTION_SECRET). */
+export const SSO_SECRET_SALT = "stratum-sso-secret-salt";
+
+/**
+ * Derive encryption key from environment secret using PBKDF2. The salt
+ * partitions key material per use-case so two subsystems sharing this helper
+ * can never decrypt each other's ciphertexts even under a reused env secret.
+ */
+async function getEncryptionKey(secret: string, salt: string): Promise<CryptoKey> {
   const encoder = new TextEncoder();
   const keyData = encoder.encode(secret);
 
@@ -69,7 +81,7 @@ async function getEncryptionKey(secret: string): Promise<CryptoKey> {
   return crypto.subtle.deriveKey(
     {
       name: "PBKDF2",
-      salt: encoder.encode("stratum-github-token-salt"),
+      salt: encoder.encode(salt),
       iterations: 100000,
       hash: "SHA-256",
     },
@@ -81,10 +93,14 @@ async function getEncryptionKey(secret: string): Promise<CryptoKey> {
 }
 
 /**
- * Encrypt a GitHub token using AES-GCM
+ * Encrypt a secret using AES-GCM (GitHub-token salt by default).
  */
-export async function encryptToken(plaintext: string, secret: string): Promise<string> {
-  const key = await getEncryptionKey(secret);
+export async function encryptToken(
+  plaintext: string,
+  secret: string,
+  salt: string = GITHUB_TOKEN_SALT,
+): Promise<string> {
+  const key = await getEncryptionKey(secret, salt);
   const encoder = new TextEncoder();
   const iv = crypto.getRandomValues(new Uint8Array(12));
 
@@ -102,11 +118,15 @@ export async function encryptToken(plaintext: string, secret: string): Promise<s
 }
 
 /**
- * Decrypt a GitHub token
+ * Decrypt a secret encrypted by `encryptToken` (same salt required).
  */
-export async function decryptToken(ciphertext: string, secret: string): Promise<string | null> {
+export async function decryptToken(
+  ciphertext: string,
+  secret: string,
+  salt: string = GITHUB_TOKEN_SALT,
+): Promise<string | null> {
   try {
-    const key = await getEncryptionKey(secret);
+    const key = await getEncryptionKey(secret, salt);
 
     const combined = new Uint8Array(
       atob(ciphertext)

--- a/tests/auth-signup-login.test.ts
+++ b/tests/auth-signup-login.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authRouter } from "../src/routes/auth";
 import { emailAuthRouter } from "../src/routes/email-auth";
 import { recordAudit } from "../src/storage/audit";
+import type { UpsertIdentityInput } from "../src/storage/identities";
+import { upsertIdentity } from "../src/storage/identities";
 import type { Env, User } from "../src/types";
 import { NotFoundError } from "../src/utils/errors";
 import type { Logger } from "../src/utils/logger";
@@ -188,6 +190,26 @@ vi.mock("../src/storage/sessions", () => ({
 // login records NO session.created row.
 vi.mock("../src/storage/audit", () => ({
   recordAudit: vi.fn(async () => ({ success: true, data: undefined })),
+}));
+
+// Identities are forward-provisioning for SSO: default to "nothing linked yet"
+// with successful persistence; tests assert on the upsert calls.
+vi.mock("../src/storage/identities", () => ({
+  upsertIdentity: vi.fn(async (_db: unknown, _logger: unknown, input: UpsertIdentityInput) => ({
+    success: true,
+    data: {
+      id: "idn_test",
+      createdAt: new Date().toISOString(),
+      ...input,
+      connectionId: input.connectionId ?? null,
+    },
+  })),
+  getIdentityByIssuerSubject: vi.fn(
+    async (_db: unknown, _logger: unknown, issuer: string, subject: string) => ({
+      success: false,
+      error: new NotFoundError("Identity", `${issuer}#${subject}`),
+    }),
+  ),
 }));
 
 // ============================================================================
@@ -1437,6 +1459,219 @@ describe("Auth Signup/Login Integration Tests", () => {
       expect(res.status).toBe(302);
 
       // Restore fetch
+      vi.restoreAllMocks();
+    });
+
+    function mockGitHubFetch(
+      user: { id: number; login: string },
+      emails: { email: string; primary: boolean; verified: boolean }[],
+    ) {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: "gh_token" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => user,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => emails,
+        });
+    }
+
+    async function githubCallback(state: string, extraQuery = ""): Promise<Response> {
+      await env.STATE.put(`oauth_state:${state}`, "1", { expirationTtl: 600 });
+      return app.fetch(
+        request(`/auth/github/callback?code=test-code&state=${state}${extraQuery}`, {
+          headers: { Cookie: `stratum_oauth_state=${state}` },
+        }),
+        env,
+      );
+    }
+
+    it("refuses to link or create an account from unverified GitHub emails", async () => {
+      mockGitHubFetch({ id: 55555, login: "unverifieduser" }, [
+        { email: "unverified@example.com", primary: true, verified: false },
+      ]);
+
+      const res = await githubCallback("unverified-email-state");
+
+      expect(res.status).toBe(422);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain("No verified email");
+      const { upsertGitHubUser } = await import("../src/storage/users");
+      expect(upsertGitHubUser).not.toHaveBeenCalled();
+      const { createSession } = await import("../src/storage/sessions");
+      expect(createSession).not.toHaveBeenCalled();
+      expect(res.headers.get("set-cookie") ?? "").not.toContain("stratum_session");
+
+      vi.restoreAllMocks();
+    });
+
+    it("signs in an existing github_id-matched user whose emails are all unverified", async () => {
+      const { createUser } = await import("../src/storage/users");
+      await createUser(env.DB, "linked@example.com", {} as unknown as Logger, "linkeduser");
+      const user = mockUsers.get("email:linked@example.com");
+      if (!user) throw new Error("seed failed");
+      user.githubId = "77777";
+
+      mockGitHubFetch({ id: 77777, login: "linkeduser" }, [
+        { email: "unverified@example.com", primary: true, verified: false },
+      ]);
+
+      const res = await githubCallback("linked-unverified-state");
+
+      // The GitHub account id — not an email — is the credential here, so the
+      // returning user is not locked out by unverified addresses.
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/");
+      expect(res.headers.get("set-cookie")).toContain("stratum_session");
+      // The identity row records the account's own email, never the unverified one.
+      expect(upsertIdentity).toHaveBeenCalledWith(env.DB, expect.anything(), {
+        userId: user.id,
+        provider: "github",
+        issuer: "https://github.com",
+        subject: "77777",
+        email: "linked@example.com",
+      });
+
+      vi.restoreAllMocks();
+    });
+
+    it("persists an identities row on a verified GitHub sign-in", async () => {
+      mockGitHubFetch({ id: 12345, login: "testuser" }, [
+        { email: "github@example.com", primary: true, verified: true },
+      ]);
+
+      const res = await githubCallback("identity-row-state");
+
+      expect(res.status).toBe(302);
+      const created = mockUsers.get("email:github@example.com");
+      if (!created) throw new Error("expected the callback to create an account");
+      expect(upsertIdentity).toHaveBeenCalledWith(env.DB, expect.anything(), {
+        userId: created.id,
+        provider: "github",
+        issuer: "https://github.com",
+        subject: "12345",
+        email: "github@example.com",
+      });
+
+      vi.restoreAllMocks();
+    });
+
+    it("links with a verified email when the primary email is unverified", async () => {
+      mockGitHubFetch({ id: 66666, login: "mixeduser" }, [
+        { email: "unverified-primary@example.com", primary: true, verified: false },
+        { email: "verified@example.com", primary: false, verified: true },
+      ]);
+
+      const res = await githubCallback("mixed-emails-state");
+
+      expect(res.status).toBe(302);
+      const { upsertGitHubUser } = await import("../src/storage/users");
+      expect(upsertGitHubUser).toHaveBeenCalledWith(
+        env.DB,
+        expect.objectContaining({ email: "verified@example.com" }),
+        expect.anything(),
+      );
+
+      vi.restoreAllMocks();
+    });
+
+    it("lowercases a mixed-case verified GitHub email so it matches the stored account", async () => {
+      const { createUser } = await import("../src/storage/users");
+      await createUser(env.DB, "cased@example.com", {} as unknown as Logger, "caseduser");
+
+      mockGitHubFetch({ id: 44444, login: "caseduser" }, [
+        { email: "Cased@Example.com", primary: true, verified: true },
+      ]);
+
+      const res = await githubCallback("cased-email-state");
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/");
+      const { upsertGitHubUser } = await import("../src/storage/users");
+      expect(upsertGitHubUser).toHaveBeenCalledWith(
+        env.DB,
+        expect.objectContaining({ email: "cased@example.com" }),
+        expect.anything(),
+      );
+
+      vi.restoreAllMocks();
+    });
+
+    it("beta gate: a returning github_id-matched user with unverified emails still signs in", async () => {
+      const gateEnv = makeEnv({
+        ...env,
+        BETA_GATE: "1",
+        REFERRAL_SERVICE_URL: "http://referral.test",
+      });
+      const { createUser } = await import("../src/storage/users");
+      await createUser(gateEnv.DB, "gated@example.com", {} as unknown as Logger, "gateduser");
+      const user = mockUsers.get("email:gated@example.com");
+      if (!user) throw new Error("seed failed");
+      user.githubId = "66677";
+
+      mockGitHubFetch({ id: 66677, login: "gateduser" }, [
+        { email: "unverified@example.com", primary: true, verified: false },
+      ]);
+      const state = "gate-linked-state";
+      await gateEnv.STATE.put(`oauth_state:${state}`, "1", { expirationTtl: 600 });
+
+      const res = await app.fetch(
+        request(`/auth/github/callback?code=test-code&state=${state}`, {
+          headers: { Cookie: `stratum_oauth_state=${state}` },
+        }),
+        gateEnv,
+      );
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/");
+      expect(res.headers.get("set-cookie")).toContain("stratum_session");
+
+      vi.restoreAllMocks();
+    });
+
+    it("beta gate: an unmatched user with a verified email is redirected to invite_required", async () => {
+      const gateEnv = makeEnv({
+        ...env,
+        BETA_GATE: "1",
+        REFERRAL_SERVICE_URL: "http://referral.test",
+      });
+      mockGitHubFetch({ id: 88811, login: "newgated" }, [
+        { email: "brandnew@example.com", primary: true, verified: true },
+      ]);
+      const state = "gate-new-state";
+      await gateEnv.STATE.put(`oauth_state:${state}`, "1", { expirationTtl: 600 });
+
+      const res = await app.fetch(
+        request(`/auth/github/callback?code=test-code&state=${state}`, {
+          headers: { Cookie: `stratum_oauth_state=${state}` },
+        }),
+        gateEnv,
+      );
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/auth/signup?error=invite_required");
+      const { upsertGitHubUser } = await import("../src/storage/users");
+      expect(upsertGitHubUser).not.toHaveBeenCalled();
+
+      vi.restoreAllMocks();
+    });
+
+    it("ignores a next query param on the callback (always redirects home)", async () => {
+      mockGitHubFetch({ id: 12345, login: "testuser" }, [
+        { email: "github@example.com", primary: true, verified: true },
+      ]);
+
+      const res = await githubCallback("next-param-state", "&next=%2Fdashboard");
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/");
+
       vi.restoreAllMocks();
     });
 

--- a/tests/auth-signup-login.test.ts
+++ b/tests/auth-signup-login.test.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authRouter } from "../src/routes/auth";
 import { emailAuthRouter } from "../src/routes/email-auth";
+import { recordAudit } from "../src/storage/audit";
 import type { Env, User } from "../src/types";
 import { NotFoundError } from "../src/utils/errors";
 import type { Logger } from "../src/utils/logger";
@@ -88,6 +89,16 @@ vi.mock("../src/storage/users", () => {
       return { success: true, data: user };
     }),
 
+    getUserByGitHubId: vi.fn(async (_db, githubId: string) => {
+      const users = getMockUsers();
+      for (const user of users.values()) {
+        if (user.githubId === githubId) {
+          return { success: true, data: user };
+        }
+      }
+      return { success: false, error: new NotFoundError("User", githubId) };
+    }),
+
     getUserByUsername: vi.fn(async (_db, username: string) => {
       const users = getMockUsers();
       const user = users.get(`username:${username.toLowerCase()}`);
@@ -171,6 +182,12 @@ vi.mock("../src/storage/sessions", () => ({
   getUserSessions: vi.fn(),
   deleteAllUserSessions: vi.fn(),
   refreshSession: vi.fn(),
+}));
+
+// Audit is mocked so the disabled-account tests can assert that a refused
+// login records NO session.created row.
+vi.mock("../src/storage/audit", () => ({
+  recordAudit: vi.fn(async () => ({ success: true, data: undefined })),
 }));
 
 // ============================================================================
@@ -1590,6 +1607,202 @@ describe("Auth Signup/Login Integration Tests", () => {
 
       expect(res.status).toBe(302);
       expect(res.headers.get("location")).toContain("error=rate_limited");
+    });
+  });
+
+  // ============================================================================
+  // Disabled account enforcement (disabled_at) — no session mint, no mail,
+  // no session.created audit row on any refused login.
+  // ============================================================================
+
+  describe("Disabled account enforcement", () => {
+    const DISABLED_AT = "2026-08-01T00:00:00.000Z";
+
+    async function seedDisabledUser(email: string, username: string): Promise<User> {
+      const { createUser } = await import("../src/storage/users");
+      await createUser(env.DB, email, {} as unknown as Logger, username);
+      const user = mockUsers.get(`email:${email}`);
+      if (!user) throw new Error(`Failed to seed user ${email}`);
+      user.disabledAt = DISABLED_AT;
+      return user;
+    }
+
+    it("send-login answers with the enumeration-safe success but sends no mail", async () => {
+      await seedDisabledUser("disabled@example.com", "disableduser");
+
+      const res = await app.fetch(
+        request("/auth/email/send-login", {
+          method: "POST",
+          body: createFormData({ email: "disabled@example.com" }),
+        }),
+        env,
+      );
+
+      expect(res.status).toBe(302);
+      // Same response as an unknown address — disabled accounts are not an
+      // enumeration oracle.
+      expect(res.headers.get("location")).toContain("success=login_link_sent");
+      expect(env.EMAIL?.send).not.toHaveBeenCalled();
+      expect(await extractMagicLinkToken(env)).toBeNull();
+    });
+
+    it("legacy send answers with the uniform success but sends no mail", async () => {
+      await seedDisabledUser("disabled-legacy@example.com", "disabledlegacy");
+
+      const res = await app.fetch(
+        request("/auth/email/send", {
+          method: "POST",
+          body: createFormData({ email: "disabled-legacy@example.com" }),
+        }),
+        env,
+      );
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toContain("success=email_sent");
+      expect(env.EMAIL?.send).not.toHaveBeenCalled();
+      expect(await extractMagicLinkToken(env)).toBeNull();
+    });
+
+    it("verify hard-rejects a login link for a disabled account with no session or audit row", async () => {
+      await seedDisabledUser("disabled-verify@example.com", "disabledverify");
+      // A link minted BEFORE the account was disabled must still be refused.
+      magicStore.set("pre-disable-token", {
+        email: "disabled-verify@example.com",
+        intent: "login",
+        createdAt: Date.now(),
+        rememberMe: true,
+      });
+
+      const res = await app.fetch(verifyReq("pre-disable-token"), env);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toContain("error=account_disabled");
+      expect(res.headers.get("set-cookie")).toBeNull();
+      const { createSession } = await import("../src/storage/sessions");
+      expect(createSession).not.toHaveBeenCalled();
+      expect(recordAudit).not.toHaveBeenCalled();
+    });
+
+    it("verify refuses the signup-collides-with-existing-account fallback for a disabled account", async () => {
+      await seedDisabledUser("disabled-signup@example.com", "disabledsignup");
+      magicStore.set("signup-collision-token", {
+        email: "disabled-signup@example.com",
+        username: "someoneelse",
+        intent: "signup",
+        createdAt: Date.now(),
+        rememberMe: true,
+      });
+
+      const res = await app.fetch(verifyReq("signup-collision-token"), env);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toContain("error=account_disabled");
+      expect(res.headers.get("set-cookie")).toBeNull();
+      expect(recordAudit).not.toHaveBeenCalled();
+    });
+
+    it("GitHub callback refuses a disabled account before minting a session", async () => {
+      const user = await seedDisabledUser("disabled-github@example.com", "disabledgithub");
+      user.githubId = "99999";
+
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: "gh_token_disabled" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ id: 99999, login: "disabledgithub" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [
+            { email: "disabled-github@example.com", primary: true, verified: true },
+          ],
+        });
+
+      const state = "disabled-github-state";
+      await env.STATE.put(`oauth_state:${state}`, "1", { expirationTtl: 600 });
+
+      const res = await app.fetch(
+        request(`/auth/github/callback?code=test-code&state=${state}`, {
+          headers: { Cookie: `stratum_oauth_state=${state}` },
+        }),
+        env,
+      );
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/auth/login?error=account_disabled");
+      expect(res.headers.get("set-cookie") ?? "").not.toContain("stratum_session");
+      const { createSession } = await import("../src/storage/sessions");
+      expect(createSession).not.toHaveBeenCalled();
+      expect(recordAudit).not.toHaveBeenCalled();
+
+      vi.restoreAllMocks();
+    });
+
+    it("GitHub callback refuses a disabled account matched by email WITHOUT linking github_id", async () => {
+      // The refusal must come before upsertGitHubUser: linking a GitHub id
+      // onto the frozen row would hand it a working credential at re-enable.
+      const user = await seedDisabledUser("disabled-nolink@example.com", "disablednolink");
+      expect(user.githubId).toBeUndefined();
+
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: "gh_token_nolink" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ id: 88888, login: "disablednolink" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [
+            { email: "disabled-nolink@example.com", primary: true, verified: true },
+          ],
+        });
+
+      const state = "disabled-nolink-state";
+      await env.STATE.put(`oauth_state:${state}`, "1", { expirationTtl: 600 });
+
+      const res = await app.fetch(
+        request(`/auth/github/callback?code=test-code&state=${state}`, {
+          headers: { Cookie: `stratum_oauth_state=${state}` },
+        }),
+        env,
+      );
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/auth/login?error=account_disabled");
+      const { upsertGitHubUser } = await import("../src/storage/users");
+      expect(upsertGitHubUser).not.toHaveBeenCalled();
+      expect(user.githubId).toBeUndefined();
+
+      vi.restoreAllMocks();
+    });
+
+    it("verify hard-rejects a soft-deleting account the same as a disabled one", async () => {
+      const { createUser } = await import("../src/storage/users");
+      await createUser(env.DB, "deleting@example.com", {} as unknown as Logger, "deletinguser");
+      const user = mockUsers.get("email:deleting@example.com");
+      if (!user) throw new Error("seed failed");
+      user.deletingAt = "2026-08-01T00:00:00.000Z";
+      magicStore.set("deleting-user-token", {
+        email: "deleting@example.com",
+        intent: "login",
+        createdAt: Date.now(),
+        rememberMe: true,
+      });
+
+      const res = await app.fetch(verifyReq("deleting-user-token"), env);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toContain("error=account_disabled");
+      expect(res.headers.get("set-cookie") ?? "").not.toContain("stratum_session");
+      expect(recordAudit).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/auth-signup-login.test.ts
+++ b/tests/auth-signup-login.test.ts
@@ -1898,6 +1898,49 @@ describe("Auth Signup/Login Integration Tests", () => {
       expect(await extractMagicLinkToken(env)).toBeNull();
     });
 
+    async function seedDeletingUser(email: string, username: string): Promise<User> {
+      const { createUser } = await import("../src/storage/users");
+      await createUser(env.DB, email, {} as unknown as Logger, username);
+      const user = mockUsers.get(`email:${email}`);
+      if (!user) throw new Error(`Failed to seed user ${email}`);
+      user.deletingAt = "2026-08-01T00:00:00.000Z";
+      return user;
+    }
+
+    it("send-login treats a deleting account like a disabled one: uniform success, no mail", async () => {
+      await seedDeletingUser("deleting-send@example.com", "deletingsend");
+
+      const res = await app.fetch(
+        request("/auth/email/send-login", {
+          method: "POST",
+          body: createFormData({ email: "deleting-send@example.com" }),
+        }),
+        env,
+      );
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toContain("success=login_link_sent");
+      expect(env.EMAIL?.send).not.toHaveBeenCalled();
+      expect(await extractMagicLinkToken(env)).toBeNull();
+    });
+
+    it("legacy send treats a deleting account like a disabled one: uniform success, no mail", async () => {
+      await seedDeletingUser("deleting-legacy@example.com", "deletinglegacy");
+
+      const res = await app.fetch(
+        request("/auth/email/send", {
+          method: "POST",
+          body: createFormData({ email: "deleting-legacy@example.com" }),
+        }),
+        env,
+      );
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toContain("success=email_sent");
+      expect(env.EMAIL?.send).not.toHaveBeenCalled();
+      expect(await extractMagicLinkToken(env)).toBeNull();
+    });
+
     it("verify hard-rejects a login link for a disabled account with no session or audit row", async () => {
       await seedDisabledUser("disabled-verify@example.com", "disabledverify");
       // A link minted BEFORE the account was disabled must still be refused.

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -22,8 +22,14 @@ vi.mock("../src/storage/agents", () => ({
   getAgentByToken: vi.fn(),
 }));
 
+vi.mock("../src/storage/sessions", () => ({
+  getSession: vi.fn(),
+  deleteSession: vi.fn(),
+}));
+
 import { getAgentByToken } from "../src/storage/agents";
-import { getUserByToken } from "../src/storage/users";
+import { deleteSession, getSession } from "../src/storage/sessions";
+import { getUser, getUserByToken } from "../src/storage/users";
 
 function makeApp() {
   const app = new Hono<{ Bindings: Env }>();
@@ -153,5 +159,80 @@ describe("authMiddleware", () => {
     expect(res.status).toBe(401);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("Invalid token");
+  });
+});
+
+// disabled_at is reversible (unlike deleting_at): every path must reject while
+// it is set, and the SAME credential must work again once it is cleared.
+describe("authMiddleware — disabled_at enforcement", () => {
+  let app: ReturnType<typeof makeApp>;
+  let env: Env;
+
+  const liveUser = {
+    id: "usr_abc",
+    email: "test@example.com",
+    username: "test",
+    tokenHash: "hash",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+  const disabledUser = { ...liveUser, disabledAt: "2026-08-01T00:00:00.000Z" };
+  const agent = {
+    id: "agt_xyz",
+    name: "my-agent",
+    ownerId: "usr_abc",
+    tokenHash: "hash",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+  const session = { id: "sess_1", userId: "usr_abc", expiresAt: "2099-01-01T00:00:00.000Z" };
+
+  beforeEach(() => {
+    app = makeApp();
+    env = makeEnv();
+    vi.clearAllMocks();
+  });
+
+  it("rejects a disabled user's token with 401, then the SAME token works after re-enable", async () => {
+    const req = () => request("/test", { Authorization: "Bearer stratum_user_abc123" });
+
+    vi.mocked(getUserByToken).mockResolvedValueOnce({ success: true, data: disabledUser });
+    const denied = await app.fetch(req(), env);
+    expect(denied.status).toBe(401);
+    expect(((await denied.json()) as { error: string }).error).toBe("Invalid token");
+
+    vi.mocked(getUserByToken).mockResolvedValueOnce({ success: true, data: liveUser });
+    const allowed = await app.fetch(req(), env);
+    expect(allowed.status).toBe(200);
+    expect(((await allowed.json()) as { userId: string | null }).userId).toBe("usr_abc");
+  });
+
+  it("rejects an agent whose OWNER is disabled with 401, then the SAME token works after re-enable", async () => {
+    const req = () => request("/test", { Authorization: "Bearer stratum_agent_xyz123" });
+    vi.mocked(getAgentByToken).mockResolvedValue({ success: true, data: agent });
+
+    vi.mocked(getUser).mockResolvedValueOnce({ success: true, data: disabledUser });
+    const denied = await app.fetch(req(), env);
+    expect(denied.status).toBe(401);
+
+    vi.mocked(getUser).mockResolvedValueOnce({ success: true, data: liveUser });
+    const allowed = await app.fetch(req(), env);
+    expect(allowed.status).toBe(200);
+    expect(((await allowed.json()) as { agentId: string | null }).agentId).toBe("agt_xyz");
+  });
+
+  it("rejects a disabled user's session with 401 (session kept), then the SAME cookie works after re-enable", async () => {
+    const req = () => request("/test", { Cookie: "stratum_session=sess_1" });
+    vi.mocked(getSession).mockResolvedValue({ success: true, data: session });
+
+    vi.mocked(getUser).mockResolvedValueOnce({ success: true, data: disabledUser });
+    const denied = await app.fetch(req(), env);
+    expect(denied.status).toBe(401);
+    // Disable is reversible: the session row must survive so re-enabling
+    // restores access without a fresh login.
+    expect(deleteSession).not.toHaveBeenCalled();
+
+    vi.mocked(getUser).mockResolvedValueOnce({ success: true, data: liveUser });
+    const allowed = await app.fetch(req(), env);
+    expect(allowed.status).toBe(200);
+    expect(((await allowed.json()) as { userId: string | null }).userId).toBe("usr_abc");
   });
 });

--- a/tests/crypto.test.ts
+++ b/tests/crypto.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { constantTimeEqual, generateApiKey, hashToken, verifyToken } from "../src/utils/crypto";
+import {
+  SSO_SECRET_SALT,
+  constantTimeEqual,
+  decryptToken,
+  encryptToken,
+  generateApiKey,
+  hashToken,
+  verifyToken,
+} from "../src/utils/crypto";
 
 describe("constantTimeEqual", () => {
   it("returns true for identical strings", () => {
@@ -61,5 +69,31 @@ describe("generateApiKey", () => {
     const prefix = "stratum_user";
     const key = await generateApiKey(prefix);
     expect(key).toHaveLength(prefix.length + 1 + 32);
+  });
+});
+
+describe("encryptToken / decryptToken salt parameterization", () => {
+  const secret = "test-encryption-secret";
+  const plaintext = "gho_sensitive_github_token";
+
+  it("default salt path round-trips", async () => {
+    const ciphertext = await encryptToken(plaintext, secret);
+    expect(await decryptToken(ciphertext, secret)).toBe(plaintext);
+  });
+
+  it("default salt is byte-compatible with the explicit historical GitHub salt", async () => {
+    // Existing GitHub-token ciphertexts were produced under the previously
+    // hardcoded salt; the parameterization must not change that key material.
+    const githubSalt = "stratum-github-token-salt";
+    const viaDefault = await encryptToken(plaintext, secret);
+    const viaExplicit = await encryptToken(plaintext, secret, githubSalt);
+    expect(await decryptToken(viaDefault, secret, githubSalt)).toBe(plaintext);
+    expect(await decryptToken(viaExplicit, secret)).toBe(plaintext);
+  });
+
+  it("SSO salt round-trips and is not decryptable under the default salt", async () => {
+    const ciphertext = await encryptToken(plaintext, secret, SSO_SECRET_SALT);
+    expect(await decryptToken(ciphertext, secret, SSO_SECRET_SALT)).toBe(plaintext);
+    expect(await decryptToken(ciphertext, secret)).toBeNull();
   });
 });

--- a/tests/deletion-sso.test.ts
+++ b/tests/deletion-sso.test.ts
@@ -185,6 +185,24 @@ describe("deleteAccountCascade — SSO/SCIM tables", () => {
     expect(survivor.disabled_at).toBeNull();
     expect(countWhere(raw, "scim_members", "connection_id", "conn_1")).toBe(0);
     expect(countWhere(raw, "org_sso_connections", "org_id", "org_1")).toBe(0);
+
+    // ONE summary audit for the batch re-enable, not a per-user fan-out.
+    const audits = raw
+      .prepare("SELECT action, actor_type, detail FROM audit_log WHERE subject = 'org_1'")
+      .all() as Array<{ action: string; actor_type: string; detail: string }>;
+    const summary = audits.find((row) => row.action === "sso.connection.deleted");
+    expect(summary).toBeDefined();
+    expect(summary?.actor_type).toBe("system");
+    const detail = JSON.parse(summary?.detail ?? "{}") as {
+      via: string;
+      orgId: string;
+      connectionId: string;
+      reenabledUserIds: string[];
+    };
+    expect(detail.via).toBe("org.deleted");
+    expect(detail.orgId).toBe("org_1");
+    expect(detail.connectionId).toBe("conn_1");
+    expect(detail.reenabledUserIds).toEqual(["usr_2"]);
   });
 
   it("keeps the connection when the org survives via successor promotion", async () => {

--- a/tests/deletion-sso.test.ts
+++ b/tests/deletion-sso.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import { deleteAccountCascade } from "../src/storage/deletion";
+import type { Env } from "../src/types";
+import type { Logger } from "../src/utils/logger";
+import { makeKvStub } from "./helpers/deletion-stubs";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
+
+/**
+ * Zero-orphan coverage for the SSO/SCIM tables (migration 041) in the deletion
+ * cascades, against the REAL schema (FK enforcement on) so a wrong delete
+ * order fails here instead of in production.
+ */
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+type Raw = ReturnType<typeof makeSqliteD1>["raw"];
+
+function seedUser(raw: Raw, id: string): void {
+  raw
+    .prepare("INSERT INTO users (id, email, username, token_hash) VALUES (?, ?, ?, ?)")
+    .run(id, `${id}@example.com`, id.replace(/_/g, "-"), `hash_${id}`);
+}
+
+function seedOrg(raw: Raw, id: string, ownerId: string, members: [string, string][]): void {
+  raw
+    .prepare("INSERT INTO orgs (id, name, slug, owner_id) VALUES (?, ?, ?, ?)")
+    .run(id, id, id.replace(/_/g, "-"), ownerId);
+  for (const [userId, role] of members) {
+    raw
+      .prepare("INSERT INTO org_members (org_id, user_id, role) VALUES (?, ?, ?)")
+      .run(id, userId, role);
+  }
+}
+
+function seedConnection(raw: Raw, id: string, orgId: string): void {
+  raw
+    .prepare(
+      `INSERT INTO org_sso_connections
+         (id, org_id, issuer, client_id, client_secret_ciphertext, authorization_endpoint,
+          token_endpoint, jwks_uri, email_domains, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      orgId,
+      "https://idp.example.com",
+      "client",
+      "ciphertext",
+      "https://idp.example.com/authorize",
+      "https://idp.example.com/token",
+      "https://idp.example.com/jwks",
+      '["example.com"]',
+      "2026-01-01T00:00:00.000Z",
+      "2026-01-01T00:00:00.000Z",
+    );
+}
+
+function seedIdentity(
+  raw: Raw,
+  id: string,
+  userId: string,
+  subject: string,
+  connectionId?: string,
+): void {
+  raw
+    .prepare(
+      "INSERT INTO identities (id, user_id, provider, issuer, subject, email, connection_id) VALUES (?, ?, 'oidc', 'https://idp.example.com', ?, ?, ?)",
+    )
+    .run(id, userId, subject, `${userId}@example.com`, connectionId ?? null);
+}
+
+function seedScimMember(raw: Raw, connectionId: string, userId: string): void {
+  raw
+    .prepare("INSERT INTO scim_members (connection_id, user_id) VALUES (?, ?)")
+    .run(connectionId, userId);
+}
+
+function countWhere(raw: Raw, table: string, column: string, value: string): number {
+  const row = raw.prepare(`SELECT COUNT(*) AS n FROM ${table} WHERE ${column} = ?`).get(value) as {
+    n: number;
+  };
+  return row.n;
+}
+
+function makeEnv(db: D1Database): Env {
+  return {
+    DB: db,
+    STATE: makeKvStub(50).kv,
+    ARTIFACTS: { delete: async () => true } as unknown as Env["ARTIFACTS"],
+  } as Env;
+}
+
+describe("deleteAccountCascade — SSO/SCIM tables", () => {
+  it("removes the user's identities and scim_members rows, leaving other users' intact", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    seedUser(raw, "usr_2");
+    seedOrg(raw, "org_1", "usr_2", [
+      ["usr_1", "member"],
+      ["usr_2", "admin"],
+    ]);
+    seedConnection(raw, "conn_1", "org_1");
+    seedIdentity(raw, "idn_1", "usr_1", "sub-1");
+    seedIdentity(raw, "idn_2", "usr_2", "sub-2");
+    seedScimMember(raw, "conn_1", "usr_1");
+    seedScimMember(raw, "conn_1", "usr_2");
+
+    const result = await deleteAccountCascade(makeEnv(db), "usr_1", mockLogger);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.residuals).toEqual([]);
+
+    // Zero orphans for the erased user, users row gone last.
+    expect(countWhere(raw, "identities", "user_id", "usr_1")).toBe(0);
+    expect(countWhere(raw, "scim_members", "user_id", "usr_1")).toBe(0);
+    expect(countWhere(raw, "users", "id", "usr_1")).toBe(0);
+
+    // The surviving user's rows and the org's connection are untouched.
+    expect(countWhere(raw, "identities", "user_id", "usr_2")).toBe(1);
+    expect(countWhere(raw, "scim_members", "user_id", "usr_2")).toBe(1);
+    expect(countWhere(raw, "org_sso_connections", "id", "conn_1")).toBe(1);
+  });
+
+  it("deletes the empty sole-owner org's connection and ALL its scim_members rows", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    // usr_2 was adopted by the connection but is no longer an org member — the
+    // connection-scoped delete must still remove that mapping.
+    seedUser(raw, "usr_2");
+    seedOrg(raw, "org_1", "usr_1", [["usr_1", "admin"]]);
+    seedConnection(raw, "conn_1", "org_1");
+    seedScimMember(raw, "conn_1", "usr_1");
+    seedScimMember(raw, "conn_1", "usr_2");
+    // usr_2 was JIT-provisioned by the connection: their identity's soft
+    // connection_id reference must be nulled, not left dangling.
+    seedIdentity(raw, "idn_2", "usr_2", "sub-2", "conn_1");
+
+    const result = await deleteAccountCascade(makeEnv(db), "usr_1", mockLogger);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.residuals).toEqual([]);
+
+    expect(countWhere(raw, "orgs", "id", "org_1")).toBe(0);
+    expect(countWhere(raw, "org_sso_connections", "org_id", "org_1")).toBe(0);
+    expect(countWhere(raw, "scim_members", "connection_id", "conn_1")).toBe(0);
+    expect(countWhere(raw, "users", "id", "usr_1")).toBe(0);
+    // The other mapped user is not erased — only the mapping is; their identity
+    // survives with the dead connection reference cleared.
+    expect(countWhere(raw, "users", "id", "usr_2")).toBe(1);
+    const survivor = raw
+      .prepare("SELECT connection_id FROM identities WHERE id = 'idn_2'")
+      .get() as { connection_id: string | null };
+    expect(survivor.connection_id).toBeNull();
+  });
+
+  it("keeps the connection when the org survives via successor promotion", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    seedUser(raw, "usr_2");
+    seedOrg(raw, "org_1", "usr_1", [
+      ["usr_1", "admin"],
+      ["usr_2", "admin"],
+    ]);
+    seedConnection(raw, "conn_1", "org_1");
+    seedScimMember(raw, "conn_1", "usr_1");
+    seedScimMember(raw, "conn_1", "usr_2");
+
+    const result = await deleteAccountCascade(makeEnv(db), "usr_1", mockLogger);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.residuals).toEqual([]);
+
+    const org = raw.prepare("SELECT owner_id FROM orgs WHERE id = 'org_1'").get() as {
+      owner_id: string;
+    };
+    expect(org.owner_id).toBe("usr_2");
+    expect(countWhere(raw, "org_sso_connections", "org_id", "org_1")).toBe(1);
+    expect(countWhere(raw, "scim_members", "user_id", "usr_2")).toBe(1);
+    // The erased user's mapping is gone even though the connection remains.
+    expect(countWhere(raw, "scim_members", "user_id", "usr_1")).toBe(0);
+  });
+});

--- a/tests/deletion-sso.test.ts
+++ b/tests/deletion-sso.test.ts
@@ -77,10 +77,10 @@ function seedIdentity(
     .run(id, userId, subject, `${userId}@example.com`, connectionId ?? null);
 }
 
-function seedScimMember(raw: Raw, connectionId: string, userId: string): void {
+function seedScimMember(raw: Raw, connectionId: string, userId: string, active = 1): void {
   raw
-    .prepare("INSERT INTO scim_members (connection_id, user_id) VALUES (?, ?)")
-    .run(connectionId, userId);
+    .prepare("INSERT INTO scim_members (connection_id, user_id, active) VALUES (?, ?, ?)")
+    .run(connectionId, userId, active);
 }
 
 function countWhere(raw: Raw, table: string, column: string, value: string): number {
@@ -157,6 +157,34 @@ describe("deleteAccountCascade — SSO/SCIM tables", () => {
       .prepare("SELECT connection_id FROM identities WHERE id = 'idn_2'")
       .get() as { connection_id: string | null };
     expect(survivor.connection_id).toBeNull();
+  });
+
+  it("re-enables SCIM-disabled users before deleting the empty org's connection", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    // usr_2 is not an org member: the connection deactivated them via SCIM and
+    // disabled their account. Org erasure must give the account back, not
+    // strand it disabled with the connection gone.
+    seedUser(raw, "usr_2");
+    raw
+      .prepare("UPDATE users SET disabled_at = ? WHERE id = 'usr_2'")
+      .run("2026-02-01T00:00:00.000Z");
+    seedOrg(raw, "org_1", "usr_1", [["usr_1", "admin"]]);
+    seedConnection(raw, "conn_1", "org_1");
+    seedScimMember(raw, "conn_1", "usr_2", 0);
+
+    const result = await deleteAccountCascade(makeEnv(db), "usr_1", mockLogger);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.residuals).toEqual([]);
+
+    // usr_2 still exists and is re-enabled; the mapping and connection are gone.
+    expect(countWhere(raw, "users", "id", "usr_2")).toBe(1);
+    const survivor = raw.prepare("SELECT disabled_at FROM users WHERE id = 'usr_2'").get() as {
+      disabled_at: string | null;
+    };
+    expect(survivor.disabled_at).toBeNull();
+    expect(countWhere(raw, "scim_members", "connection_id", "conn_1")).toBe(0);
+    expect(countWhere(raw, "org_sso_connections", "org_id", "org_1")).toBe(0);
   });
 
   it("keeps the connection when the org survives via successor promotion", async () => {

--- a/tests/dev-login-gate.test.ts
+++ b/tests/dev-login-gate.test.ts
@@ -68,6 +68,8 @@ describe("SEC-5: /dev-login gating", () => {
 
     const res = await app.fetch(devLoginRequest(), makeEnv({ DEV_LOGIN_ENABLED: "true" }));
     expect(res.status).toBe(403);
+    // No session cookie may be minted for the refused disabled account.
+    expect(res.headers.get("set-cookie")).toBeNull();
   });
 
   it("stays forbidden on a non-localhost host even when enabled", async () => {

--- a/tests/dev-login-gate.test.ts
+++ b/tests/dev-login-gate.test.ts
@@ -55,6 +55,21 @@ describe("SEC-5: /dev-login gating", () => {
     expect(res.status).toBe(302);
   });
 
+  it("refuses a disabled account even when the gate is open", async () => {
+    const { getUserByEmail } = await import("../src/storage/users");
+    vi.mocked(getUserByEmail).mockResolvedValueOnce({
+      success: true,
+      data: {
+        id: "usr_dev",
+        email: "dev@example.com",
+        disabledAt: "2026-08-01T00:00:00.000Z",
+      },
+    } as Awaited<ReturnType<typeof getUserByEmail>>);
+
+    const res = await app.fetch(devLoginRequest(), makeEnv({ DEV_LOGIN_ENABLED: "true" }));
+    expect(res.status).toBe(403);
+  });
+
   it("stays forbidden on a non-localhost host even when enabled", async () => {
     const res = await app.fetch(
       new Request("https://app.usestratum.dev/dev-login?email=dev@example.com", { method: "GET" }),

--- a/tests/git-http.test.ts
+++ b/tests/git-http.test.ts
@@ -27,6 +27,10 @@ const DELETING_TOKEN = "stratum_user_deleting00000000000000";
 const DELETING_AGENT_TOKEN = "stratum_agent_deleting0000000000000";
 // An agent whose owner cannot be resolved — auth must fail closed.
 const GHOST_AGENT_TOKEN = "stratum_agent_ghost000000000000000";
+// A disabled owner (reversible, SCIM deprovisioning) and their agent: both must
+// lose git access while disabled_at is set.
+const DISABLED_TOKEN = "stratum_user_disabled00000000000000";
+const DISABLED_AGENT_TOKEN = "stratum_agent_disabled0000000000000";
 
 // The gated-push handler calls the change-flow service; mock its two entry
 // points so these tests exercise the wire protocol, not the eval pipeline
@@ -75,6 +79,11 @@ vi.mock("../src/storage/users", () => ({
         success: true,
         data: { id: "user_owner", email: "o@x.io", username: "owner", deletingAt: "2026-01-01" },
       };
+    if (token === DISABLED_TOKEN)
+      return {
+        success: true,
+        data: { id: "user_owner", email: "o@x.io", username: "owner", disabledAt: "2026-01-01" },
+      };
     return { success: false, error: { message: "not found" } };
   }),
   getUser: vi.fn(async (_db: unknown, id: string) => {
@@ -84,6 +93,11 @@ vi.mock("../src/storage/users", () => ({
       return {
         success: true,
         data: { id, email: "d@x.io", username: "deleter", deletingAt: "2026-01-01" },
+      };
+    if (id === "user_disabled_owner")
+      return {
+        success: true,
+        data: { id, email: "s@x.io", username: "suspended", disabledAt: "2026-01-01" },
       };
     return { success: false, error: { message: "not found" } };
   }),
@@ -97,6 +111,8 @@ vi.mock("../src/storage/agents", () => ({
       return { success: true, data: { id: "agent_2", ownerId: "user_deleting_owner" } };
     if (token === GHOST_AGENT_TOKEN)
       return { success: true, data: { id: "agent_3", ownerId: "user_ghost" } };
+    if (token === DISABLED_AGENT_TOKEN)
+      return { success: true, data: { id: "agent_4", ownerId: "user_disabled_owner" } };
     return { success: false, error: { message: "not found" } };
   }),
 }));
@@ -332,6 +348,24 @@ describe("git smart-HTTP proxy — auth & authorization truth table (Task 2)", (
     await seedProject(env, { visibility: "private" });
     const fetchMock = stubFetch(() => okUpstream());
     const res = await app.fetch(req(ADVERTISE, { headers: basic(DELETING_AGENT_TOKEN) }), env);
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("disabled owner token + private → treated as anonymous (401), no upstream call", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "private" });
+    const fetchMock = stubFetch(() => okUpstream());
+    const res = await app.fetch(req(ADVERTISE, { headers: basic(DISABLED_TOKEN) }), env);
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("agent whose owner is disabled + private → treated as anonymous (401)", async () => {
+    const env = makeEnv();
+    await seedProject(env, { visibility: "private" });
+    const fetchMock = stubFetch(() => okUpstream());
+    const res = await app.fetch(req(ADVERTISE, { headers: basic(DISABLED_AGENT_TOKEN) }), env);
     expect(res.status).toBe(401);
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/tests/google-oauth.test.ts
+++ b/tests/google-oauth.test.ts
@@ -5,7 +5,9 @@ import type { Env } from "../src/types";
 
 vi.mock("../src/storage/users", () => ({
   createUser: vi.fn(),
+  getUser: vi.fn(),
   getUserByEmail: vi.fn(),
+  getUserByGitHubId: vi.fn(),
   upsertGitHubUser: vi.fn(),
 }));
 
@@ -19,9 +21,18 @@ vi.mock("../src/storage/audit", () => ({
   recordAudit: vi.fn().mockResolvedValue({ success: true, data: undefined }),
 }));
 
+vi.mock("../src/storage/identities", () => ({
+  getIdentityByIssuerSubject: vi.fn(),
+  upsertIdentity: vi.fn(),
+}));
+
 import { recordAudit } from "../src/storage/audit";
+import { getIdentityByIssuerSubject, upsertIdentity } from "../src/storage/identities";
 import { createSession } from "../src/storage/sessions";
-import { createUser, getUserByEmail } from "../src/storage/users";
+import { createUser, getUser, getUserByEmail } from "../src/storage/users";
+import { AppError, NotFoundError } from "../src/utils/errors";
+
+const GOOGLE_ISSUER = "https://accounts.google.com";
 
 const fetchMock = vi.fn();
 
@@ -60,6 +71,16 @@ describe("Google OAuth", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubGlobal("fetch", fetchMock);
+    // Defaults: no identity linked yet (fall through to email match), and
+    // identity persistence succeeds. Individual tests override as needed.
+    vi.mocked(getIdentityByIssuerSubject).mockResolvedValue({
+      success: false,
+      error: new NotFoundError("Identity", "none"),
+    });
+    vi.mocked(upsertIdentity).mockImplementation(async (_db, _logger, input) => ({
+      success: true,
+      data: { id: "idn_1", createdAt: "", ...input, connectionId: input.connectionId ?? null },
+    }));
   });
 
   afterEach(() => {
@@ -253,5 +274,235 @@ describe("Google OAuth", () => {
       env,
     );
     expect(res.status).toBe(422);
+  });
+
+  function mockGoogleUserinfo(user: { sub: string; email?: string; email_verified?: boolean }) {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith("https://oauth2.googleapis.com/token")) {
+        return new Response(JSON.stringify({ access_token: "google-token" }), { status: 200 });
+      }
+      if (url.startsWith("https://www.googleapis.com/oauth2/v3/userinfo")) {
+        return new Response(JSON.stringify(user), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+  }
+
+  function callbackRequest() {
+    return new Request("http://localhost/auth/google/callback?code=ok&state=goodstate", {
+      headers: { Cookie: "stratum_oauth_state=goodstate" },
+    });
+  }
+
+  it("persists an identities row keyed by sub after sign-in", async () => {
+    const app = makeApp();
+    const env = makeEnv({ STATE: makeKv({ "oauth_state:goodstate": "1" }) });
+    mockGoogleUserinfo({ sub: "g-123", email: "user@example.com", email_verified: true });
+
+    vi.mocked(getUserByEmail).mockResolvedValue({
+      success: true,
+      data: {
+        id: "usr_1",
+        email: "user@example.com",
+        username: "user",
+        tokenHash: "h",
+        createdAt: "",
+      },
+    });
+    vi.mocked(createSession).mockResolvedValue({
+      success: true,
+      data: { id: "sess_1", userId: "usr_1", expiresAt: "2099-01-01T00:00:00.000Z" },
+    });
+
+    const res = await app.fetch(callbackRequest(), env);
+    expect(res.status).toBe(302);
+    expect(upsertIdentity).toHaveBeenCalledWith(env.DB, expect.anything(), {
+      userId: "usr_1",
+      provider: "google",
+      issuer: GOOGLE_ISSUER,
+      subject: "g-123",
+      email: "user@example.com",
+    });
+  });
+
+  it("resolves by (issuer, sub) before email — the sub match wins", async () => {
+    const app = makeApp();
+    const env = makeEnv({ STATE: makeKv({ "oauth_state:goodstate": "1" }) });
+    // Identity for sub g-sub-x points at user A; user B holds the email.
+    mockGoogleUserinfo({ sub: "g-sub-x", email: "shared@example.com", email_verified: true });
+
+    vi.mocked(getIdentityByIssuerSubject).mockResolvedValue({
+      success: true,
+      data: {
+        id: "idn_a",
+        userId: "usr_a",
+        provider: "google",
+        issuer: GOOGLE_ISSUER,
+        subject: "g-sub-x",
+        email: "old@example.com",
+        connectionId: null,
+        createdAt: "",
+      },
+    });
+    vi.mocked(getUser).mockResolvedValue({
+      success: true,
+      data: { id: "usr_a", email: "old@example.com", username: "a", tokenHash: "h", createdAt: "" },
+    });
+    vi.mocked(getUserByEmail).mockResolvedValue({
+      success: true,
+      data: {
+        id: "usr_b",
+        email: "shared@example.com",
+        username: "b",
+        tokenHash: "h",
+        createdAt: "",
+      },
+    });
+    vi.mocked(createSession).mockResolvedValue({
+      success: true,
+      data: { id: "sess_a", userId: "usr_a", expiresAt: "2099-01-01T00:00:00.000Z" },
+    });
+
+    const res = await app.fetch(callbackRequest(), env);
+    expect(res.status).toBe(302);
+    expect(getIdentityByIssuerSubject).toHaveBeenCalledWith(
+      env.DB,
+      expect.anything(),
+      GOOGLE_ISSUER,
+      "g-sub-x",
+    );
+    expect(createSession).toHaveBeenCalledWith(env.DB, "usr_a", expect.anything());
+    expect(getUserByEmail).not.toHaveBeenCalled();
+  });
+
+  it("signs in a linked user whose email claim is unverified — the sub is the credential", async () => {
+    const app = makeApp();
+    const env = makeEnv({ STATE: makeKv({ "oauth_state:goodstate": "1" }) });
+    mockGoogleUserinfo({ sub: "g-sub-uv", email: "linked@example.com", email_verified: false });
+
+    vi.mocked(getIdentityByIssuerSubject).mockResolvedValue({
+      success: true,
+      data: {
+        id: "idn_uv",
+        userId: "usr_uv",
+        provider: "google",
+        issuer: GOOGLE_ISSUER,
+        subject: "g-sub-uv",
+        email: "stored@example.com",
+        connectionId: null,
+        createdAt: "",
+      },
+    });
+    vi.mocked(getUser).mockResolvedValue({
+      success: true,
+      data: {
+        id: "usr_uv",
+        email: "stored@example.com",
+        username: "uv",
+        tokenHash: "h",
+        createdAt: "",
+      },
+    });
+    vi.mocked(createSession).mockResolvedValue({
+      success: true,
+      data: { id: "sess_uv", userId: "usr_uv", expiresAt: "2099-01-01T00:00:00.000Z" },
+    });
+
+    const res = await app.fetch(callbackRequest(), env);
+
+    expect(res.status).toBe(302);
+    expect(createSession).toHaveBeenCalledWith(env.DB, "usr_uv", expect.anything());
+    // The unverified claim must not overwrite the identity email.
+    expect(upsertIdentity).toHaveBeenCalledWith(
+      env.DB,
+      expect.anything(),
+      expect.objectContaining({ subject: "g-sub-uv", email: "stored@example.com" }),
+    );
+  });
+
+  it("refuses a disabled account matched by identity before minting a session", async () => {
+    const app = makeApp();
+    const env = makeEnv({ STATE: makeKv({ "oauth_state:goodstate": "1" }) });
+    mockGoogleUserinfo({ sub: "g-dis", email: "disabled@example.com", email_verified: true });
+
+    vi.mocked(getIdentityByIssuerSubject).mockResolvedValue({
+      success: true,
+      data: {
+        id: "idn_d",
+        userId: "usr_disabled",
+        provider: "google",
+        issuer: GOOGLE_ISSUER,
+        subject: "g-dis",
+        email: "disabled@example.com",
+        connectionId: null,
+        createdAt: "",
+      },
+    });
+    vi.mocked(getUser).mockResolvedValue({
+      success: true,
+      data: {
+        id: "usr_disabled",
+        email: "disabled@example.com",
+        username: "disabled",
+        tokenHash: "h",
+        createdAt: "",
+        disabledAt: "2026-08-01T00:00:00.000Z",
+      },
+    });
+
+    const res = await app.fetch(callbackRequest(), env);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/auth/login?error=account_disabled");
+    expect(createSession).not.toHaveBeenCalled();
+    expect(recordAudit).not.toHaveBeenCalled();
+  });
+
+  it("fails the login closed when the identity lookup hits a storage error", async () => {
+    const app = makeApp();
+    const env = makeEnv({ STATE: makeKv({ "oauth_state:goodstate": "1" }) });
+    mockGoogleUserinfo({ sub: "g-err", email: "user@example.com", email_verified: true });
+
+    // A DB failure must NOT fall through to email match / account creation —
+    // that path could mint a duplicate account for an already-linked subject.
+    vi.mocked(getIdentityByIssuerSubject).mockResolvedValue({
+      success: false,
+      error: new AppError("Failed to get identity", "STORAGE_ERROR", 500),
+    });
+
+    const res = await app.fetch(callbackRequest(), env);
+    expect(res.status).toBe(500);
+    expect(res.headers.get("Set-Cookie") ?? "").not.toContain("stratum_session");
+    expect(getUserByEmail).not.toHaveBeenCalled();
+    expect(createUser).not.toHaveBeenCalled();
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
+  it("still signs in when persisting the identity row fails (non-fatal)", async () => {
+    const app = makeApp();
+    const env = makeEnv({ STATE: makeKv({ "oauth_state:goodstate": "1" }) });
+    mockGoogleUserinfo({ sub: "g-123", email: "user@example.com", email_verified: true });
+
+    vi.mocked(getUserByEmail).mockResolvedValue({
+      success: true,
+      data: {
+        id: "usr_1",
+        email: "user@example.com",
+        username: "user",
+        tokenHash: "h",
+        createdAt: "",
+      },
+    });
+    vi.mocked(upsertIdentity).mockResolvedValue({
+      success: false,
+      error: new AppError("Failed to upsert identity", "STORAGE_ERROR", 500),
+    });
+    vi.mocked(createSession).mockResolvedValue({
+      success: true,
+      data: { id: "sess_1", userId: "usr_1", expiresAt: "2099-01-01T00:00:00.000Z" },
+    });
+
+    const res = await app.fetch(callbackRequest(), env);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Set-Cookie")).toContain("stratum_session=sess_1");
   });
 });

--- a/tests/google-oauth.test.ts
+++ b/tests/google-oauth.test.ts
@@ -19,6 +19,7 @@ vi.mock("../src/storage/audit", () => ({
   recordAudit: vi.fn().mockResolvedValue({ success: true, data: undefined }),
 }));
 
+import { recordAudit } from "../src/storage/audit";
 import { createSession } from "../src/storage/sessions";
 import { createUser, getUserByEmail } from "../src/storage/users";
 
@@ -190,6 +191,45 @@ describe("Google OAuth", () => {
     );
     expect(res.status).toBe(302);
     expect(createUser).toHaveBeenCalledWith(env.DB, "new@example.com", expect.any(Object));
+  });
+
+  it("refuses a disabled account before minting a session (no session.created audit)", async () => {
+    const app = makeApp();
+    const env = makeEnv({ STATE: makeKv({ "oauth_state:goodstate": "1" }) });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith("https://oauth2.googleapis.com/token")) {
+        return new Response(JSON.stringify({ access_token: "google-token" }), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({ sub: "g-123", email: "disabled@example.com", email_verified: true }),
+        { status: 200 },
+      );
+    });
+
+    vi.mocked(getUserByEmail).mockResolvedValue({
+      success: true,
+      data: {
+        id: "usr_disabled",
+        email: "disabled@example.com",
+        username: "disabled",
+        tokenHash: "h",
+        createdAt: "",
+        disabledAt: "2026-08-01T00:00:00.000Z",
+      },
+    });
+
+    const res = await app.fetch(
+      new Request("http://localhost/auth/google/callback?code=ok&state=goodstate", {
+        headers: { Cookie: "stratum_oauth_state=goodstate" },
+      }),
+      env,
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/auth/login?error=account_disabled");
+    expect(res.headers.get("Set-Cookie") ?? "").not.toContain("stratum_session");
+    expect(createSession).not.toHaveBeenCalled();
+    expect(recordAudit).not.toHaveBeenCalled();
   });
 
   it("rejects unverified Google emails", async () => {

--- a/tests/identities.test.ts
+++ b/tests/identities.test.ts
@@ -1,0 +1,394 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  deleteIdentitiesForUser,
+  getIdentityByIssuerSubject,
+  upsertIdentity,
+} from "../src/storage/identities";
+import type { Logger } from "../src/utils/logger";
+import { makeSqliteD1, makeThrowingD1 } from "./helpers/sqlite-d1";
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+const GITHUB_ISSUER = "https://github.com";
+const GOOGLE_ISSUER = "https://accounts.google.com";
+
+function seedUser(raw: ReturnType<typeof makeSqliteD1>["raw"], id: string): void {
+  raw
+    .prepare("INSERT INTO users (id, email, username, token_hash) VALUES (?, ?, ?, ?)")
+    .run(id, `${id}@example.com`, id.replace(/_/g, "-"), `hash_${id}`);
+}
+
+function identityRows(
+  raw: ReturnType<typeof makeSqliteD1>["raw"],
+): { user_id: string; issuer: string; subject: string }[] {
+  return raw
+    .prepare("SELECT user_id, issuer, subject FROM identities ORDER BY issuer, subject")
+    .all() as { user_id: string; issuer: string; subject: string }[];
+}
+
+describe("migration 041 schema", () => {
+  it("adds the users disabled/github-drift columns", () => {
+    const { raw } = makeSqliteD1();
+    const columns = (raw.prepare("PRAGMA table_info(users)").all() as { name: string }[]).map(
+      (c) => c.name,
+    );
+    expect(columns).toContain("disabled_at");
+    expect(columns).toContain("github_refresh_token");
+    expect(columns).toContain("github_token_expires_at");
+  });
+
+  it("rejects a provider outside the CHECK list", () => {
+    const { raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    expect(() =>
+      raw
+        .prepare(
+          "INSERT INTO identities (id, user_id, provider, issuer, subject, email) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .run("idn_1", "usr_1", "saml", "https://idp.example.com", "sub-1", "a@example.com"),
+    ).toThrow();
+  });
+
+  it("rejects empty issuer/subject at the schema level", () => {
+    const { raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    expect(() =>
+      raw
+        .prepare(
+          "INSERT INTO identities (id, user_id, provider, issuer, subject, email) VALUES ('idn_x', 'usr_1', 'oidc', 'https://idp.example.com', '', 'a@example.com')",
+        )
+        .run(),
+    ).toThrow(/CHECK/);
+  });
+
+  it("enforces UNIQUE(issuer, subject) at the schema level", () => {
+    const { raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    seedUser(raw, "usr_2");
+    const insert = raw.prepare(
+      "INSERT INTO identities (id, user_id, provider, issuer, subject, email) VALUES (?, ?, ?, ?, ?, ?)",
+    );
+    insert.run("idn_1", "usr_1", "github", GITHUB_ISSUER, "12345", "a@example.com");
+    expect(() =>
+      insert.run("idn_2", "usr_2", "github", GITHUB_ISSUER, "12345", "b@example.com"),
+    ).toThrow();
+  });
+
+  it("enforces one SSO connection per org (org_id UNIQUE)", () => {
+    const { raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    raw
+      .prepare("INSERT INTO orgs (id, name, slug, owner_id) VALUES (?, ?, ?, ?)")
+      .run("org_1", "Acme", "acme", "usr_1");
+    const insert = raw.prepare(
+      `INSERT INTO org_sso_connections
+         (id, org_id, issuer, client_id, client_secret_ciphertext, authorization_endpoint,
+          token_endpoint, jwks_uri, email_domains, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const bind = (id: string) => [
+      id,
+      "org_1",
+      "https://idp.example.com",
+      "client",
+      "ciphertext",
+      "https://idp.example.com/authorize",
+      "https://idp.example.com/token",
+      "https://idp.example.com/jwks",
+      '["acme.com"]',
+      "2026-01-01T00:00:00.000Z",
+      "2026-01-01T00:00:00.000Z",
+    ];
+    insert.run(...bind("conn_1"));
+    expect(() => insert.run(...bind("conn_2"))).toThrow();
+  });
+});
+
+describe("upsertIdentity", () => {
+  it("creates an identity and finds it by (issuer, subject)", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+
+    const upserted = await upsertIdentity(db, mockLogger, {
+      userId: "usr_1",
+      provider: "github",
+      issuer: GITHUB_ISSUER,
+      subject: "12345",
+      email: "usr_1@example.com",
+    });
+    expect(upserted.success).toBe(true);
+    if (!upserted.success) return;
+    expect(upserted.data.userId).toBe("usr_1");
+    expect(upserted.data.connectionId).toBeNull();
+
+    const found = await getIdentityByIssuerSubject(db, mockLogger, GITHUB_ISSUER, "12345");
+    expect(found.success).toBe(true);
+    expect(found.success && found.data.id).toBe(upserted.data.id);
+  });
+
+  it("keeps the stored id/created_at when re-upserting the same (issuer, subject)", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+
+    const first = await upsertIdentity(db, mockLogger, {
+      userId: "usr_1",
+      provider: "google",
+      issuer: GOOGLE_ISSUER,
+      subject: "g-sub",
+      email: "old@example.com",
+    });
+    const second = await upsertIdentity(db, mockLogger, {
+      userId: "usr_1",
+      provider: "google",
+      issuer: GOOGLE_ISSUER,
+      subject: "g-sub",
+      email: "new@example.com",
+    });
+    expect(first.success && second.success).toBe(true);
+    if (!first.success || !second.success) return;
+    expect(second.data.id).toBe(first.data.id);
+    expect(second.data.createdAt).toBe(first.data.createdAt);
+    expect(second.data.email).toBe("new@example.com");
+    expect(identityRows(raw).length).toBe(1);
+  });
+
+  it("replaces the user's previous subject at the same issuer (one per (user_id, issuer))", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+
+    await upsertIdentity(db, mockLogger, {
+      userId: "usr_1",
+      provider: "oidc",
+      issuer: "https://idp.example.com",
+      subject: "old-sub",
+      email: "usr_1@example.com",
+      connectionId: "conn_1",
+    });
+    const rotated = await upsertIdentity(db, mockLogger, {
+      userId: "usr_1",
+      provider: "oidc",
+      issuer: "https://idp.example.com",
+      subject: "new-sub",
+      email: "usr_1@example.com",
+      connectionId: "conn_1",
+    });
+    expect(rotated.success).toBe(true);
+
+    expect(identityRows(raw)).toEqual([
+      { user_id: "usr_1", issuer: "https://idp.example.com", subject: "new-sub" },
+    ]);
+    const gone = await getIdentityByIssuerSubject(
+      db,
+      mockLogger,
+      "https://idp.example.com",
+      "old-sub",
+    );
+    expect(gone.success).toBe(false);
+  });
+
+  it("allows one user to hold identities from multiple issuers", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+
+    await upsertIdentity(db, mockLogger, {
+      userId: "usr_1",
+      provider: "github",
+      issuer: GITHUB_ISSUER,
+      subject: "12345",
+      email: "usr_1@example.com",
+    });
+    await upsertIdentity(db, mockLogger, {
+      userId: "usr_1",
+      provider: "google",
+      issuer: GOOGLE_ISSUER,
+      subject: "g-sub",
+      email: "usr_1@example.com",
+    });
+
+    expect(identityRows(raw).length).toBe(2);
+  });
+
+  it("re-points an existing (issuer, subject) row at the upserting user", async () => {
+    // The IdP owns the (issuer, subject) pair: if it now asserts the pair for a
+    // different Stratum user, the old link must not survive as a duplicate.
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    seedUser(raw, "usr_2");
+
+    await upsertIdentity(db, mockLogger, {
+      userId: "usr_1",
+      provider: "github",
+      issuer: GITHUB_ISSUER,
+      subject: "12345",
+      email: "usr_1@example.com",
+    });
+    const moved = await upsertIdentity(db, mockLogger, {
+      userId: "usr_2",
+      provider: "github",
+      issuer: GITHUB_ISSUER,
+      subject: "12345",
+      email: "usr_2@example.com",
+    });
+    expect(moved.success && moved.data.userId).toBe("usr_2");
+    expect(identityRows(raw)).toEqual([
+      { user_id: "usr_2", issuer: GITHUB_ISSUER, subject: "12345" },
+    ]);
+  });
+
+  it("resets created_at when the pair moves to a different user", async () => {
+    // The new owner's "linked at" must not predate their link: the previous
+    // owner's created_at would be forensic noise after a re-point.
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    seedUser(raw, "usr_2");
+
+    raw
+      .prepare(
+        "INSERT INTO identities (id, user_id, provider, issuer, subject, email, created_at) VALUES (?, ?, 'github', ?, ?, ?, ?)",
+      )
+      .run(
+        "idn_old",
+        "usr_1",
+        GITHUB_ISSUER,
+        "12345",
+        "usr_1@example.com",
+        "2020-01-01T00:00:00.000Z",
+      );
+    const moved = await upsertIdentity(db, mockLogger, {
+      userId: "usr_2",
+      provider: "github",
+      issuer: GITHUB_ISSUER,
+      subject: "12345",
+      email: "usr_2@example.com",
+    });
+
+    expect(moved.success && moved.data.createdAt).not.toBe("2020-01-01T00:00:00.000Z");
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "Identity re-pointed from another user",
+      expect.objectContaining({ previousUserId: "usr_1", userId: "usr_2" }),
+    );
+  });
+
+  it("rejects empty and oversized issuer/subject/email", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    const base = {
+      userId: "usr_1",
+      provider: "oidc" as const,
+      issuer: "https://idp.example.com",
+      subject: "sub-1",
+      email: "usr_1@example.com",
+    };
+
+    for (const overrides of [
+      { subject: "" },
+      { subject: "   " },
+      { issuer: "" },
+      { email: "" },
+      { subject: "s".repeat(1025) },
+    ]) {
+      const result = await upsertIdentity(db, mockLogger, { ...base, ...overrides });
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.code).toBe("VALIDATION_ERROR");
+    }
+    expect(identityRows(raw)).toEqual([]);
+  });
+
+  it("stores the email lowercased and trimmed", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    const result = await upsertIdentity(db, mockLogger, {
+      userId: "usr_1",
+      provider: "oidc",
+      issuer: "https://idp.example.com",
+      subject: "sub-1",
+      email: "  John.Doe@Corp.example.com ",
+    });
+    expect(result.success && result.data.email).toBe("john.doe@corp.example.com");
+    const stored = raw.prepare("SELECT email FROM identities").get() as { email: string };
+    expect(stored.email).toBe("john.doe@corp.example.com");
+  });
+
+  it("returns a STORAGE_ERROR (not NotFound) on a database failure", async () => {
+    const result = await upsertIdentity(makeThrowingD1(), mockLogger, {
+      userId: "usr_1",
+      provider: "github",
+      issuer: GITHUB_ISSUER,
+      subject: "12345",
+      email: "usr_1@example.com",
+    });
+    expect(result.success).toBe(false);
+    expect(!result.success && result.error.code).toBe("STORAGE_ERROR");
+  });
+});
+
+describe("getIdentityByIssuerSubject", () => {
+  it("returns NotFound for an unknown pair", async () => {
+    const { db } = makeSqliteD1();
+    const result = await getIdentityByIssuerSubject(db, mockLogger, GITHUB_ISSUER, "nope");
+    expect(result.success).toBe(false);
+    expect(!result.success && result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("fails closed with STORAGE_ERROR on a database failure", async () => {
+    // NotFound falls through to email-matching/JIT in the SSO resolution chain;
+    // an infra error must be distinguishable so the login can 500 instead.
+    const result = await getIdentityByIssuerSubject(
+      makeThrowingD1(),
+      mockLogger,
+      GITHUB_ISSUER,
+      "12345",
+    );
+    expect(result.success).toBe(false);
+    expect(!result.success && result.error.code).toBe("STORAGE_ERROR");
+  });
+});
+
+describe("deleteIdentitiesForUser", () => {
+  it("removes every identity for the user and only that user", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    seedUser(raw, "usr_2");
+
+    await upsertIdentity(db, mockLogger, {
+      userId: "usr_1",
+      provider: "github",
+      issuer: GITHUB_ISSUER,
+      subject: "111",
+      email: "usr_1@example.com",
+    });
+    await upsertIdentity(db, mockLogger, {
+      userId: "usr_1",
+      provider: "google",
+      issuer: GOOGLE_ISSUER,
+      subject: "g-1",
+      email: "usr_1@example.com",
+    });
+    await upsertIdentity(db, mockLogger, {
+      userId: "usr_2",
+      provider: "github",
+      issuer: GITHUB_ISSUER,
+      subject: "222",
+      email: "usr_2@example.com",
+    });
+
+    const result = await deleteIdentitiesForUser(db, mockLogger, "usr_1");
+    expect(result.success && result.data).toBe(2);
+    expect(identityRows(raw)).toEqual([
+      { user_id: "usr_2", issuer: GITHUB_ISSUER, subject: "222" },
+    ]);
+  });
+
+  it("returns err on a database failure", async () => {
+    const result = await deleteIdentitiesForUser(makeThrowingD1(), mockLogger, "usr_1");
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/identities.test.ts
+++ b/tests/identities.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   deleteIdentitiesForUser,
   getIdentityByIssuerSubject,
@@ -19,6 +19,12 @@ const mockLogger: Logger = {
 
 const GITHUB_ISSUER = "https://github.com";
 const GOOGLE_ISSUER = "https://accounts.google.com";
+
+beforeEach(() => {
+  // The shared mockLogger persists across tests; without a reset, the
+  // re-point warn assertion could pass on a stale call from an earlier test.
+  vi.clearAllMocks();
+});
 
 function seedUser(raw: ReturnType<typeof makeSqliteD1>["raw"], id: string): void {
   raw

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -38,6 +38,10 @@ const EXPECTED_CORE_TABLES = [
   "teams",
   "webhooks",
   "audit_log",
+  "identities",
+  "org_sso_connections",
+  "scim_members",
+  "oidc_login_states",
 ];
 
 // 024 was duplicated historically and is already applied to production under

--- a/tests/oidc-discovery.test.ts
+++ b/tests/oidc-discovery.test.ts
@@ -1,0 +1,324 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  checkDomainTxtRecord,
+  verificationRecordName,
+  verificationTxtValue,
+} from "../src/services/domain-verification";
+import {
+  discoverOidcConfiguration,
+  validateIssuer,
+  validateOidcUrl,
+} from "../src/services/oidc-discovery";
+import type { Logger } from "../src/utils/logger";
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+const ISSUER = "https://idp.example.com";
+
+function discoveryDoc(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    issuer: ISSUER,
+    authorization_endpoint: `${ISSUER}/authorize`,
+    token_endpoint: `${ISSUER}/token`,
+    jwks_uri: `${ISSUER}/jwks`,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("validateOidcUrl — SSRF host rules", () => {
+  const reject = (url: string) => expect(validateOidcUrl(url, "issuer")).not.toBeNull();
+  const accept = (url: string) => expect(validateOidcUrl(url, "issuer")).toBeNull();
+
+  it("accepts a public https URL", () => {
+    accept("https://idp.example.com");
+    accept("https://login.okta.example.io/oauth2/default");
+  });
+
+  it("rejects http://", () => {
+    reject("http://idp.example.com");
+  });
+
+  it("rejects non-URL garbage", () => {
+    reject("not a url");
+  });
+
+  it("rejects embedded credentials", () => {
+    reject("https://user:pass@idp.example.com");
+    reject("https://user@idp.example.com");
+  });
+
+  it("rejects IPv4 and IPv6 literals", () => {
+    reject("https://127.0.0.1");
+    reject("https://10.0.0.5/issuer");
+    reject("https://[::1]");
+    reject("https://[fd00::1]/x");
+  });
+
+  it("rejects localhost and private/reserved names", () => {
+    reject("https://localhost");
+    reject("https://foo.localhost");
+    reject("https://printer.local");
+    reject("https://vault.internal");
+    reject("https://router.home.arpa");
+  });
+
+  it("rejects single-label hostnames (bare internal names)", () => {
+    reject("https://metadata");
+  });
+
+  it("rejects trailing-dot forms of blocked hosts (FQDN-dot bypass)", () => {
+    reject("https://localhost./x");
+    reject("https://metadata./x");
+    reject("https://foo.internal./x");
+  });
+});
+
+describe("validateIssuer", () => {
+  it("rejects the reserved GitHub and Google issuers (any casing / trailing slash)", () => {
+    expect(validateIssuer("https://github.com")).not.toBeNull();
+    expect(validateIssuer("https://github.com/")).not.toBeNull();
+    expect(validateIssuer("https://accounts.google.com")).not.toBeNull();
+    expect(validateIssuer("https://ACCOUNTS.GOOGLE.COM")).not.toBeNull();
+  });
+
+  it("rejects an issuer with a query or fragment", () => {
+    expect(validateIssuer("https://idp.example.com?x=1")).not.toBeNull();
+    expect(validateIssuer("https://idp.example.com#frag")).not.toBeNull();
+  });
+
+  it("accepts a normal corporate issuer", () => {
+    expect(validateIssuer("https://idp.example.com/oauth2/default")).toBeNull();
+  });
+});
+
+describe("discoverOidcConfiguration", () => {
+  it("returns the three endpoints on a valid document", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(discoveryDoc()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await discoverOidcConfiguration(ISSUER, mockLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toEqual({
+      authorizationEndpoint: `${ISSUER}/authorize`,
+      tokenEndpoint: `${ISSUER}/token`,
+      jwksUri: `${ISSUER}/jwks`,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${ISSUER}/.well-known/openid-configuration`,
+      expect.objectContaining({ redirect: "error" }),
+    );
+  });
+
+  it("rejects invalid issuers without fetching", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    for (const issuer of [
+      "http://idp.example.com",
+      "https://127.0.0.1",
+      "https://localhost",
+      "https://github.com",
+      "https://accounts.google.com",
+    ]) {
+      const result = await discoverOidcConfiguration(issuer, mockLogger);
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error.code).toBe("VALIDATION_ERROR");
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a document whose issuer does not exactly match", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse(discoveryDoc({ issuer: "https://evil.example.com" }))),
+    );
+    const result = await discoverOidcConfiguration(ISSUER, mockLogger);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toMatch(/issuer does not match/);
+  });
+
+  it("rejects a document missing any of the three endpoints", async () => {
+    for (const missing of ["authorization_endpoint", "token_endpoint", "jwks_uri"]) {
+      const doc = discoveryDoc();
+      delete doc[missing];
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(doc)));
+      const result = await discoverOidcConfiguration(ISSUER, mockLogger);
+      expect(result.success, `missing ${missing} must fail`).toBe(false);
+      if (!result.success) expect(result.error.message).toContain(missing);
+    }
+  });
+
+  it("rejects a discovered endpoint pointing at a private host", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse(discoveryDoc({ token_endpoint: "https://169.254.169.254/token" })),
+        ),
+    );
+    const result = await discoverOidcConfiguration(ISSUER, mockLogger);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("rejects a non-JSON content type", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(discoveryDoc()), {
+          status: 200,
+          headers: { "Content-Type": "text/html" },
+        }),
+      ),
+    );
+    const result = await discoverOidcConfiguration(ISSUER, mockLogger);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toMatch(/application\/json/);
+  });
+
+  it("rejects an oversized document", async () => {
+    const doc = discoveryDoc({ padding: "x".repeat(70 * 1024) });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(doc)));
+    const result = await discoverOidcConfiguration(ISSUER, mockLogger);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toMatch(/size limit/);
+  });
+
+  it("maps a failed fetch to an external-service error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+    const result = await discoverOidcConfiguration(ISSUER, mockLogger);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("EXTERNAL_SERVICE_ERROR");
+  });
+
+  it("maps a non-OK discovery status to an external-service error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({}, { status: 404 })));
+    const result = await discoverOidcConfiguration(ISSUER, mockLogger);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("EXTERNAL_SERVICE_ERROR");
+  });
+});
+
+describe("checkDomainTxtRecord (DNS-over-HTTPS)", () => {
+  const TOKEN = "abc123def456";
+
+  function dohResponse(answers: Array<{ type: number; data: string }>): Response {
+    return new Response(JSON.stringify({ Status: 0, Answer: answers }), {
+      status: 200,
+      headers: { "Content-Type": "application/dns-json" },
+    });
+  }
+
+  it("builds the expected record name and value", () => {
+    expect(verificationRecordName("corp.example.com")).toBe("_stratum-sso.corp.example.com");
+    expect(verificationTxtValue(TOKEN)).toBe(`stratum-sso-verify=${TOKEN}`);
+  });
+
+  it("finds a matching quoted TXT record", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(dohResponse([{ type: 16, data: `"stratum-sso-verify=${TOKEN}"` }]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await checkDomainTxtRecord("corp.example.com", TOKEN, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe(true);
+    const requestedUrl = fetchMock.mock.calls[0]?.[0] as string;
+    expect(requestedUrl).toContain("cloudflare-dns.com/dns-query");
+    expect(requestedUrl).toContain(encodeURIComponent("_stratum-sso.corp.example.com"));
+  });
+
+  it("reports false when no TXT record matches the token", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(dohResponse([{ type: 16, data: '"stratum-sso-verify=WRONG"' }])),
+    );
+    const result = await checkDomainTxtRecord("corp.example.com", TOKEN, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe(false);
+  });
+
+  it("reports false on an authoritative NXDOMAIN (Status 3, no Answer)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ Status: 3 }), {
+          status: 200,
+          headers: { "Content-Type": "application/dns-json" },
+        }),
+      ),
+    );
+    const result = await checkDomainTxtRecord("corp.example.com", TOKEN, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe(false);
+  });
+
+  it("surfaces a non-authoritative DNS status (Status 2, SERVFAIL) as retryable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ Status: 2 }), {
+          status: 200,
+          headers: { "Content-Type": "application/dns-json" },
+        }),
+      ),
+    );
+    const result = await checkDomainTxtRecord("corp.example.com", TOKEN, mockLogger);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("EXTERNAL_SERVICE_ERROR");
+  });
+
+  it("rejects a TXT record that merely contains the expected value", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          dohResponse([{ type: 16, data: `"prefix stratum-sso-verify=${TOKEN} suffix"` }]),
+        ),
+    );
+    const result = await checkDomainTxtRecord("corp.example.com", TOKEN, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe(false);
+  });
+
+  it("ignores non-TXT answers even when the data matches", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(dohResponse([{ type: 5, data: `stratum-sso-verify=${TOKEN}` }])),
+    );
+    const result = await checkDomainTxtRecord("corp.example.com", TOKEN, mockLogger);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe(false);
+  });
+
+  it("surfaces a lookup failure as an error (not 'unverified')", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("doh unreachable")));
+    const result = await checkDomainTxtRecord("corp.example.com", TOKEN, mockLogger);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("EXTERNAL_SERVICE_ERROR");
+  });
+});

--- a/tests/oidc-discovery.test.ts
+++ b/tests/oidc-discovery.test.ts
@@ -121,6 +121,7 @@ describe("discoverOidcConfiguration", () => {
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.data).toEqual({
+      issuer: ISSUER,
       authorizationEndpoint: `${ISSUER}/authorize`,
       tokenEndpoint: `${ISSUER}/token`,
       jwksUri: `${ISSUER}/jwks`,
@@ -128,6 +129,23 @@ describe("discoverOidcConfiguration", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       `${ISSUER}/.well-known/openid-configuration`,
       expect.objectContaining({ redirect: "error" }),
+    );
+  });
+
+  it("normalizes a trailing-slash issuer: discovery succeeds and the returned issuer is canonical", async () => {
+    // The compliant stub advertises the canonical (no-trailing-slash) issuer;
+    // the admin typed one with a slash. The normalized form must drive the
+    // discovery URL, the RFC 8414 equality check, AND the returned issuer.
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(discoveryDoc()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await discoverOidcConfiguration(`${ISSUER}/`, mockLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.issuer).toBe(ISSUER);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${ISSUER}/.well-known/openid-configuration`,
+      expect.anything(),
     );
   });
 

--- a/tests/org-sso.test.ts
+++ b/tests/org-sso.test.ts
@@ -1,0 +1,706 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authMiddleware } from "../src/middleware/auth";
+import { orgSsoRouter } from "../src/routes/org-sso";
+import type { SsoConnection } from "../src/storage/sso";
+import type { Env } from "../src/types";
+import { NotFoundError } from "../src/utils/errors";
+
+vi.mock("../src/storage/users", () => ({
+  getUser: vi.fn(),
+  getUserByToken: vi.fn(),
+  enableUser: vi.fn(),
+}));
+
+vi.mock("../src/storage/agents", () => ({
+  getAgentByToken: vi.fn(),
+}));
+
+vi.mock("../src/storage/sessions", () => ({
+  getSession: vi.fn(),
+  deleteSession: vi.fn(),
+}));
+
+vi.mock("../src/storage/orgs", () => ({
+  getOrgBySlug: vi.fn(),
+  isOrgAdmin: vi.fn(),
+  isOrgMember: vi.fn(),
+}));
+
+// Keep normalizeEmailDomains (pure validation incl. the public-domain
+// deny-list) real; mock the persistence functions.
+vi.mock("../src/storage/sso", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/storage/sso")>();
+  return {
+    ...actual,
+    upsertSsoConnection: vi.fn(),
+    getSsoConnectionByOrgId: vi.fn(),
+    deleteSsoConnection: vi.fn(),
+    listDeactivatedScimUserIds: vi.fn(),
+    findVerifiedDomainConflicts: vi.fn(),
+    setSsoDomainsVerified: vi.fn(),
+    setSsoConnectionEnabled: vi.fn(),
+    rotateScimToken: vi.fn(),
+  };
+});
+
+vi.mock("../src/services/oidc-discovery", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/services/oidc-discovery")>();
+  return { ...actual, discoverOidcConfiguration: vi.fn() };
+});
+
+vi.mock("../src/services/domain-verification", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/services/domain-verification")>();
+  return { ...actual, checkDomainTxtRecord: vi.fn() };
+});
+
+vi.mock("../src/storage/audit", () => ({
+  recordAudit: vi.fn().mockResolvedValue({ success: true, data: undefined }),
+}));
+
+import { checkDomainTxtRecord } from "../src/services/domain-verification";
+import { discoverOidcConfiguration } from "../src/services/oidc-discovery";
+import { recordAudit } from "../src/storage/audit";
+import { getOrgBySlug, isOrgAdmin, isOrgMember } from "../src/storage/orgs";
+import {
+  deleteSsoConnection,
+  findVerifiedDomainConflicts,
+  getSsoConnectionByOrgId,
+  listDeactivatedScimUserIds,
+  rotateScimToken,
+  setSsoConnectionEnabled,
+  setSsoDomainsVerified,
+  upsertSsoConnection,
+} from "../src/storage/sso";
+import { enableUser, getUserByToken } from "../src/storage/users";
+
+function makeApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", authMiddleware);
+  app.route("/api/orgs", orgSsoRouter);
+  return app;
+}
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    ARTIFACTS: {} as Env["ARTIFACTS"],
+    STATE: {} as KVNamespace,
+    DB: {} as D1Database,
+    SSO_ENCRYPTION_SECRET: "test-sso-encryption-secret",
+    ...overrides,
+  };
+}
+
+function request(
+  method: string,
+  path: string,
+  body?: unknown,
+  headers?: Record<string, string>,
+): Request {
+  const hasBody = body !== undefined;
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: {
+      ...(hasBody ? { "Content-Type": "application/json" } : {}),
+      ...headers,
+    },
+    ...(hasBody ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+const mockUser = {
+  id: "usr_admin",
+  email: "admin@example.com",
+  username: "admin",
+  tokenHash: "hash",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+const mockOrg = {
+  id: "org_abc",
+  name: "Acme",
+  slug: "acme",
+  ownerId: "usr_owner",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+const SECRET_CIPHERTEXT = "CIPHERTEXT_NEVER_ECHOED";
+const SCIM_HASH = "SCIM_HASH_NEVER_ECHOED";
+
+function mockConnection(overrides: Partial<SsoConnection> = {}): SsoConnection {
+  return {
+    id: "ssoc_1",
+    orgId: "org_abc",
+    protocol: "oidc",
+    issuer: "https://idp.example.com",
+    clientId: "client-123",
+    clientSecretCiphertext: SECRET_CIPHERTEXT,
+    authorizationEndpoint: "https://idp.example.com/authorize",
+    tokenEndpoint: "https://idp.example.com/token",
+    jwksUri: "https://idp.example.com/jwks",
+    emailDomains: ["corp.example.com"],
+    domainsVerifiedAt: null,
+    domainVerificationToken: "aabbccdd00112233aabbccdd00112233",
+    scimTokenHash: SCIM_HASH,
+    enabled: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const authHeader = { Authorization: "Bearer stratum_user_token" };
+
+const validPutBody = {
+  issuer: "https://idp.example.com",
+  clientId: "client-123",
+  clientSecret: "super-secret-value",
+  emailDomains: ["corp.example.com"],
+};
+
+function grantAdmin() {
+  vi.mocked(isOrgAdmin).mockResolvedValue({ success: true, data: true });
+  vi.mocked(isOrgMember).mockResolvedValue({ success: true, data: true });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getUserByToken).mockResolvedValue({ success: true, data: mockUser });
+  vi.mocked(getOrgBySlug).mockResolvedValue({ success: true, data: mockOrg });
+  vi.mocked(recordAudit).mockResolvedValue({ success: true, data: undefined });
+  vi.mocked(discoverOidcConfiguration).mockResolvedValue({
+    success: true,
+    data: {
+      authorizationEndpoint: "https://idp.example.com/authorize",
+      tokenEndpoint: "https://idp.example.com/token",
+      jwksUri: "https://idp.example.com/jwks",
+    },
+  });
+});
+
+describe("authz gate (shared across endpoints)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    const res = await makeApp().fetch(request("GET", "/api/orgs/acme/sso"), makeEnv());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 to a non-member (no existence leak)", async () => {
+    vi.mocked(isOrgAdmin).mockResolvedValue({ success: true, data: false });
+    vi.mocked(isOrgMember).mockResolvedValue({ success: true, data: false });
+    const res = await makeApp().fetch(
+      request("GET", "/api/orgs/acme/sso", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(404);
+    expect(getSsoConnectionByOrgId).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 to a member who is not an admin", async () => {
+    vi.mocked(isOrgAdmin).mockResolvedValue({ success: true, data: false });
+    vi.mocked(isOrgMember).mockResolvedValue({ success: true, data: true });
+    const res = await makeApp().fetch(
+      request("GET", "/api/orgs/acme/sso", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(403);
+    expect(getSsoConnectionByOrgId).not.toHaveBeenCalled();
+  });
+
+  it("allows an org admin", async () => {
+    grantAdmin();
+    vi.mocked(getSsoConnectionByOrgId).mockResolvedValue({
+      success: true,
+      data: mockConnection(),
+    });
+    const res = await makeApp().fetch(
+      request("GET", "/api/orgs/acme/sso", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("allows the org owner even without a member row", async () => {
+    vi.mocked(getOrgBySlug).mockResolvedValue({
+      success: true,
+      data: { ...mockOrg, ownerId: mockUser.id },
+    });
+    vi.mocked(isOrgAdmin).mockResolvedValue({ success: true, data: false });
+    vi.mocked(isOrgMember).mockResolvedValue({ success: true, data: false });
+    vi.mocked(getSsoConnectionByOrgId).mockResolvedValue({
+      success: true,
+      data: mockConnection(),
+    });
+    const res = await makeApp().fetch(
+      request("GET", "/api/orgs/acme/sso", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 404 for an unknown org", async () => {
+    vi.mocked(getOrgBySlug).mockResolvedValue({
+      success: false,
+      error: new NotFoundError("Org", "nope"),
+    });
+    const res = await makeApp().fetch(
+      request("GET", "/api/orgs/nope/sso", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 501 on every endpoint when SSO_ENCRYPTION_SECRET is unset", async () => {
+    grantAdmin();
+    const env = makeEnv({ SSO_ENCRYPTION_SECRET: undefined });
+    const app = makeApp();
+    const calls: [string, string, unknown?][] = [
+      ["PUT", "/api/orgs/acme/sso", validPutBody],
+      ["GET", "/api/orgs/acme/sso"],
+      ["DELETE", "/api/orgs/acme/sso"],
+      ["POST", "/api/orgs/acme/sso/verify-domains"],
+      ["POST", "/api/orgs/acme/sso/enable"],
+      ["POST", "/api/orgs/acme/sso/disable"],
+      ["POST", "/api/orgs/acme/sso/scim-token"],
+    ];
+    for (const [method, path, body] of calls) {
+      const res = await app.fetch(request(method, path, body, authHeader), env);
+      expect(res.status, `${method} ${path} must 501 unconfigured`).toBe(501);
+    }
+    expect(upsertSsoConnection).not.toHaveBeenCalled();
+    expect(getSsoConnectionByOrgId).not.toHaveBeenCalled();
+  });
+});
+
+describe("PUT /api/orgs/:slug/sso", () => {
+  beforeEach(() => {
+    grantAdmin();
+    vi.mocked(upsertSsoConnection).mockResolvedValue({
+      success: true,
+      data: { connection: mockConnection({ scimTokenHash: null }), created: true },
+    });
+  });
+
+  it("creates a connection, returns verification info, and never echoes the secret", async () => {
+    const res = await makeApp().fetch(
+      request("PUT", "/api/orgs/acme/sso", validPutBody, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(201);
+    const text = await res.text();
+    expect(text).not.toContain("super-secret-value");
+    expect(text).not.toContain(SECRET_CIPHERTEXT);
+    const body = JSON.parse(text) as {
+      connection: Record<string, unknown>;
+      domainVerification: { token: string; records: { name: string; value: string }[] };
+    };
+    expect(body.connection.clientSecret).toBeUndefined();
+    expect(body.connection.clientSecretCiphertext).toBeUndefined();
+    expect(body.domainVerification.token).toBe("aabbccdd00112233aabbccdd00112233");
+    expect(body.domainVerification.records[0]?.name).toBe("_stratum-sso.corp.example.com");
+    expect(body.domainVerification.records[0]?.value).toBe(
+      "stratum-sso-verify=aabbccdd00112233aabbccdd00112233",
+    );
+    expect(recordAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ action: "sso.connection.created", actorId: mockUser.id }),
+    );
+    // The secret reaches storage only as ciphertext, never as the plaintext.
+    const input = vi.mocked(upsertSsoConnection).mock.calls[0]?.[2];
+    expect(input?.clientSecretCiphertext).toBeDefined();
+    expect(input?.clientSecretCiphertext).not.toBe("super-secret-value");
+  });
+
+  it("audits sso.connection.updated on replace", async () => {
+    vi.mocked(upsertSsoConnection).mockResolvedValue({
+      success: true,
+      data: { connection: mockConnection(), created: false },
+    });
+    const res = await makeApp().fetch(
+      request("PUT", "/api/orgs/acme/sso", validPutBody, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(200);
+    expect(recordAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ action: "sso.connection.updated" }),
+    );
+  });
+
+  it("rejects a deny-listed public email domain at create time", async () => {
+    const res = await makeApp().fetch(
+      request(
+        "PUT",
+        "/api/orgs/acme/sso",
+        { ...validPutBody, emailDomains: ["gmail.com"] },
+        authHeader,
+      ),
+      makeEnv(),
+    );
+    expect(res.status).toBe(400);
+    expect(discoverOidcConfiguration).not.toHaveBeenCalled();
+    expect(upsertSsoConnection).not.toHaveBeenCalled();
+  });
+
+  it("propagates discovery rejections (SSRF/reserved issuer) as 400", async () => {
+    // The real discovery module rejects these pre-fetch; here the mock stands
+    // in for that contract.
+    const { ValidationError } = await import("../src/utils/errors");
+    vi.mocked(discoverOidcConfiguration).mockResolvedValue({
+      success: false,
+      error: new ValidationError("issuer must use https"),
+    });
+    const res = await makeApp().fetch(
+      request(
+        "PUT",
+        "/api/orgs/acme/sso",
+        { ...validPutBody, issuer: "http://idp.example.com" },
+        authHeader,
+      ),
+      makeEnv(),
+    );
+    expect(res.status).toBe(400);
+    expect(upsertSsoConnection).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 (not 500) for a malformed JSON body", async () => {
+    const res = await makeApp().fetch(
+      new Request("http://localhost/api/orgs/acme/sso", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", ...authHeader },
+        body: "{not json",
+      }),
+      makeEnv(),
+    );
+    expect(res.status).toBe(400);
+    expect(upsertSsoConnection).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing fields", async () => {
+    const app = makeApp();
+    for (const missing of ["issuer", "clientId", "clientSecret", "emailDomains"]) {
+      const body: Record<string, unknown> = { ...validPutBody };
+      delete body[missing];
+      const res = await app.fetch(
+        request("PUT", "/api/orgs/acme/sso", body, authHeader),
+        makeEnv(),
+      );
+      expect(res.status, `missing ${missing} must 400`).toBe(400);
+    }
+    expect(upsertSsoConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/orgs/:slug/sso", () => {
+  beforeEach(() => {
+    grantAdmin();
+  });
+
+  it("returns the redacted connection with verification info", async () => {
+    vi.mocked(getSsoConnectionByOrgId).mockResolvedValue({
+      success: true,
+      data: mockConnection({ domainsVerifiedAt: "2026-02-01T00:00:00.000Z", enabled: true }),
+    });
+    const res = await makeApp().fetch(
+      request("GET", "/api/orgs/acme/sso", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).not.toContain(SECRET_CIPHERTEXT);
+    expect(text).not.toContain(SCIM_HASH);
+    const body = JSON.parse(text) as {
+      connection: Record<string, unknown>;
+      domainVerification: { token: string };
+    };
+    expect(body.connection.issuer).toBe("https://idp.example.com");
+    expect(body.connection.domainsVerifiedAt).toBe("2026-02-01T00:00:00.000Z");
+    expect(body.connection.enabled).toBe(true);
+    expect(body.connection.scimTokenSet).toBe(true);
+    expect(body.domainVerification.token).toBe("aabbccdd00112233aabbccdd00112233");
+  });
+
+  it("returns 404 when the org has no connection", async () => {
+    vi.mocked(getSsoConnectionByOrgId).mockResolvedValue({
+      success: false,
+      error: new NotFoundError("SSO connection", "org_abc"),
+    });
+    const res = await makeApp().fetch(
+      request("GET", "/api/orgs/acme/sso", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /api/orgs/:slug/sso", () => {
+  beforeEach(() => {
+    grantAdmin();
+    vi.mocked(getSsoConnectionByOrgId).mockResolvedValue({
+      success: true,
+      data: mockConnection(),
+    });
+    vi.mocked(deleteSsoConnection).mockResolvedValue({ success: true, data: undefined });
+  });
+
+  it("re-enables users the connection disabled, then deletes it", async () => {
+    vi.mocked(listDeactivatedScimUserIds).mockResolvedValue({
+      success: true,
+      data: ["usr_x", "usr_y"],
+    });
+    vi.mocked(enableUser).mockResolvedValue({ success: true, data: undefined });
+
+    const res = await makeApp().fetch(
+      request("DELETE", "/api/orgs/acme/sso", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { deleted: boolean; reenabledUserIds: string[] };
+    expect(body.deleted).toBe(true);
+    expect(body.reenabledUserIds).toEqual(["usr_x", "usr_y"]);
+    expect(enableUser).toHaveBeenCalledTimes(2);
+    expect(enableUser).toHaveBeenCalledWith(expect.anything(), "usr_x", expect.anything());
+    expect(enableUser).toHaveBeenCalledWith(expect.anything(), "usr_y", expect.anything());
+    expect(deleteSsoConnection).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "ssoc_1",
+    );
+    expect(recordAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ action: "sso.connection.deleted" }),
+    );
+  });
+
+  it("deletes cleanly when no user was disabled", async () => {
+    vi.mocked(listDeactivatedScimUserIds).mockResolvedValue({ success: true, data: [] });
+    const res = await makeApp().fetch(
+      request("DELETE", "/api/orgs/acme/sso", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(200);
+    expect(enableUser).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/orgs/:slug/sso/verify-domains", () => {
+  beforeEach(() => {
+    grantAdmin();
+    vi.mocked(getSsoConnectionByOrgId).mockResolvedValue({
+      success: true,
+      data: mockConnection({ emailDomains: ["corp.example.com", "eng.example.com"] }),
+    });
+    vi.mocked(findVerifiedDomainConflicts).mockResolvedValue({ success: true, data: [] });
+    vi.mocked(setSsoDomainsVerified).mockResolvedValue({
+      success: true,
+      data: "2026-02-01T00:00:00.000Z",
+    });
+  });
+
+  it("verifies when every domain has the TXT record", async () => {
+    vi.mocked(checkDomainTxtRecord).mockResolvedValue({ success: true, data: true });
+    const res = await makeApp().fetch(
+      request("POST", "/api/orgs/acme/sso/verify-domains", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { verified: boolean; domainsVerifiedAt: string };
+    expect(body.verified).toBe(true);
+    expect(body.domainsVerifiedAt).toBe("2026-02-01T00:00:00.000Z");
+    expect(checkDomainTxtRecord).toHaveBeenCalledTimes(2);
+    expect(recordAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ action: "sso.domain.verified" }),
+    );
+  });
+
+  it("fails with the missing domains when a TXT record is absent", async () => {
+    vi.mocked(checkDomainTxtRecord)
+      .mockResolvedValueOnce({ success: true, data: true })
+      .mockResolvedValueOnce({ success: true, data: false });
+    const res = await makeApp().fetch(
+      request("POST", "/api/orgs/acme/sso/verify-domains", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { failedDomains: string[] };
+    expect(body.failedDomains).toEqual(["eng.example.com"]);
+    expect(setSsoDomainsVerified).not.toHaveBeenCalled();
+  });
+
+  it("stamps verification against the exact domain list that was checked", async () => {
+    vi.mocked(checkDomainTxtRecord).mockResolvedValue({ success: true, data: true });
+    await makeApp().fetch(
+      request("POST", "/api/orgs/acme/sso/verify-domains", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(setSsoDomainsVerified).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "ssoc_1",
+      ["corp.example.com", "eng.example.com"],
+    );
+  });
+
+  it("returns 409 when the connection changed during verification", async () => {
+    const { ConflictError } = await import("../src/utils/errors");
+    vi.mocked(checkDomainTxtRecord).mockResolvedValue({ success: true, data: true });
+    vi.mocked(setSsoDomainsVerified).mockResolvedValue({
+      success: false,
+      error: new ConflictError("connection changed during verification; retry"),
+    });
+    const res = await makeApp().fetch(
+      request("POST", "/api/orgs/acme/sso/verify-domains", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 400 when the stored domain list is empty (malformed row), checking nothing", async () => {
+    vi.mocked(getSsoConnectionByOrgId).mockResolvedValue({
+      success: true,
+      // rowToConnection parses a malformed email_domains TEXT to [].
+      data: mockConnection({ emailDomains: [] }),
+    });
+    const res = await makeApp().fetch(
+      request("POST", "/api/orgs/acme/sso/verify-domains", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(400);
+    expect(checkDomainTxtRecord).not.toHaveBeenCalled();
+    expect(setSsoDomainsVerified).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when a domain is already verified by another connection", async () => {
+    vi.mocked(findVerifiedDomainConflicts).mockResolvedValue({
+      success: true,
+      data: ["corp.example.com"],
+    });
+    const res = await makeApp().fetch(
+      request("POST", "/api/orgs/acme/sso/verify-domains", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(409);
+    expect(checkDomainTxtRecord).not.toHaveBeenCalled();
+    expect(setSsoDomainsVerified).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/orgs/:slug/sso/enable and /disable", () => {
+  beforeEach(() => {
+    grantAdmin();
+    vi.mocked(findVerifiedDomainConflicts).mockResolvedValue({ success: true, data: [] });
+    vi.mocked(setSsoConnectionEnabled).mockResolvedValue({ success: true, data: undefined });
+  });
+
+  it("refuses to enable before domains are verified", async () => {
+    vi.mocked(getSsoConnectionByOrgId).mockResolvedValue({
+      success: true,
+      data: mockConnection({ domainsVerifiedAt: null }),
+    });
+    const res = await makeApp().fetch(
+      request("POST", "/api/orgs/acme/sso/enable", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(400);
+    expect(setSsoConnectionEnabled).not.toHaveBeenCalled();
+  });
+
+  it("enables a verified connection", async () => {
+    vi.mocked(getSsoConnectionByOrgId).mockResolvedValue({
+      success: true,
+      data: mockConnection({ domainsVerifiedAt: "2026-02-01T00:00:00.000Z" }),
+    });
+    const res = await makeApp().fetch(
+      request("POST", "/api/orgs/acme/sso/enable", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(200);
+    expect(setSsoConnectionEnabled).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "ssoc_1",
+      true,
+    );
+  });
+
+  it("returns 409 on an enable-time domain conflict", async () => {
+    vi.mocked(getSsoConnectionByOrgId).mockResolvedValue({
+      success: true,
+      data: mockConnection({ domainsVerifiedAt: "2026-02-01T00:00:00.000Z" }),
+    });
+    vi.mocked(findVerifiedDomainConflicts).mockResolvedValue({
+      success: true,
+      data: ["corp.example.com"],
+    });
+    const res = await makeApp().fetch(
+      request("POST", "/api/orgs/acme/sso/enable", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(409);
+    expect(setSsoConnectionEnabled).not.toHaveBeenCalled();
+  });
+
+  it("disables regardless of verification state", async () => {
+    vi.mocked(getSsoConnectionByOrgId).mockResolvedValue({
+      success: true,
+      data: mockConnection({ enabled: true }),
+    });
+    const res = await makeApp().fetch(
+      request("POST", "/api/orgs/acme/sso/disable", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(200);
+    expect(setSsoConnectionEnabled).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "ssoc_1",
+      false,
+    );
+  });
+});
+
+describe("POST /api/orgs/:slug/sso/scim-token", () => {
+  beforeEach(() => {
+    grantAdmin();
+    vi.mocked(getSsoConnectionByOrgId).mockResolvedValue({
+      success: true,
+      data: mockConnection(),
+    });
+  });
+
+  it("returns the plaintext once and audits the rotation", async () => {
+    vi.mocked(rotateScimToken).mockResolvedValue({
+      success: true,
+      data: "stratum_scim_00112233445566778899aabbccddeeff",
+    });
+    const res = await makeApp().fetch(
+      request("POST", "/api/orgs/acme/sso/scim-token", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { scimToken: string };
+    expect(body.scimToken).toBe("stratum_scim_00112233445566778899aabbccddeeff");
+    expect(recordAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ action: "sso.scim_token.rotated" }),
+    );
+  });
+
+  it("returns 404 when no connection exists", async () => {
+    vi.mocked(getSsoConnectionByOrgId).mockResolvedValue({
+      success: false,
+      error: new NotFoundError("SSO connection", "org_abc"),
+    });
+    const res = await makeApp().fetch(
+      request("POST", "/api/orgs/acme/sso/scim-token", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(404);
+    expect(rotateScimToken).not.toHaveBeenCalled();
+  });
+});

--- a/tests/org-sso.test.ts
+++ b/tests/org-sso.test.ts
@@ -9,7 +9,6 @@ import { NotFoundError } from "../src/utils/errors";
 vi.mock("../src/storage/users", () => ({
   getUser: vi.fn(),
   getUserByToken: vi.fn(),
-  enableUser: vi.fn(),
 }));
 
 vi.mock("../src/storage/agents", () => ({
@@ -36,7 +35,7 @@ vi.mock("../src/storage/sso", async (importOriginal) => {
     upsertSsoConnection: vi.fn(),
     getSsoConnectionByOrgId: vi.fn(),
     deleteSsoConnection: vi.fn(),
-    listDeactivatedScimUserIds: vi.fn(),
+    reenableUsersForConnectionRemoval: vi.fn(),
     findVerifiedDomainConflicts: vi.fn(),
     setSsoDomainsVerified: vi.fn(),
     setSsoConnectionEnabled: vi.fn(),
@@ -66,13 +65,13 @@ import {
   deleteSsoConnection,
   findVerifiedDomainConflicts,
   getSsoConnectionByOrgId,
-  listDeactivatedScimUserIds,
+  reenableUsersForConnectionRemoval,
   rotateScimToken,
   setSsoConnectionEnabled,
   setSsoDomainsVerified,
   upsertSsoConnection,
 } from "../src/storage/sso";
-import { enableUser, getUserByToken } from "../src/storage/users";
+import { getUserByToken } from "../src/storage/users";
 
 function makeApp() {
   const app = new Hono<{ Bindings: Env }>();
@@ -171,6 +170,7 @@ beforeEach(() => {
   vi.mocked(discoverOidcConfiguration).mockResolvedValue({
     success: true,
     data: {
+      issuer: "https://idp.example.com",
       authorizationEndpoint: "https://idp.example.com/authorize",
       tokenEndpoint: "https://idp.example.com/token",
       jwksUri: "https://idp.example.com/jwks",
@@ -364,6 +364,21 @@ describe("PUT /api/orgs/:slug/sso", () => {
     expect(upsertSsoConnection).not.toHaveBeenCalled();
   });
 
+  it("stores the discovery module's canonical issuer, not the raw trailing-slash input", async () => {
+    const res = await makeApp().fetch(
+      request(
+        "PUT",
+        "/api/orgs/acme/sso",
+        { ...validPutBody, issuer: "https://idp.example.com/" },
+        authHeader,
+      ),
+      makeEnv(),
+    );
+    expect(res.status).toBe(201);
+    const input = vi.mocked(upsertSsoConnection).mock.calls[0]?.[2];
+    expect(input?.issuer).toBe("https://idp.example.com");
+  });
+
   it("returns 400 (not 500) for a malformed JSON body", async () => {
     const res = await makeApp().fetch(
       new Request("http://localhost/api/orgs/acme/sso", {
@@ -445,11 +460,10 @@ describe("DELETE /api/orgs/:slug/sso", () => {
   });
 
   it("re-enables users the connection disabled, then deletes it", async () => {
-    vi.mocked(listDeactivatedScimUserIds).mockResolvedValue({
+    vi.mocked(reenableUsersForConnectionRemoval).mockResolvedValue({
       success: true,
       data: ["usr_x", "usr_y"],
     });
-    vi.mocked(enableUser).mockResolvedValue({ success: true, data: undefined });
 
     const res = await makeApp().fetch(
       request("DELETE", "/api/orgs/acme/sso", undefined, authHeader),
@@ -459,9 +473,11 @@ describe("DELETE /api/orgs/:slug/sso", () => {
     const body = (await res.json()) as { deleted: boolean; reenabledUserIds: string[] };
     expect(body.deleted).toBe(true);
     expect(body.reenabledUserIds).toEqual(["usr_x", "usr_y"]);
-    expect(enableUser).toHaveBeenCalledTimes(2);
-    expect(enableUser).toHaveBeenCalledWith(expect.anything(), "usr_x", expect.anything());
-    expect(enableUser).toHaveBeenCalledWith(expect.anything(), "usr_y", expect.anything());
+    expect(reenableUsersForConnectionRemoval).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "ssoc_1",
+    );
     expect(deleteSsoConnection).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
@@ -470,18 +486,41 @@ describe("DELETE /api/orgs/:slug/sso", () => {
     expect(recordAudit).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
-      expect.objectContaining({ action: "sso.connection.deleted" }),
+      expect.objectContaining({
+        action: "sso.connection.deleted",
+        detail: expect.objectContaining({ reenabledUserIds: ["usr_x", "usr_y"] }),
+      }),
     );
   });
 
   it("deletes cleanly when no user was disabled", async () => {
-    vi.mocked(listDeactivatedScimUserIds).mockResolvedValue({ success: true, data: [] });
+    vi.mocked(reenableUsersForConnectionRemoval).mockResolvedValue({ success: true, data: [] });
     const res = await makeApp().fetch(
       request("DELETE", "/api/orgs/acme/sso", undefined, authHeader),
       makeEnv(),
     );
     expect(res.status).toBe(200);
-    expect(enableUser).not.toHaveBeenCalled();
+    const body = (await res.json()) as { reenabledUserIds: string[] };
+    expect(body.reenabledUserIds).toEqual([]);
+  });
+
+  it("a failed re-enable returns the error and does NOT delete the connection", async () => {
+    const { AppError } = await import("../src/utils/errors");
+    vi.mocked(reenableUsersForConnectionRemoval).mockResolvedValue({
+      success: false,
+      error: new AppError("Failed to re-enable SCIM-disabled users", "STORAGE_ERROR", 500),
+    });
+    const res = await makeApp().fetch(
+      request("DELETE", "/api/orgs/acme/sso", undefined, authHeader),
+      makeEnv(),
+    );
+    expect(res.status).toBe(500);
+    expect(deleteSsoConnection).not.toHaveBeenCalled();
+    expect(recordAudit).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ action: "sso.connection.deleted" }),
+    );
   });
 });
 

--- a/tests/scheduled.test.ts
+++ b/tests/scheduled.test.ts
@@ -11,6 +11,7 @@ const noopRunners: JobRunners = {
   backup: () => Promise.resolve(),
   "ttl-sweep": () => Promise.resolve(),
   "project-sync": () => Promise.resolve(),
+  "oidc-state-purge": () => Promise.resolve(),
 };
 
 describe("jobsForCron", () => {
@@ -22,7 +23,7 @@ describe("jobsForCron", () => {
 
   it("runs housekeeping (no backup) on the 0 6 trigger", () => {
     const jobs = jobsForCron("0 6 * * *");
-    expect(jobs).toEqual(["ttl-sweep", "project-sync"]);
+    expect(jobs).toEqual(["ttl-sweep", "project-sync", "oidc-state-purge"]);
     expect(jobs).not.toContain("backup");
   });
 
@@ -47,9 +48,9 @@ describe("runScheduledJobs", () => {
   });
 
   it("registers a SEPARATE waitUntil per job (not one batched Promise.all)", () => {
-    // The 06:00 cron has two jobs; each must be its own waitUntil so one failing
-    // job can't reject the other — a single Promise.all would show up as length 1.
-    expect(collect("0 6 * * *")).toHaveLength(2);
+    // The 06:00 cron has three jobs; each must be its own waitUntil so one failing
+    // job can't reject the others — a single Promise.all would show up as length 1.
+    expect(collect("0 6 * * *")).toHaveLength(3);
   });
 
   it("registers nothing for an unknown cron", () => {

--- a/tests/scim-auth.test.ts
+++ b/tests/scim-auth.test.ts
@@ -1,0 +1,213 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authMiddleware } from "../src/middleware/auth";
+import { rateLimitMiddleware } from "../src/middleware/rate-limit";
+import type { Env } from "../src/types";
+import { hashToken } from "../src/utils/crypto";
+import { AppError, NotFoundError } from "../src/utils/errors";
+import { makeFakeKV } from "./helpers/fake-kv";
+
+vi.mock("../src/storage/users", () => ({
+  getUserByToken: vi.fn(),
+  getUser: vi.fn(),
+}));
+
+vi.mock("../src/storage/agents", () => ({
+  getAgentByToken: vi.fn(),
+}));
+
+vi.mock("../src/storage/sessions", () => ({
+  getSession: vi.fn(),
+  deleteSession: vi.fn(),
+}));
+
+vi.mock("../src/storage/sso", () => ({
+  getSsoConnectionByScimTokenHash: vi.fn(),
+}));
+
+import { getSsoConnectionByScimTokenHash } from "../src/storage/sso";
+import { getUserByToken } from "../src/storage/users";
+
+interface EchoBody {
+  userId: string | null;
+  agentId: string | null;
+  scimConnectionId: string | null;
+}
+
+function makeApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", authMiddleware);
+  app.get("/test", (c) => {
+    return c.json({
+      userId: c.get("userId") ?? null,
+      agentId: c.get("agentId") ?? null,
+      scimConnectionId: c.get("scimConnectionId") ?? null,
+    });
+  });
+  return app;
+}
+
+function makeEnv(): Env {
+  return {
+    ARTIFACTS: {} as Env["ARTIFACTS"],
+    STATE: {} as KVNamespace,
+    DB: {} as D1Database,
+  };
+}
+
+function request(path: string, headers?: Record<string, string>): Request {
+  return new Request(`http://localhost${path}`, headers ? { headers } : {});
+}
+
+const connection = {
+  id: "ssoc_1",
+  orgId: "org_1",
+  protocol: "oidc" as const,
+  issuer: "https://idp.example.com",
+  clientId: "cid",
+  clientSecretCiphertext: "ct",
+  authorizationEndpoint: "https://idp.example.com/auth",
+  tokenEndpoint: "https://idp.example.com/token",
+  jwksUri: "https://idp.example.com/jwks",
+  emailDomains: ["corp.example.com"],
+  domainsVerifiedAt: "2026-01-01T00:00:00.000Z",
+  domainVerificationToken: "tok",
+  scimTokenHash: "hash",
+  enabled: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("authMiddleware — stratum_scim_* bearer", () => {
+  let app: ReturnType<typeof makeApp>;
+  let env: Env;
+
+  beforeEach(() => {
+    app = makeApp();
+    env = makeEnv();
+    vi.clearAllMocks();
+  });
+
+  it("sets scimConnectionId (and NO userId) for a valid SCIM token", async () => {
+    vi.mocked(getSsoConnectionByScimTokenHash).mockResolvedValue({
+      success: true,
+      data: connection,
+    });
+
+    const token = "stratum_scim_abc123";
+    const res = await app.fetch(request("/test", { Authorization: `Bearer ${token}` }), env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as EchoBody;
+    expect(body.scimConnectionId).toBe("ssoc_1");
+    expect(body.userId).toBeNull();
+    expect(body.agentId).toBeNull();
+    // The lookup receives the token's HASH — plaintext never reaches storage.
+    expect(getSsoConnectionByScimTokenHash).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      await hashToken(token),
+    );
+  });
+
+  it("returns 401 for an unknown SCIM token, exactly like other invalid tokens", async () => {
+    vi.mocked(getSsoConnectionByScimTokenHash).mockResolvedValue({
+      success: false,
+      error: new NotFoundError("SSO connection", "by-scim-token"),
+    });
+
+    const res = await app.fetch(
+      request("/test", { Authorization: "Bearer stratum_scim_unknown" }),
+      env,
+    );
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe("Invalid token");
+  });
+
+  it("returns 401 when the connection lookup errors (fail closed)", async () => {
+    vi.mocked(getSsoConnectionByScimTokenHash).mockResolvedValue({
+      success: false,
+      error: new AppError("boom", "STORAGE_ERROR", 500),
+    });
+
+    const res = await app.fetch(
+      request("/test", { Authorization: "Bearer stratum_scim_broken" }),
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("does NOT set scimConnectionId for a user token", async () => {
+    vi.mocked(getUserByToken).mockResolvedValue({
+      success: true,
+      data: {
+        id: "usr_abc",
+        email: "test@example.com",
+        username: "test",
+        tokenHash: "hash",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+
+    const res = await app.fetch(
+      request("/test", { Authorization: "Bearer stratum_user_abc123" }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as EchoBody;
+    expect(body.userId).toBe("usr_abc");
+    expect(body.scimConnectionId).toBeNull();
+    expect(getSsoConnectionByScimTokenHash).not.toHaveBeenCalled();
+  });
+});
+
+describe("rateLimitMiddleware — per-connection SCIM bucket", () => {
+  const HOUR_MS = 3600 * 1000;
+
+  function makeScimApp(connectionId: string) {
+    const app = new Hono<{ Bindings: Env }>();
+    app.use("*", async (c, next) => {
+      c.set("scimConnectionId", connectionId);
+      await next();
+    });
+    app.use("*", rateLimitMiddleware());
+    app.get("/scim/v2/Users", (c) => c.json({ ok: true }));
+    return app;
+  }
+
+  it("counts SCIM requests in a per-connection hourly bucket", async () => {
+    const kv = makeFakeKV();
+    const env = { ...makeEnv(), STATE: kv };
+    const app = makeScimApp("ssoc_rl");
+
+    const res = await app.fetch(request("/scim/v2/Users"), env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("3000");
+
+    const bucket = Math.floor(Date.now() / HOUR_MS);
+    expect(kv.store.get(`ratelimit:scim:ssoc_rl:${bucket}`)).toBe("1");
+  });
+
+  it("returns 429 once the connection's 3000/hour window is exhausted", async () => {
+    const kv = makeFakeKV();
+    const env = { ...makeEnv(), STATE: kv };
+    const app = makeScimApp("ssoc_rl");
+
+    const bucket = Math.floor(Date.now() / HOUR_MS);
+    kv.store.set(`ratelimit:scim:ssoc_rl:${bucket}`, "3000");
+
+    const res = await app.fetch(request("/scim/v2/Users"), env);
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("keys the bucket per connection — one tenant cannot exhaust another's", async () => {
+    const kv = makeFakeKV();
+    const env = { ...makeEnv(), STATE: kv };
+
+    const bucket = Math.floor(Date.now() / HOUR_MS);
+    kv.store.set(`ratelimit:scim:ssoc_busy:${bucket}`, "3000");
+
+    const res = await makeScimApp("ssoc_quiet").fetch(request("/scim/v2/Users"), env);
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/scim-auth.test.ts
+++ b/tests/scim-auth.test.ts
@@ -109,7 +109,7 @@ describe("authMiddleware — stratum_scim_* bearer", () => {
     );
   });
 
-  it("returns 401 for an unknown SCIM token, exactly like other invalid tokens", async () => {
+  it("returns a SCIM-envelope 401 for an unknown SCIM token", async () => {
     vi.mocked(getSsoConnectionByScimTokenHash).mockResolvedValue({
       success: false,
       error: new NotFoundError("SSO connection", "by-scim-token"),
@@ -120,10 +120,14 @@ describe("authMiddleware — stratum_scim_* bearer", () => {
       env,
     );
     expect(res.status).toBe(401);
-    expect(((await res.json()) as { error: string }).error).toBe("Invalid token");
+    expect(res.headers.get("Content-Type")).toBe("application/scim+json");
+    const body = (await res.json()) as { schemas: string[]; status: string; detail: string };
+    expect(body.schemas).toEqual(["urn:ietf:params:scim:api:messages:2.0:Error"]);
+    expect(body.status).toBe("401");
+    expect(body.detail).toBe("Invalid token");
   });
 
-  it("returns 401 when the connection lookup errors (fail closed)", async () => {
+  it("returns a SCIM-envelope 401 when the connection lookup errors (fail closed)", async () => {
     vi.mocked(getSsoConnectionByScimTokenHash).mockResolvedValue({
       success: false,
       error: new AppError("boom", "STORAGE_ERROR", 500),
@@ -134,6 +138,10 @@ describe("authMiddleware — stratum_scim_* bearer", () => {
       env,
     );
     expect(res.status).toBe(401);
+    expect(res.headers.get("Content-Type")).toBe("application/scim+json");
+    expect(((await res.json()) as { schemas: string[] }).schemas).toEqual([
+      "urn:ietf:params:scim:api:messages:2.0:Error",
+    ]);
   });
 
   it("does NOT set scimConnectionId for a user token", async () => {

--- a/tests/scim.test.ts
+++ b/tests/scim.test.ts
@@ -1,0 +1,914 @@
+/**
+ * SCIM 2.0 Users endpoints (#253 Task 6): real routers + real middleware
+ * against a real SQLite D1 (every migration applied). Only external I/O
+ * (Artifacts, KV) is faked; auth, storage, and the SCIM lifecycle run for
+ * real — including the PRD Goal-8 E2E (deactivate → every credential dead →
+ * reactivate → restored).
+ */
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authMiddleware } from "../src/middleware/auth";
+import { csrfMiddleware } from "../src/middleware/csrf";
+import { rateLimitMiddleware } from "../src/middleware/rate-limit";
+import { gitHttpRouter } from "../src/routes/git-http";
+import { scimRouter } from "../src/routes/scim";
+import { createAgent } from "../src/storage/agents";
+import { addOrgMember } from "../src/storage/orgs";
+import { createSession } from "../src/storage/sessions";
+import {
+  deprovisionUser,
+  getSsoConnectionByScimTokenHash,
+  reactivateUser,
+  rotateScimToken,
+  setSsoConnectionEnabled,
+  setSsoDomainsVerified,
+  upsertSsoConnection,
+} from "../src/storage/sso";
+import { createUser } from "../src/storage/users";
+import type { Env } from "../src/types";
+import { hashToken } from "../src/utils/crypto";
+import { AppError } from "../src/utils/errors";
+import type { Logger } from "../src/utils/logger";
+import { makeFakeKV } from "./helpers/fake-kv";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
+
+// Everything real except createUser, which is a passthrough spy so ONE test
+// (the POST email-race heal) can make a single call fail after inserting the
+// row — the shape of losing the email UNIQUE race to a concurrent writer.
+vi.mock("../src/storage/users", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/storage/users")>();
+  return { ...actual, createUser: vi.fn(actual.createUser) };
+});
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+} as unknown as Logger;
+
+const BASE = "https://stratum.test";
+const DOMAIN = "corp.example.com";
+const USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+const LIST_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
+const ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";
+
+type Raw = ReturnType<typeof makeSqliteD1>["raw"];
+
+interface ScimResource {
+  schemas: string[];
+  id: string;
+  userName: string;
+  externalId?: string;
+  active: boolean;
+  name: { formatted: string };
+  emails: Array<{ value: string; primary: boolean }>;
+  meta: { resourceType: string; created: string; location: string };
+}
+
+interface ListResponse {
+  schemas: string[];
+  totalResults: number;
+  startIndex: number;
+  itemsPerPage: number;
+  Resources: ScimResource[];
+}
+
+let db: D1Database;
+let raw: Raw;
+let env: Env;
+let app: Hono<{ Bindings: Env }>;
+let connectionId: string;
+let scimToken: string;
+
+async function makeConnection(
+  orgId: string,
+  slug: string,
+  ownerId: string,
+  domain: string,
+): Promise<string> {
+  raw
+    .prepare("INSERT INTO orgs (id, name, slug, owner_id) VALUES (?, ?, ?, ?)")
+    .run(orgId, slug, slug, ownerId);
+  const upserted = await upsertSsoConnection(db, logger, {
+    orgId,
+    issuer: `https://idp.${slug}.example.com`,
+    clientId: "client-id",
+    clientSecretCiphertext: "ciphertext",
+    authorizationEndpoint: `https://idp.${slug}.example.com/authorize`,
+    tokenEndpoint: `https://idp.${slug}.example.com/token`,
+    jwksUri: `https://idp.${slug}.example.com/jwks`,
+    emailDomains: [domain],
+  });
+  if (!upserted.success) throw new Error("seed: upsertSsoConnection failed");
+  const id = upserted.data.connection.id;
+  const verified = await setSsoDomainsVerified(db, logger, id, [domain]);
+  if (!verified.success) throw new Error("seed: verify failed");
+  const enabled = await setSsoConnectionEnabled(db, logger, id, true);
+  if (!enabled.success) throw new Error("seed: enable failed");
+  return id;
+}
+
+beforeEach(async () => {
+  ({ db, raw } = makeSqliteD1());
+  env = {
+    ARTIFACTS: {} as Env["ARTIFACTS"],
+    STATE: makeFakeKV(),
+    DB: db,
+  };
+
+  raw
+    .prepare("INSERT INTO users (id, email, username, token_hash) VALUES (?, ?, ?, ?)")
+    .run("usr_owner", `owner@${DOMAIN}`, "owner", "hash_owner");
+  connectionId = await makeConnection("org_1", "acme", "usr_owner", DOMAIN);
+  const rotated = await rotateScimToken(db, logger, connectionId);
+  if (!rotated.success) throw new Error("seed: rotateScimToken failed");
+  scimToken = rotated.data;
+
+  // Same middleware chain (and order) as src/index.ts, trimmed to the routers
+  // under test plus an authMiddleware-protected echo route.
+  app = new Hono<{ Bindings: Env }>();
+  app.use("*", authMiddleware);
+  app.use("*", csrfMiddleware);
+  app.use("*", rateLimitMiddleware());
+  app.route("/scim/v2", scimRouter);
+  app.route("/", gitHttpRouter);
+  app.get("/api/whoami", (c) =>
+    c.json({
+      userId: c.get("userId") ?? null,
+      agentId: c.get("agentId") ?? null,
+      scimConnectionId: c.get("scimConnectionId") ?? null,
+    }),
+  );
+});
+
+function scimFetch(
+  method: string,
+  path: string,
+  opts: { body?: unknown; token?: string | null; headers?: Record<string, string> } = {},
+): Promise<Response> {
+  const token = opts.token === undefined ? scimToken : opts.token;
+  const headers: Record<string, string> = { ...opts.headers };
+  if (token !== null) headers.Authorization = `Bearer ${token}`;
+  if (opts.body !== undefined) headers["Content-Type"] = "application/scim+json";
+  return Promise.resolve(
+    app.fetch(
+      new Request(`${BASE}${path}`, {
+        method,
+        headers,
+        ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+      }),
+      env,
+    ),
+  );
+}
+
+async function provision(
+  email: string,
+  extra: Record<string, unknown> = {},
+): Promise<ScimResource> {
+  const res = await scimFetch("POST", "/scim/v2/Users", {
+    body: { schemas: [USER_SCHEMA], userName: email, ...extra },
+  });
+  if (res.status !== 201 && res.status !== 200) {
+    throw new Error(`provision failed: ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as ScimResource;
+}
+
+function disabledAtOf(userId: string): string | null {
+  const row = raw.prepare("SELECT disabled_at FROM users WHERE id = ?").get(userId) as {
+    disabled_at: string | null;
+  };
+  return row.disabled_at;
+}
+
+function scimRowOf(
+  connId: string,
+  userId: string,
+): { scim_external_id: string | null; active: number } | undefined {
+  return raw
+    .prepare(
+      "SELECT scim_external_id, active FROM scim_members WHERE connection_id = ? AND user_id = ?",
+    )
+    .get(connId, userId) as { scim_external_id: string | null; active: number } | undefined;
+}
+
+function auditActions(subject: string): Array<{ action: string; actor_type: string }> {
+  return raw
+    .prepare("SELECT action, actor_type FROM audit_log WHERE subject = ? ORDER BY rowid")
+    .all(subject) as Array<{ action: string; actor_type: string }>;
+}
+
+describe("getSsoConnectionByScimTokenHash", () => {
+  it("resolves an enabled, verified connection by token hash", async () => {
+    const result = await getSsoConnectionByScimTokenHash(db, logger, await hashToken(scimToken));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.id).toBe(connectionId);
+  });
+
+  it("does not resolve a disabled connection", async () => {
+    await setSsoConnectionEnabled(db, logger, connectionId, false);
+    const result = await getSsoConnectionByScimTokenHash(db, logger, await hashToken(scimToken));
+    expect(result.success).toBe(false);
+  });
+
+  it("does not resolve an unverified connection", async () => {
+    raw
+      .prepare("UPDATE org_sso_connections SET domains_verified_at = NULL WHERE id = ?")
+      .run(connectionId);
+    const result = await getSsoConnectionByScimTokenHash(db, logger, await hashToken(scimToken));
+    expect(result.success).toBe(false);
+  });
+
+  it("a disabled connection's token gets a plain 401 from the middleware", async () => {
+    await setSsoConnectionEnabled(db, logger, connectionId, false);
+    const res = await scimFetch("GET", "/scim/v2/Users");
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe("Invalid token");
+  });
+});
+
+describe("fail-closed: only a SCIM bearer is honored on /scim/v2", () => {
+  async function expectScimUnauthorized(res: Response): Promise<void> {
+    expect(res.status).toBe(401);
+    expect(res.headers.get("Content-Type")).toBe("application/scim+json");
+    const body = (await res.json()) as { schemas: string[]; status: string };
+    expect(body.schemas).toEqual([ERROR_SCHEMA]);
+    expect(body.status).toBe("401");
+  }
+
+  it("no auth → 401 SCIM error", async () => {
+    await expectScimUnauthorized(await scimFetch("GET", "/scim/v2/Users", { token: null }));
+  });
+
+  it("user bearer → 401 SCIM error", async () => {
+    const created = await createUser(db, `human@${DOMAIN}`, logger);
+    if (!created.success) throw new Error("seed failed");
+    await expectScimUnauthorized(
+      await scimFetch("GET", "/scim/v2/Users", { token: created.data.plaintext }),
+    );
+  });
+
+  it("session cookie → 401 SCIM error", async () => {
+    const session = await createSession(db, "usr_owner", logger);
+    if (!session.success) throw new Error("seed failed");
+    const res = await app.fetch(
+      new Request(`${BASE}/scim/v2/Users`, {
+        headers: { Cookie: `stratum_session=${session.data.id}` },
+      }),
+      env,
+    );
+    await expectScimUnauthorized(res);
+  });
+
+  it("discovery endpoints are gated too", async () => {
+    await expectScimUnauthorized(
+      await scimFetch("GET", "/scim/v2/ServiceProviderConfig", { token: null }),
+    );
+  });
+});
+
+describe("discovery endpoints", () => {
+  it("ServiceProviderConfig advertises patch + filter, everything else off", async () => {
+    const res = await scimFetch("GET", "/scim/v2/ServiceProviderConfig");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/scim+json");
+    const body = (await res.json()) as Record<string, { supported?: boolean; maxResults?: number }>;
+    expect(body.patch?.supported).toBe(true);
+    expect(body.filter?.supported).toBe(true);
+    expect(body.filter?.maxResults).toBe(200);
+    expect(body.changePassword?.supported).toBe(false);
+    expect(body.sort?.supported).toBe(false);
+    expect(body.etag?.supported).toBe(false);
+    expect(body.bulk?.supported).toBe(false);
+    const schemes = body.authenticationSchemes as unknown as Array<{ type: string }>;
+    expect(schemes[0]?.type).toBe("oauthbearertoken");
+  });
+
+  it("ResourceTypes lists the User resource in a ListResponse envelope", async () => {
+    const res = await scimFetch("GET", "/scim/v2/ResourceTypes");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ListResponse;
+    expect(body.schemas).toEqual([LIST_SCHEMA]);
+    expect(body.totalResults).toBe(1);
+    expect((body.Resources[0] as unknown as { id: string; schema: string }).id).toBe("User");
+    expect((body.Resources[0] as unknown as { schema: string }).schema).toBe(USER_SCHEMA);
+  });
+
+  it("Schemas lists the core User schema in a ListResponse envelope", async () => {
+    const res = await scimFetch("GET", "/scim/v2/Schemas");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ListResponse;
+    expect(body.schemas).toEqual([LIST_SCHEMA]);
+    expect((body.Resources[0] as unknown as { id: string }).id).toBe(USER_SCHEMA);
+    const attrs = (
+      body.Resources[0] as unknown as { attributes: Array<{ name: string; required: boolean }> }
+    ).attributes;
+    expect(attrs.find((a) => a.name === "userName")?.required).toBe(true);
+  });
+});
+
+describe("POST /Users (provision + adopt)", () => {
+  it("Okta-shaped POST creates the user with membership, scim row, and externalId", async () => {
+    const res = await scimFetch("POST", "/scim/v2/Users", {
+      body: {
+        schemas: [USER_SCHEMA],
+        userName: `Alice@${DOMAIN}`,
+        externalId: "okta-123",
+        name: { givenName: "Alice", familyName: "Example" },
+        emails: [{ value: `alice@${DOMAIN}`, primary: true, type: "work" }],
+        active: true,
+      },
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as ScimResource;
+    expect(body.schemas).toEqual([USER_SCHEMA]);
+    expect(body.userName).toBe(`alice@${DOMAIN}`);
+    expect(body.externalId).toBe("okta-123");
+    expect(body.active).toBe(true);
+    expect(body.emails).toEqual([{ value: `alice@${DOMAIN}`, primary: true }]);
+    expect(body.meta.resourceType).toBe("User");
+    expect(body.meta.location).toBe(`${BASE}/scim/v2/Users/${body.id}`);
+
+    // Username derived exactly like SSO JIT / signup would.
+    const user = raw.prepare("SELECT username, email FROM users WHERE id = ?").get(body.id) as {
+      username: string;
+      email: string;
+    };
+    expect(user.username).toBe("alice");
+    expect(user.email).toBe(`alice@${DOMAIN}`);
+    const member = raw
+      .prepare("SELECT role FROM org_members WHERE org_id = 'org_1' AND user_id = ?")
+      .get(body.id) as { role: string };
+    expect(member.role).toBe("member");
+    expect(scimRowOf(connectionId, body.id)).toEqual({
+      scim_external_id: "okta-123",
+      active: 1,
+    });
+
+    const actions = auditActions(body.id).map((row) => row.action);
+    expect(actions).toContain("scim.user.provisioned");
+    for (const row of auditActions(body.id)) expect(row.actor_type).toBe("system");
+  });
+
+  it("POST with active:false provisions the user already deactivated", async () => {
+    const body = await provision(`suspended@${DOMAIN}`, { active: false });
+    expect(body.active).toBe(false);
+    expect(disabledAtOf(body.id)).not.toBeNull();
+  });
+
+  it("rejects an email outside the verified domains with 400 invalidValue", async () => {
+    const res = await scimFetch("POST", "/scim/v2/Users", {
+      body: { schemas: [USER_SCHEMA], userName: "intruder@evil.example.net" },
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { schemas: string[]; scimType: string };
+    expect(body.schemas).toEqual([ERROR_SCHEMA]);
+    expect(body.scimType).toBe("invalidValue");
+  });
+
+  it("rejects a missing userName with 400", async () => {
+    const res = await scimFetch("POST", "/scim/v2/Users", { body: { schemas: [USER_SCHEMA] } });
+    expect(res.status).toBe(400);
+  });
+
+  it("adopts an existing verified-domain account with 200, preserving its admin role", async () => {
+    const created = await createUser(db, `carol@${DOMAIN}`, logger);
+    if (!created.success) throw new Error("seed failed");
+    const carolId = created.data.user.id;
+    await addOrgMember(db, logger, "org_1", carolId, "admin");
+
+    const res = await scimFetch("POST", "/scim/v2/Users", {
+      body: { schemas: [USER_SCHEMA], userName: `carol@${DOMAIN}`, externalId: "idp-carol" },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ScimResource;
+    expect(body.id).toBe(carolId);
+    expect(body.externalId).toBe("idp-carol");
+
+    // Adoption must not demote the pre-existing role.
+    const member = raw
+      .prepare("SELECT role FROM org_members WHERE org_id = 'org_1' AND user_id = ?")
+      .get(carolId) as { role: string };
+    expect(member.role).toBe("admin");
+    expect(scimRowOf(connectionId, carolId)?.active).toBe(1);
+  });
+
+  it("a second POST for an already-managed user is 409 uniqueness", async () => {
+    await provision(`dana@${DOMAIN}`);
+    const res = await scimFetch("POST", "/scim/v2/Users", {
+      body: { schemas: [USER_SCHEMA], userName: `dana@${DOMAIN}` },
+    });
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { scimType: string }).scimType).toBe("uniqueness");
+  });
+
+  it("heals the concurrent-email race: a lost createUser insert falls into the adopt path (200)", async () => {
+    const actualUsers =
+      await vi.importActual<typeof import("../src/storage/users")>("../src/storage/users");
+    // Simulate a concurrent OIDC JIT login (or duplicate POST) winning the
+    // email UNIQUE race: by the time our insert reports failure, the row
+    // exists.
+    vi.mocked(createUser).mockImplementationOnce(async (dbArg, email, log, preferred) => {
+      await actualUsers.createUser(dbArg, email, log, preferred);
+      return {
+        success: false,
+        error: new AppError("simulated email UNIQUE race", "STORAGE_ERROR", 500),
+      };
+    });
+
+    const res = await scimFetch("POST", "/scim/v2/Users", {
+      body: { schemas: [USER_SCHEMA], userName: `raced@${DOMAIN}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ScimResource;
+    expect(body.userName).toBe(`raced@${DOMAIN}`);
+    expect(scimRowOf(connectionId, body.id)?.active).toBe(1);
+  });
+});
+
+describe("GET /Users (list, filters, pagination)", () => {
+  it("lists managed users plus verified-domain org members (visible for adoption)", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+    // The org owner is an org member within the verified domain → visible.
+    await addOrgMember(db, logger, "org_1", "usr_owner", "admin");
+    // An org member OUTSIDE the verified domains is not in scope.
+    const outsider = await createUser(db, "guest@other.example.net", logger);
+    if (!outsider.success) throw new Error("seed failed");
+    await addOrgMember(db, logger, "org_1", outsider.data.user.id, "member");
+
+    const res = await scimFetch("GET", "/scim/v2/Users");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ListResponse;
+    expect(body.schemas).toEqual([LIST_SCHEMA]);
+    const ids = body.Resources.map((r) => r.id);
+    expect(ids).toContain(alice.id);
+    expect(ids).toContain("usr_owner");
+    expect(ids).not.toContain(outsider.data.user.id);
+    expect(body.totalResults).toBe(2);
+  });
+
+  it("paginates with 1-based startIndex and clamps count", async () => {
+    for (const name of ["u1", "u2", "u3"]) await provision(`${name}@${DOMAIN}`);
+
+    const page = await scimFetch("GET", "/scim/v2/Users?startIndex=2&count=1");
+    const body = (await page.json()) as ListResponse;
+    expect(body.totalResults).toBe(3);
+    expect(body.startIndex).toBe(2);
+    expect(body.itemsPerPage).toBe(1);
+    expect(body.Resources).toHaveLength(1);
+
+    const clamped = await scimFetch("GET", "/scim/v2/Users?count=9999");
+    expect(((await clamped.json()) as ListResponse).itemsPerPage).toBe(3);
+  });
+
+  it("count=0 returns totalResults with no Resources (RFC 7644 §3.4.2.4)", async () => {
+    for (const name of ["u1", "u2"]) await provision(`${name}@${DOMAIN}`);
+
+    const zero = await scimFetch("GET", "/scim/v2/Users?count=0");
+    expect(zero.status).toBe(200);
+    const body = (await zero.json()) as ListResponse;
+    expect(body.totalResults).toBe(2);
+    expect(body.itemsPerPage).toBe(0);
+    expect(body.Resources).toEqual([]);
+
+    // A negative count is treated as 0.
+    const negative = await scimFetch("GET", "/scim/v2/Users?count=-5");
+    expect(((await negative.json()) as ListResponse).Resources).toEqual([]);
+  });
+
+  it('filters by userName eq "..." (attribute case-insensitive)', async () => {
+    await provision(`erin@${DOMAIN}`);
+    await provision(`frank@${DOMAIN}`);
+
+    const res = await scimFetch(
+      "GET",
+      `/scim/v2/Users?filter=${encodeURIComponent(`username eq "Erin@${DOMAIN}"`)}`,
+    );
+    const body = (await res.json()) as ListResponse;
+    expect(body.totalResults).toBe(1);
+    expect(body.Resources[0]?.userName).toBe(`erin@${DOMAIN}`);
+  });
+
+  it('filters by externalId eq "..."', async () => {
+    await provision(`gina@${DOMAIN}`, { externalId: "ext-gina" });
+    await provision(`hank@${DOMAIN}`, { externalId: "ext-hank" });
+
+    const res = await scimFetch(
+      "GET",
+      `/scim/v2/Users?filter=${encodeURIComponent('externalId eq "ext-hank"')}`,
+    );
+    const body = (await res.json()) as ListResponse;
+    expect(body.totalResults).toBe(1);
+    expect(body.Resources[0]?.userName).toBe(`hank@${DOMAIN}`);
+  });
+
+  it("any other filter is 501 per RFC 7644 §3.4.2.2", async () => {
+    const res = await scimFetch(
+      "GET",
+      `/scim/v2/Users?filter=${encodeURIComponent('emails.value co "corp"')}`,
+    );
+    expect(res.status).toBe(501);
+    expect(((await res.json()) as { schemas: string[] }).schemas).toEqual([ERROR_SCHEMA]);
+  });
+
+  it("GET /Users/:id returns the resource, 404 SCIM error out of scope", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+    const found = await scimFetch("GET", `/scim/v2/Users/${alice.id}`);
+    expect(found.status).toBe(200);
+    expect(((await found.json()) as ScimResource).id).toBe(alice.id);
+
+    // A real user outside the connection's scope is indistinguishable from a
+    // missing one.
+    const stranger = await createUser(db, "stranger@elsewhere.example.net", logger);
+    if (!stranger.success) throw new Error("seed failed");
+    const miss = await scimFetch("GET", `/scim/v2/Users/${stranger.data.user.id}`);
+    expect(miss.status).toBe(404);
+    expect(((await miss.json()) as { schemas: string[] }).schemas).toEqual([ERROR_SCHEMA]);
+  });
+});
+
+describe("PUT /Users/:id", () => {
+  it("rejects a userName change with 400 mutability", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+    const res = await scimFetch("PUT", `/scim/v2/Users/${alice.id}`, {
+      body: { schemas: [USER_SCHEMA], userName: `renamed@${DOMAIN}`, active: true },
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { scimType: string }).scimType).toBe("mutability");
+  });
+
+  it("applies externalId and active (same userName is not a change)", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+    const res = await scimFetch("PUT", `/scim/v2/Users/${alice.id}`, {
+      body: {
+        schemas: [USER_SCHEMA],
+        userName: `ALICE@${DOMAIN}`,
+        externalId: "ext-new",
+        active: false,
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ScimResource;
+    expect(body.externalId).toBe("ext-new");
+    expect(body.active).toBe(false);
+    expect(disabledAtOf(alice.id)).not.toBeNull();
+  });
+
+  it("a no-op PUT adopts an adoption-visible user (creates the scim_members row)", async () => {
+    const created = await createUser(db, `visible@${DOMAIN}`, logger);
+    if (!created.success) throw new Error("seed failed");
+    const userId = created.data.user.id;
+    await addOrgMember(db, logger, "org_1", userId, "member");
+    expect(scimRowOf(connectionId, userId)).toBeUndefined();
+
+    const res = await scimFetch("PUT", `/scim/v2/Users/${userId}`, {
+      body: { schemas: [USER_SCHEMA], userName: `visible@${DOMAIN}`, active: true },
+    });
+    expect(res.status).toBe(200);
+    // The IdP now believes it manages this user; the row records that so the
+    // user cannot silently fall out of the connection's scope.
+    expect(scimRowOf(connectionId, userId)).toEqual({ scim_external_id: null, active: 1 });
+  });
+});
+
+describe("PATCH /Users/:id", () => {
+  it('Entra-shaped {"op":"Replace","path":"active","value":"False"} deactivates', async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+    const res = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
+      body: {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        Operations: [{ op: "Replace", path: "active", value: "False" }],
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as ScimResource).active).toBe(false);
+    expect(disabledAtOf(alice.id)).not.toBeNull();
+    expect(scimRowOf(connectionId, alice.id)?.active).toBe(0);
+  });
+
+  it("boolean values and no-path value objects work too", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+
+    const off = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
+      body: { Operations: [{ op: "replace", value: { active: false } }] },
+    });
+    expect(((await off.json()) as ScimResource).active).toBe(false);
+
+    const on = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
+      body: { Operations: [{ op: "replace", path: "Active", value: true }] },
+    });
+    expect(((await on.json()) as ScimResource).active).toBe(true);
+    expect(disabledAtOf(alice.id)).toBeNull();
+  });
+
+  it("replaces externalId via path", async () => {
+    const alice = await provision(`alice@${DOMAIN}`, { externalId: "before" });
+    const res = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
+      body: { Operations: [{ op: "replace", path: "externalId", value: "after" }] },
+    });
+    expect(((await res.json()) as ScimResource).externalId).toBe("after");
+  });
+
+  it("ignores unknown-attribute replaces (Okta/Entra profile sync) instead of erroring", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+    const res = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
+      body: {
+        Operations: [
+          { op: "replace", path: "displayName", value: "Alice E." },
+          { op: "replace", value: { "name.givenName": "Alice" } },
+        ],
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as ScimResource).active).toBe(true);
+  });
+
+  it("rejects non-replace ops with 400 and malformed active values with invalidValue", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+    const add = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
+      body: { Operations: [{ op: "remove", path: "active" }] },
+    });
+    expect(add.status).toBe(400);
+    expect(((await add.json()) as { scimType: string }).scimType).toBe("invalidPath");
+
+    const bad = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
+      body: { Operations: [{ op: "replace", path: "active", value: "maybe" }] },
+    });
+    expect(bad.status).toBe(400);
+    expect(((await bad.json()) as { scimType: string }).scimType).toBe("invalidValue");
+  });
+
+  it("404s for a user outside the connection's scope", async () => {
+    const res = await scimFetch("PATCH", "/scim/v2/Users/usr_ghost", {
+      body: { Operations: [{ op: "replace", path: "active", value: false }] },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("repairs the drift state: active:false on a half-deprovisioned user actually disables", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+    const session = await createSession(db, alice.id, logger);
+    if (!session.success) throw new Error("seed failed");
+    // Drift left by a partial deprovision failure: the vote was recorded but
+    // the enforced flag never landed.
+    raw
+      .prepare("UPDATE scim_members SET active = 0 WHERE connection_id = ? AND user_id = ?")
+      .run(connectionId, alice.id);
+    expect(disabledAtOf(alice.id)).toBeNull();
+
+    const res = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
+      body: { Operations: [{ op: "replace", path: "active", value: false }] },
+    });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as ScimResource).active).toBe(false);
+    expect(disabledAtOf(alice.id)).not.toBeNull();
+    const sessions = raw
+      .prepare("SELECT COUNT(*) AS n FROM sessions WHERE user_id = ?")
+      .get(alice.id) as { n: number };
+    expect(sessions.n).toBe(0);
+  });
+
+  it("records this connection's deactivation vote even when another connection already disabled the user", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+    const otherConnectionId = await makeConnection(
+      "org_2",
+      "globex",
+      "usr_owner",
+      "globex.example.com",
+    );
+    // Connection B disables first.
+    expect((await deprovisionUser(db, logger, otherConnectionId, alice.id)).success).toBe(true);
+
+    // A's PATCH active:false must still record A's own active=0 vote.
+    const res = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
+      body: { Operations: [{ op: "replace", path: "active", value: false }] },
+    });
+    expect(res.status).toBe(200);
+    expect(scimRowOf(connectionId, alice.id)?.active).toBe(0);
+
+    // B reactivates — A's standing vote keeps the account disabled.
+    const partial = await reactivateUser(db, logger, otherConnectionId, alice.id);
+    expect(partial.success).toBe(true);
+    if (partial.success) expect(partial.data.enabled).toBe(false);
+    expect(disabledAtOf(alice.id)).not.toBeNull();
+
+    // Once A reactivates too, the account is restored.
+    const full = await reactivateUser(db, logger, connectionId, alice.id);
+    expect(full.success).toBe(true);
+    if (full.success) expect(full.data.enabled).toBe(true);
+    expect(disabledAtOf(alice.id)).toBeNull();
+  });
+});
+
+describe("DELETE /Users/:id", () => {
+  it("deactivates (204); a later GET shows the resource with active:false", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+    const del = await scimFetch("DELETE", `/scim/v2/Users/${alice.id}`);
+    expect(del.status).toBe(204);
+    expect(disabledAtOf(alice.id)).not.toBeNull();
+
+    // Documented Okta-vs-spec deviation: DELETE deactivates rather than
+    // erases, so the resource remains GETtable with active:false.
+    const after = await scimFetch("GET", `/scim/v2/Users/${alice.id}`);
+    expect(after.status).toBe(200);
+    expect(((await after.json()) as ScimResource).active).toBe(false);
+  });
+
+  it("a retried DELETE stays 204 without re-auditing the deactivation", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+    expect((await scimFetch("DELETE", `/scim/v2/Users/${alice.id}`)).status).toBe(204);
+    const deactivations = () =>
+      auditActions(alice.id).filter((row) => row.action === "scim.user.deactivated");
+    expect(deactivations()).toHaveLength(1);
+
+    expect((await scimFetch("DELETE", `/scim/v2/Users/${alice.id}`)).status).toBe(204);
+    expect(deactivations()).toHaveLength(1);
+  });
+});
+
+describe("externalId uniqueness per connection (migration 043)", () => {
+  it("assigning a taken externalId on the same connection is 409 uniqueness", async () => {
+    await provision(`alice@${DOMAIN}`, { externalId: "ext-dup" });
+    const bob = await provision(`bob@${DOMAIN}`);
+
+    const res = await scimFetch("PATCH", `/scim/v2/Users/${bob.id}`, {
+      body: { Operations: [{ op: "replace", path: "externalId", value: "ext-dup" }] },
+    });
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { scimType: string }).scimType).toBe("uniqueness");
+    expect(scimRowOf(connectionId, bob.id)?.scim_external_id).toBeNull();
+  });
+
+  it("POSTing a second user with a taken externalId is 409 uniqueness", async () => {
+    await provision(`alice@${DOMAIN}`, { externalId: "ext-dup" });
+    const res = await scimFetch("POST", "/scim/v2/Users", {
+      body: { schemas: [USER_SCHEMA], userName: `bob@${DOMAIN}`, externalId: "ext-dup" },
+    });
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { scimType: string }).scimType).toBe("uniqueness");
+  });
+
+  it("the same externalId on a DIFFERENT connection is allowed", async () => {
+    await provision(`alice@${DOMAIN}`, { externalId: "ext-shared" });
+    const otherConnectionId = await makeConnection(
+      "org_2",
+      "globex",
+      "usr_owner",
+      "globex.example.com",
+    );
+    const rotated = await rotateScimToken(db, logger, otherConnectionId);
+    if (!rotated.success) throw new Error("seed failed");
+
+    const res = await scimFetch("POST", "/scim/v2/Users", {
+      token: rotated.data,
+      body: {
+        schemas: [USER_SCHEMA],
+        userName: "carol@globex.example.com",
+        externalId: "ext-shared",
+      },
+    });
+    expect(res.status).toBe(201);
+    expect(((await res.json()) as ScimResource).externalId).toBe("ext-shared");
+  });
+});
+
+describe("Goal-8 E2E: deactivate kills every credential; reactivate restores", () => {
+  it("session, user token, agent token, and git smart-HTTP all die and come back", async () => {
+    // Seeded like a real login: account + API token + agent + session.
+    const created = await createUser(db, `dave@${DOMAIN}`, logger);
+    if (!created.success) throw new Error("seed failed");
+    const daveId = created.data.user.id;
+    const userToken = created.data.plaintext;
+    const agent = await createAgent(db, daveId, "dave-agent", logger);
+    if (!agent.success) throw new Error("seed failed");
+    const agentToken = agent.data.plaintext;
+    const session = await createSession(db, daveId, logger);
+    if (!session.success) throw new Error("seed failed");
+    const cookie = `stratum_session=${session.data.id}`;
+
+    // Adopt into SCIM management.
+    const adopted = await scimFetch("POST", "/scim/v2/Users", {
+      body: { schemas: [USER_SCHEMA], userName: `dave@${DOMAIN}` },
+    });
+    expect(adopted.status).toBe(200);
+
+    const whoami = (headers: Record<string, string>) =>
+      app.fetch(new Request(`${BASE}/api/whoami`, { headers }), env);
+    // Project doesn't exist, so git-http answers 404 to an AUTHENTICATED
+    // caller and a 401 Basic challenge to an anonymous one — a disabled
+    // credential collapses to anonymous.
+    const gitFetch = (token: string) =>
+      app.fetch(
+        new Request(`${BASE}/@acme/repo/info/refs?service=git-upload-pack`, {
+          headers: { Authorization: `Basic ${btoa(`x:${token}`)}` },
+        }),
+        env,
+      );
+
+    // All four credentials live.
+    expect((await whoami({ Authorization: `Bearer ${userToken}` })).status).toBe(200);
+    expect((await whoami({ Authorization: `Bearer ${agentToken}` })).status).toBe(200);
+    const viaSession = await whoami({ Cookie: cookie });
+    expect(((await viaSession.json()) as { userId: string | null }).userId).toBe(daveId);
+    expect((await gitFetch(userToken)).status).toBe(404);
+
+    // SCIM deactivation (Entra-shaped PATCH).
+    const deactivate = await scimFetch("PATCH", `/scim/v2/Users/${daveId}`, {
+      body: { Operations: [{ op: "Replace", path: "active", value: "False" }] },
+    });
+    expect(deactivate.status).toBe(200);
+
+    // Sessions purged, flag set.
+    const sessions = raw
+      .prepare("SELECT COUNT(*) AS n FROM sessions WHERE user_id = ?")
+      .get(daveId) as { n: number };
+    expect(sessions.n).toBe(0);
+    expect(disabledAtOf(daveId)).not.toBeNull();
+
+    // Every credential is inert.
+    expect((await whoami({ Authorization: `Bearer ${userToken}` })).status).toBe(401);
+    expect((await whoami({ Authorization: `Bearer ${agentToken}` })).status).toBe(401);
+    const deadSession = await whoami({ Cookie: cookie });
+    expect(((await deadSession.json()) as { userId: string | null }).userId).toBeNull();
+    expect((await gitFetch(userToken)).status).toBe(401);
+    expect((await gitFetch(agentToken)).status).toBe(401);
+
+    // Audit trail: system actor, both action pairs.
+    const actions = auditActions(daveId);
+    expect(actions.map((row) => row.action)).toEqual(
+      expect.arrayContaining(["scim.user.deactivated", "user.disabled"]),
+    );
+    for (const row of actions) expect(row.actor_type).toBe("system");
+
+    // Reactivate — the SAME token and agent credentials work again (sessions
+    // were destroyed, not suspended, so the cookie stays dead).
+    const reactivate = await scimFetch("PATCH", `/scim/v2/Users/${daveId}`, {
+      body: { Operations: [{ op: "replace", path: "active", value: true }] },
+    });
+    expect(reactivate.status).toBe(200);
+    expect(disabledAtOf(daveId)).toBeNull();
+    expect((await whoami({ Authorization: `Bearer ${userToken}` })).status).toBe(200);
+    expect((await whoami({ Authorization: `Bearer ${agentToken}` })).status).toBe(200);
+    expect((await gitFetch(userToken)).status).toBe(404);
+
+    expect(auditActions(daveId).map((row) => row.action)).toEqual(
+      expect.arrayContaining(["scim.user.reactivated", "user.enabled"]),
+    );
+  });
+});
+
+describe("deprovisionUser / reactivateUser (storage)", () => {
+  it("deprovision is idempotent and keeps the earliest disabled_at", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+
+    const first = await deprovisionUser(db, logger, connectionId, alice.id);
+    expect(first.success).toBe(true);
+    const stamped = disabledAtOf(alice.id);
+
+    const again = await deprovisionUser(db, logger, connectionId, alice.id);
+    expect(again.success).toBe(true);
+    expect(disabledAtOf(alice.id)).toBe(stamped);
+    if (again.success) expect(again.data.disabledAt).toBe(stamped);
+  });
+
+  it("reactivation guard: another connection's standing deactivation keeps the account disabled", async () => {
+    const created = await createUser(db, `shared@${DOMAIN}`, logger);
+    if (!created.success) throw new Error("seed failed");
+    const userId = created.data.user.id;
+    const otherConnectionId = await makeConnection(
+      "org_2",
+      "globex",
+      "usr_owner",
+      "globex.example.com",
+    );
+
+    expect((await deprovisionUser(db, logger, connectionId, userId)).success).toBe(true);
+    expect((await deprovisionUser(db, logger, otherConnectionId, userId)).success).toBe(true);
+    expect(disabledAtOf(userId)).not.toBeNull();
+
+    // First connection reactivates — the other's active=0 row still stands.
+    const partial = await reactivateUser(db, logger, connectionId, userId);
+    expect(partial.success).toBe(true);
+    if (partial.success) expect(partial.data.enabled).toBe(false);
+    expect(disabledAtOf(userId)).not.toBeNull();
+
+    // Once BOTH have reactivated, the account is restored.
+    const full = await reactivateUser(db, logger, otherConnectionId, userId);
+    expect(full.success).toBe(true);
+    if (full.success) expect(full.data.enabled).toBe(true);
+    expect(disabledAtOf(userId)).toBeNull();
+  });
+
+  it("reactivate is idempotent on an already-active user", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+    const result = await reactivateUser(db, logger, connectionId, alice.id);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.enabled).toBe(true);
+    expect(disabledAtOf(alice.id)).toBeNull();
+  });
+});

--- a/tests/scim.test.ts
+++ b/tests/scim.test.ts
@@ -224,11 +224,15 @@ describe("getSsoConnectionByScimTokenHash", () => {
     expect(result.success).toBe(false);
   });
 
-  it("a disabled connection's token gets a plain 401 from the middleware", async () => {
+  it("a disabled connection's token gets a SCIM-envelope 401 from the middleware", async () => {
     await setSsoConnectionEnabled(db, logger, connectionId, false);
     const res = await scimFetch("GET", "/scim/v2/Users");
     expect(res.status).toBe(401);
-    expect(((await res.json()) as { error: string }).error).toBe("Invalid token");
+    expect(res.headers.get("Content-Type")).toBe("application/scim+json");
+    const body = (await res.json()) as { schemas: string[]; status: string; detail: string };
+    expect(body.schemas).toEqual([ERROR_SCHEMA]);
+    expect(body.status).toBe("401");
+    expect(body.detail).toBe("Invalid token");
   });
 });
 
@@ -333,6 +337,7 @@ describe("POST /Users (provision + adopt)", () => {
     expect(body.emails).toEqual([{ value: `alice@${DOMAIN}`, primary: true }]);
     expect(body.meta.resourceType).toBe("User");
     expect(body.meta.location).toBe(`${BASE}/scim/v2/Users/${body.id}`);
+    expect(res.headers.get("Location")).toBe(body.meta.location);
 
     // Username derived exactly like SSO JIT / signup would.
     const user = raw.prepare("SELECT username, email FROM users WHERE id = ?").get(body.id) as {
@@ -376,7 +381,7 @@ describe("POST /Users (provision + adopt)", () => {
     expect(res.status).toBe(400);
   });
 
-  it("adopts an existing verified-domain account with 200, preserving its admin role", async () => {
+  it("adopts an existing verified-domain account with 201 + Location, preserving its admin role", async () => {
     const created = await createUser(db, `carol@${DOMAIN}`, logger);
     if (!created.success) throw new Error("seed failed");
     const carolId = created.data.user.id;
@@ -385,7 +390,8 @@ describe("POST /Users (provision + adopt)", () => {
     const res = await scimFetch("POST", "/scim/v2/Users", {
       body: { schemas: [USER_SCHEMA], userName: `carol@${DOMAIN}`, externalId: "idp-carol" },
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
+    expect(res.headers.get("Location")).toBe(`${BASE}/scim/v2/Users/${carolId}`);
     const body = (await res.json()) as ScimResource;
     expect(body.id).toBe(carolId);
     expect(body.externalId).toBe("idp-carol");
@@ -398,16 +404,65 @@ describe("POST /Users (provision + adopt)", () => {
     expect(scimRowOf(connectionId, carolId)?.active).toBe(1);
   });
 
-  it("a second POST for an already-managed user is 409 uniqueness", async () => {
-    await provision(`dana@${DOMAIN}`);
+  it("a plain duplicate POST converges idempotently (201, no duplicate rows)", async () => {
+    const first = await provision(`dana@${DOMAIN}`);
     const res = await scimFetch("POST", "/scim/v2/Users", {
       body: { schemas: [USER_SCHEMA], userName: `dana@${DOMAIN}` },
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as ScimResource;
+    expect(body.id).toBe(first.id);
+
+    const users = raw
+      .prepare("SELECT COUNT(*) AS n FROM users WHERE email = ?")
+      .get(`dana@${DOMAIN}`) as { n: number };
+    expect(users.n).toBe(1);
+    const members = raw
+      .prepare("SELECT COUNT(*) AS n FROM scim_members WHERE connection_id = ? AND user_id = ?")
+      .get(connectionId, first.id) as { n: number };
+    expect(members.n).toBe(1);
+  });
+
+  it("a retried POST after a partial provision finishes the job (deactivation applied)", async () => {
+    // Partial state: the first POST created the user and the scim_members row
+    // (active=1, no externalId) but died before applying active:false. The IdP
+    // retries the same POST; a 409 would end its retries and strand the
+    // account enabled.
+    const alice = await provision(`alice@${DOMAIN}`);
+    expect(disabledAtOf(alice.id)).toBeNull();
+
+    const res = await scimFetch("POST", "/scim/v2/Users", {
+      body: { schemas: [USER_SCHEMA], userName: `alice@${DOMAIN}`, active: false },
+    });
+    expect(res.status).toBe(201);
+    expect(((await res.json()) as ScimResource).active).toBe(false);
+    expect(disabledAtOf(alice.id)).not.toBeNull();
+    expect(scimRowOf(connectionId, alice.id)?.active).toBe(0);
+  });
+
+  it("a retried POST with active:true reactivates a deactivated account (both directions)", async () => {
+    const alice = await provision(`alice@${DOMAIN}`, { active: false });
+    expect(disabledAtOf(alice.id)).not.toBeNull();
+
+    const res = await scimFetch("POST", "/scim/v2/Users", {
+      body: { schemas: [USER_SCHEMA], userName: `alice@${DOMAIN}`, active: true },
+    });
+    expect(res.status).toBe(201);
+    expect(((await res.json()) as ScimResource).active).toBe(true);
+    expect(disabledAtOf(alice.id)).toBeNull();
+    expect(scimRowOf(connectionId, alice.id)?.active).toBe(1);
+  });
+
+  it("a POST whose externalId mismatches the stored one is a genuine 409 uniqueness", async () => {
+    await provision(`dana@${DOMAIN}`, { externalId: "idp-dana" });
+    const res = await scimFetch("POST", "/scim/v2/Users", {
+      body: { schemas: [USER_SCHEMA], userName: `dana@${DOMAIN}`, externalId: "idp-other" },
     });
     expect(res.status).toBe(409);
     expect(((await res.json()) as { scimType: string }).scimType).toBe("uniqueness");
   });
 
-  it("heals the concurrent-email race: a lost createUser insert falls into the adopt path (200)", async () => {
+  it("heals the concurrent-email race: a lost createUser insert falls into the adopt path (201)", async () => {
     const actualUsers =
       await vi.importActual<typeof import("../src/storage/users")>("../src/storage/users");
     // Simulate a concurrent OIDC JIT login (or duplicate POST) winning the
@@ -424,7 +479,7 @@ describe("POST /Users (provision + adopt)", () => {
     const res = await scimFetch("POST", "/scim/v2/Users", {
       body: { schemas: [USER_SCHEMA], userName: `raced@${DOMAIN}` },
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = (await res.json()) as ScimResource;
     expect(body.userName).toBe(`raced@${DOMAIN}`);
     expect(scimRowOf(connectionId, body.id)?.active).toBe(1);
@@ -574,6 +629,21 @@ describe("PUT /Users/:id", () => {
     // user cannot silently fall out of the connection's scope.
     expect(scimRowOf(connectionId, userId)).toEqual({ scim_external_id: null, active: 1 });
   });
+
+  it("an invalid PUT (userName change) does NOT adopt the user", async () => {
+    const created = await createUser(db, `visible@${DOMAIN}`, logger);
+    if (!created.success) throw new Error("seed failed");
+    const userId = created.data.user.id;
+    await addOrgMember(db, logger, "org_1", userId, "member");
+
+    const res = await scimFetch("PUT", `/scim/v2/Users/${userId}`, {
+      body: { schemas: [USER_SCHEMA], userName: `renamed@${DOMAIN}`, active: true },
+    });
+    expect(res.status).toBe(400);
+    // A 400 must not adopt: the IdP was told the write failed, so no
+    // scim_members row may record it as managing this user.
+    expect(scimRowOf(connectionId, userId)).toBeUndefined();
+  });
 });
 
 describe("PATCH /Users/:id", () => {
@@ -614,13 +684,25 @@ describe("PATCH /Users/:id", () => {
     expect(((await res.json()) as ScimResource).externalId).toBe("after");
   });
 
-  it("ignores unknown-attribute replaces (Okta/Entra profile sync) instead of erroring", async () => {
+  it("accepts an add op on a stored path (Entra sends Add on link)", async () => {
+    const alice = await provision(`alice@${DOMAIN}`);
+    const res = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
+      body: { Operations: [{ op: "Add", path: "externalId", value: "linked" }] },
+    });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as ScimResource).externalId).toBe("linked");
+  });
+
+  it("ignores unknown-attribute ops (Okta/Entra profile sync) instead of erroring", async () => {
     const alice = await provision(`alice@${DOMAIN}`);
     const res = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
       body: {
         Operations: [
           { op: "replace", path: "displayName", value: "Alice E." },
           { op: "replace", value: { "name.givenName": "Alice" } },
+          // An add (or any op) on an unknown path is ignored too — the path
+          // resolves first, so the op type never matters for unstored paths.
+          { op: "add", path: "nickName", value: "Al" },
         ],
       },
     });
@@ -628,19 +710,33 @@ describe("PATCH /Users/:id", () => {
     expect(((await res.json()) as ScimResource).active).toBe(true);
   });
 
-  it("rejects non-replace ops with 400 and malformed active values with invalidValue", async () => {
+  it("rejects remove ops on stored paths with 400 and malformed active values with invalidValue", async () => {
     const alice = await provision(`alice@${DOMAIN}`);
-    const add = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
+    const removed = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
       body: { Operations: [{ op: "remove", path: "active" }] },
     });
-    expect(add.status).toBe(400);
-    expect(((await add.json()) as { scimType: string }).scimType).toBe("invalidPath");
+    expect(removed.status).toBe(400);
+    expect(((await removed.json()) as { scimType: string }).scimType).toBe("invalidPath");
 
     const bad = await scimFetch("PATCH", `/scim/v2/Users/${alice.id}`, {
       body: { Operations: [{ op: "replace", path: "active", value: "maybe" }] },
     });
     expect(bad.status).toBe(400);
     expect(((await bad.json()) as { scimType: string }).scimType).toBe("invalidValue");
+  });
+
+  it("an invalid PATCH (non-array Operations) does NOT adopt the user", async () => {
+    const created = await createUser(db, `patchable@${DOMAIN}`, logger);
+    if (!created.success) throw new Error("seed failed");
+    const userId = created.data.user.id;
+    await addOrgMember(db, logger, "org_1", userId, "member");
+
+    const res = await scimFetch("PATCH", `/scim/v2/Users/${userId}`, {
+      body: { Operations: { op: "replace", path: "active", value: false } },
+    });
+    expect(res.status).toBe(400);
+    // A 400 must not adopt — see the PUT counterpart.
+    expect(scimRowOf(connectionId, userId)).toBeUndefined();
   });
 
   it("404s for a user outside the connection's scope", async () => {
@@ -795,7 +891,7 @@ describe("Goal-8 E2E: deactivate kills every credential; reactivate restores", (
     const adopted = await scimFetch("POST", "/scim/v2/Users", {
       body: { schemas: [USER_SCHEMA], userName: `dave@${DOMAIN}` },
     });
-    expect(adopted.status).toBe(200);
+    expect(adopted.status).toBe(201);
 
     const whoami = (headers: Record<string, string>) =>
       app.fetch(new Request(`${BASE}/api/whoami`, { headers }), env);

--- a/tests/sso-login.test.ts
+++ b/tests/sso-login.test.ts
@@ -670,6 +670,13 @@ describe("OIDC SSO login", () => {
       setIdToken(await signIdToken({ nonce: first.nonce, emailVerified: true }));
       const okRes = await app.fetch(callbackRequest(first.state, first.cookie), env);
       expect(okRes.headers.get("Location")).toBe("/");
+
+      // Absent claim: the org controls both the DNS-verified domain and the
+      // IdP, so a missing email_verified is treated as verified.
+      const second = await startLogin();
+      setIdToken(await signIdToken({ nonce: second.nonce }));
+      const absentRes = await app.fetch(callbackRequest(second.state, second.cookie), env);
+      expect(absentRes.headers.get("Location")).toBe("/");
     });
 
     it("rejects an out-of-domain guest with domain_not_allowed", async () => {

--- a/tests/sso-login.test.ts
+++ b/tests/sso-login.test.ts
@@ -1,0 +1,881 @@
+/**
+ * OIDC SSO login flow (#253 Task 5): real routers against a real SQLite D1
+ * (every migration applied) and REAL crypto — the stubbed IdP serves a genuine
+ * ES256 JWKS and signs genuine id_tokens, so jose's verification runs for
+ * real. Only `globalThis.fetch` (token endpoint + JWKS) is mocked.
+ */
+import { Hono } from "hono";
+import { SignJWT, exportJWK, generateKeyPair } from "jose";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ssoRouter } from "../src/routes/sso";
+import { upsertIdentity } from "../src/storage/identities";
+import {
+  consumeOidcLoginState,
+  createOidcLoginState,
+  purgeExpiredOidcStates,
+  setSsoConnectionEnabled,
+  setSsoDomainsVerified,
+  upsertSsoConnection,
+} from "../src/storage/sso";
+import { createUser, disableUser } from "../src/storage/users";
+import type { Env } from "../src/types";
+import { SSO_SECRET_SALT, encryptToken } from "../src/utils/crypto";
+import type { Logger } from "../src/utils/logger";
+import { makeFakeKV } from "./helpers/fake-kv";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+} as unknown as Logger;
+
+const ISSUER = "https://idp.example.com";
+const CLIENT_ID = "stratum-client";
+const CLIENT_SECRET = "idp-client-secret";
+const TOKEN_ENDPOINT = "https://idp.example.com/oauth2/token";
+const JWKS_URI = "https://idp.example.com/oauth2/jwks";
+const AUTHZ_ENDPOINT = "https://idp.example.com/oauth2/authorize";
+const SSO_SECRET = "test-sso-encryption-secret";
+const ORG_SLUG = "acme";
+const EMAIL_DOMAIN = "corp.example.com";
+const BASE = "https://stratum.test";
+
+type Raw = ReturnType<typeof makeSqliteD1>["raw"];
+
+// One real ES256 key pair for the whole suite (key generation is slow-ish).
+const keys = await generateKeyPair("ES256");
+const publicJwk = { ...(await exportJWK(keys.publicKey)), kid: "test-key", alg: "ES256" };
+
+interface IdTokenOptions {
+  nonce: string;
+  sub?: string;
+  email?: string | null;
+  emailVerified?: boolean | string;
+  issuer?: string;
+  audience?: string | string[];
+  azp?: string;
+}
+
+async function signIdToken(opts: IdTokenOptions): Promise<string> {
+  const claims: Record<string, unknown> = { nonce: opts.nonce };
+  const email = opts.email === undefined ? `alice@${EMAIL_DOMAIN}` : opts.email;
+  if (email !== null) claims.email = email;
+  if (opts.emailVerified !== undefined) claims.email_verified = opts.emailVerified;
+  if (opts.azp !== undefined) claims.azp = opts.azp;
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: "ES256", kid: "test-key" })
+    .setIssuer(opts.issuer ?? ISSUER)
+    .setAudience(opts.audience ?? CLIENT_ID)
+    .setSubject(opts.sub ?? "idp-subject-1")
+    .setIssuedAt()
+    .setExpirationTime("5m")
+    .sign(keys.privateKey);
+}
+
+/** An HS256 token "signed" with the shared client secret — must be refused. */
+async function signHs256IdToken(nonce: string): Promise<string> {
+  return new SignJWT({ nonce, email: `alice@${EMAIL_DOMAIN}` })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer(ISSUER)
+    .setAudience(CLIENT_ID)
+    .setSubject("idp-subject-1")
+    .setIssuedAt()
+    .setExpirationTime("5m")
+    .sign(new TextEncoder().encode(CLIENT_SECRET));
+}
+
+describe("OIDC SSO login", () => {
+  let db: D1Database;
+  let raw: Raw;
+  let env: Env;
+  let app: Hono<{ Bindings: Env }>;
+  let connectionId: string;
+  let orgId: string;
+  /** What the stubbed token endpoint returns; tests set the id_token per flow. */
+  let tokenResponse: () => Response;
+  let tokenRequests: URLSearchParams[];
+
+  function setIdToken(idToken: string): void {
+    tokenResponse = () =>
+      new Response(JSON.stringify({ id_token: idToken, token_type: "Bearer" }), {
+        headers: { "content-type": "application/json" },
+      });
+  }
+
+  beforeEach(async () => {
+    ({ db, raw } = makeSqliteD1());
+    env = {
+      DB: db,
+      STATE: makeFakeKV(),
+      SSO_ENCRYPTION_SECRET: SSO_SECRET,
+    } as unknown as Env;
+    app = new Hono<{ Bindings: Env }>();
+    app.route("/auth/sso", ssoRouter);
+
+    // Seed owner, org, and a verified+enabled connection.
+    raw
+      .prepare("INSERT INTO users (id, email, username, token_hash) VALUES (?, ?, ?, ?)")
+      .run("usr_owner", "owner@example.com", "owner-user", "hash_owner");
+    orgId = "org_acme";
+    raw
+      .prepare("INSERT INTO orgs (id, name, slug, owner_id, created_at) VALUES (?, ?, ?, ?, ?)")
+      .run(orgId, "Acme", ORG_SLUG, "usr_owner", new Date().toISOString());
+
+    const ciphertext = await encryptToken(CLIENT_SECRET, SSO_SECRET, SSO_SECRET_SALT);
+    const upserted = await upsertSsoConnection(db, logger, {
+      orgId,
+      issuer: ISSUER,
+      clientId: CLIENT_ID,
+      clientSecretCiphertext: ciphertext,
+      authorizationEndpoint: AUTHZ_ENDPOINT,
+      tokenEndpoint: TOKEN_ENDPOINT,
+      jwksUri: JWKS_URI,
+      emailDomains: [EMAIL_DOMAIN],
+    });
+    if (!upserted.success) throw new Error("seed connection failed");
+    connectionId = upserted.data.connection.id;
+    const verified = await setSsoDomainsVerified(db, logger, connectionId, [EMAIL_DOMAIN]);
+    if (!verified.success) throw new Error("seed verify failed");
+    const enabled = await setSsoConnectionEnabled(db, logger, connectionId, true);
+    if (!enabled.success) throw new Error("seed enable failed");
+
+    tokenRequests = [];
+    tokenResponse = () => new Response("not configured by test", { status: 500 });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.startsWith(JWKS_URI)) {
+          return new Response(JSON.stringify({ keys: [publicJwk] }), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url.startsWith(TOKEN_ENDPOINT)) {
+          tokenRequests.push(new URLSearchParams(String(init?.body)));
+          return tokenResponse();
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  async function startLogin(
+    slug = ORG_SLUG,
+    query = "",
+  ): Promise<{ state: string; nonce: string; cookie: string; location: URL }> {
+    const res = await app.fetch(new Request(`${BASE}/auth/sso/${slug}/start${query}`), env);
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get("Location") ?? "");
+    const setCookie = res.headers.get("Set-Cookie") ?? "";
+    const cookie = /stratum_sso_state=([^;]+)/.exec(setCookie)?.[1] ?? "";
+    return {
+      state: location.searchParams.get("state") ?? "",
+      nonce: location.searchParams.get("nonce") ?? "",
+      cookie,
+      location,
+    };
+  }
+
+  function callbackRequest(state: string, cookie?: string, code = "authcode-1"): Request {
+    const headers: Record<string, string> = {};
+    if (cookie !== undefined) headers.Cookie = `stratum_sso_state=${cookie}`;
+    return new Request(`${BASE}/auth/sso/callback?code=${code}&state=${state}`, { headers });
+  }
+
+  function userRow(email: string): { id: string; username: string } | undefined {
+    return raw.prepare("SELECT id, username FROM users WHERE email = ?").get(email) as
+      | { id: string; username: string }
+      | undefined;
+  }
+
+  // ==========================================================================
+  // 501 unconfigured
+  // ==========================================================================
+
+  it("returns 501 on every /auth/sso endpoint when SSO_ENCRYPTION_SECRET is unset", async () => {
+    const bare = { ...env, SSO_ENCRYPTION_SECRET: undefined } as unknown as Env;
+    for (const path of ["/auth/sso", `/auth/sso/${ORG_SLUG}/start`, "/auth/sso/callback"]) {
+      const res = await app.fetch(new Request(`${BASE}${path}`), bare);
+      expect(res.status).toBe(501);
+    }
+  });
+
+  // ==========================================================================
+  // Picker page
+  // ==========================================================================
+
+  describe("picker page", () => {
+    it("renders the form", async () => {
+      const res = await app.fetch(new Request(`${BASE}/auth/sso`), env);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("Single sign-on");
+      expect(html).toContain('name="identifier"');
+    });
+
+    it("resolves an org slug to its start route", async () => {
+      const res = await app.fetch(new Request(`${BASE}/auth/sso?identifier=${ORG_SLUG}`), env);
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe(`/auth/sso/${ORG_SLUG}/start`);
+    });
+
+    it("resolves a work email by verified domain and carries a valid redirect_to", async () => {
+      const res = await app.fetch(
+        new Request(
+          `${BASE}/auth/sso?identifier=someone%40${EMAIL_DOMAIN}&redirect_to=%2Fprojects%2Ffoo`,
+        ),
+        env,
+      );
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe(
+        `/auth/sso/${ORG_SLUG}/start?redirect_to=%2Fprojects%2Ffoo`,
+      );
+    });
+
+    it("shows the generic not-found message for an unknown identifier", async () => {
+      const res = await app.fetch(
+        new Request(`${BASE}/auth/sso?identifier=nobody%40unknown.example`),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.text()).toContain(
+        "No SSO configuration found for that organization or email domain.",
+      );
+    });
+
+    it("does not resolve a disabled connection by slug", async () => {
+      await setSsoConnectionEnabled(db, logger, connectionId, false);
+      const res = await app.fetch(new Request(`${BASE}/auth/sso?identifier=${ORG_SLUG}`), env);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toContain("No SSO configuration found");
+    });
+
+    it("renders callback error codes from the query string", async () => {
+      const res = await app.fetch(new Request(`${BASE}/auth/sso?error=domain_not_allowed`), env);
+      expect(await res.text()).toContain("Guest accounts cannot sign in here");
+    });
+  });
+
+  // ==========================================================================
+  // Start
+  // ==========================================================================
+
+  describe("start", () => {
+    it("redirects to the IdP with code+PKCE parameters and sets the binding cookie", async () => {
+      const { state, nonce, cookie, location } = await startLogin();
+      expect(location.origin + location.pathname).toBe(AUTHZ_ENDPOINT);
+      expect(location.searchParams.get("response_type")).toBe("code");
+      expect(location.searchParams.get("client_id")).toBe(CLIENT_ID);
+      expect(location.searchParams.get("redirect_uri")).toBe(`${BASE}/auth/sso/callback`);
+      expect(location.searchParams.get("scope")).toBe("openid email profile");
+      expect(location.searchParams.get("code_challenge_method")).toBe("S256");
+      expect(location.searchParams.get("code_challenge")).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      expect(state).toMatch(/^[0-9a-f]{64}$/);
+      expect(nonce).toMatch(/^[0-9a-f]{64}$/);
+      expect(cookie).toBe(state);
+
+      const row = raw
+        .prepare("SELECT * FROM oidc_login_states WHERE state = ?")
+        .get(state) as Record<string, unknown>;
+      expect(row.connection_id).toBe(connectionId);
+      expect(row.consumed_at).toBeNull();
+    });
+
+    it("renders a generic 404 page for an unknown slug", async () => {
+      const res = await app.fetch(new Request(`${BASE}/auth/sso/nope/start`), env);
+      expect(res.status).toBe(404);
+      expect(await res.text()).toContain("No SSO configuration found");
+    });
+
+    it("refuses a disabled connection", async () => {
+      await setSsoConnectionEnabled(db, logger, connectionId, false);
+      const res = await app.fetch(new Request(`${BASE}/auth/sso/${ORG_SLUG}/start`), env);
+      expect(res.status).toBe(404);
+    });
+
+    it("stores a valid redirect_to and drops external / scheme-relative ones", async () => {
+      const good = await startLogin(ORG_SLUG, "?redirect_to=%2Fprojects%2Ffoo");
+      const goodRow = raw
+        .prepare("SELECT redirect_to FROM oidc_login_states WHERE state = ?")
+        .get(good.state) as { redirect_to: string | null };
+      expect(goodRow.redirect_to).toBe("/projects/foo");
+
+      // The %09 cases hide an ASCII tab at index 1: browsers strip tab/newline
+      // from a Location per the WHATWG URL spec, turning "/\t/evil.com" into
+      // the scheme-relative "//evil.com".
+      for (const bad of [
+        "https%3A%2F%2Fevil.example",
+        "%2F%2Fevil.example",
+        "%2F%5Cevil",
+        "%2F%09%2Fevil.com",
+        "%2F%09%5Cevil.com",
+      ]) {
+        const started = await startLogin(ORG_SLUG, `?redirect_to=${bad}`);
+        const badRow = raw
+          .prepare("SELECT redirect_to FROM oidc_login_states WHERE state = ?")
+          .get(started.state) as { redirect_to: string | null };
+        expect(badRow.redirect_to).toBeNull();
+      }
+    });
+
+    it("blocks the 31st start from one IP within the hour", async () => {
+      for (let i = 0; i < 30; i++) {
+        const res = await app.fetch(new Request(`${BASE}/auth/sso/${ORG_SLUG}/start`), env);
+        expect(res.status).toBe(302);
+      }
+      const blocked = await app.fetch(new Request(`${BASE}/auth/sso/${ORG_SLUG}/start`), env);
+      expect(blocked.status).toBe(429);
+      expect(await blocked.text()).toContain("Too many sign-in attempts");
+    });
+  });
+
+  // ==========================================================================
+  // Callback: state binding + replay
+  // ==========================================================================
+
+  describe("callback state validation", () => {
+    it("redirects IdP error params to the generic idp_error code without reflecting them", async () => {
+      const res = await app.fetch(
+        new Request(
+          `${BASE}/auth/sso/callback?error=access_denied&error_description=%3Cscript%3Ex%3C%2Fscript%3E`,
+        ),
+        env,
+      );
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=idp_error");
+    });
+
+    it("rejects a callback with no binding cookie and leaves the state unconsumed", async () => {
+      const { state } = await startLogin();
+      const res = await app.fetch(callbackRequest(state), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=invalid_state");
+      const row = raw
+        .prepare("SELECT consumed_at FROM oidc_login_states WHERE state = ?")
+        .get(state) as { consumed_at: string | null };
+      expect(row.consumed_at).toBeNull();
+    });
+
+    it("rejects a callback whose cookie does not match the state", async () => {
+      const { state } = await startLogin();
+      const other = await startLogin();
+      const res = await app.fetch(callbackRequest(state, other.cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=invalid_state");
+    });
+
+    it("rejects a missing state parameter", async () => {
+      const res = await app.fetch(new Request(`${BASE}/auth/sso/callback?code=x`), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=invalid_state");
+    });
+
+    it("rejects an expired state", async () => {
+      const { state, cookie } = await startLogin();
+      raw
+        .prepare("UPDATE oidc_login_states SET expires_at = ? WHERE state = ?")
+        .run(Math.floor(Date.now() / 1000) - 10, state);
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=invalid_state");
+    });
+
+    it("drops a control-character redirect_to end-to-end and lands on /", async () => {
+      const { state, nonce, cookie } = await startLogin(ORG_SLUG, "?redirect_to=%2F%09%2Fevil.com");
+      setIdToken(await signIdToken({ nonce }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/");
+    });
+
+    it("re-validates the stored redirect_to at callback time (DB value is not trusted)", async () => {
+      const { state, nonce, cookie } = await startLogin();
+      raw
+        .prepare("UPDATE oidc_login_states SET redirect_to = ? WHERE state = ?")
+        .run("/\t/evil.com", state);
+      setIdToken(await signIdToken({ nonce }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/");
+    });
+
+    it("rejects a replayed state (second callback with the same state)", async () => {
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce }));
+      const first = await app.fetch(callbackRequest(state, cookie), env);
+      expect(first.headers.get("Location")).toBe("/");
+      const replay = await app.fetch(callbackRequest(state, cookie), env);
+      expect(replay.headers.get("Location")).toBe("/auth/sso?error=invalid_state");
+    });
+  });
+
+  // ==========================================================================
+  // Callback: token + id_token verification
+  // ==========================================================================
+
+  describe("id_token verification", () => {
+    it("completes the happy path: JIT user, membership, scim row, identity, session, audit", async () => {
+      const { state, nonce, cookie } = await startLogin(ORG_SLUG, "?redirect_to=%2Fprojects%2Ffoo");
+      setIdToken(await signIdToken({ nonce, email: `Alice@${EMAIL_DOMAIN}` }));
+
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/projects/foo");
+      expect(res.headers.get("Set-Cookie")).toContain("stratum_session=");
+
+      // Token exchange used client_secret_post + PKCE against the stub.
+      const tokenReq = tokenRequests[0];
+      expect(tokenReq?.get("grant_type")).toBe("authorization_code");
+      expect(tokenReq?.get("client_id")).toBe(CLIENT_ID);
+      expect(tokenReq?.get("client_secret")).toBe(CLIENT_SECRET);
+      expect(tokenReq?.get("code")).toBe("authcode-1");
+      expect(tokenReq?.get("redirect_uri")).toBe(`${BASE}/auth/sso/callback`);
+      expect(tokenReq?.get("code_verifier")).toMatch(/^[A-Za-z0-9_-]{43}$/);
+
+      // Email normalized to lowercase; username derived from the local part.
+      const user = userRow(`alice@${EMAIL_DOMAIN}`);
+      expect(user).toBeDefined();
+      expect(user?.username).toBe("alice");
+
+      const member = raw
+        .prepare("SELECT role FROM org_members WHERE org_id = ? AND user_id = ?")
+        .get(orgId, user?.id) as { role: string } | undefined;
+      expect(member?.role).toBe("member");
+
+      const scim = raw
+        .prepare("SELECT active FROM scim_members WHERE connection_id = ? AND user_id = ?")
+        .get(connectionId, user?.id) as { active: number } | undefined;
+      expect(scim?.active).toBe(1);
+
+      const identity = raw
+        .prepare(
+          "SELECT user_id, provider, connection_id FROM identities WHERE issuer = ? AND subject = ?",
+        )
+        .get(ISSUER, "idp-subject-1") as Record<string, unknown> | undefined;
+      expect(identity?.user_id).toBe(user?.id);
+      expect(identity?.provider).toBe("oidc");
+      expect(identity?.connection_id).toBe(connectionId);
+
+      const audit = raw
+        .prepare("SELECT detail FROM audit_log WHERE action = 'session.created' AND actor_id = ?")
+        .get(user?.id) as { detail: string } | undefined;
+      expect(audit).toBeDefined();
+      const detail = JSON.parse(audit?.detail ?? "{}") as Record<string, unknown>;
+      expect(detail.method).toBe("oidc");
+      expect(detail.orgId).toBe(orgId);
+    });
+
+    it("signs a returning user in via the (issuer, sub) identity without re-writing membership", async () => {
+      const first = await startLogin();
+      setIdToken(await signIdToken({ nonce: first.nonce }));
+      await app.fetch(callbackRequest(first.state, first.cookie), env);
+      const user = userRow(`alice@${EMAIL_DOMAIN}`);
+      raw.prepare("DELETE FROM org_members WHERE org_id = ? AND user_id = ?").run(orgId, user?.id);
+
+      const second = await startLogin();
+      setIdToken(await signIdToken({ nonce: second.nonce }));
+      const res = await app.fetch(callbackRequest(second.state, second.cookie), env);
+      expect(res.headers.get("Location")).toBe("/");
+      expect(res.headers.get("Set-Cookie")).toContain("stratum_session=");
+      // Sub-match signs in only — the removed membership is NOT re-created.
+      const member = raw
+        .prepare("SELECT role FROM org_members WHERE org_id = ? AND user_id = ?")
+        .get(orgId, user?.id);
+      expect(member).toBeUndefined();
+    });
+
+    it("adopts an existing account by email: links identity + scim_members + membership", async () => {
+      const created = await createUser(db, `bob@${EMAIL_DOMAIN}`, logger, "bob");
+      if (!created.success) throw new Error("seed user failed");
+
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce, sub: "bob-sub", email: `bob@${EMAIL_DOMAIN}` }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/");
+
+      const identity = raw
+        .prepare("SELECT user_id FROM identities WHERE issuer = ? AND subject = ?")
+        .get(ISSUER, "bob-sub") as { user_id: string } | undefined;
+      expect(identity?.user_id).toBe(created.data.user.id);
+      const scim = raw
+        .prepare("SELECT active FROM scim_members WHERE connection_id = ? AND user_id = ?")
+        .get(connectionId, created.data.user.id) as { active: number } | undefined;
+      expect(scim?.active).toBe(1);
+      const member = raw
+        .prepare("SELECT role FROM org_members WHERE org_id = ? AND user_id = ?")
+        .get(orgId, created.data.user.id) as { role: string } | undefined;
+      expect(member?.role).toBe("member");
+    });
+
+    it("adopting an existing org admin keeps their role (no demotion to member)", async () => {
+      const created = await createUser(db, `frank@${EMAIL_DOMAIN}`, logger, "frank");
+      if (!created.success) throw new Error("seed user failed");
+      raw
+        .prepare(
+          "INSERT INTO org_members (org_id, user_id, role, joined_at) VALUES (?, ?, 'admin', ?)",
+        )
+        .run(orgId, created.data.user.id, new Date().toISOString());
+
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce, sub: "frank-sub", email: `frank@${EMAIL_DOMAIN}` }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/");
+
+      const member = raw
+        .prepare("SELECT role FROM org_members WHERE org_id = ? AND user_id = ?")
+        .get(orgId, created.data.user.id) as { role: string } | undefined;
+      expect(member?.role).toBe("admin");
+    });
+
+    it("grants the second org's membership on a cross-connection (issuer, sub) match", async () => {
+      // Org B: the same IdP issuer serving a second org with its own verified domain.
+      const betaDomain = "beta.example.com";
+      raw
+        .prepare("INSERT INTO orgs (id, name, slug, owner_id, created_at) VALUES (?, ?, ?, ?, ?)")
+        .run("org_beta", "Beta", "beta", "usr_owner", new Date().toISOString());
+      const ciphertext = await encryptToken(CLIENT_SECRET, SSO_SECRET, SSO_SECRET_SALT);
+      const upserted = await upsertSsoConnection(db, logger, {
+        orgId: "org_beta",
+        issuer: ISSUER,
+        clientId: CLIENT_ID,
+        clientSecretCiphertext: ciphertext,
+        authorizationEndpoint: AUTHZ_ENDPOINT,
+        tokenEndpoint: TOKEN_ENDPOINT,
+        jwksUri: JWKS_URI,
+        emailDomains: [betaDomain],
+      });
+      if (!upserted.success) throw new Error("seed beta connection failed");
+      const betaConnectionId = upserted.data.connection.id;
+      await setSsoDomainsVerified(db, logger, betaConnectionId, [betaDomain]);
+      await setSsoConnectionEnabled(db, logger, betaConnectionId, true);
+
+      // The identity was established through org A's connection.
+      const created = await createUser(db, `gina@${betaDomain}`, logger, "gina");
+      if (!created.success) throw new Error("seed user failed");
+      await upsertIdentity(db, logger, {
+        userId: created.data.user.id,
+        provider: "oidc",
+        issuer: ISSUER,
+        subject: "gina-sub",
+        email: `gina@${betaDomain}`,
+        connectionId,
+      });
+
+      const { state, nonce, cookie } = await startLogin("beta");
+      setIdToken(await signIdToken({ nonce, sub: "gina-sub", email: `gina@${betaDomain}` }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/");
+      expect(res.headers.get("Set-Cookie")).toContain("stratum_session=");
+
+      const member = raw
+        .prepare("SELECT role FROM org_members WHERE org_id = ? AND user_id = ?")
+        .get("org_beta", created.data.user.id) as { role: string } | undefined;
+      expect(member?.role).toBe("member");
+      const scim = raw
+        .prepare("SELECT active FROM scim_members WHERE connection_id = ? AND user_id = ?")
+        .get(betaConnectionId, created.data.user.id) as { active: number } | undefined;
+      expect(scim?.active).toBe(1);
+      // The identity row still points at the connection that established it.
+      const identity = raw
+        .prepare("SELECT connection_id FROM identities WHERE issuer = ? AND subject = ?")
+        .get(ISSUER, "gina-sub") as { connection_id: string } | undefined;
+      expect(identity?.connection_id).toBe(connectionId);
+    });
+
+    it("rejects a nonce mismatch", async () => {
+      const { state, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce: "f".repeat(64) }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=invalid_state");
+    });
+
+    it("rejects an HS256 id_token (asymmetric algs only)", async () => {
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signHs256IdToken(nonce));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=sso_failed");
+    });
+
+    it("rejects a wrong issuer", async () => {
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce, issuer: "https://evil.example" }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=sso_failed");
+    });
+
+    it("rejects a wrong audience", async () => {
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce, audience: "some-other-client" }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=sso_failed");
+    });
+
+    it("rejects a multi-audience token whose azp is not our client_id", async () => {
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(
+        await signIdToken({ nonce, audience: [CLIENT_ID, "other-client"], azp: "other-client" }),
+      );
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=sso_failed");
+    });
+
+    it("accepts a multi-audience token whose azp is our client_id", async () => {
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(
+        await signIdToken({ nonce, audience: [CLIENT_ID, "other-client"], azp: CLIENT_ID }),
+      );
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/");
+    });
+
+    it("rejects a token whose exchange fails", async () => {
+      const { state, cookie } = await startLogin();
+      tokenResponse = () => new Response("{}", { status: 400 });
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=sso_failed");
+    });
+  });
+
+  // ==========================================================================
+  // Callback: email claim rules
+  // ==========================================================================
+
+  describe("email claim rules", () => {
+    it("rejects a missing email claim", async () => {
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce, email: null }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=no_email");
+    });
+
+    it("rejects email_verified boolean false", async () => {
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce, emailVerified: false }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=unverified_email");
+    });
+
+    it('rejects email_verified string "false" (Entra string booleans)', async () => {
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce, emailVerified: "false" }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=unverified_email");
+    });
+
+    it("accepts email_verified true and absent alike", async () => {
+      const first = await startLogin();
+      setIdToken(await signIdToken({ nonce: first.nonce, emailVerified: true }));
+      const okRes = await app.fetch(callbackRequest(first.state, first.cookie), env);
+      expect(okRes.headers.get("Location")).toBe("/");
+    });
+
+    it("rejects an out-of-domain guest with domain_not_allowed", async () => {
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce, email: "guest@partner.example" }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=domain_not_allowed");
+      // No account was provisioned for the guest.
+      expect(userRow("guest@partner.example")).toBeUndefined();
+    });
+  });
+
+  // ==========================================================================
+  // Callback: disabled accounts + connection lifecycle
+  // ==========================================================================
+
+  describe("disabled accounts and connection lifecycle", () => {
+    it("refuses a disabled user on the (issuer, sub) branch", async () => {
+      const created = await createUser(db, `carol@${EMAIL_DOMAIN}`, logger, "carol");
+      if (!created.success) throw new Error("seed user failed");
+      await upsertIdentity(db, logger, {
+        userId: created.data.user.id,
+        provider: "oidc",
+        issuer: ISSUER,
+        subject: "carol-sub",
+        email: `carol@${EMAIL_DOMAIN}`,
+        connectionId,
+      });
+      await disableUser(db, created.data.user.id, logger);
+
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce, sub: "carol-sub", email: `carol@${EMAIL_DOMAIN}` }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=account_disabled");
+      expect(res.headers.get("Set-Cookie") ?? "").not.toContain("stratum_session=");
+    });
+
+    it("refuses a disabled user on the email-adopt branch (no membership written)", async () => {
+      const created = await createUser(db, `dave@${EMAIL_DOMAIN}`, logger, "dave");
+      if (!created.success) throw new Error("seed user failed");
+      await disableUser(db, created.data.user.id, logger);
+
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce, sub: "dave-sub", email: `dave@${EMAIL_DOMAIN}` }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=account_disabled");
+      const scim = raw
+        .prepare("SELECT * FROM scim_members WHERE user_id = ?")
+        .get(created.data.user.id);
+      expect(scim).toBeUndefined();
+    });
+
+    it("refuses when the connection was disabled between start and callback", async () => {
+      const { state, nonce, cookie } = await startLogin();
+      await setSsoConnectionEnabled(db, logger, connectionId, false);
+      setIdToken(await signIdToken({ nonce }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/auth/sso?error=sso_failed");
+    });
+  });
+
+  // ==========================================================================
+  // JIT username collisions
+  // ==========================================================================
+
+  describe("JIT username derivation", () => {
+    it("dedupes a taken username with a numeric suffix", async () => {
+      const taken = await createUser(db, "eve@elsewhere.example", logger, "eve");
+      if (!taken.success) throw new Error("seed user failed");
+
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce, sub: "eve-sub", email: `eve@${EMAIL_DOMAIN}` }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/");
+      expect(userRow(`eve@${EMAIL_DOMAIN}`)?.username).toBe("eve-2");
+    });
+
+    it("does not claim an existing org slug as a JIT username", async () => {
+      // The org slug "acme" already exists — the derived base must skip to -2.
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce, sub: "acme-sub", email: `acme@${EMAIL_DOMAIN}` }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/");
+      expect(userRow(`acme@${EMAIL_DOMAIN}`)?.username).toBe("acme-2");
+    });
+
+    it("truncates a long local part to the 39-char cap instead of the random fallback", async () => {
+      const local = "a".repeat(50);
+      const { state, nonce, cookie } = await startLogin();
+      setIdToken(await signIdToken({ nonce, sub: "long-sub", email: `${local}@${EMAIL_DOMAIN}` }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/");
+      expect(userRow(`${local}@${EMAIL_DOMAIN}`)?.username).toBe("a".repeat(39));
+    });
+
+    it("falls back to a generated username when the local part cannot produce one", async () => {
+      const { state, nonce, cookie } = await startLogin();
+      // "123" sanitizes to nothing valid (numbers-only local part).
+      setIdToken(await signIdToken({ nonce, sub: "num-sub", email: `123@${EMAIL_DOMAIN}` }));
+      const res = await app.fetch(callbackRequest(state, cookie), env);
+      expect(res.headers.get("Location")).toBe("/");
+      expect(userRow(`123@${EMAIL_DOMAIN}`)?.username).toMatch(/^sso-[0-9a-f]{6}$/);
+    });
+  });
+});
+
+// ============================================================================
+// Storage: oidc_login_states
+// ============================================================================
+
+describe("oidc_login_states storage", () => {
+  it("createOidcLoginState persists a row consumable exactly once", async () => {
+    const { db } = makeSqliteD1();
+    const created = await createOidcLoginState(db, logger, {
+      connectionId: "ssoc_1",
+      nonce: "n1",
+      codeVerifier: "v1",
+      redirectTo: "/somewhere",
+    });
+    expect(created.success).toBe(true);
+    if (!created.success) return;
+
+    const consumed = await consumeOidcLoginState(db, logger, created.data);
+    expect(consumed.success).toBe(true);
+    if (!consumed.success) return;
+    expect(consumed.data).toEqual({
+      state: created.data,
+      connectionId: "ssoc_1",
+      nonce: "n1",
+      codeVerifier: "v1",
+      redirectTo: "/somewhere",
+    });
+
+    const again = await consumeOidcLoginState(db, logger, created.data);
+    expect(again.success).toBe(true);
+    if (again.success) expect(again.data).toBeNull();
+  });
+
+  it("concurrent consumes have exactly one winner", async () => {
+    const { db } = makeSqliteD1();
+    const created = await createOidcLoginState(db, logger, {
+      connectionId: "ssoc_1",
+      nonce: "n1",
+      codeVerifier: "v1",
+      redirectTo: null,
+    });
+    if (!created.success) throw new Error("create failed");
+
+    const results = await Promise.all([
+      consumeOidcLoginState(db, logger, created.data),
+      consumeOidcLoginState(db, logger, created.data),
+    ]);
+    const winners = results.filter((r) => r.success && r.data !== null);
+    expect(winners).toHaveLength(1);
+  });
+
+  it("returns null for an unknown state", async () => {
+    const { db } = makeSqliteD1();
+    const consumed = await consumeOidcLoginState(db, logger, "no-such-state");
+    expect(consumed.success).toBe(true);
+    if (consumed.success) expect(consumed.data).toBeNull();
+  });
+
+  it("returns null for an expired state and purge removes it", async () => {
+    const { db, raw } = makeSqliteD1();
+    const created = await createOidcLoginState(db, logger, {
+      connectionId: "ssoc_1",
+      nonce: "n1",
+      codeVerifier: "v1",
+      redirectTo: null,
+    });
+    if (!created.success) throw new Error("create failed");
+    raw
+      .prepare("UPDATE oidc_login_states SET expires_at = ? WHERE state = ?")
+      .run(Math.floor(Date.now() / 1000) - 10, created.data);
+
+    const consumed = await consumeOidcLoginState(db, logger, created.data);
+    expect(consumed.success).toBe(true);
+    if (consumed.success) expect(consumed.data).toBeNull();
+
+    const purged = await purgeExpiredOidcStates(db, logger);
+    expect(purged.success).toBe(true);
+    if (purged.success) expect(purged.data).toBe(1);
+    const remaining = raw.prepare("SELECT COUNT(*) as n FROM oidc_login_states").get() as {
+      n: number;
+    };
+    expect(remaining.n).toBe(0);
+  });
+
+  it("purge keeps unexpired rows (consumed tombstones included)", async () => {
+    const { db, raw } = makeSqliteD1();
+    const created = await createOidcLoginState(db, logger, {
+      connectionId: "ssoc_1",
+      nonce: "n1",
+      codeVerifier: "v1",
+      redirectTo: null,
+    });
+    if (!created.success) throw new Error("create failed");
+    await consumeOidcLoginState(db, logger, created.data);
+
+    const purged = await purgeExpiredOidcStates(db, logger);
+    expect(purged.success).toBe(true);
+    if (purged.success) expect(purged.data).toBe(0);
+    const remaining = raw.prepare("SELECT COUNT(*) as n FROM oidc_login_states").get() as {
+      n: number;
+    };
+    expect(remaining.n).toBe(1);
+  });
+});

--- a/tests/sso-storage.test.ts
+++ b/tests/sso-storage.test.ts
@@ -7,8 +7,8 @@ import {
   getSsoConnectionByOrgId,
   getSsoConnectionByOrgSlug,
   getSsoConnectionByVerifiedDomain,
-  listDeactivatedScimUserIds,
   normalizeEmailDomains,
+  reenableUsersForConnectionRemoval,
   rotateScimToken,
   setSsoConnectionEnabled,
   setSsoDomainsVerified,
@@ -413,15 +413,95 @@ describe("deleteSsoConnection", () => {
       )
       .run(connection.id, "usr_b", 1, new Date().toISOString());
 
-    const deactivated = await listDeactivatedScimUserIds(db, mockLogger, connection.id);
-    expect(deactivated.success).toBe(true);
-    if (deactivated.success) expect(deactivated.data).toEqual(["usr_a"]);
-
     const result = await deleteSsoConnection(db, mockLogger, connection.id);
     expect(result.success).toBe(true);
 
     expect(raw.prepare("SELECT COUNT(*) AS n FROM scim_members").get()).toEqual({ n: 0 });
     expect(raw.prepare("SELECT COUNT(*) AS n FROM org_sso_connections").get()).toEqual({ n: 0 });
+  });
+});
+
+describe("reenableUsersForConnectionRemoval", () => {
+  function addScimMember(raw: Raw, connectionId: string, userId: string, active: number): void {
+    raw
+      .prepare(
+        "INSERT INTO scim_members (connection_id, user_id, active, created_at) VALUES (?, ?, ?, ?)",
+      )
+      .run(connectionId, userId, active, new Date().toISOString());
+  }
+
+  function disableUserRow(raw: Raw, userId: string): void {
+    raw
+      .prepare("UPDATE users SET disabled_at = ? WHERE id = ?")
+      .run("2026-02-01T00:00:00.000Z", userId);
+  }
+
+  function disabledAtOf(raw: Raw, userId: string): string | null {
+    const row = raw.prepare("SELECT disabled_at FROM users WHERE id = ?").get(userId) as {
+      disabled_at: string | null;
+    };
+    return row.disabled_at;
+  }
+
+  it("re-enables exactly the users this connection deactivated", async () => {
+    const { db, raw } = setup();
+    seedUser(raw, "usr_a");
+    seedUser(raw, "usr_b");
+    const connection = await seedConnection(db, "org_1");
+    addScimMember(raw, connection.id, "usr_a", 0);
+    disableUserRow(raw, "usr_a");
+    // usr_b is managed but holds no deactivation vote here; a stray
+    // disabled_at must not be cleared by an active=1 row.
+    addScimMember(raw, connection.id, "usr_b", 1);
+    disableUserRow(raw, "usr_b");
+
+    const result = await reenableUsersForConnectionRemoval(db, mockLogger, connection.id);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(["usr_a"]);
+    expect(disabledAtOf(raw, "usr_a")).toBeNull();
+    expect(disabledAtOf(raw, "usr_b")).not.toBeNull();
+  });
+
+  it("cross-connection guard: another connection's standing deactivation keeps disabled_at", async () => {
+    const { db, raw } = setup();
+    seedUser(raw, "usr_shared");
+    seedOrg(raw, "org_2", "globex", "usr_owner");
+    const first = await seedConnection(db, "org_1", ["corp.example.com"]);
+    const second = await seedConnection(db, "org_2", ["globex.example.com"]);
+    addScimMember(raw, first.id, "usr_shared", 0);
+    addScimMember(raw, second.id, "usr_shared", 0);
+    disableUserRow(raw, "usr_shared");
+
+    // Removing connection A must not resurrect the account B still deactivates.
+    const result = await reenableUsersForConnectionRemoval(db, mockLogger, first.id);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual([]);
+    expect(disabledAtOf(raw, "usr_shared")).not.toBeNull();
+  });
+
+  it("excludeUserId leaves the excluded (being-erased) user untouched", async () => {
+    const { db, raw } = setup();
+    seedUser(raw, "usr_erased");
+    seedUser(raw, "usr_kept");
+    const connection = await seedConnection(db, "org_1");
+    addScimMember(raw, connection.id, "usr_erased", 0);
+    addScimMember(raw, connection.id, "usr_kept", 0);
+    disableUserRow(raw, "usr_erased");
+    disableUserRow(raw, "usr_kept");
+
+    const result = await reenableUsersForConnectionRemoval(db, mockLogger, connection.id, {
+      excludeUserId: "usr_erased",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(["usr_kept"]);
+    expect(disabledAtOf(raw, "usr_erased")).not.toBeNull();
+    expect(disabledAtOf(raw, "usr_kept")).toBeNull();
+  });
+
+  it("returns STORAGE_ERROR when the database fails", async () => {
+    const result = await reenableUsersForConnectionRemoval(makeThrowingD1(), mockLogger, "ssoc_x");
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("STORAGE_ERROR");
   });
 });
 

--- a/tests/sso-storage.test.ts
+++ b/tests/sso-storage.test.ts
@@ -1,0 +1,435 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  PUBLIC_EMAIL_DOMAINS,
+  deleteSsoConnection,
+  findVerifiedDomainConflicts,
+  getSsoConnectionById,
+  getSsoConnectionByOrgId,
+  getSsoConnectionByOrgSlug,
+  getSsoConnectionByVerifiedDomain,
+  listDeactivatedScimUserIds,
+  normalizeEmailDomains,
+  rotateScimToken,
+  setSsoConnectionEnabled,
+  setSsoDomainsVerified,
+  upsertSsoConnection,
+} from "../src/storage/sso";
+import { SSO_SECRET_SALT, decryptToken, encryptToken, hashToken } from "../src/utils/crypto";
+import type { Logger } from "../src/utils/logger";
+import { makeSqliteD1, makeThrowingD1 } from "./helpers/sqlite-d1";
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+type Raw = ReturnType<typeof makeSqliteD1>["raw"];
+
+function seedUser(raw: Raw, id: string): void {
+  raw
+    .prepare("INSERT INTO users (id, email, username, token_hash) VALUES (?, ?, ?, ?)")
+    .run(id, `${id}@example.com`, id.replace(/_/g, "-"), `hash_${id}`);
+}
+
+function seedOrg(raw: Raw, id: string, slug: string, ownerId: string): void {
+  raw
+    .prepare("INSERT INTO orgs (id, name, slug, owner_id, created_at) VALUES (?, ?, ?, ?, ?)")
+    .run(id, slug, slug, ownerId, new Date().toISOString());
+}
+
+async function seedConnection(
+  db: D1Database,
+  orgId: string,
+  emailDomains: string[] = ["corp.example.com"],
+) {
+  const result = await upsertSsoConnection(db, mockLogger, {
+    orgId,
+    issuer: "https://idp.example.com",
+    clientId: "client-123",
+    clientSecretCiphertext: "ciphertext",
+    authorizationEndpoint: "https://idp.example.com/authorize",
+    tokenEndpoint: "https://idp.example.com/token",
+    jwksUri: "https://idp.example.com/jwks",
+    emailDomains,
+  });
+  if (!result.success) throw new Error("seedConnection failed");
+  return result.data.connection;
+}
+
+function setup() {
+  const { db, raw } = makeSqliteD1();
+  seedUser(raw, "usr_owner");
+  seedOrg(raw, "org_1", "acme", "usr_owner");
+  return { db, raw };
+}
+
+describe("normalizeEmailDomains", () => {
+  it("lowercases, trims, and dedupes", () => {
+    const result = normalizeEmailDomains([" Corp.Example.COM ", "corp.example.com", "b.example"]);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(["corp.example.com", "b.example"]);
+  });
+
+  it("rejects an empty list", () => {
+    const result = normalizeEmailDomains([]);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects malformed domains", () => {
+    for (const bad of ["no-dot", "-x.example.com", "a..b", "corp example.com"]) {
+      const result = normalizeEmailDomains([bad]);
+      expect(result.success, `'${bad}' must be rejected`).toBe(false);
+    }
+  });
+
+  it("caps domains at 240 octets (room for the `_stratum-sso.` DoH prefix)", () => {
+    const base = `${"a".repeat(63)}.${"b".repeat(63)}.${"c".repeat(63)}`;
+    const at240 = `${base}.${"d".repeat(48)}`;
+    const at241 = `${base}.${"d".repeat(49)}`;
+    expect(at240.length).toBe(240);
+    expect(normalizeEmailDomains([at240]).success).toBe(true);
+    expect(normalizeEmailDomains([at241]).success).toBe(false);
+  });
+
+  it("rejects a domain with a label over 63 octets", () => {
+    const result = normalizeEmailDomains([`${"a".repeat(64)}.example.com`]);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects every deny-listed public email domain", () => {
+    for (const domain of PUBLIC_EMAIL_DOMAINS) {
+      const result = normalizeEmailDomains([domain]);
+      expect(result.success, `'${domain}' must be deny-listed`).toBe(false);
+      if (!result.success) expect(result.error.code).toBe("VALIDATION_ERROR");
+    }
+  });
+});
+
+describe("upsertSsoConnection", () => {
+  it("creates a connection with a verification token, disabled and unverified", async () => {
+    const { db } = setup();
+    const connection = await seedConnection(db, "org_1");
+
+    expect(connection.enabled).toBe(false);
+    expect(connection.domainsVerifiedAt).toBeNull();
+    expect(connection.domainVerificationToken).toMatch(/^[0-9a-f]{32}$/);
+    expect(connection.scimTokenHash).toBeNull();
+
+    const fetched = await getSsoConnectionByOrgId(db, mockLogger, "org_1");
+    expect(fetched.success).toBe(true);
+    if (fetched.success) expect(fetched.data.id).toBe(connection.id);
+  });
+
+  it("replace keeps verification and enabled state when domains are unchanged", async () => {
+    const { db } = setup();
+    const created = await seedConnection(db, "org_1");
+    await setSsoDomainsVerified(db, mockLogger, created.id, created.emailDomains);
+    await setSsoConnectionEnabled(db, mockLogger, created.id, true);
+
+    const replaced = await upsertSsoConnection(db, mockLogger, {
+      orgId: "org_1",
+      issuer: "https://other-idp.example.com",
+      clientId: "client-456",
+      clientSecretCiphertext: "new-ciphertext",
+      authorizationEndpoint: "https://other-idp.example.com/authorize",
+      tokenEndpoint: "https://other-idp.example.com/token",
+      jwksUri: "https://other-idp.example.com/jwks",
+      emailDomains: ["corp.example.com"],
+    });
+    expect(replaced.success).toBe(true);
+    if (!replaced.success) return;
+    expect(replaced.data.created).toBe(false);
+    expect(replaced.data.connection.id).toBe(created.id);
+    expect(replaced.data.connection.domainsVerifiedAt).not.toBeNull();
+    expect(replaced.data.connection.enabled).toBe(true);
+    expect(replaced.data.connection.domainVerificationToken).toBe(created.domainVerificationToken);
+  });
+
+  it("editing email domains clears verification, disables, and keeps the token", async () => {
+    const { db } = setup();
+    const created = await seedConnection(db, "org_1");
+    await setSsoDomainsVerified(db, mockLogger, created.id, created.emailDomains);
+    await setSsoConnectionEnabled(db, mockLogger, created.id, true);
+
+    const replaced = await upsertSsoConnection(db, mockLogger, {
+      orgId: "org_1",
+      issuer: created.issuer,
+      clientId: created.clientId,
+      clientSecretCiphertext: created.clientSecretCiphertext,
+      authorizationEndpoint: created.authorizationEndpoint,
+      tokenEndpoint: created.tokenEndpoint,
+      jwksUri: created.jwksUri,
+      emailDomains: ["new-domain.example.com"],
+    });
+    expect(replaced.success).toBe(true);
+    if (!replaced.success) return;
+    expect(replaced.data.connection.domainsVerifiedAt).toBeNull();
+    expect(replaced.data.connection.enabled).toBe(false);
+    expect(replaced.data.connection.domainVerificationToken).toBe(created.domainVerificationToken);
+
+    const fetched = await getSsoConnectionById(db, mockLogger, created.id);
+    expect(fetched.success).toBe(true);
+    if (fetched.success) {
+      expect(fetched.data.domainsVerifiedAt).toBeNull();
+      expect(fetched.data.enabled).toBe(false);
+    }
+  });
+
+  it("replace regenerates a verification token for a pre-042 row with NULL token", async () => {
+    const { db, raw } = setup();
+    const created = await seedConnection(db, "org_1");
+    raw
+      .prepare("UPDATE org_sso_connections SET domain_verification_token = NULL WHERE id = ?")
+      .run(created.id);
+
+    const replaced = await upsertSsoConnection(db, mockLogger, {
+      orgId: "org_1",
+      issuer: created.issuer,
+      clientId: created.clientId,
+      clientSecretCiphertext: created.clientSecretCiphertext,
+      authorizationEndpoint: created.authorizationEndpoint,
+      tokenEndpoint: created.tokenEndpoint,
+      jwksUri: created.jwksUri,
+      emailDomains: ["corp.example.com"],
+    });
+    expect(replaced.success).toBe(true);
+    if (!replaced.success) return;
+    expect(replaced.data.connection.domainVerificationToken).toMatch(/^[0-9a-f]{32}$/);
+
+    const row = raw
+      .prepare("SELECT domain_verification_token FROM org_sso_connections WHERE id = ?")
+      .get(created.id) as { domain_verification_token: string | null };
+    expect(row.domain_verification_token).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("returns STORAGE_ERROR when the database fails", async () => {
+    const result = await upsertSsoConnection(makeThrowingD1(), mockLogger, {
+      orgId: "org_1",
+      issuer: "https://idp.example.com",
+      clientId: "c",
+      clientSecretCiphertext: "ct",
+      authorizationEndpoint: "https://idp.example.com/a",
+      tokenEndpoint: "https://idp.example.com/t",
+      jwksUri: "https://idp.example.com/j",
+      emailDomains: ["corp.example.com"],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("STORAGE_ERROR");
+  });
+});
+
+describe("connection resolution", () => {
+  it("resolves by org slug via join", async () => {
+    const { db } = setup();
+    const connection = await seedConnection(db, "org_1");
+    const bySlug = await getSsoConnectionByOrgSlug(db, mockLogger, "acme");
+    expect(bySlug.success).toBe(true);
+    if (bySlug.success) expect(bySlug.data.id).toBe(connection.id);
+
+    const missing = await getSsoConnectionByOrgSlug(db, mockLogger, "no-such-org");
+    expect(missing.success).toBe(false);
+    if (!missing.success) expect(missing.error.code).toBe("NOT_FOUND");
+  });
+
+  it("resolves by verified email domain only when verified (and enabled by default)", async () => {
+    const { db } = setup();
+    const connection = await seedConnection(db, "org_1");
+
+    // Unverified: never resolvable by domain.
+    let byDomain = await getSsoConnectionByVerifiedDomain(db, mockLogger, "corp.example.com");
+    expect(byDomain.success).toBe(false);
+
+    await setSsoDomainsVerified(db, mockLogger, connection.id, connection.emailDomains);
+
+    // Verified but disabled: hidden from enabled-only callers…
+    byDomain = await getSsoConnectionByVerifiedDomain(db, mockLogger, "corp.example.com");
+    expect(byDomain.success).toBe(false);
+
+    // …but visible when the caller does not require enabled.
+    byDomain = await getSsoConnectionByVerifiedDomain(db, mockLogger, "CORP.example.com", {
+      requireEnabled: false,
+    });
+    expect(byDomain.success).toBe(true);
+
+    await setSsoConnectionEnabled(db, mockLogger, connection.id, true);
+    byDomain = await getSsoConnectionByVerifiedDomain(db, mockLogger, "corp.example.com");
+    expect(byDomain.success).toBe(true);
+    if (byDomain.success) expect(byDomain.data.id).toBe(connection.id);
+  });
+});
+
+describe("malformed stored email_domains", () => {
+  it("parses to an empty domain list instead of crashing", async () => {
+    const { db, raw } = setup();
+    const created = await seedConnection(db, "org_1");
+    raw
+      .prepare("UPDATE org_sso_connections SET email_domains = 'not-json' WHERE id = ?")
+      .run(created.id);
+
+    const fetched = await getSsoConnectionById(db, mockLogger, created.id);
+    expect(fetched.success).toBe(true);
+    if (fetched.success) expect(fetched.data.emailDomains).toEqual([]);
+  });
+});
+
+describe("findVerifiedDomainConflicts", () => {
+  it("reports domains verified by another connection and ignores its own", async () => {
+    const { db, raw } = setup();
+    seedUser(raw, "usr_other");
+    seedOrg(raw, "org_2", "other", "usr_other");
+
+    const first = await seedConnection(db, "org_1", ["corp.example.com"]);
+    await setSsoDomainsVerified(db, mockLogger, first.id, first.emailDomains);
+    const second = await seedConnection(db, "org_2", ["corp.example.com", "unique.example.com"]);
+
+    const conflicts = await findVerifiedDomainConflicts(
+      db,
+      mockLogger,
+      second.emailDomains,
+      second.id,
+    );
+    expect(conflicts.success).toBe(true);
+    if (conflicts.success) expect(conflicts.data).toEqual(["corp.example.com"]);
+
+    // The first connection checking its own domains sees no conflict.
+    const own = await findVerifiedDomainConflicts(db, mockLogger, first.emailDomains, first.id);
+    expect(own.success).toBe(true);
+    if (own.success) expect(own.data).toEqual([]);
+  });
+});
+
+describe("setSsoDomainsVerified", () => {
+  it("refuses to stamp when the stored domain list is not the one checked", async () => {
+    const { db, raw } = setup();
+    const connection = await seedConnection(db, "org_1");
+
+    const result = await setSsoDomainsVerified(db, mockLogger, connection.id, [
+      "never-checked.example.com",
+    ]);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("CONFLICT");
+
+    const row = raw
+      .prepare("SELECT domains_verified_at FROM org_sso_connections WHERE id = ?")
+      .get(connection.id) as { domains_verified_at: string | null };
+    expect(row.domains_verified_at).toBeNull();
+  });
+
+  it("returns NOT_FOUND for a missing connection", async () => {
+    const { db } = setup();
+    const result = await setSsoDomainsVerified(db, mockLogger, "ssoc_missing", [
+      "corp.example.com",
+    ]);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("setSsoConnectionEnabled", () => {
+  it("refuses to enable an unverified connection (SQL guard)", async () => {
+    const { db } = setup();
+    const connection = await seedConnection(db, "org_1");
+    const result = await setSsoConnectionEnabled(db, mockLogger, connection.id, true);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("enables once verified and disables again", async () => {
+    const { db } = setup();
+    const connection = await seedConnection(db, "org_1");
+    await setSsoDomainsVerified(db, mockLogger, connection.id, connection.emailDomains);
+
+    expect((await setSsoConnectionEnabled(db, mockLogger, connection.id, true)).success).toBe(true);
+    let fetched = await getSsoConnectionById(db, mockLogger, connection.id);
+    if (fetched.success) expect(fetched.data.enabled).toBe(true);
+
+    expect((await setSsoConnectionEnabled(db, mockLogger, connection.id, false)).success).toBe(
+      true,
+    );
+    fetched = await getSsoConnectionById(db, mockLogger, connection.id);
+    if (fetched.success) expect(fetched.data.enabled).toBe(false);
+  });
+
+  it("returns NOT_FOUND for a missing connection", async () => {
+    const { db } = setup();
+    const result = await setSsoConnectionEnabled(db, mockLogger, "ssoc_missing", true);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("rotateScimToken", () => {
+  it("returns a stratum_scim_ token and stores only its hash", async () => {
+    const { db, raw } = setup();
+    const connection = await seedConnection(db, "org_1");
+
+    const result = await rotateScimToken(db, mockLogger, connection.id);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const plaintext = result.data;
+    expect(plaintext).toMatch(/^stratum_scim_[0-9a-f]{32}$/);
+
+    const row = raw
+      .prepare("SELECT scim_token_hash FROM org_sso_connections WHERE id = ?")
+      .get(connection.id) as { scim_token_hash: string };
+    expect(row.scim_token_hash).toBe(await hashToken(plaintext));
+    expect(row.scim_token_hash).not.toContain(plaintext);
+  });
+
+  it("rotation replaces the previous hash", async () => {
+    const { db, raw } = setup();
+    const connection = await seedConnection(db, "org_1");
+    await rotateScimToken(db, mockLogger, connection.id);
+    const before = raw
+      .prepare("SELECT scim_token_hash FROM org_sso_connections WHERE id = ?")
+      .get(connection.id) as { scim_token_hash: string };
+    await rotateScimToken(db, mockLogger, connection.id);
+    const after = raw
+      .prepare("SELECT scim_token_hash FROM org_sso_connections WHERE id = ?")
+      .get(connection.id) as { scim_token_hash: string };
+    expect(after.scim_token_hash).not.toBe(before.scim_token_hash);
+  });
+});
+
+describe("deleteSsoConnection", () => {
+  it("deletes the connection and its scim_members rows atomically", async () => {
+    const { db, raw } = setup();
+    seedUser(raw, "usr_a");
+    seedUser(raw, "usr_b");
+    const connection = await seedConnection(db, "org_1");
+    raw
+      .prepare(
+        "INSERT INTO scim_members (connection_id, user_id, active, created_at) VALUES (?, ?, ?, ?)",
+      )
+      .run(connection.id, "usr_a", 0, new Date().toISOString());
+    raw
+      .prepare(
+        "INSERT INTO scim_members (connection_id, user_id, active, created_at) VALUES (?, ?, ?, ?)",
+      )
+      .run(connection.id, "usr_b", 1, new Date().toISOString());
+
+    const deactivated = await listDeactivatedScimUserIds(db, mockLogger, connection.id);
+    expect(deactivated.success).toBe(true);
+    if (deactivated.success) expect(deactivated.data).toEqual(["usr_a"]);
+
+    const result = await deleteSsoConnection(db, mockLogger, connection.id);
+    expect(result.success).toBe(true);
+
+    expect(raw.prepare("SELECT COUNT(*) AS n FROM scim_members").get()).toEqual({ n: 0 });
+    expect(raw.prepare("SELECT COUNT(*) AS n FROM org_sso_connections").get()).toEqual({ n: 0 });
+  });
+});
+
+describe("client secret encryption (SSO salt)", () => {
+  it("round-trips under the SSO salt and never under the GitHub-default salt", async () => {
+    const secret = "sso-env-secret";
+    const ciphertext = await encryptToken("idp-client-secret", secret, SSO_SECRET_SALT);
+    expect(await decryptToken(ciphertext, secret, SSO_SECRET_SALT)).toBe("idp-client-secret");
+    expect(await decryptToken(ciphertext, secret)).toBeNull();
+  });
+});

--- a/tests/users-disable.test.ts
+++ b/tests/users-disable.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import { disableUser, enableUser, getUser, getUserByToken } from "../src/storage/users";
+import type { Logger } from "../src/utils/logger";
+import { makeSqliteD1, makeThrowingD1 } from "./helpers/sqlite-d1";
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+function seedUser(raw: ReturnType<typeof makeSqliteD1>["raw"], id: string): void {
+  raw
+    .prepare("INSERT INTO users (id, email, username, token_hash) VALUES (?, ?, ?, ?)")
+    .run(id, `${id}@example.com`, id.replace(/_/g, "-"), `hash_${id}`);
+}
+
+function disabledAtOf(raw: ReturnType<typeof makeSqliteD1>["raw"], id: string): string | null {
+  const row = raw.prepare("SELECT disabled_at FROM users WHERE id = ?").get(id) as {
+    disabled_at: string | null;
+  };
+  return row.disabled_at;
+}
+
+describe("disableUser / enableUser", () => {
+  it("disableUser sets disabled_at and getUser surfaces it as disabledAt", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+
+    const result = await disableUser(db, "usr_1", mockLogger);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("disableUser failed");
+    expect(disabledAtOf(raw, "usr_1")).toBe(result.data);
+
+    const fetched = await getUser(db, "usr_1", mockLogger);
+    expect(fetched.success).toBe(true);
+    if (fetched.success) expect(fetched.data.disabledAt).toBe(result.data);
+  });
+
+  it("disableUser is idempotent — re-disabling keeps the earliest timestamp", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    const earliest = "2020-01-01T00:00:00.000Z";
+    raw.prepare("UPDATE users SET disabled_at = ? WHERE id = 'usr_1'").run(earliest);
+
+    const again = await disableUser(db, "usr_1", mockLogger);
+    expect(again.success).toBe(true);
+    expect(disabledAtOf(raw, "usr_1")).toBe(earliest);
+    // The RETURNED value must be the stored timestamp, not the newer one —
+    // an audit/SCIM response built from it must not misreport disablement time.
+    expect(again.success && again.data).toBe(earliest);
+  });
+
+  it("enableUser clears disabled_at so the row reads as enabled again", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    const disabled = await disableUser(db, "usr_1", mockLogger);
+    expect(disabled.success).toBe(true);
+
+    const enabled = await enableUser(db, "usr_1", mockLogger);
+    expect(enabled.success).toBe(true);
+    expect(disabledAtOf(raw, "usr_1")).toBeNull();
+
+    const fetched = await getUser(db, "usr_1", mockLogger);
+    expect(fetched.success).toBe(true);
+    if (fetched.success) expect(fetched.data.disabledAt).toBeUndefined();
+  });
+
+  it("enableUser is idempotent on an already-enabled account", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+
+    const result = await enableUser(db, "usr_1", mockLogger);
+    expect(result.success).toBe(true);
+    expect(disabledAtOf(raw, "usr_1")).toBeNull();
+  });
+
+  it("returns NOT_FOUND for an unknown user", async () => {
+    const { db } = makeSqliteD1();
+
+    const disable = await disableUser(db, "usr_ghost", mockLogger);
+    expect(disable.success).toBe(false);
+    if (!disable.success) expect(disable.error.code).toBe("NOT_FOUND");
+
+    const enable = await enableUser(db, "usr_ghost", mockLogger);
+    expect(enable.success).toBe(false);
+    if (!enable.success) expect(enable.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns STORAGE_ERROR when D1 throws", async () => {
+    const db = makeThrowingD1();
+
+    const disable = await disableUser(db, "usr_1", mockLogger);
+    expect(disable.success).toBe(false);
+    if (!disable.success) expect(disable.error.code).toBe("STORAGE_ERROR");
+
+    const enable = await enableUser(db, "usr_1", mockLogger);
+    expect(enable.success).toBe(false);
+    if (!enable.success) expect(enable.error.code).toBe("STORAGE_ERROR");
+  });
+
+  it("getUserByToken surfaces disabledAt — the git-http auth path sees the flag", async () => {
+    const { db, raw } = makeSqliteD1();
+    seedUser(raw, "usr_1");
+    // Real token hashing is exercised elsewhere; here the hash IS the lookup key.
+    const { hashToken } = await import("../src/utils/crypto");
+    const plaintext = "stratum_user_disabletest";
+    raw
+      .prepare("UPDATE users SET token_hash = ? WHERE id = 'usr_1'")
+      .run(await hashToken(plaintext));
+    await disableUser(db, "usr_1", mockLogger);
+
+    const fetched = await getUserByToken(db, plaintext, mockLogger);
+    expect(fetched.success).toBe(true);
+    if (fetched.success) expect(fetched.data.disabledAt).toBeDefined();
+  });
+});

--- a/website/src/content/docs/guides/faq.md
+++ b/website/src/content/docs/guides/faq.md
@@ -49,7 +49,10 @@ at all. You choose the level of buy-in, and you can start with layer mode.
 
 No. Email magic-link authentication is the recommended sign-in and has no
 external dependencies. GitHub OAuth (needed for GitHub sync) and Google OAuth
-are alternatives; all resolve to the same email-based identity.
+are alternatives, and organizations can configure enterprise SSO (OIDC) for
+sign-in at `/auth/sso`; all resolve to the same email-based account. Note that
+SSO does not yet lock out the other methods — magic-link sign-in still works
+for corporate emails until an enforcement toggle ships.
 
 ## What happens when an evaluation fails?
 

--- a/website/src/content/docs/guides/getting-started.md
+++ b/website/src/content/docs/guides/getting-started.md
@@ -27,8 +27,11 @@ Sign in with any of:
 - **GitHub OAuth** at `/auth/github` — required later if you want bidirectional
   GitHub sync.
 - **Google OAuth** at `/auth/google`.
+- **Single sign-on (SSO)** at `/auth/sso` — if your organization has
+  configured OIDC SSO, enter your org's slug or your work email.
 
-All three resolve to the same email-identity account, so you can mix methods.
+All of these resolve to the same account (matched by verified email), so you
+can mix methods.
 
 ### Self-hosting
 

--- a/website/src/content/docs/reference/authentication.md
+++ b/website/src/content/docs/reference/authentication.md
@@ -18,6 +18,11 @@ For programmatic access:
 - **Agent tokens**: `stratum_agent_xxxxx` — short-lived, scoped to the owning
   user, and attributed to the agent in provenance. Agent tokens can never
   approve changes, on any surface.
+- **SCIM tokens**: `stratum_scim_xxxxx` — per-SSO-connection bearer accepted
+  only by the SCIM endpoints under `/scim/v2` (which accept no other
+  credential). Rotated by an org admin via
+  `POST /api/orgs/{slug}/sso/scim-token`; the plaintext is returned exactly
+  once.
 
 ```bash
 curl -H "Authorization: Bearer stratum_user_xxxxx" \
@@ -26,9 +31,10 @@ curl -H "Authorization: Bearer stratum_user_xxxxx" \
 
 ## Session cookies
 
-Signing in through the web UI (email magic link, GitHub OAuth, or Google
-OAuth) sets a `stratum_session` cookie, which authenticates browser requests
-to the same endpoints.
+Signing in through the web UI (email magic link, GitHub OAuth, Google OAuth,
+or single sign-on at `/auth/sso` for organizations with an enabled OIDC
+connection) sets a `stratum_session` cookie, which authenticates browser
+requests to the same endpoints.
 
 ## Anonymous access
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -150,6 +150,7 @@ OAUTH_REDIRECT_URI = "http://localhost:8787/auth/github/callback"
 # GOOGLE_CLIENT_SECRET =
 # EMAIL_FROM_ADDRESS = "noreply@yourdomain.com"  # for magic link emails
 # REFERRAL_SERVICE_SECRET =  # closed-beta gate shared secret (must match the referral service)
+# SSO_ENCRYPTION_SECRET =  # encrypts org SSO client secrets at rest; unset → SSO endpoints 501
 
 # =============================================================================
 # [env.production] — the maintainer's hosted instance (app.usestratum.dev).


### PR DESCRIPTION
Closes #253.

## What this adds

**Per-org OIDC SSO against customer IdPs (Okta, Entra, etc.)**
- Admin API at `/api/orgs/:slug/sso`: configure issuer + client credentials (secret AES-GCM-encrypted under new `SSO_ENCRYPTION_SECRET`), verify email domains, enable/disable, rotate the SCIM token.
- **DNS-TXT domain verification is required before a connection can be enabled** (`_stratum-sso.<domain>` TXT checked over DoH, public-domain deny-list, globally unique verified domains). Without this, open org creation + an attacker-controlled IdP would be an account-takeover primitive — so it ships in v1, not as a follow-up.
- OIDC discovery is SSRF-hardened: https-only, no IP literals / private / single-label / trailing-dot hosts, discovered endpoints re-validated, size caps + timeouts, redirects refused, reserved GitHub/Google issuers rejected.

**SSO login at `/auth/sso`**
- Authorization-code + PKCE (S256) + nonce, single-use D1 state with atomic consumption, browser-binding cookie, per-IP rate limiting, open-redirect-hardened `redirect_to`.
- `id_token` verified with `jose@6.2.10` (RS256/ES256 pinned, iss/aud/nonce/azp, 60s tolerance); Entra string-boolean `email_verified` handled.
- Identity resolution: stable `(issuer, sub)` match → adopt existing verified-domain account → JIT-provision into the org (org-slug-safe usernames, non-downgrading membership).

**SCIM 2.0 Users at `/scim/v2`**
- Per-connection `stratum_scim_*` bearer (fail-closed: session cookies and user/agent tokens are never honored), own burst-tolerant rate limit sized for full IdP syncs.
- Users CRUD with Okta/Entra compatibility: `userName`/`externalId` eq filters, discovery endpoints, capitalized PATCH ops, string booleans, `externalId` unique per connection, **adopt-existing-account semantics** so pre-existing users become deprovisionable.
- Deactivation sets a reversible `users.disabled_at`, purges sessions, and is **enforced at every credential path** — API tokens, agent tokens, session cookies, git smart-HTTP (which bypasses the auth middleware), and all login flows. Reactivation restores the same credentials. Transitions are direction-aware and repair partial-failure drift; cross-connection deactivation votes are preserved.

**Existing OAuth flows fixed** (the "make sure current SSO options work" half of the issue)
- GitHub can no longer link accounts via unverified emails (takeover vector); resolves by `github_id` first; truthful error message.
- Google resolves by stable `sub` (new `identities` table) before email; fail-closed identity lookups; create-race recovery.
- Dead redirect code removed; `github_refresh_token`/`github_token_expires_at` schema drift repaired; emails normalized end to end.

## Not in scope (documented in the docs updates)
SAML, SCIM Groups, SSO login enforcement (magic-link still works for corporate emails until a toggle ships — offboarding is unaffected since disabled users fail every login path), management UI (API-only v1), multiple connections per org.

## Verification
- `tsc --noEmit`, Biome, and 2,440 passing tests (~226 added), including an E2E that signs in via a stubbed IdP with real ES256-signed JWTs, deactivates via SCIM, proves every credential (session, user token, agent token, git smart-HTTP) is dead, then reactivates and proves restoration.
- 18 adversarial review-agent passes across the six code tranches; ~49 confirmed findings fixed (SSRF trailing-dot bypass, control-char open redirect, domain-verification TOCTOU, admin demotion on adopt, deprovision-retry no-op, among others); accepted trade-offs logged in `.claude/ship/TASKS.md`.
- Note: the 43 failures in `tests/issues*.test.ts` are pre-existing on `main` (verified with this branch's changes stashed) and untouched here.

## Deploy notes
- Migrations 041–043 (new tables + `users.disabled_at` + drift columns + externalId index).
- New secret `SSO_ENCRYPTION_SECRET` (SSO admin/login APIs return 501 until set).
- New dependency: `jose@6.2.10` (exact pin; first crypto dependency — sits on the auth trust boundary, flagged for supply-chain review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYqju5Dtdyw3bGT9R4t1k6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enterprise OIDC single sign-on with organization setup, verified domains, secure sign-in, and account provisioning.
  * Added SCIM 2.0 user provisioning, lifecycle management, discovery, pagination, filtering, and per-connection token rotation.
  * Added account disablement enforcement across sign-in, sessions, agents, and Git access.
* **Documentation**
  * Documented SSO and SCIM setup, authentication, endpoints, configuration, domain verification, provisioning, and current limitations.
* **Bug Fixes**
  * Improved identity linking and account-status handling across OAuth and email authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->