### PR TITLE
Add a changelog-driven release process and cut v0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,12 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.repository.default_branch }}
-          # The tag step needs history and push credentials; the default token
-          # is enough given `contents: write` above.
-          fetch-depth: 0
+          # This job holds `contents: write`, and the `npm ci` below runs
+          # dependency lifecycle scripts. Persisting the token in .git/config
+          # would leave a repository-write credential within reach of any
+          # postinstall script, so git never gets it: the tag is created through
+          # the API, which needs no local credential.
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -64,9 +67,13 @@ jobs:
           else
             VERSION="$(npm run --silent release:latest)"
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Releasing v$VERSION"
+          {
+            echo "version=$VERSION"
+            echo "tag=v$VERSION"
+            echo "previous=$(npm run --silent release:previous -- "$VERSION")"
+            echo "sha=$(git rev-parse HEAD)"
+          } >> "$GITHUB_OUTPUT"
+          echo "Releasing v$VERSION from $(git rev-parse --short HEAD)"
 
       - name: Check the changelog
         run: npm run --silent release:check
@@ -104,20 +111,56 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: npm run test:coverage
 
+      # This version's changelog link is `compare/v<previous>...v<version>`, so
+      # publishing before the predecessor is tagged would ship a release whose
+      # history link 404s — exactly the breakage this whole process exists to
+      # prevent. Fail loudly instead, naming the tag to backfill.
+      - name: Verify the predecessor tag exists
+        if: steps.version.outputs.previous != ''
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          PREVIOUS_TAG: v${{ steps.version.outputs.previous }}
+        with:
+          script: |
+            const tag = process.env.PREVIOUS_TAG;
+            const { owner, repo } = context.repo;
+            try {
+              await github.rest.git.getRef({ owner, repo, ref: `tags/${tag}` });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              core.setFailed(
+                `${tag} is not tagged yet, and this release's changelog compare link points at it. ` +
+                  `Backfill it first: git tag -a ${tag} <commit> -m "${tag}" && git push origin ${tag}`,
+              );
+            }
+
       - name: Create the tag
         if: github.event_name == 'workflow_dispatch' && !inputs.dry_run
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          set -euo pipefail
-          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "::notice::$TAG already exists on origin; refreshing its release notes only."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "$TAG"
-          git push origin "refs/tags/$TAG"
+          SHA: ${{ steps.version.outputs.sha }}
+        with:
+          script: |
+            const tag = process.env.TAG;
+            const sha = process.env.SHA;
+            const { owner, repo } = context.repo;
+
+            try {
+              const { data: existing } = await github.rest.git.getRef({
+                owner, repo, ref: `tags/${tag}`,
+              });
+              core.notice(`${tag} already exists at ${existing.object.sha}; publishing its notes only.`);
+              return;
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+            const { data: object } = await github.rest.git.createTag({
+              owner, repo, tag, message: tag, object: sha, type: "commit",
+            });
+            await github.rest.git.createRef({ owner, repo, ref: `refs/tags/${tag}`, sha: object.sha });
+            core.notice(`Tagged ${tag} at ${sha}`);
 
       - name: Publish the GitHub release
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
@@ -157,7 +200,7 @@ jobs:
           {
             echo "### Dry run — nothing tagged or published"
             echo
-            echo "Would release \`${{ steps.version.outputs.tag }}\` with these notes:"
+            echo "Would release \`${{ steps.version.outputs.tag }}\` at \`${{ steps.version.outputs.sha }}\` with these notes:"
             echo
             cat release-notes.md
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,163 @@
+name: Release
+
+# Two ways in, one outcome — a `vX.Y.Z` tag and a GitHub release whose notes are
+# that version's CHANGELOG section:
+#
+#   workflow_dispatch  Tag whatever is on the default branch right now. The
+#                      version comes from CHANGELOG.md, so the release PR from
+#                      `npm run release:prepare` must be merged first.
+#   push: tags         Publish (or refresh) the release for a tag pushed by hand,
+#                      including tags backfilled onto commits that predate this
+#                      workflow.
+#
+# Both paths read CHANGELOG.md and the release tooling from the default branch,
+# never from the tagged tree: the changelog on the default branch is the record
+# of every version, and a backfilled tag points at a commit that has neither.
+#
+# See docs/developer/releasing.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run the checks and print the notes without tagging or publishing"
+        type: boolean
+        default: false
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Tag & Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the default branch
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          # The tag step needs history and push credentials; the default token
+          # is enough given `contents: write` above.
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Resolve the version
+        id: version
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="$(npm run --silent release:latest)"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing v$VERSION"
+
+      - name: Check the changelog
+        run: npm run --silent release:check
+
+      - name: Extract the release notes
+        run: |
+          set -euo pipefail
+          npm run --silent release:notes -- "${{ steps.version.outputs.version }}" > release-notes.md
+          echo "--- release notes ---"
+          cat release-notes.md
+
+      # Only on the dispatch path: we are about to tag this exact tree, and a tag
+      # is permanent, so re-run the gates rather than trust that the last push to
+      # the default branch was green.
+      - name: Verify the tree matches the version
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "$PKG" != "$VERSION" ]; then
+            echo "::error::package.json is $PKG but CHANGELOG.md's newest release is $VERSION. Run 'npm run release:prepare' and merge that PR first."
+            exit 1
+          fi
+
+      - name: Lint
+        if: github.event_name == 'workflow_dispatch'
+        run: npm run lint
+
+      - name: Typecheck
+        if: github.event_name == 'workflow_dispatch'
+        run: npm run typecheck
+
+      - name: Test
+        if: github.event_name == 'workflow_dispatch'
+        run: npm run test:coverage
+
+      - name: Create the tag
+        if: github.event_name == 'workflow_dispatch' && !inputs.dry_run
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::notice::$TAG already exists on origin; refreshing its release notes only."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "$TAG"
+          git push origin "refs/tags/$TAG"
+
+      - name: Publish the GitHub release
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        with:
+          script: |
+            const fs = require("node:fs");
+            const body = fs.readFileSync("release-notes.md", "utf8").trim();
+            const tag = process.env.TAG;
+            const { owner, repo } = context.repo;
+
+            // Idempotent: re-running for a tag that already has a release
+            // refreshes its notes instead of failing, so a changelog correction
+            // can be republished.
+            let existing = null;
+            try {
+              existing = (await github.rest.repos.getReleaseByTag({ owner, repo, tag })).data;
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+            const release = existing
+              ? (await github.rest.repos.updateRelease({
+                  owner, repo, release_id: existing.id, name: tag, body,
+                })).data
+              : (await github.rest.repos.createRelease({
+                  owner, repo, tag_name: tag, name: tag, body,
+                })).data;
+
+            core.notice(`${existing ? "Updated" : "Published"} ${release.html_url}`);
+
+      - name: Dry-run summary
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+        run: |
+          {
+            echo "### Dry run — nothing tagged or published"
+            echo
+            echo "Would release \`${{ steps.version.outputs.tag }}\` with these notes:"
+            echo
+            cat release-notes.md
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ npm run test:integration  # tests/integration/
 npm run typecheck    # tsc --noEmit
 npm run lint         # biome check src tests
 npm run lint:fix     # biome check --write src tests
+npm run release:check   # validate CHANGELOG.md against package.json
+npm run release:prepare # cut a release from the Unreleased section (maintainers)
 ```
 
 `npm run test:smoke` hits a **live deployed instance** (set `STAGING_URL` + `TEST_AUTH_TOKEN`);
@@ -64,6 +66,9 @@ Mirror lint → typecheck → test locally before pushing.
 - **Comments explain *why*, not *what*.** Add one only for a non-obvious constraint, invariant, or
   workaround. JSDoc on public APIs is welcome.
 - **Server-rendered only.** Do not introduce client-side JS into the UI.
+- **Every user-visible change gets a `CHANGELOG.md` entry** under `## [Unreleased]`, in the same
+  PR, under a Keep a Changelog group. That text ships verbatim as the release notes; the release
+  tooling infers the version bump from which groups are present (`docs/developer/releasing.md`).
 - Highlight.js / type gotchas and the full ship flow live in `docs/developer/`.
 
 ## Operational rules (do not violate)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-29
+
 ### Security
 - Workspace commit/delete now require project write access (was unauthenticated in practice).
 - Bulk import enforces own-namespace ownership (no more namespace squatting).
@@ -21,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to restore it.
 
 ### Added
+- **A release process.** `CHANGELOG.md` is now the source of truth for the version:
+  `npm run release:prepare` moves `Unreleased` into a dated section, infers the SemVer
+  bump from which groups are present, rewrites the compare links, and bumps
+  `package.json`; the `Release` workflow tags the result and publishes a GitHub release
+  whose notes are that section. `npm run release:check` (and `npm test`) fail on a
+  changelog that would produce a dead link. See `docs/developer/releasing.md`.
 - **Gated `git push` (ADR 005 slice 2b), staging-flagged.** With
   `GIT_PUSH_GATED_ENABLED`, pushing to a project's default branch lands the pack
   on a server-managed workspace fork and opens an eval-gated change through the
@@ -84,5 +92,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes, GitHub import/sync, server-rendered web UI, email and GitHub OAuth authentication,
   API tokens, agent identities, and provenance tracking.
 
-[Unreleased]: https://github.com/stratum-eng/stratum/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/stratum-eng/stratum/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/stratum-eng/stratum/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/stratum-eng/stratum/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,18 @@ token.**
   Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
   ```
 
+## Changelog & releases
+
+Every user-visible change belongs in the `## [Unreleased]` section of
+[`CHANGELOG.md`](CHANGELOG.md), in the same PR, under a
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) group (`Breaking`, `Added`,
+`Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). That text becomes the release
+notes verbatim, so write it for someone deciding whether to upgrade.
+
+Releases are cut from the changelog with `npm run release:prepare` and published by the
+**Release** workflow. Maintainers: see
+[`docs/developer/releasing.md`](docs/developer/releasing.md).
+
 ## Reporting bugs & requesting features
 
 Use the [issue templates](.github/ISSUE_TEMPLATE/). For anything security-related, **do not open a

--- a/README.md
+++ b/README.md
@@ -419,7 +419,8 @@ Working with an AI coding agent? Point it at [AGENTS.md](AGENTS.md) — the agen
 version of the contributor guide.
 
 This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). Notable changes are
-recorded in [CHANGELOG.md](CHANGELOG.md).
+recorded in [CHANGELOG.md](CHANGELOG.md); every version is tagged and published on the
+[releases page](https://github.com/stratum-eng/stratum/releases).
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ Working with an AI coding agent? Point it at [AGENTS.md](AGENTS.md) — the agen
 version of the contributor guide.
 
 This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). Notable changes are
-recorded in [CHANGELOG.md](CHANGELOG.md); every version is tagged and published on the
+recorded in [CHANGELOG.md](CHANGELOG.md), and tagged versions are published on the
 [releases page](https://github.com/stratum-eng/stratum/releases).
 
 ## Security

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -8,6 +8,7 @@
 4. [Queues](queues.md)
 5. [Testing](testing.md)
 6. [Deployment](deployment.md)
+7. [Releasing](releasing.md)
 
 ## Tech Stack
 

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -1,0 +1,105 @@
+# Releasing
+
+Stratum releases are **changelog-driven**: `CHANGELOG.md` is the source of truth for
+what the current version is and what shipped in it. The tooling reads that file —
+nothing derives a version from commit messages, and nobody edits a version number by
+hand.
+
+Every released version has a `vX.Y.Z` git tag and a GitHub release whose notes are
+that version's changelog section, so `.../releases/tag/vX.Y.Z` and the `compare`
+links in `CHANGELOG.md` always resolve.
+
+## The habit
+
+Add to the `## [Unreleased]` section in the same PR as the change, under a
+Keep a Changelog group (`Breaking`, `Added`, `Changed`, `Deprecated`, `Removed`,
+`Fixed`, `Security`). Then cut a release whenever a meaningful feature lands —
+small and often beats a quarterly mega-release.
+
+## Cutting a release
+
+**1. Prepare (local, one command).**
+
+```bash
+npm run release:prepare            # auto-picks the bump from the Unreleased groups
+npm run release:prepare -- --dry-run          # print the version, write nothing
+npm run release:prepare -- --bump minor       # or major / minor / patch
+```
+
+This moves everything under `## [Unreleased]` into a new dated `## [X.Y.Z]` section,
+opens a fresh empty `Unreleased`, rewrites the compare links, and bumps `version` in
+the root `package.json`.
+
+The bump comes from the group headings in `Unreleased`:
+
+| Groups present | Bump |
+|---|---|
+| `Breaking` or `Removed` | major |
+| `Added` | minor |
+| anything else (`Changed`, `Fixed`, `Security`, `Deprecated`) | patch |
+
+While the major version is `0`, an inferred major is clamped to a minor — per SemVer,
+`0.y.z` may break at any time. Reaching `1.0.0` is a deliberate act:
+`npm run release:prepare -- --bump major`.
+
+**2. Open the release PR.** Commit as `chore(release): vX.Y.Z`, get it reviewed and
+merged like any other change. The release PR is the last chance to reword entries —
+the changelog text *is* the release notes.
+
+**3. Publish.** Run the **Release** workflow (Actions → Release → Run workflow). It
+reads the version from `CHANGELOG.md`, checks `package.json` agrees, re-runs
+lint → typecheck → test:coverage against the tree it is about to tag, pushes the
+annotated `vX.Y.Z` tag, and creates the GitHub release from the changelog section.
+
+Tick **dry run** to see the resolved version and the exact release body in the job
+summary without tagging or publishing anything.
+
+**4. Deploy.** Releasing does not deploy. Run **Deploy Production** as usual; the tag
+records what that deploy contains.
+
+## Publishing a tag pushed by hand
+
+Pushing a `vX.Y.Z` tag also triggers the workflow, which publishes the release from
+the changelog section for that version. This is how tags are backfilled onto commits
+that predate the release tooling:
+
+```bash
+git tag -a v0.1.0 <commit> -m "v0.1.0"
+git push origin v0.1.0
+```
+
+Both paths read `CHANGELOG.md` and the tooling from the default branch, never from
+the tagged tree — an old commit has neither. Re-running for a tag that already has a
+release refreshes its notes rather than failing, so a changelog correction can be
+republished.
+
+## Checking the changelog
+
+```bash
+npm run release:check                # structure + package.json agreement
+npm run release:notes                # print the newest release's notes
+npm run release:notes -- 0.1.0       # …or a specific version's
+npm run release:latest               # print the newest released version
+```
+
+`release:check` catches exactly the failure this process exists to prevent: a version
+with no link definition, an undated or out-of-order release, a `package.json` that
+has drifted from the changelog. `tests/changelog.test.ts` runs the same validation
+against the real `CHANGELOG.md`, so `npm test` fails before a malformed changelog can
+reach the release workflow.
+
+## Scope
+
+The root `package.json` version covers the Worker — the deployed platform. The
+publishable packages under `cli/`, `agent/`, and `mcp/` version and publish
+independently; `release:prepare` does not touch them.
+
+## Files
+
+| File | Role |
+|---|---|
+| `CHANGELOG.md` | Source of truth: versions, dates, notes, links |
+| `scripts/changelog.ts` | Pure parsing, bump inference, and rewriting |
+| `scripts/release.ts` | The `check` / `latest` / `notes` / `prepare` CLI |
+| `tests/changelog.test.ts` | Unit tests, plus validation of the real changelog |
+| `.github/workflows/release.yml` | Tags and publishes the GitHub release |

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -5,9 +5,15 @@ what the current version is and what shipped in it. The tooling reads that file 
 nothing derives a version from commit messages, and nobody edits a version number by
 hand.
 
-Every released version has a `vX.Y.Z` git tag and a GitHub release whose notes are
-that version's changelog section, so `.../releases/tag/vX.Y.Z` and the `compare`
-links in `CHANGELOG.md` always resolve.
+Every version released through this process gets a `vX.Y.Z` git tag and a GitHub
+release whose notes are that version's changelog section, so
+`.../releases/tag/vX.Y.Z` and the `compare` links in `CHANGELOG.md` resolve.
+
+Versions that shipped before this process need their tags backfilled — see
+[Publishing a tag pushed by hand](#publishing-a-tag-pushed-by-hand). Until
+`v0.1.0` is backfilled its links still 404, and the Release workflow refuses to
+publish a version whose predecessor tag is missing rather than ship a release
+whose history link is dead.
 
 ## The habit
 
@@ -48,8 +54,13 @@ the changelog text *is* the release notes.
 
 **3. Publish.** Run the **Release** workflow (Actions → Release → Run workflow). It
 reads the version from `CHANGELOG.md`, checks `package.json` agrees, re-runs
-lint → typecheck → test:coverage against the tree it is about to tag, pushes the
-annotated `vX.Y.Z` tag, and creates the GitHub release from the changelog section.
+lint → typecheck → test:coverage against the tree it is about to tag, verifies the
+predecessor version is already tagged, then creates the annotated `vX.Y.Z` tag and
+the GitHub release from the changelog section.
+
+The tag is created through the GitHub API rather than `git push`, so the checkout
+never persists a repository-write credential that a dependency's install script
+could reach.
 
 Tick **dry run** to see the resolved version and the exact release body in the job
 summary without tagging or publishing anything.
@@ -80,6 +91,7 @@ npm run release:check                # structure + package.json agreement
 npm run release:notes                # print the newest release's notes
 npm run release:notes -- 0.1.0       # …or a specific version's
 npm run release:latest               # print the newest released version
+npm run release:previous             # print the version below it (empty if none)
 ```
 
 `release:check` catches exactly the failure this process exists to prevent: a version
@@ -100,6 +112,6 @@ independently; `release:prepare` does not touch them.
 |---|---|
 | `CHANGELOG.md` | Source of truth: versions, dates, notes, links |
 | `scripts/changelog.ts` | Pure parsing, bump inference, and rewriting |
-| `scripts/release.ts` | The `check` / `latest` / `notes` / `prepare` CLI |
+| `scripts/release.ts` | The `check` / `latest` / `previous` / `notes` / `prepare` CLI |
 | `tests/changelog.test.ts` | Unit tests, plus validation of the real changelog |
 | `.github/workflows/release.yml` | Tags and publishes the GitHub release |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratum",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "engines": {
     "//": "node:sqlite is unflagged only from 22.13.0; tests/helpers/sqlite-d1.ts imports it.",
     "node": ">=22.13.0"
@@ -22,6 +22,10 @@
     "lint": "biome check src tests",
     "lint:fix": "biome check --write src tests",
     "typecheck": "tsc --noEmit",
+    "release:check": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/release.ts check",
+    "release:latest": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/release.ts latest",
+    "release:notes": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/release.ts notes",
+    "release:prepare": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/release.ts prepare",
     "cf-typegen": "wrangler types"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "typecheck": "tsc --noEmit",
     "release:check": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/release.ts check",
     "release:latest": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/release.ts latest",
+    "release:previous": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/release.ts previous",
     "release:notes": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/release.ts notes",
     "release:prepare": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/release.ts prepare",
     "cf-typegen": "wrangler types"

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -1,0 +1,322 @@
+/**
+ * Keep a Changelog parsing and the version mechanics behind `scripts/release.ts`.
+ *
+ * Pure string in, string out: no file system, no Node built-ins, no imports.
+ * `tests/changelog.test.ts` type-checks under the Workers tsconfig (which has no
+ * `@types/node`), and `scripts/release.ts` runs under bare `node`, which needs
+ * explicit `.ts` import specifiers that the same tsconfig rejects. Keeping this
+ * module dependency-free is what lets both consume it unchanged.
+ */
+
+/**
+ * Same shape as `src/utils/result.ts`, redeclared for the reason above — this
+ * module cannot import from `src/`.
+ */
+export type Result<T, E = string> = { success: true; data: T } | { success: false; error: E };
+
+export type Bump = "major" | "minor" | "patch";
+export type BumpRequest = Bump | "auto";
+
+export const UNRELEASED = "Unreleased";
+
+/** Group headings that force a major bump under `auto`. */
+const BREAKING_GROUPS = new Set(["breaking", "removed"]);
+
+/** Group headings that force at least a minor bump under `auto`. */
+const FEATURE_GROUPS = new Set(["added"]);
+
+const HEADING_RE = /^## \[([^\]]+)\](?:\s+-\s+(\S+))?\s*$/;
+const GROUP_RE = /^### (.+?)\s*$/;
+const LINK_RE = /^\[([^\]]+)\]:\s*(\S+)\s*$/;
+const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export interface ChangelogSection {
+  /** `Unreleased`, or a semver string such as `0.1.0`. */
+  version: string;
+  /** The `YYYY-MM-DD` on the heading. Absent on `Unreleased`. */
+  date?: string;
+  /** Everything under the heading, with surrounding blank lines trimmed. */
+  body: string;
+}
+
+export interface ParsedChangelog {
+  /** Everything above the first `## [...]` heading, trailing blanks trimmed. */
+  preamble: string;
+  sections: ChangelogSection[];
+  /** `[0.1.0]: https://…` reference definitions, keyed by label, in file order. */
+  links: Map<string, string>;
+}
+
+/** Trim leading and trailing blank lines without touching interior blank lines. */
+function trimBlankLines(lines: string[]): string {
+  let start = 0;
+  let end = lines.length;
+  while (start < end && lines[start]?.trim() === "") start++;
+  while (end > start && lines[end - 1]?.trim() === "") end--;
+  return lines.slice(start, end).join("\n");
+}
+
+/**
+ * Split a changelog into its preamble, its `## [version]` sections, and its
+ * link-reference definitions. Link definitions are pulled out wherever they
+ * appear rather than assumed to be a trailing block, so a section body never
+ * carries one into the rendered release notes.
+ */
+export function parseChangelog(text: string): ParsedChangelog {
+  const preamble: string[] = [];
+  const sections: ChangelogSection[] = [];
+  const links = new Map<string, string>();
+
+  let current: { version: string; date?: string; lines: string[] } | null = null;
+
+  const flush = (): void => {
+    if (!current) return;
+    const section: ChangelogSection = {
+      version: current.version,
+      body: trimBlankLines(current.lines),
+    };
+    if (current.date !== undefined) section.date = current.date;
+    sections.push(section);
+    current = null;
+  };
+
+  for (const line of text.split("\n")) {
+    const link = LINK_RE.exec(line);
+    if (link?.[1] && link[2]) {
+      links.set(link[1], link[2]);
+      continue;
+    }
+
+    const heading = HEADING_RE.exec(line);
+    if (heading?.[1]) {
+      flush();
+      current = heading[2]
+        ? { version: heading[1], date: heading[2], lines: [] }
+        : { version: heading[1], lines: [] };
+      continue;
+    }
+
+    if (current) current.lines.push(line);
+    else preamble.push(line);
+  }
+  flush();
+
+  return { preamble: trimBlankLines(preamble), sections, links };
+}
+
+/** The `### Group` headings present in a section body, lowercased. */
+export function groupsIn(body: string): string[] {
+  const groups: string[] = [];
+  for (const line of body.split("\n")) {
+    const match = GROUP_RE.exec(line);
+    if (match?.[1]) groups.push(match[1].toLowerCase());
+  }
+  return groups;
+}
+
+/**
+ * Derive a bump from what the `Unreleased` section actually says: a `Breaking`
+ * or `Removed` group is a major, an `Added` group is a minor, anything else
+ * (Changed, Fixed, Security, Deprecated) is a patch.
+ */
+export function inferBump(body: string): Bump {
+  const groups = groupsIn(body);
+  if (groups.some((group) => BREAKING_GROUPS.has(group))) return "major";
+  if (groups.some((group) => FEATURE_GROUPS.has(group))) return "minor";
+  return "patch";
+}
+
+/**
+ * Apply an explicit bump request, or infer one. While the major version is 0
+ * an inferred major is clamped to a minor, per SemVer's "anything MAY change
+ * at any time" rule for 0.y.z — an explicit `major` still means 1.0.0.
+ */
+export function resolveBump(
+  current: string,
+  request: BumpRequest,
+  unreleasedBody: string,
+): Result<Bump> {
+  const parsed = SEMVER_RE.exec(current);
+  if (!parsed) return { success: false, error: `Current version is not semver: ${current}` };
+  if (request !== "auto") return { success: true, data: request };
+
+  const inferred = inferBump(unreleasedBody);
+  const isZeroMajor = parsed[1] === "0";
+  return { success: true, data: isZeroMajor && inferred === "major" ? "minor" : inferred };
+}
+
+/** Increment `current` by `bump`, dropping any prerelease or build metadata. */
+export function nextVersion(current: string, bump: Bump): Result<string> {
+  const parsed = SEMVER_RE.exec(current);
+  if (!parsed?.[1] || !parsed[2] || !parsed[3]) {
+    return { success: false, error: `Current version is not semver: ${current}` };
+  }
+  const major = Number(parsed[1]);
+  const minor = Number(parsed[2]);
+  const patch = Number(parsed[3]);
+
+  if (bump === "major") return { success: true, data: `${major + 1}.0.0` };
+  if (bump === "minor") return { success: true, data: `${major}.${minor + 1}.0` };
+  return { success: true, data: `${major}.${minor}.${patch + 1}` };
+}
+
+export function isSemver(version: string): boolean {
+  return SEMVER_RE.test(version);
+}
+
+/** The most recently released version, or null when nothing has shipped yet. */
+export function latestRelease(text: string): string | null {
+  const released = parseChangelog(text).sections.find((section) => section.version !== UNRELEASED);
+  return released?.version ?? null;
+}
+
+/**
+ * The body of one release's section, ready to be a GitHub release description.
+ * Fails loudly on a missing or empty section rather than publishing a release
+ * with no notes.
+ */
+export function releaseNotes(text: string, version: string): Result<string> {
+  const section = parseChangelog(text).sections.find((entry) => entry.version === version);
+  if (!section) return { success: false, error: `No \`## [${version}]\` section in CHANGELOG.md` };
+  if (section.body.trim() === "")
+    return { success: false, error: `The \`## [${version}]\` section is empty` };
+  return { success: true, data: section.body };
+}
+
+function renderChangelog(parsed: ParsedChangelog): string {
+  const parts = [parsed.preamble, ""];
+  for (const section of parsed.sections) {
+    parts.push(
+      section.date ? `## [${section.version}] - ${section.date}` : `## [${section.version}]`,
+    );
+    if (section.body !== "") parts.push("", section.body);
+    parts.push("");
+  }
+  for (const [label, url] of parsed.links) parts.push(`[${label}]: ${url}`);
+  return `${parts.join("\n")}\n`;
+}
+
+export interface CutOptions {
+  /** The version being cut, e.g. `0.2.0`. */
+  version: string;
+  /** Release date as `YYYY-MM-DD`. */
+  date: string;
+  /** Repository URL without a trailing slash, e.g. `https://github.com/owner/repo`. */
+  repoUrl: string;
+}
+
+/**
+ * Move everything under `Unreleased` into a dated section for `version`, open a
+ * fresh empty `Unreleased`, and rewrite the compare links so `Unreleased` spans
+ * from the new tag and the new version spans from its predecessor.
+ */
+export function cutRelease(text: string, options: CutOptions): Result<string> {
+  const { version, date, repoUrl } = options;
+  if (!isSemver(version)) return { success: false, error: `Not a semver version: ${version}` };
+  if (!DATE_RE.test(date)) return { success: false, error: `Not a YYYY-MM-DD date: ${date}` };
+
+  const parsed = parseChangelog(text);
+  const unreleased = parsed.sections.find((section) => section.version === UNRELEASED);
+  if (!unreleased)
+    return { success: false, error: "CHANGELOG.md has no `## [Unreleased]` section" };
+  if (unreleased.body.trim() === "") {
+    return { success: false, error: "Nothing to release: the `Unreleased` section is empty" };
+  }
+  if (parsed.sections.some((section) => section.version === version)) {
+    return { success: false, error: `CHANGELOG.md already has a \`## [${version}]\` section` };
+  }
+
+  const previous = latestRelease(text);
+  const rest = parsed.sections.filter((section) => section.version !== UNRELEASED);
+
+  const links = new Map<string, string>();
+  links.set(UNRELEASED, `${repoUrl}/compare/v${version}...HEAD`);
+  links.set(
+    version,
+    previous
+      ? `${repoUrl}/compare/v${previous}...v${version}`
+      : `${repoUrl}/releases/tag/v${version}`,
+  );
+  for (const [label, url] of parsed.links) {
+    if (label !== UNRELEASED && label !== version) links.set(label, url);
+  }
+
+  return {
+    success: true,
+    data: renderChangelog({
+      preamble: parsed.preamble,
+      sections: [
+        { version: UNRELEASED, body: "" },
+        { version, date, body: unreleased.body },
+        ...rest,
+      ],
+      links,
+    }),
+  };
+}
+
+/**
+ * Structural problems that would break the release automation later: a missing
+ * `Unreleased` heading, an undated or non-semver release, a version with no
+ * link definition (the dead-link failure mode this file exists to prevent), or
+ * releases listed out of order. Returns an empty array when the file is sound.
+ */
+export function validateChangelog(text: string): string[] {
+  const problems: string[] = [];
+  const parsed = parseChangelog(text);
+  const seen = new Set<string>();
+
+  if (!parsed.sections.some((section) => section.version === UNRELEASED)) {
+    problems.push("Missing an `## [Unreleased]` section");
+  }
+
+  const releases: string[] = [];
+  for (const section of parsed.sections) {
+    if (seen.has(section.version)) problems.push(`Duplicate section: ${section.version}`);
+    seen.add(section.version);
+
+    if (section.version === UNRELEASED) {
+      if (section.date) problems.push("`Unreleased` must not carry a date");
+      continue;
+    }
+
+    if (!isSemver(section.version)) problems.push(`Not a semver version: ${section.version}`);
+    else releases.push(section.version);
+
+    if (!section.date) problems.push(`\`${section.version}\` has no release date`);
+    else if (!DATE_RE.test(section.date))
+      problems.push(`\`${section.version}\` date is not YYYY-MM-DD`);
+
+    if (section.body.trim() === "") problems.push(`\`${section.version}\` has no entries`);
+  }
+
+  for (const version of seen) {
+    if (!parsed.links.has(version)) problems.push(`No link definition for \`${version}\``);
+  }
+  for (const label of parsed.links.keys()) {
+    if (!seen.has(label)) problems.push(`Link definition \`${label}\` has no matching section`);
+  }
+
+  for (let i = 1; i < releases.length; i++) {
+    const newer = releases[i - 1];
+    const older = releases[i];
+    if (newer && older && compareVersions(newer, older) <= 0) {
+      problems.push(`Releases are out of order: \`${newer}\` is listed above \`${older}\``);
+    }
+  }
+
+  return problems;
+}
+
+/** Compare two semver cores; prerelease identifiers are ignored. */
+export function compareVersions(a: string, b: string): number {
+  const left = SEMVER_RE.exec(a);
+  const right = SEMVER_RE.exec(b);
+  if (!left || !right) return 0;
+  for (let i = 1; i <= 3; i++) {
+    const diff = Number(left[i]) - Number(right[i]);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -41,6 +41,7 @@ interface ParsedVersion {
   prerelease: string[];
 }
 
+/** Split a canonical SemVer string into its core numbers and prerelease identifiers. */
 function parseVersion(version: string): ParsedVersion | null {
   const match = SEMVER_RE.exec(version);
   if (!match?.[1] || !match[2] || !match[3]) return null;
@@ -199,6 +200,7 @@ export function nextVersion(current: string, bump: Bump): Result<string> {
   return { success: true, data: `${major}.${minor}.${patch + 1}` };
 }
 
+/** Whether `version` is canonical SemVer 2.0.0 — the form a release tag must take. */
 export function isSemver(version: string): boolean {
   return SEMVER_RE.test(version);
 }
@@ -222,6 +224,7 @@ export function releaseNotes(text: string, version: string): Result<string> {
   return { success: true, data: section.body };
 }
 
+/** Serialise a parsed changelog back to Keep a Changelog markdown, links last. */
 function renderChangelog(parsed: ParsedChangelog): string {
   const parts = [parsed.preamble, ""];
   for (const section of parsed.sections) {
@@ -366,6 +369,7 @@ export function compareVersions(a: string, b: string): number {
   return comparePrerelease(left.prerelease, right.prerelease);
 }
 
+/** Compare two prerelease identifier sets under SemVer §11.4. */
 function comparePrerelease(left: string[], right: string[]): number {
   // A version without a prerelease has higher precedence than one with it.
   if (left.length === 0) return right.length === 0 ? 0 : 1;

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -85,6 +85,38 @@ export function isCalendarDate(value: string): boolean {
   );
 }
 
+/**
+ * Set the root `version` in a package manifest, editing the text surgically so
+ * the rest of the file keeps its formatting — re-serialising would expand the
+ * hand-written one-line objects in this repo's manifest and bury the change.
+ *
+ * The pattern matches the first line-anchored `"version"` at any nesting depth,
+ * so the result is verified structurally: a nested hit would otherwise rewrite
+ * the wrong field, leave the root version stale, and still look like a success.
+ */
+export function setPackageVersion(raw: string, version: string): Result<string> {
+  const updated = raw.replace(/^(\s*"version"\s*:\s*)"[^"]*"/m, `$1"${version}"`);
+  if (updated === raw) {
+    return { success: false, error: 'No `"version"` field found in the manifest' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(updated);
+  } catch (error) {
+    return { success: false, error: `Rewriting the version produced invalid JSON: ${error}` };
+  }
+
+  const root = (parsed as { version?: unknown }).version;
+  if (root !== version) {
+    return {
+      success: false,
+      error: `Rewrote a nested \`"version"\` rather than the root one — the root is still ${JSON.stringify(root)}`,
+    };
+  }
+  return { success: true, data: updated };
+}
+
 export interface ChangelogSection {
   /** `Unreleased`, or a semver string such as `0.1.0`. */
   version: string;

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -36,7 +36,8 @@ const DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
 const NUMERIC_RE = /^\d+$/;
 
 interface ParsedVersion {
-  core: [number, number, number];
+  /** Major, minor, patch, kept as canonical decimal strings — see `compareNumeric`. */
+  core: [string, string, string];
   /** Dot-separated prerelease identifiers; empty for a final release. */
   prerelease: string[];
 }
@@ -46,9 +47,23 @@ function parseVersion(version: string): ParsedVersion | null {
   const match = SEMVER_RE.exec(version);
   if (!match?.[1] || !match[2] || !match[3]) return null;
   return {
-    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    core: [match[1], match[2], match[3]],
     prerelease: match[4] ? match[4].split(".") : [],
   };
+}
+
+/**
+ * Order two SemVer numeric identifiers without going through `Number`, which
+ * silently collapses anything past 2^53 — `9007199254740993` and
+ * `9007199254740992` compare equal as floats, which would make
+ * `validateChangelog` reject a correctly ordered history. Canonical SemVer
+ * forbids leading zeros, so a longer digit run is always the larger number and
+ * equal-length runs compare lexically.
+ */
+function compareNumeric(a: string, b: string): number {
+  if (a.length !== b.length) return a.length - b.length;
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
 }
 
 /**
@@ -363,7 +378,7 @@ export function compareVersions(a: string, b: string): number {
   if (!left || !right) return 0;
 
   for (let i = 0; i < 3; i++) {
-    const diff = (left.core[i] ?? 0) - (right.core[i] ?? 0);
+    const diff = compareNumeric(left.core[i] ?? "0", right.core[i] ?? "0");
     if (diff !== 0) return diff;
   }
   return comparePrerelease(left.prerelease, right.prerelease);
@@ -385,7 +400,7 @@ function comparePrerelease(left: string[], right: string[]): number {
 
     const aNumeric = NUMERIC_RE.test(a);
     const bNumeric = NUMERIC_RE.test(b);
-    if (aNumeric && bNumeric) return Number(a) - Number(b);
+    if (aNumeric && bNumeric) return compareNumeric(a, b);
     // Numeric identifiers always rank below alphanumeric ones.
     if (aNumeric !== bNumeric) return aNumeric ? -1 : 1;
     return a < b ? -1 : 1;

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -28,8 +28,46 @@ const FEATURE_GROUPS = new Set(["added"]);
 const HEADING_RE = /^## \[([^\]]+)\](?:\s+-\s+(\S+))?\s*$/;
 const GROUP_RE = /^### (.+?)\s*$/;
 const LINK_RE = /^\[([^\]]+)\]:\s*(\S+)\s*$/;
-const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/;
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+// Canonical SemVer 2.0.0 (semver.org): no leading zeros in the core or in a
+// numeric prerelease identifier, so `01.2.3` and `1.2.3-01` are rejected.
+const SEMVER_RE =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const NUMERIC_RE = /^\d+$/;
+
+interface ParsedVersion {
+  core: [number, number, number];
+  /** Dot-separated prerelease identifiers; empty for a final release. */
+  prerelease: string[];
+}
+
+function parseVersion(version: string): ParsedVersion | null {
+  const match = SEMVER_RE.exec(version);
+  if (!match?.[1] || !match[2] || !match[3]) return null;
+  return {
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4] ? match[4].split(".") : [],
+  };
+}
+
+/**
+ * A real UTC calendar date, not just the `YYYY-MM-DD` shape: `2026-02-30` and
+ * `2026-00-00` match the pattern but are not dates, and a changelog carrying one
+ * would publish a release with impossible metadata.
+ */
+export function isCalendarDate(value: string): boolean {
+  const match = DATE_RE.exec(value);
+  if (!match?.[1] || !match[2] || !match[3]) return false;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+  );
+}
 
 export interface ChangelogSection {
   /** `Unreleased`, or a semver string such as `0.1.0`. */
@@ -214,7 +252,7 @@ export interface CutOptions {
 export function cutRelease(text: string, options: CutOptions): Result<string> {
   const { version, date, repoUrl } = options;
   if (!isSemver(version)) return { success: false, error: `Not a semver version: ${version}` };
-  if (!DATE_RE.test(date)) return { success: false, error: `Not a YYYY-MM-DD date: ${date}` };
+  if (!isCalendarDate(date)) return { success: false, error: `Not a YYYY-MM-DD date: ${date}` };
 
   const parsed = parseChangelog(text);
   const unreleased = parsed.sections.find((section) => section.version === UNRELEASED);
@@ -285,8 +323,8 @@ export function validateChangelog(text: string): string[] {
     else releases.push(section.version);
 
     if (!section.date) problems.push(`\`${section.version}\` has no release date`);
-    else if (!DATE_RE.test(section.date))
-      problems.push(`\`${section.version}\` date is not YYYY-MM-DD`);
+    else if (!isCalendarDate(section.date))
+      problems.push(`\`${section.version}\` date is not a real YYYY-MM-DD date`);
 
     if (section.body.trim() === "") problems.push(`\`${section.version}\` has no entries`);
   }
@@ -309,14 +347,59 @@ export function validateChangelog(text: string): string[] {
   return problems;
 }
 
-/** Compare two semver cores; prerelease identifiers are ignored. */
+/**
+ * SemVer 2.0.0 precedence (§11), including prerelease ordering: a final release
+ * outranks any of its prereleases, numeric identifiers compare numerically and
+ * rank below alphanumeric ones, and a shorter identifier set loses to a longer
+ * one that shares its prefix. Build metadata is ignored, as the spec requires.
+ * Returns 0 for input that is not canonical SemVer.
+ */
 export function compareVersions(a: string, b: string): number {
-  const left = SEMVER_RE.exec(a);
-  const right = SEMVER_RE.exec(b);
+  const left = parseVersion(a);
+  const right = parseVersion(b);
   if (!left || !right) return 0;
-  for (let i = 1; i <= 3; i++) {
-    const diff = Number(left[i]) - Number(right[i]);
+
+  for (let i = 0; i < 3; i++) {
+    const diff = (left.core[i] ?? 0) - (right.core[i] ?? 0);
     if (diff !== 0) return diff;
   }
+  return comparePrerelease(left.prerelease, right.prerelease);
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+  // A version without a prerelease has higher precedence than one with it.
+  if (left.length === 0) return right.length === 0 ? 0 : 1;
+  if (right.length === 0) return -1;
+
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const a = left[i];
+    const b = right[i];
+    // The set that runs out first has lower precedence.
+    if (a === undefined) return -1;
+    if (b === undefined) return 1;
+    if (a === b) continue;
+
+    const aNumeric = NUMERIC_RE.test(a);
+    const bNumeric = NUMERIC_RE.test(b);
+    if (aNumeric && bNumeric) return Number(a) - Number(b);
+    // Numeric identifiers always rank below alphanumeric ones.
+    if (aNumeric !== bNumeric) return aNumeric ? -1 : 1;
+    return a < b ? -1 : 1;
+  }
   return 0;
+}
+
+/**
+ * The release listed immediately below `version` — the predecessor its compare
+ * link points at, and therefore the tag that must already exist before this
+ * version's release is published. Null when `version` is the oldest release or
+ * is not listed at all.
+ */
+export function previousRelease(text: string, version: string): string | null {
+  const released = parseChangelog(text)
+    .sections.filter((section) => section.version !== UNRELEASED)
+    .map((section) => section.version);
+  const index = released.indexOf(version);
+  if (index === -1) return null;
+  return released[index + 1] ?? null;
 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -34,6 +34,7 @@ import {
   previousRelease,
   releaseNotes,
   resolveBump,
+  setPackageVersion,
   validateChangelog,
 } from "./changelog.ts";
 
@@ -62,17 +63,6 @@ function readPackage(): { raw: string; version: string; repoUrl: string } {
   if (typeof parsed.version !== "string") fail("package.json has no version");
   if (typeof url !== "string") fail("package.json has no repository.url");
   return { raw, version: parsed.version, repoUrl: url.replace(/\.git$/, "").replace(/\/$/, "") };
-}
-
-/**
- * Rewrite only the top-level `"version"` field, textually. Re-serialising the
- * parsed object would reformat the whole file and fight with the repo's
- * hand-maintained key order and comment keys.
- */
-function withVersion(raw: string, version: string): string {
-  const updated = raw.replace(/^(\s*"version"\s*:\s*)"[^"]*"/m, `$1"${version}"`);
-  if (updated === raw) fail('Could not find a top-level "version" field in package.json');
-  return updated;
 }
 
 /** The value following `flag`, or undefined when it is absent; exits if the value is missing. */
@@ -170,13 +160,18 @@ function commandPrepare(args: string[]): void {
   const cut = cutRelease(changelog, { version: next.data, date, repoUrl: pkg.repoUrl });
   if (!cut.success) fail(cut.error);
 
+  // Resolve both files before writing either: a manifest failure after the
+  // changelog was already rewritten would leave the release half-cut.
+  const bumped = setPackageVersion(pkg.raw, next.data);
+  if (!bumped.success) fail(`package.json: ${bumped.error}`);
+
   if (dryRun) {
     console.log(`${pkg.version} → ${next.data} (${resolved.data}, dry run — nothing written)`);
     return;
   }
 
   writeFileSync(CHANGELOG_PATH, cut.data);
-  writeFileSync(PACKAGE_PATH, withVersion(pkg.raw, next.data));
+  writeFileSync(PACKAGE_PATH, bumped.data);
   console.log(`✓ Prepared v${next.data} (${resolved.data} from ${pkg.version}), dated ${date}`);
   console.log("  Review the diff, open a PR, and merge it; then run the Release workflow.");
 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -43,15 +43,18 @@ const PACKAGE_PATH = resolve(REPO_ROOT, "package.json");
 
 const BUMPS: BumpRequest[] = ["auto", "major", "minor", "patch"];
 
+/** Report a fatal problem and exit non-zero, so CI stops on a bad changelog. */
 function fail(message: string): never {
   console.error(`✗ ${message}`);
   process.exit(1);
 }
 
+/** Read CHANGELOG.md from the repository root, wherever the script is invoked from. */
 function readChangelog(): string {
   return readFileSync(CHANGELOG_PATH, "utf8");
 }
 
+/** The root manifest's raw text, its version, and its repository URL without the `.git` suffix. */
 function readPackage(): { raw: string; version: string; repoUrl: string } {
   const raw = readFileSync(PACKAGE_PATH, "utf8");
   const parsed = JSON.parse(raw);
@@ -72,6 +75,7 @@ function withVersion(raw: string, version: string): string {
   return updated;
 }
 
+/** The value following `flag`, or undefined when it is absent; exits if the value is missing. */
 function argValue(args: string[], flag: string): string | undefined {
   const index = args.indexOf(flag);
   if (index === -1) return undefined;
@@ -80,6 +84,7 @@ function argValue(args: string[], flag: string): string | undefined {
   return value;
 }
 
+/** `check`: report every structural problem in CHANGELOG.md, plus package.json drift. */
 function commandCheck(): void {
   const changelog = readChangelog();
   const problems = validateChangelog(changelog);
@@ -97,12 +102,14 @@ function commandCheck(): void {
   console.log(`✓ CHANGELOG.md is well-formed; latest release is ${latest ?? "(none)"}`);
 }
 
+/** `latest`: print the newest released version. */
 function commandLatest(): void {
   const latest = latestRelease(readChangelog());
   if (!latest) fail("CHANGELOG.md has no released version yet");
   console.log(latest);
 }
 
+/** `previous`: print the predecessor whose tag a version's compare link depends on. */
 function commandPrevious(args: string[]): void {
   const changelog = readChangelog();
   const requested = args[0]?.replace(/^v/, "") ?? latestRelease(changelog);
@@ -113,6 +120,7 @@ function commandPrevious(args: string[]): void {
   console.log(previousRelease(changelog, requested) ?? "");
 }
 
+/** `notes`: print one release's changelog entries, ready to be a GitHub release body. */
 function commandNotes(args: string[]): void {
   const changelog = readChangelog();
   const requested = args[0]?.replace(/^v/, "") ?? latestRelease(changelog);
@@ -123,6 +131,7 @@ function commandNotes(args: string[]): void {
   console.log(notes.data);
 }
 
+/** `prepare`: cut a release — date the `Unreleased` section, relink it, bump package.json. */
 function commandPrepare(args: string[]): void {
   const bump = (argValue(args, "--bump") ?? "auto") as BumpRequest;
   if (!BUMPS.includes(bump)) fail(`--bump must be one of ${BUMPS.join(", ")}`);
@@ -161,6 +170,7 @@ function commandPrepare(args: string[]): void {
   console.log("  Review the diff, open a PR, and merge it; then run the Release workflow.");
 }
 
+/** Dispatch the subcommand named by the first argument. */
 function main(argv: string[]): void {
   const [command, ...args] = argv;
   switch (command) {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -3,10 +3,12 @@
  *
  * Run with: node --experimental-strip-types scripts/release.ts <command>
  *
- *   check              Validate CHANGELOG.md and that package.json agrees with it
- *   latest             Print the most recently released version (no `v` prefix)
- *   notes [version]    Print one release's changelog entries (default: latest)
- *   prepare [options]  Move `Unreleased` into a dated section and bump package.json
+ *   check                  Validate CHANGELOG.md and that package.json agrees with it
+ *   latest                 Print the most recently released version (no `v` prefix)
+ *   previous [version]     Print the release listed below `version` (default: latest);
+ *                          prints nothing when there is none
+ *   notes [version]        Print one release's changelog entries (default: latest)
+ *   prepare [options]      Move `Unreleased` into a dated section and bump package.json
  *
  * `prepare` options:
  *   --bump auto|major|minor|patch   Default: auto (derived from the `Unreleased` groups)
@@ -29,6 +31,7 @@ import {
   latestRelease,
   nextVersion,
   parseChangelog,
+  previousRelease,
   releaseNotes,
   resolveBump,
   validateChangelog,
@@ -100,6 +103,16 @@ function commandLatest(): void {
   console.log(latest);
 }
 
+function commandPrevious(args: string[]): void {
+  const changelog = readChangelog();
+  const requested = args[0]?.replace(/^v/, "") ?? latestRelease(changelog);
+  if (!requested) fail("CHANGELOG.md has no released version yet");
+
+  // Empty output is a valid answer — the oldest release has no predecessor — so
+  // callers distinguish "none" from "failed" by the exit code, not the output.
+  console.log(previousRelease(changelog, requested) ?? "");
+}
+
 function commandNotes(args: string[]): void {
   const changelog = readChangelog();
   const requested = args[0]?.replace(/^v/, "") ?? latestRelease(changelog);
@@ -157,6 +170,9 @@ function main(argv: string[]): void {
     case "latest":
       commandLatest();
       break;
+    case "previous":
+      commandPrevious(args);
+      break;
     case "notes":
       commandNotes(args);
       break;
@@ -164,7 +180,9 @@ function main(argv: string[]): void {
       commandPrepare(args);
       break;
     default:
-      fail(`Unknown command: ${command ?? "(none)"}. Expected check, latest, notes, or prepare.`);
+      fail(
+        `Unknown command: ${command ?? "(none)"}. Expected check, latest, previous, notes, or prepare.`,
+      );
   }
 }
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -149,6 +149,17 @@ function commandPrepare(args: string[]): void {
     fail("Fix CHANGELOG.md before cutting a release (npm run release:check)");
   }
 
+  // The next version is computed from package.json, but the changelog is the
+  // record. If they have drifted, cutting from the manifest would write a
+  // section out of order with the history above it.
+  const latest = latestRelease(changelog);
+  if (latest && latest !== pkg.version) {
+    fail(
+      `package.json is ${pkg.version} but the newest CHANGELOG release is ${latest}. ` +
+        "Reconcile them before cutting (npm run release:check).",
+    );
+  }
+
   const unreleased = parseChangelog(changelog).sections.find((s) => s.version === UNRELEASED);
   const resolved = resolveBump(pkg.version, bump, unreleased?.body ?? "");
   if (!resolved.success) fail(resolved.error);

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,171 @@
+/**
+ * Release plumbing for the repository itself.
+ *
+ * Run with: node --experimental-strip-types scripts/release.ts <command>
+ *
+ *   check              Validate CHANGELOG.md and that package.json agrees with it
+ *   latest             Print the most recently released version (no `v` prefix)
+ *   notes [version]    Print one release's changelog entries (default: latest)
+ *   prepare [options]  Move `Unreleased` into a dated section and bump package.json
+ *
+ * `prepare` options:
+ *   --bump auto|major|minor|patch   Default: auto (derived from the `Unreleased` groups)
+ *   --date YYYY-MM-DD               Default: today, UTC
+ *   --dry-run                       Print the resulting version, write nothing
+ *
+ * The npm wrappers are `npm run release:check`, `release:notes`, `release:prepare`.
+ * See docs/developer/releasing.md for the whole flow.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import {
+  type BumpRequest,
+  UNRELEASED,
+  cutRelease,
+  isSemver,
+  latestRelease,
+  nextVersion,
+  parseChangelog,
+  releaseNotes,
+  resolveBump,
+  validateChangelog,
+} from "./changelog.ts";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const CHANGELOG_PATH = resolve(REPO_ROOT, "CHANGELOG.md");
+const PACKAGE_PATH = resolve(REPO_ROOT, "package.json");
+
+const BUMPS: BumpRequest[] = ["auto", "major", "minor", "patch"];
+
+function fail(message: string): never {
+  console.error(`✗ ${message}`);
+  process.exit(1);
+}
+
+function readChangelog(): string {
+  return readFileSync(CHANGELOG_PATH, "utf8");
+}
+
+function readPackage(): { raw: string; version: string; repoUrl: string } {
+  const raw = readFileSync(PACKAGE_PATH, "utf8");
+  const parsed = JSON.parse(raw);
+  const url = parsed.repository?.url;
+  if (typeof parsed.version !== "string") fail("package.json has no version");
+  if (typeof url !== "string") fail("package.json has no repository.url");
+  return { raw, version: parsed.version, repoUrl: url.replace(/\.git$/, "").replace(/\/$/, "") };
+}
+
+/**
+ * Rewrite only the top-level `"version"` field, textually. Re-serialising the
+ * parsed object would reformat the whole file and fight with the repo's
+ * hand-maintained key order and comment keys.
+ */
+function withVersion(raw: string, version: string): string {
+  const updated = raw.replace(/^(\s*"version"\s*:\s*)"[^"]*"/m, `$1"${version}"`);
+  if (updated === raw) fail('Could not find a top-level "version" field in package.json');
+  return updated;
+}
+
+function argValue(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  if (index === -1) return undefined;
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith("--")) fail(`${flag} needs a value`);
+  return value;
+}
+
+function commandCheck(): void {
+  const changelog = readChangelog();
+  const problems = validateChangelog(changelog);
+
+  const latest = latestRelease(changelog);
+  const pkg = readPackage();
+  if (latest && latest !== pkg.version) {
+    problems.push(`package.json is ${pkg.version} but the newest CHANGELOG release is ${latest}`);
+  }
+
+  if (problems.length > 0) {
+    for (const problem of problems) console.error(`  • ${problem}`);
+    fail(`CHANGELOG.md has ${problems.length} problem(s)`);
+  }
+  console.log(`✓ CHANGELOG.md is well-formed; latest release is ${latest ?? "(none)"}`);
+}
+
+function commandLatest(): void {
+  const latest = latestRelease(readChangelog());
+  if (!latest) fail("CHANGELOG.md has no released version yet");
+  console.log(latest);
+}
+
+function commandNotes(args: string[]): void {
+  const changelog = readChangelog();
+  const requested = args[0]?.replace(/^v/, "") ?? latestRelease(changelog);
+  if (!requested) fail("CHANGELOG.md has no released version yet");
+
+  const notes = releaseNotes(changelog, requested);
+  if (!notes.success) fail(notes.error);
+  console.log(notes.data);
+}
+
+function commandPrepare(args: string[]): void {
+  const bump = (argValue(args, "--bump") ?? "auto") as BumpRequest;
+  if (!BUMPS.includes(bump)) fail(`--bump must be one of ${BUMPS.join(", ")}`);
+
+  const date = argValue(args, "--date") ?? new Date().toISOString().slice(0, 10);
+  const dryRun = args.includes("--dry-run");
+
+  const changelog = readChangelog();
+  const pkg = readPackage();
+  if (!isSemver(pkg.version)) fail(`package.json version is not semver: ${pkg.version}`);
+
+  const problems = validateChangelog(changelog);
+  if (problems.length > 0) {
+    for (const problem of problems) console.error(`  • ${problem}`);
+    fail("Fix CHANGELOG.md before cutting a release (npm run release:check)");
+  }
+
+  const unreleased = parseChangelog(changelog).sections.find((s) => s.version === UNRELEASED);
+  const resolved = resolveBump(pkg.version, bump, unreleased?.body ?? "");
+  if (!resolved.success) fail(resolved.error);
+
+  const next = nextVersion(pkg.version, resolved.data);
+  if (!next.success) fail(next.error);
+
+  const cut = cutRelease(changelog, { version: next.data, date, repoUrl: pkg.repoUrl });
+  if (!cut.success) fail(cut.error);
+
+  if (dryRun) {
+    console.log(`${pkg.version} → ${next.data} (${resolved.data}, dry run — nothing written)`);
+    return;
+  }
+
+  writeFileSync(CHANGELOG_PATH, cut.data);
+  writeFileSync(PACKAGE_PATH, withVersion(pkg.raw, next.data));
+  console.log(`✓ Prepared v${next.data} (${resolved.data} from ${pkg.version}), dated ${date}`);
+  console.log("  Review the diff, open a PR, and merge it; then run the Release workflow.");
+}
+
+function main(argv: string[]): void {
+  const [command, ...args] = argv;
+  switch (command) {
+    case "check":
+      commandCheck();
+      break;
+    case "latest":
+      commandLatest();
+      break;
+    case "notes":
+      commandNotes(args);
+      break;
+    case "prepare":
+      commandPrepare(args);
+      break;
+    default:
+      fail(`Unknown command: ${command ?? "(none)"}. Expected check, latest, notes, or prepare.`);
+  }
+}
+
+main(process.argv.slice(2));

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -1,0 +1,320 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+// The repository's own changelog, so the release automation is exercised against
+// the real file rather than only fixtures. Imported raw (not via node:fs) to keep
+// this suite type-checking under the Workers tsconfig.
+import REAL_CHANGELOG from "../CHANGELOG.md?raw";
+import {
+  compareVersions,
+  cutRelease,
+  groupsIn,
+  inferBump,
+  isSemver,
+  latestRelease,
+  nextVersion,
+  parseChangelog,
+  releaseNotes,
+  resolveBump,
+  validateChangelog,
+} from "../scripts/changelog";
+
+const REPO = "https://github.com/stratum-eng/stratum";
+
+const FIXTURE = `# Changelog
+
+Preamble text.
+
+## [Unreleased]
+
+### Added
+- A new thing.
+
+### Fixed
+- An old thing.
+
+## [0.1.0] - 2026-06-11
+
+### Added
+- Initial release.
+
+[Unreleased]: ${REPO}/compare/v0.1.0...HEAD
+[0.1.0]: ${REPO}/releases/tag/v0.1.0
+`;
+
+describe("parseChangelog", () => {
+  it("splits preamble, sections, and link definitions", () => {
+    const parsed = parseChangelog(FIXTURE);
+
+    expect(parsed.preamble).toBe("# Changelog\n\nPreamble text.");
+    expect(parsed.sections.map((section) => section.version)).toEqual(["Unreleased", "0.1.0"]);
+    expect(parsed.sections[1]?.date).toBe("2026-06-11");
+    expect([...parsed.links.keys()]).toEqual(["Unreleased", "0.1.0"]);
+  });
+
+  it("keeps link definitions out of section bodies", () => {
+    const parsed = parseChangelog(FIXTURE);
+    expect(parsed.sections[1]?.body).toBe("### Added\n- Initial release.");
+  });
+
+  it("preserves interior blank lines but trims the edges", () => {
+    const parsed = parseChangelog(FIXTURE);
+    expect(parsed.sections[0]?.body).toBe(
+      "### Added\n- A new thing.\n\n### Fixed\n- An old thing.",
+    );
+  });
+
+  it("leaves Unreleased undated", () => {
+    expect(parseChangelog(FIXTURE).sections[0]?.date).toBeUndefined();
+  });
+});
+
+describe("groupsIn / inferBump", () => {
+  it("lists the group headings in a section", () => {
+    expect(groupsIn("### Added\n- x\n\n### Fixed\n- y")).toEqual(["added", "fixed"]);
+  });
+
+  it("does not mistake a bullet for a heading", () => {
+    expect(groupsIn("- ### Added is not a heading")).toEqual([]);
+  });
+
+  it("treats Breaking and Removed as major", () => {
+    expect(inferBump("### Breaking\n- x")).toBe("major");
+    expect(inferBump("### Removed\n- x")).toBe("major");
+  });
+
+  it("treats Added as minor", () => {
+    expect(inferBump("### Added\n- x\n\n### Fixed\n- y")).toBe("minor");
+  });
+
+  it("treats everything else as patch", () => {
+    expect(inferBump("### Fixed\n- x\n\n### Security\n- y")).toBe("patch");
+  });
+});
+
+describe("resolveBump", () => {
+  it("clamps an inferred major to a minor while the major version is 0", () => {
+    const resolved = resolveBump("0.1.0", "auto", "### Breaking\n- x");
+    expect(resolved).toEqual({ success: true, data: "minor" });
+  });
+
+  it("honours an explicit major on a 0.x version", () => {
+    expect(resolveBump("0.1.0", "major", "### Fixed\n- x")).toEqual({
+      success: true,
+      data: "major",
+    });
+  });
+
+  it("does not clamp once the major version is 1 or above", () => {
+    expect(resolveBump("1.4.2", "auto", "### Breaking\n- x")).toEqual({
+      success: true,
+      data: "major",
+    });
+  });
+
+  it("rejects a non-semver current version", () => {
+    expect(resolveBump("v1", "auto", "").success).toBe(false);
+  });
+});
+
+describe("nextVersion", () => {
+  it.each([
+    ["0.1.0", "patch", "0.1.1"],
+    ["0.1.9", "minor", "0.2.0"],
+    ["0.2.3", "major", "1.0.0"],
+    ["1.0.0-beta.1", "patch", "1.0.1"],
+  ] as const)("%s + %s = %s", (current, bump, expected) => {
+    expect(nextVersion(current, bump)).toEqual({ success: true, data: expected });
+  });
+
+  it("rejects a non-semver current version", () => {
+    expect(nextVersion("nightly", "patch").success).toBe(false);
+  });
+});
+
+describe("isSemver / compareVersions / latestRelease", () => {
+  it("accepts semver and rejects tag-shaped input", () => {
+    expect(isSemver("0.2.0")).toBe(true);
+    expect(isSemver("1.0.0-rc.1")).toBe(true);
+    expect(isSemver("v0.2.0")).toBe(false);
+    expect(isSemver("0.2")).toBe(false);
+  });
+
+  it("orders versions numerically, not lexically", () => {
+    expect(compareVersions("0.10.0", "0.9.0")).toBeGreaterThan(0);
+    expect(compareVersions("0.1.0", "0.1.0")).toBe(0);
+  });
+
+  it("reports the newest released version, skipping Unreleased", () => {
+    expect(latestRelease(FIXTURE)).toBe("0.1.0");
+  });
+
+  it("returns null when nothing has shipped", () => {
+    expect(latestRelease("# Changelog\n\n## [Unreleased]\n\n### Added\n- x\n")).toBeNull();
+  });
+});
+
+describe("releaseNotes", () => {
+  it("returns just that release's entries", () => {
+    expect(releaseNotes(FIXTURE, "0.1.0")).toEqual({
+      success: true,
+      data: "### Added\n- Initial release.",
+    });
+  });
+
+  it("fails on a version with no section", () => {
+    const result = releaseNotes(FIXTURE, "9.9.9");
+    expect(result.success).toBe(false);
+  });
+
+  it("fails on an empty section rather than publishing empty notes", () => {
+    const empty = "# Changelog\n\n## [Unreleased]\n\n## [0.1.0] - 2026-06-11\n\n[0.1.0]: x\n";
+    expect(releaseNotes(empty, "0.1.0").success).toBe(false);
+  });
+});
+
+describe("cutRelease", () => {
+  const cut = cutRelease(FIXTURE, { version: "0.2.0", date: "2026-08-29", repoUrl: REPO });
+  const text = cut.success ? cut.data : "";
+
+  it("succeeds", () => {
+    expect(cut.success).toBe(true);
+  });
+
+  it("moves the Unreleased entries into the dated section", () => {
+    expect(releaseNotes(text, "0.2.0")).toEqual({
+      success: true,
+      data: "### Added\n- A new thing.\n\n### Fixed\n- An old thing.",
+    });
+  });
+
+  it("leaves a fresh, empty Unreleased section behind", () => {
+    const parsed = parseChangelog(text);
+    expect(parsed.sections[0]).toEqual({ version: "Unreleased", body: "" });
+  });
+
+  it("points Unreleased at the new tag and the new release at its predecessor", () => {
+    const links = parseChangelog(text).links;
+    expect(links.get("Unreleased")).toBe(`${REPO}/compare/v0.2.0...HEAD`);
+    expect(links.get("0.2.0")).toBe(`${REPO}/compare/v0.1.0...v0.2.0`);
+    expect(links.get("0.1.0")).toBe(`${REPO}/releases/tag/v0.1.0`);
+  });
+
+  it("keeps older releases intact", () => {
+    expect(releaseNotes(text, "0.1.0")).toEqual({
+      success: true,
+      data: "### Added\n- Initial release.",
+    });
+    expect(parseChangelog(text).sections[2]?.date).toBe("2026-06-11");
+  });
+
+  it("produces a file that still validates", () => {
+    expect(validateChangelog(text)).toEqual([]);
+  });
+
+  it("links the very first release to its tag page, having nothing to compare against", () => {
+    const first = `# Changelog\n\n## [Unreleased]\n\n### Added\n- x\n\n[Unreleased]: ${REPO}/commits/main\n`;
+    const result = cutRelease(first, { version: "0.1.0", date: "2026-06-11", repoUrl: REPO });
+    expect(result.success && parseChangelog(result.data).links.get("0.1.0")).toBe(
+      `${REPO}/releases/tag/v0.1.0`,
+    );
+  });
+
+  it("refuses to cut an empty Unreleased section", () => {
+    const empty = FIXTURE.replace("### Added\n- A new thing.\n\n### Fixed\n- An old thing.\n", "");
+    expect(cutRelease(empty, { version: "0.2.0", date: "2026-08-29", repoUrl: REPO }).success).toBe(
+      false,
+    );
+  });
+
+  it("refuses to overwrite a version that already exists", () => {
+    expect(
+      cutRelease(FIXTURE, { version: "0.1.0", date: "2026-08-29", repoUrl: REPO }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a malformed version or date", () => {
+    expect(
+      cutRelease(FIXTURE, { version: "v0.2.0", date: "2026-08-29", repoUrl: REPO }).success,
+    ).toBe(false);
+    expect(
+      cutRelease(FIXTURE, { version: "0.2.0", date: "29 Aug 2026", repoUrl: REPO }).success,
+    ).toBe(false);
+  });
+
+  it("refuses a second cut until new entries land under Unreleased", () => {
+    expect(cutRelease(text, { version: "0.3.0", date: "2026-09-01", repoUrl: REPO }).success).toBe(
+      false,
+    );
+  });
+
+  it("chains compare links across successive releases", () => {
+    const refilled = text.replace(
+      "## [Unreleased]",
+      "## [Unreleased]\n\n### Fixed\n- A later fix.",
+    );
+    const second = cutRelease(refilled, { version: "0.2.1", date: "2026-09-01", repoUrl: REPO });
+    expect(second.success).toBe(true);
+    if (!second.success) return;
+
+    const parsed = parseChangelog(second.data);
+    expect(parsed.sections.map((section) => section.version)).toEqual([
+      "Unreleased",
+      "0.2.1",
+      "0.2.0",
+      "0.1.0",
+    ]);
+    expect(parsed.links.get("0.2.1")).toBe(`${REPO}/compare/v0.2.0...v0.2.1`);
+    expect(parsed.links.get("Unreleased")).toBe(`${REPO}/compare/v0.2.1...HEAD`);
+    expect(validateChangelog(second.data)).toEqual([]);
+  });
+});
+
+describe("validateChangelog", () => {
+  it("passes a well-formed file", () => {
+    expect(validateChangelog(FIXTURE)).toEqual([]);
+  });
+
+  it("flags a missing Unreleased section", () => {
+    const text = FIXTURE.replace("## [Unreleased]", "## [0.0.9] - 2026-01-01");
+    expect(validateChangelog(text).join("\n")).toContain("Unreleased");
+  });
+
+  it("flags a release with no link definition — the dead-link failure mode", () => {
+    const text = FIXTURE.replace(`[0.1.0]: ${REPO}/releases/tag/v0.1.0\n`, "");
+    expect(validateChangelog(text)).toContain("No link definition for `0.1.0`");
+  });
+
+  it("flags a link definition with no matching section", () => {
+    const text = FIXTURE.replace("[0.1.0]:", "[0.9.0]:");
+    expect(validateChangelog(text)).toContain("Link definition `0.9.0` has no matching section");
+  });
+
+  it("flags an undated release", () => {
+    const text = FIXTURE.replace("## [0.1.0] - 2026-06-11", "## [0.1.0]");
+    expect(validateChangelog(text)).toContain("`0.1.0` has no release date");
+  });
+
+  it("flags releases listed out of order", () => {
+    const text = FIXTURE.replace(
+      "## [0.1.0] - 2026-06-11",
+      "## [0.1.0] - 2026-06-11\n\n### Added\n- x\n\n## [0.2.0] - 2026-07-01",
+    ).replace(`[0.1.0]: ${REPO}`, `[0.2.0]: ${REPO}/x\n[0.1.0]: ${REPO}`);
+    expect(validateChangelog(text).join("\n")).toContain("out of order");
+  });
+});
+
+describe("the repository's own CHANGELOG.md", () => {
+  it("is structurally sound, so a release can always be cut from it", () => {
+    expect(validateChangelog(REAL_CHANGELOG)).toEqual([]);
+  });
+
+  it("has release notes for every shipped version", () => {
+    const released = parseChangelog(REAL_CHANGELOG).sections.filter(
+      (section) => section.version !== "Unreleased",
+    );
+    expect(released.length).toBeGreaterThan(0);
+    for (const section of released) {
+      expect(releaseNotes(REAL_CHANGELOG, section.version).success).toBe(true);
+    }
+  });
+});

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -9,10 +9,12 @@ import {
   cutRelease,
   groupsIn,
   inferBump,
+  isCalendarDate,
   isSemver,
   latestRelease,
   nextVersion,
   parseChangelog,
+  previousRelease,
   releaseNotes,
   resolveBump,
   validateChangelog,
@@ -131,17 +133,94 @@ describe("nextVersion", () => {
   });
 });
 
-describe("isSemver / compareVersions / latestRelease", () => {
+describe("isSemver", () => {
   it("accepts semver and rejects tag-shaped input", () => {
     expect(isSemver("0.2.0")).toBe(true);
     expect(isSemver("1.0.0-rc.1")).toBe(true);
+    expect(isSemver("1.0.0+build.5")).toBe(true);
     expect(isSemver("v0.2.0")).toBe(false);
     expect(isSemver("0.2")).toBe(false);
   });
 
+  it("rejects noncanonical versions with leading zeros", () => {
+    expect(isSemver("01.2.3")).toBe(false);
+    expect(isSemver("1.02.3")).toBe(false);
+    expect(isSemver("1.2.03")).toBe(false);
+    expect(isSemver("1.2.3-01")).toBe(false);
+  });
+
+  it("still accepts a prerelease identifier that only looks numeric", () => {
+    expect(isSemver("1.2.3-0")).toBe(true);
+    expect(isSemver("1.2.3-0a")).toBe(true);
+    expect(isSemver("1.2.3-rc.0")).toBe(true);
+  });
+});
+
+describe("isCalendarDate", () => {
+  it("accepts real dates, including a leap day", () => {
+    expect(isCalendarDate("2026-08-29")).toBe(true);
+    expect(isCalendarDate("2024-02-29")).toBe(true);
+  });
+
+  it("rejects a date that is only the right shape", () => {
+    expect(isCalendarDate("2026-02-30")).toBe(false);
+    expect(isCalendarDate("2026-00-00")).toBe(false);
+    expect(isCalendarDate("2026-13-01")).toBe(false);
+    expect(isCalendarDate("2025-02-29")).toBe(false);
+  });
+
+  it("rejects anything that is not YYYY-MM-DD", () => {
+    expect(isCalendarDate("29 Aug 2026")).toBe(false);
+    expect(isCalendarDate("2026-8-29")).toBe(false);
+  });
+});
+
+describe("compareVersions / latestRelease", () => {
   it("orders versions numerically, not lexically", () => {
     expect(compareVersions("0.10.0", "0.9.0")).toBeGreaterThan(0);
     expect(compareVersions("0.1.0", "0.1.0")).toBe(0);
+  });
+
+  it("ranks a final release above its own prereleases", () => {
+    expect(compareVersions("1.0.0", "1.0.0-rc.1")).toBeGreaterThan(0);
+    expect(compareVersions("1.0.0-rc.1", "1.0.0")).toBeLessThan(0);
+  });
+
+  it("compares numeric prerelease identifiers numerically", () => {
+    expect(compareVersions("1.0.0-beta.11", "1.0.0-beta.2")).toBeGreaterThan(0);
+  });
+
+  it("ranks numeric identifiers below alphanumeric ones", () => {
+    expect(compareVersions("1.0.0-1", "1.0.0-alpha")).toBeLessThan(0);
+  });
+
+  it("orders differing prerelease labels lexically", () => {
+    expect(compareVersions("1.0.0-beta", "1.0.0-alpha")).toBeGreaterThan(0);
+  });
+
+  it("ranks a shorter identifier set below a longer one sharing its prefix", () => {
+    expect(compareVersions("1.0.0-alpha", "1.0.0-alpha.1")).toBeLessThan(0);
+  });
+
+  it("walks the SemVer spec's own precedence chain", () => {
+    const ordered = [
+      "1.0.0-alpha",
+      "1.0.0-alpha.1",
+      "1.0.0-alpha.beta",
+      "1.0.0-beta",
+      "1.0.0-beta.2",
+      "1.0.0-beta.11",
+      "1.0.0-rc.1",
+      "1.0.0",
+    ];
+    for (let i = 1; i < ordered.length; i++) {
+      const [lower, higher] = [ordered[i - 1] as string, ordered[i] as string];
+      expect(compareVersions(higher, lower)).toBeGreaterThan(0);
+    }
+  });
+
+  it("ignores build metadata, as the spec requires", () => {
+    expect(compareVersions("1.0.0+build.1", "1.0.0+build.2")).toBe(0);
   });
 
   it("reports the newest released version, skipping Unreleased", () => {
@@ -289,6 +368,19 @@ describe("validateChangelog", () => {
     expect(validateChangelog(text)).toContain("Link definition `0.9.0` has no matching section");
   });
 
+  it("flags a date that is only the right shape", () => {
+    const text = FIXTURE.replace("2026-06-11", "2026-02-30");
+    expect(validateChangelog(text)).toContain("`0.1.0` date is not a real YYYY-MM-DD date");
+  });
+
+  it("does not flag a final release listed above its own prerelease", () => {
+    const text = FIXTURE.replace(
+      "## [0.1.0] - 2026-06-11",
+      "## [1.0.0] - 2026-07-01\n\n### Added\n- Final.\n\n## [1.0.0-rc.1] - 2026-06-20\n\n### Added\n- Candidate.\n\n## [0.1.0] - 2026-06-11",
+    ).replace(`[0.1.0]: ${REPO}`, `[1.0.0]: ${REPO}/x\n[1.0.0-rc.1]: ${REPO}/y\n[0.1.0]: ${REPO}`);
+    expect(validateChangelog(text)).toEqual([]);
+  });
+
   it("flags an undated release", () => {
     const text = FIXTURE.replace("## [0.1.0] - 2026-06-11", "## [0.1.0]");
     expect(validateChangelog(text)).toContain("`0.1.0` has no release date");
@@ -300,6 +392,25 @@ describe("validateChangelog", () => {
       "## [0.1.0] - 2026-06-11\n\n### Added\n- x\n\n## [0.2.0] - 2026-07-01",
     ).replace(`[0.1.0]: ${REPO}`, `[0.2.0]: ${REPO}/x\n[0.1.0]: ${REPO}`);
     expect(validateChangelog(text).join("\n")).toContain("out of order");
+  });
+});
+
+describe("previousRelease", () => {
+  it("returns the release listed below the given one", () => {
+    const cut = cutRelease(FIXTURE, { version: "0.2.0", date: "2026-08-29", repoUrl: REPO });
+    expect(cut.success && previousRelease(cut.data, "0.2.0")).toBe("0.1.0");
+  });
+
+  it("returns null for the oldest release", () => {
+    expect(previousRelease(FIXTURE, "0.1.0")).toBeNull();
+  });
+
+  it("returns null for a version that is not listed", () => {
+    expect(previousRelease(FIXTURE, "9.9.9")).toBeNull();
+  });
+
+  it("never returns Unreleased", () => {
+    expect(previousRelease(FIXTURE, "Unreleased")).toBeNull();
   });
 });
 

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -17,6 +17,7 @@ import {
   previousRelease,
   releaseNotes,
   resolveBump,
+  setPackageVersion,
   validateChangelog,
 } from "../scripts/changelog";
 
@@ -418,6 +419,57 @@ describe("validateChangelog", () => {
       "## [0.1.0] - 2026-06-11\n\n### Added\n- x\n\n## [0.2.0] - 2026-07-01",
     ).replace(`[0.1.0]: ${REPO}`, `[0.2.0]: ${REPO}/x\n[0.1.0]: ${REPO}`);
     expect(validateChangelog(text).join("\n")).toContain("out of order");
+  });
+});
+
+describe("setPackageVersion", () => {
+  const MANIFEST = [
+    "{",
+    '  "name": "stratum",',
+    '  "version": "0.2.0",',
+    '  "repository": { "type": "git", "url": "https://github.com/stratum-eng/stratum.git" }',
+    "}",
+    "",
+  ].join("\n");
+
+  it("updates the root version and leaves the rest of the file byte-identical", () => {
+    const result = setPackageVersion(MANIFEST, "0.3.0");
+    expect(result).toEqual({ success: true, data: MANIFEST.replace('"0.2.0"', '"0.3.0"') });
+  });
+
+  it("does not reformat hand-written one-line objects", () => {
+    const result = setPackageVersion(MANIFEST, "0.3.0");
+    expect(result.success && result.data).toContain(
+      '"repository": { "type": "git", "url": "https://github.com/stratum-eng/stratum.git" }',
+    );
+  });
+
+  // The pattern is line-anchored but depth-blind, so a nested `"version"` on its
+  // own line above the root one is the case that would silently rewrite the
+  // wrong field and still look like it worked.
+  it("refuses when a nested version precedes the root one", () => {
+    const nested = [
+      "{",
+      '  "name": "stratum",',
+      '  "volta": {',
+      '    "version": "22.13.0"',
+      "  },",
+      '  "version": "0.2.0"',
+      "}",
+      "",
+    ].join("\n");
+
+    const result = setPackageVersion(nested, "0.3.0");
+    expect(result.success).toBe(false);
+    expect(result.success === false && result.error).toContain("nested");
+  });
+
+  it("refuses a manifest with no version field", () => {
+    expect(setPackageVersion('{\n  "name": "stratum"\n}\n', "0.3.0").success).toBe(false);
+  });
+
+  it("refuses when the rewrite would produce invalid JSON", () => {
+    expect(setPackageVersion('{\n  "version": "0.2.0"', "0.3.0").success).toBe(false);
   });
 });
 

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -405,7 +405,10 @@ describe("validateChangelog", () => {
   });
 
   it("does not flag a correctly ordered history of very large versions", () => {
-    const text = `# Changelog\n\n## [Unreleased]\n\n## [9007199254740993.0.0] - 2026-08-29\n\n### Added\n- x\n\n## [9007199254740992.0.0] - 2026-08-28\n\n### Added\n- y\n\n[Unreleased]: u\n[9007199254740993.0.0]: a\n[9007199254740992.0.0]: b\n`;
+    const text =
+      "# Changelog\n\n## [Unreleased]\n\n## [9007199254740993.0.0] - 2026-08-29\n\n### Added\n- x\n\n" +
+      "## [9007199254740992.0.0] - 2026-08-28\n\n### Added\n- y\n\n" +
+      "[Unreleased]: u\n[9007199254740993.0.0]: a\n[9007199254740992.0.0]: b\n";
     expect(validateChangelog(text)).toEqual([]);
   });
 

--- a/tests/changelog.test.ts
+++ b/tests/changelog.test.ts
@@ -219,6 +219,24 @@ describe("compareVersions / latestRelease", () => {
     }
   });
 
+  it("orders numeric identifiers beyond 2^53, where Number would collapse them", () => {
+    // Number("9007199254740993") === Number("9007199254740992"), so a float
+    // comparison would call these equal and flag a valid history as misordered.
+    expect(compareVersions("9007199254740993.0.0", "9007199254740992.0.0")).toBeGreaterThan(0);
+    expect(
+      compareVersions("1.0.0-beta.9007199254740993", "1.0.0-beta.9007199254740992"),
+    ).toBeGreaterThan(0);
+    expect(compareVersions("9007199254740992.0.0", "9007199254740992.0.0")).toBe(0);
+  });
+
+  it("orders long numeric identifiers by magnitude, not string length alone", () => {
+    expect(compareVersions("10.0.0", "9.0.0")).toBeGreaterThan(0);
+    expect(compareVersions("1.0.0-alpha.10", "1.0.0-alpha.9")).toBeGreaterThan(0);
+    expect(
+      compareVersions("123456789012345678901.0.0", "99999999999999999999.0.0"),
+    ).toBeGreaterThan(0);
+  });
+
   it("ignores build metadata, as the spec requires", () => {
     expect(compareVersions("1.0.0+build.1", "1.0.0+build.2")).toBe(0);
   });
@@ -384,6 +402,11 @@ describe("validateChangelog", () => {
   it("flags an undated release", () => {
     const text = FIXTURE.replace("## [0.1.0] - 2026-06-11", "## [0.1.0]");
     expect(validateChangelog(text)).toContain("`0.1.0` has no release date");
+  });
+
+  it("does not flag a correctly ordered history of very large versions", () => {
+    const text = `# Changelog\n\n## [Unreleased]\n\n## [9007199254740993.0.0] - 2026-08-29\n\n### Added\n- x\n\n## [9007199254740992.0.0] - 2026-08-28\n\n### Added\n- y\n\n[Unreleased]: u\n[9007199254740993.0.0]: a\n[9007199254740992.0.0]: b\n`;
+    expect(validateChangelog(text)).toEqual([]);
   });
 
   it("flags releases listed out of order", () => {


### PR DESCRIPTION
## Summary

`CHANGELOG.md` linked to `compare/v0.1.0...HEAD` and `releases/tag/v0.1.0`, but the repository had no tags, no releases, and no versioning process at all — both links 404ed, and nobody could answer *"what version am I running / what changed since"*.

This makes **`CHANGELOG.md` the source of truth for the version** and gives the tooling the job of reading it. Nothing derives a version from commit messages; nobody edits a version number by hand.

**The release system**

| File | Role |
|---|---|
| `scripts/changelog.ts` | Pure Keep a Changelog parsing: sections, link definitions, bump inference, and the rewrite that moves `Unreleased` into a dated section and re-chains the compare links. No I/O and no imports — so it type-checks under the Workers tsconfig (no `@types/node`) *and* runs under bare `node`. |
| `scripts/release.ts` | The `check` / `latest` / `notes` / `prepare` CLI, exposed as `npm run release:*`. |
| `.github/workflows/release.yml` | Tags and publishes the GitHub release. |
| `tests/changelog.test.ts` | 45 unit tests, plus validation of the real `CHANGELOG.md`. |
| `docs/developer/releasing.md` | The process, end to end. |

**The habit it creates**

1. Changes land with their `## [Unreleased]` entry, same PR (now stated in `CONTRIBUTING.md` and `AGENTS.md`).
2. `npm run release:prepare` cuts the release locally — dates the section, opens a fresh `Unreleased`, rewrites the links, bumps `package.json`. The bump is inferred from which groups are present: `Breaking`/`Removed` → major, `Added` → minor, everything else → patch. While the major is `0`, an inferred major is clamped to a minor per SemVer's `0.y.z` rule; reaching `1.0.0` stays a deliberate `--bump major`.
3. Merge the release PR, then run the **Release** workflow. It re-runs lint → typecheck → test:coverage against the exact tree it is about to tag, pushes the annotated `vX.Y.Z` tag, and creates the release with that changelog section as the notes. A **dry run** input prints the resolved version and exact body without tagging anything.

A hand-pushed `vX.Y.Z` tag triggers the same publish. Both paths read the changelog and the tooling **from the default branch, never the tagged tree**, so tags can be backfilled onto commits that predate this workflow. Publishing is idempotent — re-running an existing tag refreshes its notes rather than failing.

`npm run release:check` catches exactly the failure mode this PR exists to fix (a version with no link definition, an undated or out-of-order release, a `package.json` that drifted), and `tests/changelog.test.ts` runs that same validation against the real file — so `npm test` fails on a bad changelog before it can reach the release workflow.

**This PR also cuts v0.2.0** using the tooling itself: the accumulated `Unreleased` section becomes `## [0.2.0] - 2026-08-29`, `[0.2.0]` and `[Unreleased]` get real compare links, and `package.json` goes `0.1.0` → `0.2.0`. Minor rather than major because the major version is 0 — the `Breaking` group (force-merge deny-by-default) is clamped per the rule above.

### Remaining manual step

The `[0.1.0]` link resolves once **v0.1.0 is tagged**. The last commit dated `2026-06-11`, matching that changelog entry, is `40d5f46` ("feat: per-change cost tracking (#66)"):

```bash
git tag -a v0.1.0 40d5f46 -m "v0.1.0"
git push origin v0.1.0     # the Release workflow publishes the release from CHANGELOG.md
```

Left to a maintainer deliberately — a tag and a public release are permanent, and the exact commit is a judgement call. After merging, `v0.2.0` is one **Run workflow** click away.

## Related issues

Closes #261

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## How was this verified?

All three gates run locally on this branch, in CI order:

- [x] `npm run typecheck` — clean
- [x] `npm test` — `npm run test:coverage`: **2306 passed**, 27 skipped, thresholds met
- [x] `npm run lint` — clean (`scripts/` too, though it is outside the lint scope today)

Plus the CLI exercised end to end against the real changelog: `release:check` reports `0.2.0`, `release:notes -- 0.1.0` prints the 0.1.0 entry, and `release:prepare --dry-run` now correctly refuses with *"Nothing to release: the `Unreleased` section is empty"*. The v0.2.0 cut in this diff is the tool's own output, unedited.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] Docs updated where the change makes them inaccurate
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript — no UI change

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeiCW8zSVYxYSfU3Kg4CQH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated release publishing with version validation, changelog extraction, tagging, and dry-run support.
  * Added commands to validate, preview, and prepare releases.

* **Documentation**
  * Documented changelog requirements, release preparation, publication workflows, and maintainer guidance.
  * Added links to release information and the releasing guide.

* **Chores**
  * Published version 0.2.0 and updated changelog comparison links.
  * Added automated checks for release and changelog handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->