### PR TITLE
Add PR-Agent AI code review via Cloudflare AI Gateway

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,52 @@
+# AI code review via PR-Agent (https://github.com/qodo-ai/pr-agent), routed through
+# Cloudflare AI Gateway -> OpenRouter for observability and spend control.
+#
+# Model chain (fallbacks fire on API errors/context overflow, not quality):
+#   z-ai/glm-5.3 -> z-ai/glm-5.3-flash -> moonshotai/kimi-k3 -> openai/gpt-5.6-terra
+#
+# Required repository secrets (see docs/ai-review.md for setup):
+#   OPENROUTER_KEY           - OpenRouter API key
+#   AI_GATEWAY_OPENROUTER_BASE - https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_id>/openrouter/v1
+#
+# Auto-review runs on PR lifecycle events. Maintainers can also comment
+# /review, /describe, /improve, /ask <question> on any PR.
+name: PR-Agent review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+  issue_comment:
+    types: [created]
+
+jobs:
+  pr_agent:
+    # Skip bot-authored events (prevents self-trigger loops), draft PRs, and
+    # fork PRs (secrets are unavailable there; a maintainer can still request a
+    # review on a fork PR by commenting /review, which runs in base-repo context).
+    if: >
+      github.event.sender.type != 'Bot' &&
+      (github.event_name != 'pull_request' ||
+        (github.event.pull_request.draft == false &&
+         github.event.pull_request.head.repo.full_name == github.repository))
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+    steps:
+      - name: PR-Agent
+        # Pinned release; bump deliberately (upstream moves fast).
+        uses: docker://pragent/pr-agent:0.41.0-github_action
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          openrouter.key: ${{ secrets.OPENROUTER_KEY }}
+          # LiteLLM reads this env var and swaps OpenRouter's default base URL for
+          # the Cloudflare AI Gateway endpoint, keeping every LLM call observable.
+          OPENROUTER_API_BASE: ${{ secrets.AI_GATEWAY_OPENROUTER_BASE }}
+          config.model: "openrouter/z-ai/glm-5.3"
+          config.fallback_models: '["openrouter/z-ai/glm-5.3-flash","openrouter/moonshotai/kimi-k3","openrouter/openai/gpt-5.6-terra"]'
+          # OpenRouter models are not all in LiteLLM's token registry; cap explicitly.
+          config.custom_model_max_tokens: "131072"
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "false"
+          github_action_config.auto_improve: "false"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -108,6 +108,11 @@ jobs:
           # decision — suggestions render in a table only.
           pr_reviewer.require_score_review: "true"
           pr_description.publish_description_as_comment: "true"
+          # The walkthrough comment sits under the description — don't echo it back,
+          # and keep it lean: no PR-type row, no mermaid diagram.
+          pr_description.add_original_user_description: "false"
+          pr_description.enable_pr_type: "false"
+          pr_description.enable_pr_diagram: "false"
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "true"
           github_action_config.auto_improve: "true"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -44,7 +44,8 @@ jobs:
         (github.event.pull_request.draft == false &&
          github.event.pull_request.head.repo.full_name == github.repository)) &&
       (github.event_name != 'issue_comment' ||
-        (contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+        (github.event.issue.pull_request &&
+         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
                   github.event.comment.author_association) &&
          startsWith(github.event.comment.body, '/')))
     runs-on: ubuntu-latest
@@ -66,7 +67,10 @@ jobs:
           DAILY_REVIEW_CAP: "50"
         run: |
           today=$(date -u +%Y-%m-%d)
-          count=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/pr-agent.yml/runs?created=%3E%3D${today}&status=success&per_page=1" --jq '.total_count')
+          # Fail open on API errors: a transient GitHub 5xx must not red-X the
+          # PR — the cap is best-effort and the gateway spend cap backstops it.
+          count=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/pr-agent.yml/runs?created=%3E%3D${today}&status=success&per_page=1" --jq '.total_count' || echo 0)
+          count=${count:-0}
           echo "Successful pr-agent runs today: $count (cap: $DAILY_REVIEW_CAP)"
           if [ "$count" -ge "$DAILY_REVIEW_CAP" ]; then
             echo "::warning::Daily AI-review cap reached ($count/$DAILY_REVIEW_CAP); skipping review."

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -24,11 +24,14 @@ on:
 jobs:
   pr_agent:
     # Trust gates:
+    # - runs only in the canonical repo — forks of stratum skip the job silently
+    #   instead of failing for lack of secrets
     # - bot senders skipped (prevents self-trigger loops)
     # - drafts and fork PRs skipped for auto-review (secrets absent on forks anyway)
     # - comment commands restricted to owner/member/collaborator, so drive-by
     #   accounts on a public repo cannot trigger paid LLM calls
     if: >
+      github.repository == 'stratum-eng/stratum' &&
       github.event.sender.type != 'Bot' &&
       (github.event_name != 'pull_request' ||
         (github.event.pull_request.draft == false &&

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -85,6 +85,8 @@ jobs:
           config.fallback_models: '["openai/workers-ai/@cf/zai-org/glm-5.3-flash","openai/openai/gpt-5.6-terra"]'
           # Gateway models are absent from LiteLLM's token registry; cap explicitly.
           config.custom_model_max_tokens: "131072"
+          # Default pr_actions excludes synchronize; opt in so pushes re-review.
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "false"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -22,10 +22,11 @@ on:
     types: [created]
 
 # One review at a time per PR; a new push cancels the in-flight review of the
-# now-stale commit instead of paying for both.
+# now-stale commit instead of paying for both. Only push events cancel — a
+# comment-triggered run must not kill an in-flight review (reviews take minutes).
 concurrency:
   group: pr-agent-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   pr_agent:
@@ -43,17 +44,21 @@ jobs:
         (github.event.pull_request.draft == false &&
          github.event.pull_request.head.repo.full_name == github.repository)) &&
       (github.event_name != 'issue_comment' ||
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
-                 github.event.comment.author_association))
+        (contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                  github.event.comment.author_association) &&
+         startsWith(github.event.comment.body, '/')))
     runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
       contents: read
+      actions: read # the cap step lists this workflow's runs; implicit on public repos, required once private
     steps:
-      # Hard daily spend bound, independent of any Cloudflare-side control:
-      # past the cap the review step is skipped (job stays green). Cap-skipped
-      # runs also count as successful, so the counter cannot be outrun.
+      # Best-effort daily spend bound (check-then-act: concurrent runs can
+      # overshoot by the number in flight — the Cloudflare gateway spend cap is
+      # the hard limit). Past the cap the review step is skipped (job stays
+      # green), and cap-skipped runs count as successful so the counter cannot
+      # be outrun.
       - name: Daily review cap
         id: cap
         env:
@@ -81,8 +86,9 @@ jobs:
           # the real provider is chosen per-request by the model prefix in the body.
           openai.key: ${{ secrets.CLOUDFLARE_AI_TOKEN }}
           openai.api_base: ${{ secrets.AI_GATEWAY_COMPAT_BASE }}
-          config.model: "openai/workers-ai/@cf/zai-org/glm-5.3-flash"
-          config.fallback_models: '["openai/workers-ai/@cf/zai-org/glm-5.3","openai/openai/gpt-5.6-terra"]'
+          # GLM-5.3 won the same-PR head-to-head vs flash (depth + calibration).
+          config.model: "openai/workers-ai/@cf/zai-org/glm-5.3"
+          config.fallback_models: '["openai/workers-ai/@cf/zai-org/glm-5.3-flash","openai/openai/gpt-5.6-terra"]'
           # Gateway models are absent from LiteLLM's token registry; cap explicitly.
           config.custom_model_max_tokens: "131072"
           # GLM-5.3 is a reasoning model; a full review takes minutes. The default
@@ -90,6 +96,8 @@ jobs:
           config.ai_timeout: "600"
           # Default pr_actions excludes synchronize; opt in so pushes re-review.
           github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'
+          # Strictness dials (CodeRabbit-ish): inline code suggestions on, more findings.
+          pr_reviewer.num_max_findings: "8"
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
-          github_action_config.auto_improve: "false"
+          github_action_config.auto_improve: "true"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -85,6 +85,9 @@ jobs:
           config.fallback_models: '["openai/workers-ai/@cf/zai-org/glm-5.3-flash","openai/openai/gpt-5.6-terra"]'
           # Gateway models are absent from LiteLLM's token registry; cap explicitly.
           config.custom_model_max_tokens: "131072"
+          # GLM-5.3 is a reasoning model; a full review takes minutes. The default
+          # 120s timeout kills it mid-generation and retries forever.
+          config.ai_timeout: "600"
           # Default pr_actions excludes synchronize; opt in so pushes re-review.
           github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'
           github_action_config.auto_review: "true"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -81,8 +81,8 @@ jobs:
           # the real provider is chosen per-request by the model prefix in the body.
           openai.key: ${{ secrets.CLOUDFLARE_AI_TOKEN }}
           openai.api_base: ${{ secrets.AI_GATEWAY_COMPAT_BASE }}
-          config.model: "openai/workers-ai/@cf/zai-org/glm-5.3"
-          config.fallback_models: '["openai/workers-ai/@cf/zai-org/glm-5.3-flash","openai/openai/gpt-5.6-terra"]'
+          config.model: "openai/workers-ai/@cf/zai-org/glm-5.3-flash"
+          config.fallback_models: '["openai/workers-ai/@cf/zai-org/glm-5.3","openai/openai/gpt-5.6-terra"]'
           # Gateway models are absent from LiteLLM's token registry; cap explicitly.
           config.custom_model_max_tokens: "131072"
           # GLM-5.3 is a reasoning model; a full review takes minutes. The default

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -21,6 +21,12 @@ on:
   issue_comment:
     types: [created]
 
+# One review at a time per PR; a new push cancels the in-flight review of the
+# now-stale commit instead of paying for both.
+concurrency:
+  group: pr-agent-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   pr_agent:
     # Trust gates:
@@ -45,7 +51,27 @@ jobs:
       pull-requests: write
       contents: read
     steps:
+      # Hard daily spend bound, independent of any Cloudflare-side control:
+      # past the cap the review step is skipped (job stays green). Cap-skipped
+      # runs also count as successful, so the counter cannot be outrun.
+      - name: Daily review cap
+        id: cap
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DAILY_REVIEW_CAP: "50"
+        run: |
+          today=$(date -u +%Y-%m-%d)
+          count=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/pr-agent.yml/runs?created=%3E%3D${today}&status=success&per_page=1" --jq '.total_count')
+          echo "Successful pr-agent runs today: $count (cap: $DAILY_REVIEW_CAP)"
+          if [ "$count" -ge "$DAILY_REVIEW_CAP" ]; then
+            echo "::warning::Daily AI-review cap reached ($count/$DAILY_REVIEW_CAP); skipping review."
+            echo "under_cap=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "under_cap=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: PR-Agent
+        if: steps.cap.outputs.under_cap == 'true'
         # 0.41.0-github_action, pinned by immutable digest (tag alone is mutable).
         uses: docker://pragent/pr-agent@sha256:3121a7b8e3ab497b4df09dea6a444da8f01a474496c8c2f722828512c52fd266
         env:

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,15 +1,18 @@
-# AI code review via PR-Agent (https://github.com/qodo-ai/pr-agent), routed through
-# Cloudflare AI Gateway -> OpenRouter for observability and spend control.
+# AI code review via PR-Agent (https://github.com/qodo-ai/pr-agent), routed entirely
+# through Cloudflare AI Gateway's OpenAI-compatible endpoint with unified billing —
+# one Cloudflare token, one Cloudflare bill, no third-party model accounts.
 #
 # Model chain (fallbacks fire on API errors/context overflow, not quality):
-#   z-ai/glm-5.3 -> z-ai/glm-5.3-flash -> moonshotai/kimi-k3 -> openai/gpt-5.6-terra
+#   workers-ai/@cf/zai-org/glm-5.3  ($1.40/$4.40 per MTok, Cloudflare-hosted)
+#   -> workers-ai/@cf/zai-org/glm-5.3-flash
+#   -> openai/gpt-5.6-terra          (via unified billing, Cloudflare-managed credentials)
 #
-# Required repository secrets (see docs/ai-review.md for setup):
-#   OPENROUTER_KEY           - OpenRouter API key
-#   AI_GATEWAY_OPENROUTER_BASE - https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_id>/openrouter/v1
+# Required repository secrets (see docs/runbooks/ai-review.md for setup):
+#   AI_GATEWAY_COMPAT_BASE - https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_id>/compat
+#   CLOUDFLARE_AI_TOKEN    - Cloudflare API token with AI Gateway Run permission
 #
-# Auto-review runs on PR lifecycle events. Maintainers can also comment
-# /review, /describe, /improve, /ask <question> on any PR.
+# Auto-review runs on PR lifecycle events. Collaborators can also comment
+# /review, /describe, /improve, /ask <question> on any PR (including fork PRs).
 name: PR-Agent review
 
 on:
@@ -20,14 +23,19 @@ on:
 
 jobs:
   pr_agent:
-    # Skip bot-authored events (prevents self-trigger loops), draft PRs, and
-    # fork PRs (secrets are unavailable there; a maintainer can still request a
-    # review on a fork PR by commenting /review, which runs in base-repo context).
+    # Trust gates:
+    # - bot senders skipped (prevents self-trigger loops)
+    # - drafts and fork PRs skipped for auto-review (secrets absent on forks anyway)
+    # - comment commands restricted to owner/member/collaborator, so drive-by
+    #   accounts on a public repo cannot trigger paid LLM calls
     if: >
       github.event.sender.type != 'Bot' &&
       (github.event_name != 'pull_request' ||
         (github.event.pull_request.draft == false &&
-         github.event.pull_request.head.repo.full_name == github.repository))
+         github.event.pull_request.head.repo.full_name == github.repository)) &&
+      (github.event_name != 'issue_comment' ||
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                 github.event.comment.author_association))
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -35,17 +43,18 @@ jobs:
       contents: read
     steps:
       - name: PR-Agent
-        # Pinned release; bump deliberately (upstream moves fast).
-        uses: docker://pragent/pr-agent:0.41.0-github_action
+        # 0.41.0-github_action, pinned by immutable digest (tag alone is mutable).
+        uses: docker://pragent/pr-agent@sha256:3121a7b8e3ab497b4df09dea6a444da8f01a474496c8c2f722828512c52fd266
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          openrouter.key: ${{ secrets.OPENROUTER_KEY }}
-          # LiteLLM reads this env var and swaps OpenRouter's default base URL for
-          # the Cloudflare AI Gateway endpoint, keeping every LLM call observable.
-          OPENROUTER_API_BASE: ${{ secrets.AI_GATEWAY_OPENROUTER_BASE }}
-          config.model: "openrouter/z-ai/glm-5.3"
-          config.fallback_models: '["openrouter/z-ai/glm-5.3-flash","openrouter/moonshotai/kimi-k3","openrouter/openai/gpt-5.6-terra"]'
-          # OpenRouter models are not all in LiteLLM's token registry; cap explicitly.
+          # AI Gateway's /compat endpoint speaks the OpenAI chat-completions schema for
+          # every provider it fronts, so PR-Agent talks to it as an "OpenAI" endpoint;
+          # the real provider is chosen per-request by the model prefix in the body.
+          openai.key: ${{ secrets.CLOUDFLARE_AI_TOKEN }}
+          openai.api_base: ${{ secrets.AI_GATEWAY_COMPAT_BASE }}
+          config.model: "openai/workers-ai/@cf/zai-org/glm-5.3"
+          config.fallback_models: '["openai/workers-ai/@cf/zai-org/glm-5.3-flash","openai/openai/gpt-5.6-terra"]'
+          # Gateway models are absent from LiteLLM's token registry; cap explicitly.
           config.custom_model_max_tokens: "131072"
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -98,6 +98,12 @@ jobs:
           github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'
           # Strictness dials (CodeRabbit-ish): inline code suggestions on, more findings.
           pr_reviewer.num_max_findings: "8"
+          # Packaging ("safe preset"): quality-score row, walkthrough + changes
+          # diagram posted as a comment (never edits the author's description).
+          # Committable ```suggestion blocks stay OFF by documented security
+          # decision — suggestions render in a table only.
+          pr_reviewer.require_score_review: "true"
+          pr_description.publish_description_as_comment: "true"
           github_action_config.auto_review: "true"
-          github_action_config.auto_describe: "false"
+          github_action_config.auto_describe: "true"
           github_action_config.auto_improve: "true"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -15,15 +15,18 @@
 # /review, /describe, /improve, /ask <question> on any PR (including fork PRs).
 name: PR-Agent review
 
+# Auto-review runs once per PR (open/reopen/ready). Pushes do NOT re-review —
+# comment /review (full) or /review -i (incremental, commits since last review)
+# when a fresh look is wanted. Biggest spend lever + progressive-review semantics.
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [opened, reopened, ready_for_review]
   issue_comment:
     types: [created]
 
-# One review at a time per PR; a new push cancels the in-flight review of the
-# now-stale commit instead of paying for both. Only push events cancel — a
-# comment-triggered run must not kill an in-flight review (reviews take minutes).
+# One run at a time per PR. PR lifecycle events may cancel a stale in-flight
+# run; a comment-triggered run must not kill an in-flight review (reviews take
+# minutes), so comment runs queue instead.
 concurrency:
   group: pr-agent-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -98,8 +101,7 @@ jobs:
           # GLM-5.3 is a reasoning model; a full review takes minutes. The default
           # 120s timeout kills it mid-generation and retries forever.
           config.ai_timeout: "600"
-          # Default pr_actions excludes synchronize; opt in so pushes re-review.
-          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review"]'
           # Strictness dials (CodeRabbit-ish): inline code suggestions on, more findings.
           pr_reviewer.num_max_findings: "8"
           # Packaging ("safe preset"): quality-score row, walkthrough + changes

--- a/docs/runbooks/ai-review.md
+++ b/docs/runbooks/ai-review.md
@@ -49,9 +49,11 @@ pass-through. Verify actuals in AI Gateway analytics after the first week.
   `/` (ordinary discussion comments never start a run): `/review`, `/describe`, `/improve`,
   `/ask <question>`. `/review` also works on fork PRs (comment events run with base-repo
   secrets).
-- Every auto-review also posts inline code suggestions (`auto_improve`); the reviewer guide
-  lists up to 8 findings (`pr_reviewer.num_max_findings`). Turn these dials down if the bot
-  gets noisy.
+- Each PR event posts three artifacts: the reviewer guide (up to 8 findings + quality score +
+  effort/security labels), a walkthrough comment with a changes diagram (`auto_describe`,
+  as a comment — the bot never edits the author's description), and a code-suggestions table
+  (`auto_improve`). Committable ` ```suggestion ` blocks remain off by security decision.
+  Turn dials down if the bot gets noisy.
 - To change models, edit the workflow env — one line per model; no code involved.
 
 ## Security posture & abuse bounds

--- a/docs/runbooks/ai-review.md
+++ b/docs/runbooks/ai-review.md
@@ -1,0 +1,61 @@
+# AI code review (PR-Agent via Cloudflare AI Gateway)
+
+`.github/workflows/pr-agent.yml` runs [PR-Agent](https://github.com/qodo-ai/pr-agent) on every
+non-draft, non-fork PR (opened / reopened / ready_for_review / synchronize). It posts a review
+comment with findings; it never blocks a merge.
+
+All LLM traffic goes through **Cloudflare AI Gateway → OpenRouter**, so every request (tokens,
+cost, latency, errors) is visible in the Cloudflare dashboard under the gateway's analytics,
+and gateway-level caching/rate limits apply.
+
+## Model chain
+
+Configured in the workflow env (`config.model` / `config.fallback_models`). Fallbacks trigger on
+API errors or context overflow — not on review quality:
+
+| Order | Model | OpenRouter pricing (in/out per MTok, 2026-08) |
+|---|---|---|
+| 1 | `z-ai/glm-5.3` | ~$1.40 / $4.40 (official z-ai endpoint) |
+| 2 | `z-ai/glm-5.3-flash` | $0.075 / $0.25 |
+| 3 | `moonshotai/kimi-k3` | $2.55 / $12.75 |
+| 4 | `openai/gpt-5.6-terra` | $2.00 / $12.00 |
+
+Typical PR review ≈ 15–40K input + a few K output tokens → **roughly $0.02–0.08 per review** on
+GLM-5.3. Verify actuals in AI Gateway analytics after the first week.
+
+## One-time setup
+
+1. **OpenRouter**: create an API key at openrouter.ai and add credits. In OpenRouter's provider
+   settings, prefer the official `z-ai` provider for GLM models (third-party hosts may serve
+   quantized weights).
+2. **Cloudflare AI Gateway**: dashboard → AI → AI Gateway → create gateway (e.g. `stratum-reviews`).
+   The OpenRouter base URL is
+   `https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_id>/openrouter/v1`.
+3. **Repo secrets**:
+
+   ```sh
+   gh secret set OPENROUTER_KEY --body '<openrouter api key>'
+   gh secret set AI_GATEWAY_OPENROUTER_BASE \
+     --body 'https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_id>/openrouter/v1'
+   ```
+
+## Usage
+
+- Auto-review posts on PR open and on new commits.
+- Comment commands (collaborators): `/review`, `/describe`, `/improve`, `/ask <question>`.
+  `/review` also works on fork PRs (comment events run with base-repo secrets).
+- To change models, edit the workflow env — it is one line per model; no code involved.
+
+## Turning it off
+
+Disable the workflow in the Actions tab (or delete `.github/workflows/pr-agent.yml`). Gateway
+rate limits / spend caps can be set on the Cloudflare gateway itself as a backstop.
+
+## Known limitations
+
+- Fallback chain is availability-based, not quality-based; if GLM-5.3 errors persistently you
+  are silently reviewed by flash-tier — check `config.output_run_details` / gateway logs when
+  reviews look shallow.
+- Draft PRs are skipped until marked ready for review.
+- The full build-your-own alternative (Cloudflare Worker reviewer) was specced and shelved; see
+  `~/projects/indy/.claude/ship/PRD.md` for the requirements analysis behind choosing PR-Agent.

--- a/docs/runbooks/ai-review.md
+++ b/docs/runbooks/ai-review.md
@@ -45,9 +45,13 @@ pass-through. Verify actuals in AI Gateway analytics after the first week.
 ## Usage
 
 - Auto-review posts on PR open and on new commits.
-- Comment commands — restricted to owner/member/collaborator in the workflow gate: `/review`,
-  `/describe`, `/improve`, `/ask <question>`. `/review` also works on fork PRs (comment events
-  run with base-repo secrets).
+- Comment commands — restricted to owner/member/collaborator, and the comment must start with
+  `/` (ordinary discussion comments never start a run): `/review`, `/describe`, `/improve`,
+  `/ask <question>`. `/review` also works on fork PRs (comment events run with base-repo
+  secrets).
+- Every auto-review also posts inline code suggestions (`auto_improve`); the reviewer guide
+  lists up to 8 findings (`pr_reviewer.num_max_findings`). Turn these dials down if the bot
+  gets noisy.
 - To change models, edit the workflow env — one line per model; no code involved.
 
 ## Security posture & abuse bounds
@@ -56,11 +60,14 @@ Who can spend money, from broadest to narrowest:
 
 - **Strangers: nobody.** Fork PRs and non-collaborator comments skip the job before a runner
   starts — a flood of drive-by PRs produces skipped jobs, not LLM calls.
-- **Collaborators: bounded.** Per-PR concurrency cancels the in-flight review when a new push
-  supersedes it, and a daily cap (50 successful runs, checked against the Actions API before
-  the review step) bounds total spend even for a compromised collaborator account.
-- **Backstop:** gateway-level rate limits / spend caps on the Cloudflare side, plus billing
-  notifications on the account. These should never be the first line of defense.
+- **Collaborators: bounded (best-effort).** Per-PR concurrency cancels the in-flight review
+  when a new push supersedes it (push events only — comment-triggered runs never cancel a
+  review in flight), and a daily cap (50 successful runs, checked against the Actions API
+  before the review step) bounds routine spend. The cap is check-then-act, so concurrent
+  runs can overshoot it by the number in flight — it is a soft bound.
+- **Hard limit:** gateway-level spend caps / rate limits on the Cloudflare side (unified
+  billing credits are prepaid, so the Terra fallback cannot overspend structurally), plus
+  billing notifications on the account.
 
 Other hardening:
 
@@ -83,5 +90,6 @@ rate limits / spend caps on the Cloudflare gateway are the backstop.
 - Fallback chain is availability-based, not quality-based; if GLM-5.3 errors persistently you
   are silently reviewed by flash-tier — check gateway logs when reviews look shallow.
 - Draft PRs are skipped until marked ready for review.
-- The full build-your-own alternative (Cloudflare Worker reviewer) was specced and shelved; see
-  `~/projects/indy/.claude/ship/PRD.md` for the requirements analysis behind choosing PR-Agent.
+- A build-your-own alternative (a Cloudflare Worker reviewer with a custom rubric) was specced
+  and shelved in favor of PR-Agent; revisit as a Stratum-native feature once the project
+  self-hosts off GitHub.

--- a/docs/runbooks/ai-review.md
+++ b/docs/runbooks/ai-review.md
@@ -4,58 +4,72 @@
 non-draft, non-fork PR (opened / reopened / ready_for_review / synchronize). It posts a review
 comment with findings; it never blocks a merge.
 
-All LLM traffic goes through **Cloudflare AI Gateway → OpenRouter**, so every request (tokens,
-cost, latency, errors) is visible in the Cloudflare dashboard under the gateway's analytics,
-and gateway-level caching/rate limits apply.
+All LLM traffic goes through **Cloudflare AI Gateway's OpenAI-compatible `/compat` endpoint**
+with unified billing: one Cloudflare API token, one Cloudflare bill, no third-party model
+accounts. Every request (tokens, cost, latency, errors) is visible in the gateway's analytics,
+and gateway-level caching/rate limits/spend caps apply.
 
 ## Model chain
 
 Configured in the workflow env (`config.model` / `config.fallback_models`). Fallbacks trigger on
 API errors or context overflow — not on review quality:
 
-| Order | Model | OpenRouter pricing (in/out per MTok, 2026-08) |
-|---|---|---|
-| 1 | `z-ai/glm-5.3` | ~$1.40 / $4.40 (official z-ai endpoint) |
-| 2 | `z-ai/glm-5.3-flash` | $0.075 / $0.25 |
-| 3 | `moonshotai/kimi-k3` | $2.55 / $12.75 |
-| 4 | `openai/gpt-5.6-terra` | $2.00 / $12.00 |
+| Order | Model | Where it runs | Pricing (in/out per MTok, 2026-08) |
+|---|---|---|---|
+| 1 | `workers-ai/@cf/zai-org/glm-5.3` | Cloudflare Workers AI | $1.40 / $4.40 ($0.26 cached input) |
+| 2 | `workers-ai/@cf/zai-org/glm-5.3-flash` | Cloudflare Workers AI | flash tier (~20× cheaper) |
+| 3 | `openai/gpt-5.6-terra` | OpenAI via unified billing | $2.00 / $12.00 |
 
-Typical PR review ≈ 15–40K input + a few K output tokens → **roughly $0.02–0.08 per review** on
-GLM-5.3. Verify actuals in AI Gateway analytics after the first week.
+Kimi K3 was considered and dropped: Moonshot is not a Cloudflare-billable provider, so keeping
+it would have required a third-party account — the thing this setup exists to avoid.
+
+Typical PR review ≈ 15–40K input + a few K output tokens → **roughly $0.03–0.08 per review** on
+GLM-5.3. Unified billing adds a 5% fee on credit *purchases*; per-token rates are provider
+pass-through. Verify actuals in AI Gateway analytics after the first week.
 
 ## One-time setup
 
-1. **OpenRouter**: create an API key at openrouter.ai and add credits. In OpenRouter's provider
-   settings, prefer the official `z-ai` provider for GLM models (third-party hosts may serve
-   quantized weights).
-2. **Cloudflare AI Gateway**: dashboard → AI → AI Gateway → create gateway (e.g. `stratum-reviews`).
-   The OpenRouter base URL is
-   `https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_id>/openrouter/v1`.
+1. **AI Gateway**: Cloudflare dashboard → AI → AI Gateway → create gateway (e.g.
+   `stratum-reviews`). Buy unified-billing credits (needed for the GPT-5.6 Terra fallback;
+   Workers AI models bill to the account directly).
+2. **API token**: create a Cloudflare API token with **AI Gateway: Run** (and Workers AI)
+   permission.
 3. **Repo secrets**:
 
    ```sh
-   gh secret set OPENROUTER_KEY --body '<openrouter api key>'
-   gh secret set AI_GATEWAY_OPENROUTER_BASE \
-     --body 'https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_id>/openrouter/v1'
+   gh secret set CLOUDFLARE_AI_TOKEN --body '<cloudflare api token>'
+   gh secret set AI_GATEWAY_COMPAT_BASE \
+     --body 'https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_id>/compat'
    ```
 
 ## Usage
 
 - Auto-review posts on PR open and on new commits.
-- Comment commands (collaborators): `/review`, `/describe`, `/improve`, `/ask <question>`.
-  `/review` also works on fork PRs (comment events run with base-repo secrets).
-- To change models, edit the workflow env — it is one line per model; no code involved.
+- Comment commands — restricted to owner/member/collaborator in the workflow gate: `/review`,
+  `/describe`, `/improve`, `/ask <question>`. `/review` also works on fork PRs (comment events
+  run with base-repo secrets).
+- To change models, edit the workflow env — one line per model; no code involved.
+
+## Security posture
+
+- The action image is pinned by immutable sha256 digest, not by tag.
+- The job has `contents: read` — the bot can comment but never push.
+- Comment triggers are gated by `author_association`, so drive-by accounts on the public repo
+  cannot spend LLM credits.
+- **Prompt injection is an accepted residual risk**: PR diffs and descriptions are
+  attacker-influenced input to the model, so a crafted PR could steer the review's wording.
+  Blast radius is a misleading comment — treat bot reviews as advisory, never as a merge
+  gate or a substitute for human review of untrusted contributions.
 
 ## Turning it off
 
 Disable the workflow in the Actions tab (or delete `.github/workflows/pr-agent.yml`). Gateway
-rate limits / spend caps can be set on the Cloudflare gateway itself as a backstop.
+rate limits / spend caps on the Cloudflare gateway are the backstop.
 
 ## Known limitations
 
 - Fallback chain is availability-based, not quality-based; if GLM-5.3 errors persistently you
-  are silently reviewed by flash-tier — check `config.output_run_details` / gateway logs when
-  reviews look shallow.
+  are silently reviewed by flash-tier — check gateway logs when reviews look shallow.
 - Draft PRs are skipped until marked ready for review.
 - The full build-your-own alternative (Cloudflare Worker reviewer) was specced and shelved; see
   `~/projects/indy/.claude/ship/PRD.md` for the requirements analysis behind choosing PR-Agent.

--- a/docs/runbooks/ai-review.md
+++ b/docs/runbooks/ai-review.md
@@ -44,7 +44,9 @@ pass-through. Verify actuals in AI Gateway analytics after the first week.
 
 ## Usage
 
-- Auto-review posts on PR open and on new commits.
+- Auto-review posts once, when a PR is opened (or reopened / marked ready). After pushing new
+  commits, comment `/review -i` for an incremental review of just the new commits, or
+  `/review` for a fresh full pass.
 - Comment commands — restricted to owner/member/collaborator, and the comment must start with
   `/` (ordinary discussion comments never start a run): `/review`, `/describe`, `/improve`,
   `/ask <question>`. `/review` also works on fork PRs (comment events run with base-repo
@@ -62,11 +64,11 @@ Who can spend money, from broadest to narrowest:
 
 - **Strangers: nobody.** Fork PRs and non-collaborator comments skip the job before a runner
   starts — a flood of drive-by PRs produces skipped jobs, not LLM calls.
-- **Collaborators: bounded (best-effort).** Per-PR concurrency cancels the in-flight review
-  when a new push supersedes it (push events only — comment-triggered runs never cancel a
-  review in flight), and a daily cap (50 successful runs, checked against the Actions API
-  before the review step) bounds routine spend. The cap is check-then-act, so concurrent
-  runs can overshoot it by the number in flight — it is a soft bound.
+- **Collaborators: bounded (best-effort).** Auto-review runs once per PR (open/reopen/ready)
+  — pushes never re-review, so cost scales with PR count, not push count. A daily cap
+  (50 successful runs, checked against the Actions API before the review step) bounds
+  routine spend; it is check-then-act, so concurrent runs can overshoot slightly — a soft
+  bound. Per-PR concurrency serializes runs (comment-triggered runs queue, never cancel).
 - **Hard limit:** gateway-level spend caps / rate limits on the Cloudflare side (unified
   billing credits are prepaid, so the Terra fallback cannot overspend structurally), plus
   billing notifications on the account.

--- a/docs/runbooks/ai-review.md
+++ b/docs/runbooks/ai-review.md
@@ -50,7 +50,19 @@ pass-through. Verify actuals in AI Gateway analytics after the first week.
   run with base-repo secrets).
 - To change models, edit the workflow env — one line per model; no code involved.
 
-## Security posture
+## Security posture & abuse bounds
+
+Who can spend money, from broadest to narrowest:
+
+- **Strangers: nobody.** Fork PRs and non-collaborator comments skip the job before a runner
+  starts — a flood of drive-by PRs produces skipped jobs, not LLM calls.
+- **Collaborators: bounded.** Per-PR concurrency cancels the in-flight review when a new push
+  supersedes it, and a daily cap (50 successful runs, checked against the Actions API before
+  the review step) bounds total spend even for a compromised collaborator account.
+- **Backstop:** gateway-level rate limits / spend caps on the Cloudflare side, plus billing
+  notifications on the account. These should never be the first line of defense.
+
+Other hardening:
 
 - The action image is pinned by immutable sha256 digest, not by tag.
 - The job has `contents: read` — the bot can comment but never push.


### PR DESCRIPTION
Adds automatic AI code review on PRs using [PR-Agent](https://github.com/qodo-ai/pr-agent) (MIT, self-hosted-free), replacing the need for a paid CodeRabbit-style vendor — running **entirely on Cloudflare**.

## How it works
- Runs on `pull_request` (opened/reopened/ready_for_review/synchronize) and `issue_comment` events; drafts, bots, and fork PRs are skipped for auto-review, and comment commands are gated to owner/member/collaborator.
- All LLM calls go through **Cloudflare AI Gateway's OpenAI-compatible `/compat` endpoint** with unified billing: one Cloudflare token, one Cloudflare bill, no third-party model accounts. Tokens/cost/latency land in gateway analytics; gateway rate limits and spend caps apply.
- Model chain (fallback on API errors, not quality): `workers-ai/@cf/zai-org/glm-5.3` (Cloudflare-hosted, $1.40/$4.40 per MTok) → `glm-5.3-flash` → `openai/gpt-5.6-terra` (unified billing). Roughly $0.03–0.08 per review.
- Action image pinned by immutable sha256 digest; job runs with `contents: read`.

## Before merge
Two repo secrets are required (workflow fails without them): `CLOUDFLARE_AI_TOKEN` (AI Gateway Run + Workers AI permission) and `AI_GATEWAY_COMPAT_BASE`. Setup steps in `docs/runbooks/ai-review.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKFidGwgH8fguKkqGjZ6d1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull request reviews through Cloudflare AI Gateway.
  * Reviews can be triggered by pull request activity and authorized commands.
  * Added safeguards for trusted execution contexts, review serialization, usage limits, and model fallbacks.

* **Documentation**
  * Added a runbook covering setup, usage, security controls, billing, limits, shutdown procedures, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->