### PR TITLE
Skip staging/preview deploys for fork PRs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -161,7 +161,13 @@ jobs:
     name: Deploy to Staging
     needs: [integration-tests]
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # Fork PRs are excluded: pull_request withholds secrets from forks, so the
+    # deploy can only fail there — and unreviewed fork code shouldn't reach the
+    # shared staging environment anyway. Jobs that need this one cascade to
+    # skipped on fork PRs. Never convert this workflow to pull_request_target.
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     concurrency:
       group: deploy-staging-${{ github.head_ref }}
       cancel-in-progress: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -21,7 +21,10 @@ jobs:
   cleanup:
     name: Cleanup Preview Environment
     runs-on: ubuntu-latest
-    if: github.event.action == 'closed'
+    # Fork PRs never get a preview (see deploy job), so there is nothing to clean up.
+    if: >
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write
@@ -139,7 +142,12 @@ jobs:
   deploy:
     name: Deploy Preview Environment
     runs-on: ubuntu-latest
-    if: github.event.action != 'closed'
+    # Fork PRs are excluded: pull_request withholds secrets from forks, so the
+    # deploy can only fail there — and unreviewed fork code shouldn't get a live
+    # preview environment anyway. Never convert this workflow to pull_request_target.
+    if: >
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Fork PRs run under `pull_request` without secrets, so the `deploy-staging` job (pr-checks.yml) and the preview `deploy`/`cleanup` jobs (pr-preview.yml) can only fail on them — a red ✗ on every external contributor's PR that they cannot fix. These jobs now skip when the PR head repo isn't `stratum-eng/stratum`.

This is also the correct trust posture independent of the failure: unreviewed fork code shouldn't deploy to shared staging or get a live preview environment. Jobs that `need` the skipped ones cascade to skipped (which GitHub counts as passing for required checks), so fork PRs still get lint/typecheck/tests.

Guard comments note the standing rule: never convert these workflows to `pull_request_target` — that would hand Cloudflare secrets to fork-controlled code.

Companion to #328's fork guard; ci.yml fork-noise fix is in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKFidGwgH8fguKkqGjZ6d1