### PR TITLE
Guard main-branch deploys to the canonical repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,12 @@ jobs:
     name: Deploy to Staging
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Repo guard: forks pushing to their own main lack the secrets and
+    # environments, so deploys there can only fail. Tests above still run
+    # in forks, where they are actually useful.
+    if: >
+      github.repository == 'stratum-eng/stratum' &&
+      github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: staging
       url: ${{ steps.deploy.outputs.url }}
@@ -176,7 +181,10 @@ jobs:
     name: Deploy to Production
     needs: [test, deploy-staging]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Repo guard: see deploy-staging.
+    if: >
+      github.repository == 'stratum-eng/stratum' &&
+      github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: production
       url: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
Companion to #329, for the fork-*repo* case rather than fork PRs: anyone who forks stratum and pushes to their own `main` runs `ci.yml`, where the staging/production deploy jobs can only fail (no secrets, no deployment environments). Those two jobs now also require `github.repository == 'stratum-eng/stratum'`.

The test/lint jobs stay unguarded — they work fine in forks and give fork owners useful CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKFidGwgH8fguKkqGjZ6d1