### PR TITLE
Give wedged import jobs a terminal state (#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `baseSha`, the commit the diff was actually taken against, so a receiver can
   apply the hunks to the right revision instead of guessing at whatever the
   default branch happened to be when the request landed.
+- **Delete import.** A failed or cancelled import can be dismissed from the project page, clearing
+  its import chrome. Only that job is removed, so the project's import history — and the clone
+  depth the next sync reads from it — is preserved.
+- Finished import jobs are now pruned after 30 days by the daily housekeeping cron. Nothing had
+  been pruning them. The most recent job per project is always kept, because that is the row the
+  next sync reads its clone depth from.
 - **Per-user telemetry opt-out.** Settings → Privacy now has a switch to stop sending product
   analytics for your account, alongside a plain-language disclosure of exactly what is sent.
   An agent inherits its owner's choice. Telemetry remains on by default; the existing
@@ -48,6 +54,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Approvals are dismissed when the evaluated **base** moves, not only when the
   tip does. A change re-evaluated against a newer base kept approvals that were
   granted against different code.
+- **Import jobs can no longer wedge forever.** A scheduled sweep now moves stalled imports to a
+  terminal state on its own — previously recovery only ran if somebody happened to open the
+  project's progress page, so an abandoned job could show "Import in Progress" with a `CANCELLING`
+  badge indefinitely. A cancel that never finished lands in `cancelled`; anything else that stopped
+  progressing becomes `failed` with an explanatory error. Jobs that were never picked up off the
+  queue are reaped too, under a longer grace period.
+- **Stall detection never actually fired.** Both the sweep and the existing on-demand recovery
+  compared `updated_at` against SQLite's `datetime('now', …)`, which formats timestamps with a
+  space, while every job row stores an ISO-8601 string. Compared as text, `'T'` sorts after `' '`,
+  so no row matched until the UTC date itself rolled over — silently delaying recovery by up to a
+  day. Both now compare ISO instants, and migration 043 normalises any legacy timestamps.
+- **The import status `syncing` was never actually saved.** It was missing from the `import_jobs`
+  status constraint, so the write the queue consumer makes when a sync begins failed silently on
+  every run and the job kept reading as `queued` long after it had started. The constraint now
+  admits every status the code can produce (migration 043), and the write reports failures instead
+  of discarding them.
+- A cancellation that the sweep finished is now recognised as cancelled by the queue consumer, which
+  previously treated it as a failure — emailing the user about a failure they never had and, on the
+  sync path, restarting the work they had cancelled.
+- An import in its sync phase now shows as in progress, with a spinner, a Cancel button and live
+  updates. Because `syncing` could never previously be stored, the progress card had no case for it
+  and would have rendered a running import as though nothing were happening.
+- On-demand stall recovery now updates the job it actually selected. It picked the stalest row but
+  wrote back by project, which resolves to the newest row — so on a project with more than one
+  import it could fail a healthy running job and leave the wedged one in place.
+- **"Sync Now" no longer appears on an empty repository**, where it sat next to "Not synced" and an
+  in-progress import badge — three claims that could not all be true at once. It still appears when
+  the file listing merely failed, which is when it is most needed.
 - `STRATUM_TELEMETRY_DISABLED` had no effect on `deploy:production` or `deploy:staging`. It was
   declared only under top-level `[vars]`, which named wrangler environments replace rather than
   inherit, so self-hosters who set it were still sending telemetry. It is now declared per

--- a/docs/adr/003-d1-for-import-state.md
+++ b/docs/adr/003-d1-for-import-state.md
@@ -38,7 +38,8 @@ CREATE TABLE import_jobs (
   slug TEXT NOT NULL,
   status TEXT NOT NULL CHECK (status IN (
     'queued', 'cloning', 'processing', 
-    'completed', 'failed', 'cancelled', 'cancelling'
+    'completed', 'failed', 'cancelled', 'cancelling',
+    'syncing', 'checking'
   )),
   source_url TEXT NOT NULL,
   branch TEXT NOT NULL,
@@ -58,11 +59,25 @@ CREATE TABLE import_jobs (
 -- Indexes for efficient lookups
 CREATE INDEX idx_import_jobs_ns_slug ON import_jobs(namespace, slug);
 CREATE INDEX idx_import_jobs_status ON import_jobs(status) 
-  WHERE status IN ('queued', 'cloning', 'processing', 'cancelling');
+  WHERE status IN ('queued', 'cloning', 'processing', 'cancelling', 'syncing');
 CREATE INDEX idx_import_jobs_completed_at ON import_jobs(completed_at) 
   WHERE completed_at IS NOT NULL;
 CREATE INDEX idx_import_jobs_project_id ON import_jobs(project_id);
+-- Serves the scheduled stall sweep: non-terminal rows ordered by staleness.
+CREATE INDEX idx_import_jobs_status_updated_at ON import_jobs(status, updated_at);
 ```
+
+`'syncing'` and `'checking'` were added to the CHECK constraint by migration 043.
+They had always been part of the `ImportStatus` union, and the queue consumer
+wrote `'syncing'` on every sync — against a constraint that rejected it. The
+write failed silently, leaving jobs reading as `'queued'` long after they had
+been picked up (#304).
+
+There is **no unique constraint on `(namespace, slug)`**: a project accumulates
+one row per import *and* per sync. Anything that has already selected a specific
+row must therefore write back by `id` — see `updateImportProgressById` — because
+`getImportProgress` resolves to the newest row for the project, which is
+frequently not the one the caller chose.
 
 ### Optimistic Locking
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -606,6 +606,7 @@ src/
 │   ├── events.ts            # Event definitions
 │   ├── group-commit.ts      # Grouped commit handling
 │   ├── import-queue.ts      # Import job processor
+│   ├── import-sweep.ts      # Reaps wedged import jobs to a terminal state
 │   ├── issue-autoclose.ts   # Auto-close issues on merge
 │   ├── merge-queue.ts       # Merge queue durable object
 │   ├── repo-do.ts           # Repository durable object

--- a/migrations/043_import_jobs_status_check.sql
+++ b/migrations/043_import_jobs_status_check.sql
@@ -1,0 +1,116 @@
+-- Widen import_jobs.status CHECK to admit every value ImportStatus can produce (#304).
+--
+-- 010's CHECK listed only queued/cloning/processing/completed/failed/cancelled/
+-- cancelling, but `ImportStatus` (src/types.ts) and VALID_STATUSES
+-- (src/storage/imports.ts) also carry 'syncing' and 'checking', and the queue
+-- consumer actively writes 'syncing' when an import enters its sync phase.
+-- That write failed with CHECK constraint violation (SQLite error 19) on every
+-- sync, and its Result was discarded, so the row silently kept its previous
+-- status -- usually 'queued', because createImportJob always inserts 'queued'.
+-- A job the consumer had picked up and was actively syncing therefore still
+-- read as 'queued' in D1, which is a direct contributor to imports appearing
+-- wedged forever.
+--
+-- SQLite cannot ALTER a CHECK constraint, so this is the standard table
+-- rebuild. `defer_foreign_keys` is the D1-supported way to suspend FK
+-- enforcement for the duration of the transaction (D1 does not support
+-- `PRAGMA foreign_keys = off`); failed_imports carries a
+-- `REFERENCES import_jobs(id) ON DELETE SET NULL` that would otherwise block
+-- the drop.
+PRAGMA defer_foreign_keys = true;
+
+-- defer_foreign_keys postpones constraint *violation* checks to commit time,
+-- but it does not suppress ON DELETE actions: DROP TABLE import_jobs still
+-- fires SET NULL across failed_imports.import_id and silently severs every
+-- failure record from the job it describes. Snapshot the linkage here and
+-- restore it after the rename.
+CREATE TABLE import_jobs_fk_backup AS
+  SELECT id AS failed_import_id, import_id FROM failed_imports WHERE import_id IS NOT NULL;
+
+CREATE TABLE import_jobs_new (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  namespace TEXT NOT NULL,
+  slug TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('queued', 'cloning', 'processing', 'completed', 'failed', 'cancelled', 'cancelling', 'syncing', 'checking')),
+  source_url TEXT NOT NULL,
+  branch TEXT NOT NULL,
+  progress_processed_files INTEGER DEFAULT 0,
+  progress_total_files INTEGER,
+  progress_current_file TEXT,
+  progress_bytes_transferred INTEGER,
+  progress_total_bytes INTEGER,
+  logs TEXT NOT NULL DEFAULT '[]',
+  errors TEXT NOT NULL DEFAULT '[]',
+  -- Timestamps are ISO-8601 UTC strings, not SQLite's 'YYYY-MM-DD HH:MM:SS'.
+  -- The storage layer writes `new Date().toISOString()` for all three; the
+  -- DEFAULT stays only for a row written outside it, and the SELECT below
+  -- normalises any legacy value. Mixing the two formats in one column silently
+  -- breaks range queries, because these are compared as TEXT and 'T' (0x54)
+  -- sorts after ' ' (0x20).
+  started_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  completed_at DATETIME,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  version INTEGER NOT NULL DEFAULT 1,
+  depth INTEGER
+);
+
+-- Columns are named explicitly: the rebuilt table must not depend on the
+-- physical column order of the original, which 040 appended `depth` to.
+INSERT INTO import_jobs_new (
+  id, project_id, namespace, slug, status, source_url, branch,
+  progress_processed_files, progress_total_files, progress_current_file,
+  progress_bytes_transferred, progress_total_bytes, logs, errors,
+  started_at, completed_at, updated_at, version, depth
+)
+SELECT
+  id, project_id, namespace, slug, status, source_url, branch,
+  progress_processed_files, progress_total_files, progress_current_file,
+  progress_bytes_transferred, progress_total_bytes, logs, errors,
+  -- strftime parses both formats and always emits ISO, so a row that took the
+  -- CURRENT_TIMESTAMP default becomes comparable with the ones the storage
+  -- layer wrote. A NULL completed_at stays NULL.
+  strftime('%Y-%m-%dT%H:%M:%fZ', started_at),
+  strftime('%Y-%m-%dT%H:%M:%fZ', completed_at),
+  strftime('%Y-%m-%dT%H:%M:%fZ', updated_at),
+  -- version is NOT NULL in the rebuilt table: a NULL could never satisfy the
+  -- optimistic-locking `WHERE id = ? AND version = ?`, leaving the row
+  -- permanently unwritable by the stall sweep.
+  COALESCE(version, 1),
+  depth
+FROM import_jobs;
+
+DROP TABLE import_jobs;
+
+ALTER TABLE import_jobs_new RENAME TO import_jobs;
+
+UPDATE failed_imports
+SET import_id = (
+  SELECT b.import_id FROM import_jobs_fk_backup b WHERE b.failed_import_id = failed_imports.id
+)
+WHERE id IN (SELECT failed_import_id FROM import_jobs_fk_backup);
+
+DROP TABLE import_jobs_fk_backup;
+
+-- Recreate every index from 010, 011 and 040. The partial "active imports"
+-- index gains 'syncing' so the status it was always meant to cover is finally
+-- indexable; 'checking' is deliberately omitted -- it is declared in the type
+-- union but never written anywhere, so indexing it would cost writes for rows
+-- that cannot exist.
+CREATE INDEX IF NOT EXISTS idx_import_jobs_ns_slug ON import_jobs(namespace, slug);
+
+CREATE INDEX IF NOT EXISTS idx_import_jobs_status ON import_jobs(status)
+  WHERE status IN ('queued', 'cloning', 'processing', 'cancelling', 'syncing');
+
+CREATE INDEX IF NOT EXISTS idx_import_jobs_completed_at ON import_jobs(completed_at)
+  WHERE completed_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_import_jobs_project_id ON import_jobs(project_id);
+
+CREATE INDEX IF NOT EXISTS idx_import_jobs_version ON import_jobs(id, version);
+
+-- Covers the scheduled import sweep's predicate
+-- (status IN (...) AND updated_at < ? ORDER BY updated_at ASC). The partial
+-- index above cannot serve it: it omits updated_at, so the sweep would scan
+-- every non-terminal row on every 5-minute tick.
+CREATE INDEX IF NOT EXISTS idx_import_jobs_status_updated_at ON import_jobs(status, updated_at);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stratum",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stratum",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@isomorphic-git/lightning-fs": "^4.6.2",
@@ -28,6 +28,10 @@
         "typescript": "^5.8.3",
         "vitest": "^3.1.3",
         "wrangler": "^4.0.0"
+      },
+      "engines": {
+        "//": "node:sqlite is unflagged only from 22.13.0; tests/helpers/sqlite-d1.ts imports it.",
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/queue/import-queue.ts
+++ b/src/queue/import-queue.ts
@@ -595,8 +595,27 @@ async function processSyncJob(
       return;
     }
 
-    // Update status to syncing
-    await updateImportStatus(env.DB, namespace, slug, "syncing", logger, "Syncing repository");
+    // #304: this write silently failed for every sync until migration 043 —
+    // 'syncing' was missing from the status CHECK constraint, so the row kept
+    // its previous status (usually 'queued') and the job read as never having
+    // been picked up. A failure here must not abort a working sync, but it must
+    // not be invisible either: an unwritable status label is what makes a job
+    // look wedged to both the UI and the stall sweep.
+    const syncingStatusResult = await updateImportStatus(
+      env.DB,
+      namespace,
+      slug,
+      "syncing",
+      logger,
+      "Syncing repository",
+    );
+    if (!syncingStatusResult.success) {
+      logger.error("Failed to record 'syncing' status; continuing with sync", undefined, {
+        namespace,
+        slug,
+        error: syncingStatusResult.error.message,
+      });
+    }
 
     // #190: sync is an INCREMENTAL fetch into the existing Artifacts repo, never
     // a delete-and-re-import — re-importing destroyed Stratum-native commits and

--- a/src/queue/import-sweep.ts
+++ b/src/queue/import-sweep.ts
@@ -1,0 +1,180 @@
+import {
+  QUEUED_GRACE_MS,
+  STALLED_THRESHOLD_MS,
+  updateImportProgressById,
+} from "../storage/imports";
+import type { Env, ImportStatus } from "../types";
+import type { Logger } from "../utils/logger";
+import { createLogger } from "../utils/logger";
+
+/**
+ * Most jobs a single sweep will reap. A backlog drains over successive crons
+ * rather than risking the Worker's wall-clock budget in one invocation.
+ */
+const SWEEP_BATCH_LIMIT = 100;
+
+/** Statuses that indicate active work, and so are judged by silence. */
+const ACTIVE_STATUSES: readonly ImportStatus[] = [
+  "cloning",
+  "processing",
+  "syncing",
+  "checking",
+  "cancelling",
+];
+
+export interface ImportSweepResult {
+  /** Rows that matched the stale predicate and were considered. */
+  scanned: number;
+  /** Rows successfully moved to a terminal status. */
+  reaped: number;
+  /** Rows another writer owned — the sweep deliberately stood down. */
+  conflicted: number;
+  /** Rows that threw; counted and skipped so one bad row cannot end the batch. */
+  errored: number;
+}
+
+interface StaleJobRow {
+  id: string;
+  namespace: string;
+  slug: string;
+  status: ImportStatus;
+  version: number;
+  updated_at: string;
+}
+
+/**
+ * A cancel that the consumer never finished should land in `cancelled`, not
+ * `failed` — the user asked for it and it did happen, however untidily. Anything
+ * else that stopped progressing is a failure.
+ */
+function terminalStatusFor(status: ImportStatus): "cancelled" | "failed" {
+  return status === "cancelling" ? "cancelled" : "failed";
+}
+
+function stalledMessage(status: ImportStatus, thresholdMs: number): string {
+  const minutes = Math.round(thresholdMs / 60_000);
+  return status === "queued"
+    ? `Import was never picked up by a worker after ${minutes} minutes. The queue message was likely lost; retry to re-queue it.`
+    : `Import stalled: no progress for longer than ${minutes} minutes. This may indicate a network issue or timeout with the git provider.`;
+}
+
+/**
+ * Move wedged import jobs to a terminal status.
+ *
+ * Without this, a job whose consumer died mid-run stayed non-terminal forever:
+ * `recoverStalledImport` only ever ran on demand, for a single project, when
+ * somebody happened to load its progress page. A project nobody opened kept
+ * claiming an import was in progress indefinitely — the four-month CANCELLING
+ * badge in #304.
+ *
+ * `queued` is held to a much longer grace period than the active statuses: it
+ * means "not yet picked up", and a queue backlog of a few minutes is ordinary.
+ */
+export async function runImportSweep(
+  env: Env,
+  logger: Logger = createLogger({ component: "ImportSweep" }),
+): Promise<ImportSweepResult> {
+  const result: ImportSweepResult = { scanned: 0, reaped: 0, conflicted: 0, errored: 0 };
+
+  // Cutoffs are ISO strings, NOT `datetime('now', ...)`. `updated_at` holds
+  // `new Date().toISOString()`, and SQLite compares these as TEXT: an ISO value
+  // ('...T23:04:29.798Z') always sorts after a same-day `datetime()` value
+  // ('... 23:04:29') because 'T' (0x54) > ' ' (0x20). Comparing the two formats
+  // makes the predicate false for every row until the UTC date itself rolls
+  // over, which silently delayed reaping by up to a day. Binding an ISO string
+  // also keeps `idx_import_jobs_status_updated_at` usable, which wrapping the
+  // column in datetime()/julianday() would not.
+  const now = Date.now();
+  const activeCutoff = new Date(now - STALLED_THRESHOLD_MS).toISOString();
+  const queuedCutoff = new Date(now - QUEUED_GRACE_MS).toISOString();
+  const activePlaceholders = ACTIVE_STATUSES.map(() => "?").join(", ");
+
+  let staleJobs: StaleJobRow[];
+  try {
+    const { results } = await env.DB.prepare(
+      `SELECT id, namespace, slug, status, version, updated_at
+       FROM import_jobs
+       WHERE (status IN (${activePlaceholders}) AND updated_at < ?)
+          OR (status = 'queued' AND updated_at < ?)
+       ORDER BY updated_at ASC
+       LIMIT ?`,
+    )
+      .bind(...ACTIVE_STATUSES, activeCutoff, queuedCutoff, SWEEP_BATCH_LIMIT)
+      .all<StaleJobRow>();
+    staleJobs = results ?? [];
+  } catch (error) {
+    logger.error("Import sweep query failed", error instanceof Error ? error : undefined);
+    return result;
+  }
+
+  result.scanned = staleJobs.length;
+
+  for (const job of staleJobs) {
+    const targetStatus = terminalStatusFor(job.status);
+    const thresholdMs = job.status === "queued" ? QUEUED_GRACE_MS : STALLED_THRESHOLD_MS;
+
+    try {
+      const now = new Date().toISOString();
+      const updated = await updateImportProgressById(
+        env.DB,
+        job.id,
+        job.version,
+        {
+          status: targetStatus,
+          completedAt: now,
+          ...(targetStatus === "failed"
+            ? {
+                errors: [
+                  {
+                    file: "_import",
+                    error: stalledMessage(job.status, thresholdMs),
+                    timestamp: now,
+                  },
+                ],
+              }
+            : {}),
+        },
+        logger,
+      );
+
+      if (!updated.success) {
+        result.errored++;
+        logger.warn("Failed to reap stalled import", {
+          importId: job.id,
+          namespace: job.namespace,
+          slug: job.slug,
+          error: updated.error.message,
+        });
+        continue;
+      }
+
+      if (!updated.data.updated) {
+        // Another writer owns this row (or the cancellation path already
+        // removed it). Standing down is the correct outcome, not a failure.
+        result.conflicted++;
+        continue;
+      }
+
+      result.reaped++;
+      logger.info("Reaped stalled import", {
+        importId: job.id,
+        namespace: job.namespace,
+        slug: job.slug,
+        from: job.status,
+        to: targetStatus,
+        updatedAt: job.updated_at,
+      });
+    } catch (error) {
+      result.errored++;
+      logger.error("Error reaping stalled import", error instanceof Error ? error : undefined, {
+        importId: job.id,
+      });
+    }
+  }
+
+  if (result.scanned > 0) {
+    logger.info("Import sweep completed", { ...result });
+  }
+
+  return result;
+}

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -1,6 +1,10 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
-import { importRateLimitMiddleware, releaseImportLock } from "../middleware/rate-limit";
+import {
+  importRateLimitMiddleware,
+  rateLimitMiddleware,
+  releaseImportLock,
+} from "../middleware/rate-limit";
 import { emitEvent } from "../queue/events";
 import { syncOrImportProject } from "../services/project-sync";
 import { recordAudit } from "../storage/audit";
@@ -23,9 +27,11 @@ import {
 import { buildAuthConfig, resolveDefaultBranch } from "../storage/git-providers";
 import { finalizeImportSnapshot } from "../storage/import-finalize";
 import {
+  STALLED_THRESHOLD_MS,
   cancelImportJob,
   createImportJob,
   deleteImportJob,
+  deleteImportJobById,
   getImportProgress,
   getLatestImportDepth,
   isImportCancelled,
@@ -45,7 +51,7 @@ import {
   updateProjectAfterSync,
   updateProjectSyncError,
 } from "../storage/sync";
-import type { ArtifactsCreateResult, Env, ProjectEntry } from "../types";
+import type { ArtifactsCreateResult, Env, ImportStatus, ProjectEntry } from "../types";
 import { getArtifactsRepoName, projectDefaultBranch } from "../types";
 import { getFileContent, isValidFilePath } from "../ui/file-content";
 import {
@@ -1658,10 +1664,13 @@ app.get("/:namespace/:slug/import/status", async (c) => {
     return notFound("Import job", `${namespace}/${slug}`);
   }
 
-  // Check for stalled imports (5 minute threshold)
-  // Note: 'queued' is not included because it's a valid initial state that doesn't indicate progress
-  const STALLED_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
-  if (["cloning", "processing", "syncing"].includes(progressResult.data.status)) {
+  // Check for stalled imports. 'queued' is excluded here because it means the
+  // job has not been picked up yet rather than that it stopped progressing; the
+  // scheduled sweep covers it under a longer grace period. 'cancelling' IS
+  // included (#304): a cancel that the consumer never finished is the exact
+  // state that left projects showing a CANCELLING badge indefinitely, and
+  // `recoverStalledImport` already matches it in SQL — only this guard omitted it.
+  if (["cloning", "processing", "syncing", "cancelling"].includes(progressResult.data.status)) {
     const lastUpdatedAt = new Date(progressResult.data.updatedAt).getTime();
     const elapsedMs = Date.now() - lastUpdatedAt;
 
@@ -1921,6 +1930,90 @@ app.post(
       slug,
       status: "queued",
     });
+  },
+);
+
+/**
+ * Statuses a user may delete. Deliberately narrower than "terminal": a
+ * `completed` job is the record the next sync reads its clone depth from
+ * (`getLatestImportDepth`), so removing it would silently downgrade a
+ * full-history project to a shallow clone.
+ */
+const DELETABLE_IMPORT_STATUSES: readonly ImportStatus[] = ["failed", "cancelled"];
+
+// POST /projects/:namespace/:slug/import/delete - Discard a finished import job
+// so an abandoned failure stops rendering import chrome on the project page (#304).
+app.post(
+  "/:namespace/:slug/import/delete",
+  // A plain per-user limiter, NOT importRateLimitMiddleware: that one takes the
+  // per-project import lock and only the import paths release it, so deleting a
+  // dead job would 429 the user's next import for the lock's full duration —
+  // and clearing a failed import is exactly what someone does right before
+  // retrying. Deleting a terminal row starts no work worth serialising.
+  rateLimitMiddleware({ requestsPerMinute: 20 }),
+  async (c) => {
+    const logger = createLogger({
+      requestId: crypto.randomUUID(),
+      userId: c.get("userId"),
+      path: c.req.path,
+      method: c.req.method,
+    });
+
+    const userId = c.get("userId");
+    const username = c.get("username");
+    if (!userId || !username) return unauthorized("Authentication required");
+
+    const { namespace, slug } = c.req.param();
+    const userNamespace = getUserNamespace(username);
+
+    if (namespace !== userNamespace) {
+      return forbidden("You can only delete imports in your own namespace");
+    }
+
+    const progressResult = await getImportProgress(c.env.DB, namespace, slug, logger);
+    if (!progressResult.success) {
+      logger.error("Failed to get import progress", progressResult.error);
+      return internalError(progressResult.error.message);
+    }
+
+    if (!progressResult.data) {
+      return notFound("Import job", `${namespace}/${slug}`);
+    }
+
+    const existing = progressResult.data;
+
+    if (!DELETABLE_IMPORT_STATUSES.includes(existing.status)) {
+      // Removing a row the queue consumer still owns would orphan an in-flight
+      // import, so a live job must be cancelled before it can be discarded.
+      return c.json(
+        {
+          error: `Cannot delete an import with status: ${existing.status}. Cancel it first.`,
+        },
+        409,
+      );
+    }
+
+    // Scoped to this job's id, not to namespace+slug: a project accumulates a
+    // row per sync, and wiping them all would take the depth history with it.
+    const deleteResult = await deleteImportJobById(
+      c.env.DB,
+      existing.id,
+      DELETABLE_IMPORT_STATUSES,
+      logger,
+    );
+    if (!deleteResult.success) {
+      logger.error("Failed to delete import job", deleteResult.error);
+      return internalError(deleteResult.error.message);
+    }
+
+    if (!deleteResult.data) {
+      // Either another delete removed the row first, or a retry re-queued it
+      // between the status check above and the delete.
+      return notFound("Import job", `${namespace}/${slug}`);
+    }
+
+    logger.info("Import job deleted", { namespace, slug, importId: existing.id });
+    return ok({ message: "Import deleted", namespace, slug });
   },
 );
 

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -664,6 +664,9 @@ app.get("/p/:name", async (c) => {
   }
 
   let files: string[] = [];
+  // Distinguishes "this repo is empty" from "the listing failed": both leave
+  // `files` empty, but only the first should hide content-gated actions.
+  let filesUnavailable = false;
   let log: Array<{ sha: string; message: string; author: string; timestamp: number }> = [];
   let readme: string | null = null;
   let importProgress = null;
@@ -724,6 +727,7 @@ app.get("/p/:name", async (c) => {
       if (filesResult.success) {
         files = filesResult.data;
       } else {
+        filesUnavailable = true;
         logger.warn("Failed to list files in repo", { error: filesResult.error });
       }
 
@@ -749,6 +753,7 @@ app.get("/p/:name", async (c) => {
       }
     } catch (error) {
       // Repo may be empty or unreachable — render with empty data
+      filesUnavailable = true;
       logger.warn("Error loading repo data", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -780,6 +785,7 @@ app.get("/p/:name", async (c) => {
         autoSyncEnabled: project.autoSyncEnabled,
       }}
       files={files}
+      filesUnavailable={filesUnavailable}
       log={log}
       readme={readme}
       user={userResult}
@@ -1917,6 +1923,9 @@ app.get("/:namespace/:slug", async (c) => {
   const isDefaultBranch = branch === defaultBranch;
 
   let files: string[] = [];
+  // Distinguishes "this repo is empty" from "the listing failed": both leave
+  // `files` empty, but only the first should hide content-gated actions.
+  let filesUnavailable = false;
   let log: Array<{ sha: string; message: string; author: string; timestamp: number }> = [];
   let readme: string | null = null;
   let importProgress = null;
@@ -1970,6 +1979,7 @@ app.get("/:namespace/:slug", async (c) => {
       if (filesResult.success) {
         files = filesResult.data;
       } else {
+        filesUnavailable = true;
         logger.warn("Failed to list files in repo", { error: filesResult.error });
       }
 
@@ -1995,6 +2005,7 @@ app.get("/:namespace/:slug", async (c) => {
       }
     } catch (error) {
       // Repo may be empty or unreachable — render with empty data
+      filesUnavailable = true;
       logger.warn("Error loading repo data", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -2037,6 +2048,7 @@ app.get("/:namespace/:slug", async (c) => {
         autoSyncEnabled: project.autoSyncEnabled,
       }}
       files={files}
+      filesUnavailable={filesUnavailable}
       log={log}
       readme={readme}
       user={userResult}

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -1,17 +1,24 @@
 import { runBackup } from "./backup/run-backup";
 import { sweepDeletionJobs } from "./queue/deletion-runner";
 import { sweepStaleEvents } from "./queue/event-consumer";
+import { runImportSweep } from "./queue/import-sweep";
 import { runTtlSweep } from "./queue/ttl-sweep";
 import { syncAllProjects } from "./routes/sync";
+import { cleanupOldImports } from "./storage/imports";
 import type { Env } from "./types";
 import type { Logger } from "./utils/logger";
 
 export type ScheduledJob =
   | "event-sweep"
   | "deletion-sweep"
+  | "import-sweep"
   | "backup"
   | "ttl-sweep"
-  | "project-sync";
+  | "project-sync"
+  | "import-cleanup";
+
+/** How long a finished import job is kept before `import-cleanup` prunes it. */
+const IMPORT_RETENTION_DAYS = 30;
 
 /**
  * Cron → jobs routing. Backup runs on its OWN trigger (`0 4 * * *`), isolated
@@ -19,15 +26,19 @@ export type ScheduledJob =
  * wall-clock budget, and a slow `project-sync` sharing that budget could starve
  * or truncate the DR-critical backup. Keeping them on separate crons gives each
  * the full invocation budget.
+ *
+ * `import-sweep` is safe on the 5-minute tick despite that reasoning: it is one
+ * indexed query plus at most `SWEEP_BATCH_LIMIT` small writes, and recovery
+ * speed is the point — the job it reaps is one a user is staring at.
  */
 export function jobsForCron(cron: string): ScheduledJob[] {
   switch (cron) {
     case "*/5 * * * *":
-      return ["event-sweep", "deletion-sweep"];
+      return ["event-sweep", "deletion-sweep", "import-sweep"];
     case "0 4 * * *":
       return ["backup"];
     case "0 6 * * *":
-      return ["ttl-sweep", "project-sync"];
+      return ["ttl-sweep", "project-sync", "import-cleanup"];
     default:
       return [];
   }
@@ -38,9 +49,11 @@ export type JobRunners = Record<ScheduledJob, (env: Env, logger: Logger) => Prom
 const JOB_RUNNERS: JobRunners = {
   "event-sweep": (env, logger) => sweepStaleEvents(env, logger),
   "deletion-sweep": (env, logger) => sweepDeletionJobs(env, logger),
+  "import-sweep": (env, logger) => runImportSweep(env, logger),
   backup: (env, logger) => runBackup(env, logger, new Date().toISOString()),
   "ttl-sweep": (env, logger) => runTtlSweep(env, logger),
   "project-sync": (env) => syncAllProjects(env),
+  "import-cleanup": (env, logger) => cleanupOldImports(env.DB, IMPORT_RETENTION_DAYS, logger),
 };
 
 /**

--- a/src/storage/d1-backup.ts
+++ b/src/storage/d1-backup.ts
@@ -57,10 +57,6 @@ export const BACKUP_EXCLUDED_TABLES: readonly string[] = [
   // The backup orchestrator's own per-repo rotation cursor. It describes backup
   // progress, not user data; restoring it into a fresh DB would be meaningless.
   "backup_state",
-  // Transient rebuild alias from migration 037 (widening the verdict CHECK):
-  // renamed to change_reviews within the same migration, so it never exists in
-  // a live database. The real table is covered as change_reviews above.
-  "change_reviews_new",
 ];
 
 const PAGE_SIZE = 500;

--- a/src/storage/imports.ts
+++ b/src/storage/imports.ts
@@ -11,6 +11,31 @@ import { type Result, err, ok } from "../utils/result";
 const MAX_LOGS = 100; // Prevent unbounded growth
 const MAX_ERRORS = 50; // Prevent unbounded growth
 
+/**
+ * How long a job may sit in an actively-progressing status (`cloning`,
+ * `processing`, `syncing`, `cancelling`) without its `updated_at` advancing
+ * before it is treated as stalled.
+ *
+ * This MUST stay above a queue consumer's 15-minute maximum wall time. The
+ * consumer writes `cloning` and then calls into the clone with no intervening
+ * progress write, so a perfectly healthy import can leave `updated_at`
+ * untouched for its entire run. Anything at or under that ceiling would let the
+ * sweep mark live imports `failed`. Past 15 minutes the invocation is gone, so
+ * silence really does mean the job was abandoned.
+ *
+ * Shared by the on-demand recovery in the progress route and the scheduled
+ * sweep so the two cannot disagree about what "stalled" means.
+ */
+export const STALLED_THRESHOLD_MS = 20 * 60 * 1000;
+
+/**
+ * The grace period for `queued`, which is not a sign of progress but of a job
+ * waiting to be picked up. A queue backlog is normal for seconds to minutes, so
+ * this is deliberately longer than `STALLED_THRESHOLD_MS`; exceeding it means
+ * the queue message was almost certainly lost.
+ */
+export const QUEUED_GRACE_MS = 60 * 60 * 1000;
+
 // Valid status values for validation
 const VALID_STATUSES: ImportStatus[] = [
   "queued",
@@ -495,6 +520,148 @@ export async function updateImportProgress(
   }
 }
 
+/**
+ * Outcome of an id-scoped update. A lost optimistic-locking race is a normal,
+ * expected result for a background sweep — another writer legitimately owns the
+ * job — so it is reported as an outcome rather than an error.
+ */
+export type ImportUpdateOutcome =
+  | { updated: true; job: ImportProgress }
+  | { updated: false; reason: "version-conflict" | "not-found" };
+
+/**
+ * Update one specific import job, identified by its primary key.
+ *
+ * `updateImportProgress` resolves its target through `getImportProgress`, which
+ * is `ORDER BY started_at DESC LIMIT 1` — the newest job for a namespace/slug.
+ * That is correct for the request paths that own the current import, but wrong
+ * for any caller that has already selected a specific row: a project
+ * accumulates an `import_jobs` row per sync, so the newest row is frequently
+ * not the one the caller chose. Its `WHERE namespace = ? AND slug = ? AND
+ * version = ?` can also match several sibling rows at once, since fresh rows
+ * all start at version 1.
+ *
+ * Scoping to `id` makes the update hit exactly the intended row (id is the
+ * primary key) and makes the version check a true compare-and-swap.
+ *
+ * Unlike `updateImportProgress` this does not retry on conflict: a caller that
+ * lost the race no longer holds a current view of the job, and for the stall
+ * sweep a conflict means the job is being actively worked on — precisely the
+ * case where it must not interfere.
+ */
+export async function updateImportProgressById(
+  db: D1Database,
+  id: string,
+  expectedVersion: number,
+  updates: Partial<ImportProgress>,
+  logger: Logger,
+): Promise<Result<ImportUpdateOutcome, AppError>> {
+  const existingResult = await getImportById(db, id, logger);
+  if (!existingResult.success) {
+    return existingResult;
+  }
+
+  const existing = existingResult.data;
+  if (!existing) {
+    return ok({ updated: false, reason: "not-found" });
+  }
+
+  const updatedProgress = { ...existing.progress, ...updates.progress };
+  const updatedLogs = [...existing.logs, ...(updates.logs || [])].slice(-MAX_LOGS);
+  const updatedErrors = [...existing.errors, ...(updates.errors || [])].slice(-MAX_ERRORS);
+
+  try {
+    const result = await db
+      .prepare(
+        `UPDATE import_jobs SET
+          status = COALESCE(?, status),
+          progress_processed_files = ?,
+          progress_total_files = ?,
+          progress_current_file = ?,
+          logs = ?,
+          errors = ?,
+          completed_at = COALESCE(?, completed_at),
+          version = version + 1,
+          updated_at = ?
+        WHERE id = ? AND version = ?`,
+      )
+      .bind(
+        updates.status ?? null,
+        updatedProgress.processedFiles,
+        updatedProgress.totalFiles ?? null,
+        updatedProgress.currentFile ?? null,
+        JSON.stringify(updatedLogs),
+        JSON.stringify(updatedErrors),
+        updates.completedAt ?? null,
+        new Date().toISOString(),
+        id,
+        expectedVersion,
+      )
+      .run();
+
+    if ((result.meta?.changes ?? 0) === 0) {
+      return ok({ updated: false, reason: "version-conflict" });
+    }
+
+    const refreshed = await getImportById(db, id, logger);
+    if (!refreshed.success) {
+      return refreshed;
+    }
+    if (!refreshed.data) {
+      return err(new AppError("Import job vanished after update", "STORAGE_ERROR", 500));
+    }
+
+    return ok({ updated: true, job: refreshed.data });
+  } catch (error) {
+    logger.error(
+      "Failed to update import progress by id",
+      error instanceof Error ? error : undefined,
+      { importId: id },
+    );
+    return err(new AppError("Failed to update import progress", "STORAGE_ERROR", 500));
+  }
+}
+
+/**
+ * Delete one specific import job by primary key.
+ *
+ * Distinct from `deleteImportJob`, which removes *every* row for a
+ * namespace/slug — correct for the cancellation path that tears down a
+ * project's import state, but far too broad for a user deleting a single
+ * finished job. Wiping the history would also strip the depth record that
+ * `getLatestImportDepth` reads, silently downgrading the project's next sync to
+ * `DEFAULT_CLONE_DEPTH`.
+ *
+ * @returns whether a row was actually removed
+ */
+export async function deleteImportJobById(
+  db: D1Database,
+  id: string,
+  allowedStatuses: readonly ImportStatus[],
+  logger: Logger,
+): Promise<Result<boolean, AppError>> {
+  try {
+    // The status is re-checked here rather than trusted from the caller's
+    // earlier read: between that read and this delete the job can be re-queued
+    // by a retry, and removing a row a consumer has just picked up would orphan
+    // a live import.
+    const placeholders = allowedStatuses.map(() => "?").join(", ");
+    const result = await db
+      .prepare(`DELETE FROM import_jobs WHERE id = ? AND status IN (${placeholders})`)
+      .bind(id, ...allowedStatuses)
+      .run();
+    const deleted = (result.meta?.changes ?? 0) > 0;
+
+    logger.debug("Import job delete by id", { importId: id, deleted });
+    return ok(deleted);
+  } catch (error) {
+    logger.error("Failed to delete import job by id", error instanceof Error ? error : undefined, {
+      importId: id,
+    });
+    return err(new AppError("Failed to delete import job", "STORAGE_ERROR", 500));
+  }
+}
+
 export async function updateImportStatus(
   db: D1Database,
   namespace: string,
@@ -583,7 +750,13 @@ export async function isImportCancelled(
   if (!progressResult.success || !progressResult.data) {
     return false;
   }
-  return progressResult.data.status === "cancelling";
+  // `cancelled` counts, not just `cancelling`. The stall sweep terminalises a
+  // quiet `cancelling` job, and a consumer that was merely slow rather than
+  // dead would otherwise see a status it does not recognise as a cancellation,
+  // take its failure branch instead, overwrite `cancelled` with `failed`, email
+  // the user about a failure they never had, and — on the sync path — call
+  // msg.retry(), restarting the very work they cancelled.
+  return progressResult.data.status === "cancelling" || progressResult.data.status === "cancelled";
 }
 
 export async function deleteImportJob(
@@ -643,11 +816,27 @@ export async function cleanupOldImports(
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - olderThanDays);
 
+    // The newest job per project is retained regardless of age — deliberately
+    // "newest", not "newest finished", because that is precisely the row
+    // `getLatestImportDepth` selects (ORDER BY started_at DESC LIMIT 1, no
+    // status filter). Protecting a different row than the reader reads would
+    // let the clone depth be pruned out from under it, silently re-deriving
+    // DEFAULT_CLONE_DEPTH and turning a full-history project into a shallow
+    // clone. Depth propagates forward — each sync writes the depth it read onto
+    // the row it creates — so keeping the newest row keeps the depth reachable.
+    // Only finished rows are candidates, so an in-flight job is never at risk.
     const result = await db
       .prepare(
-        `DELETE FROM import_jobs 
-         WHERE completed_at IS NOT NULL 
-         AND completed_at < ?`,
+        `DELETE FROM import_jobs
+         WHERE completed_at IS NOT NULL
+         AND completed_at < ?
+         AND id NOT IN (
+           SELECT id FROM import_jobs AS newest
+           WHERE newest.namespace = import_jobs.namespace
+             AND newest.slug = import_jobs.slug
+           ORDER BY newest.started_at DESC
+           LIMIT 1
+         )`,
       )
       .bind(cutoffDate.toISOString())
       .run();
@@ -708,13 +897,18 @@ export async function recoverStalledImport(
   try {
     const row = await db
       .prepare(
+        // The cutoff is an ISO string, not `datetime('now', ?)`: `updated_at`
+        // stores `new Date().toISOString()`, and TEXT comparison puts an ISO
+        // value after a same-day `datetime()` value ('T' > ' '). Comparing the
+        // two formats made this predicate false for every row until the UTC
+        // date rolled over, so on-demand recovery silently never fired.
         `SELECT * FROM import_jobs
          WHERE namespace = ? AND slug = ?
          AND status IN ('cloning', 'processing', 'syncing', 'cancelling')
-         AND updated_at < datetime('now', ?)
+         AND updated_at < ?
          ORDER BY updated_at DESC LIMIT 1`,
       )
-      .bind(namespace, slug, `-${Math.ceil(maxStallMs / 1000)} seconds`)
+      .bind(namespace, slug, new Date(Date.now() - maxStallMs).toISOString())
       .first<ImportJobRow>();
 
     if (!row) {
@@ -731,12 +925,17 @@ export async function recoverStalledImport(
       updatedAt: row.updated_at,
     });
 
-    // Use updateImportProgress to properly handle MAX_ERRORS and timestamps
+    // Written by id, not by namespace+slug. The SELECT above picks the stalest
+    // matching row, but `updateImportProgress` re-resolves its target through
+    // `getImportProgress` (ORDER BY started_at DESC) — the NEWEST row for the
+    // project. A project owns one row per sync, so those are routinely
+    // different rows, and the namespace-scoped write would fail a healthy
+    // in-flight job while leaving the wedged one exactly as it was.
     const now = new Date().toISOString();
-    const updateResult = await updateImportProgress(
+    const updateResult = await updateImportProgressById(
       db,
-      namespace,
-      slug,
+      row.id,
+      row.version,
       {
         status: targetStatus,
         completedAt: now,
@@ -755,27 +954,28 @@ export async function recoverStalledImport(
       logger,
     );
 
-    if (updateResult.success) {
-      logger.info("Successfully recovered stalled import", {
-        namespace,
-        slug,
-        importId: row.id,
-      });
-      return ok(true);
+    if (!updateResult.success) {
+      return err(updateResult.error);
     }
 
-    // If update failed due to version conflict, the import was updated elsewhere
-    if (updateResult.error.code === "CONFLICT") {
+    if (!updateResult.data.updated) {
+      // Another writer owns the row (or it has since been removed) — the job is
+      // not abandoned after all, so recovery correctly stands down.
       logger.debug("Stalled import was updated elsewhere, skipping recovery", {
         namespace,
         slug,
         importId: row.id,
+        reason: updateResult.data.reason,
       });
       return ok(false);
     }
 
-    // Other error
-    return err(updateResult.error);
+    logger.info("Successfully recovered stalled import", {
+      namespace,
+      slug,
+      importId: row.id,
+    });
+    return ok(true);
   } catch (error) {
     logger.error("Failed to recover stalled import", error instanceof Error ? error : undefined, {
       namespace,

--- a/src/ui/components/import-progress.tsx
+++ b/src/ui/components/import-progress.tsx
@@ -277,19 +277,29 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
   branch,
   nonce,
 }) => {
-  const isActive = ["queued", "cloning", "processing"].includes(status);
+  // 'syncing' belongs here: until migration 043 widened the status CHECK it
+  // could never be stored, so this list never had to account for it. Now that
+  // the consumer's sync-phase write actually lands, omitting it would render a
+  // running import with no spinner, no Cancel button, and — because the live
+  // refresh script is gated on this too — no way for the page to advance.
+  const isActive = ["queued", "cloning", "processing", "syncing"].includes(status);
   const isComplete = status === "completed";
   const isFailed = status === "failed";
   const isCancelled = status === "cancelled";
   const isCancelling = status === "cancelling";
 
+  // Coarse fallbacks for phases that report no file counts. 'syncing' runs
+  // after the file work, so it sits above 'processing' rather than dropping the
+  // bar back to empty.
   const percent = progress.totalFiles
     ? Math.round((progress.processedFiles / progress.totalFiles) * 100)
     : status === "cloning"
       ? 10
       : status === "processing"
         ? 50
-        : 0;
+        : status === "syncing"
+          ? 75
+          : 0;
 
   // Safely escape for interpolation into a quoted string inside an inline
   // <script> body — JSON.stringify alone doesn't escape "<", so a namespace
@@ -441,12 +451,50 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
               Retry import
             </button>
           </form>
+          {/*
+            Delete is offered only once the job has actually finished. While it
+            is still 'cancelling' the queue consumer may yet own the row, and
+            removing it there would orphan an in-flight import.
+          */}
+          {(isFailed || isCancelled) && (
+            <form
+              id="import-delete-form"
+              method="post"
+              action={`/api/projects/${namespace}/${slug}/import/delete`}
+              class="delete-form"
+            >
+              <button type="submit" class="btn btn-secondary">
+                Delete import
+              </button>
+            </form>
+          )}
           {isCancelling && (
             <p class="help-text">
               Cancelling can take a moment. If it stays stuck, Retry re-queues the import.
             </p>
           )}
         </div>
+      )}
+
+      {(isFailed || isCancelled) && (
+        <script
+          nonce={nonce}
+          dangerouslySetInnerHTML={{
+            __html: `
+            // Progressive enhancement only: discarding the job also discards its
+            // error log, and there is no undo. Without JS the form still posts.
+            (function () {
+              var deleteForm = document.getElementById('import-delete-form');
+              if (!deleteForm) return;
+              deleteForm.addEventListener('submit', function (event) {
+                if (!confirm('Delete this import record? Its logs and error details will be lost.')) {
+                  event.preventDefault();
+                }
+              });
+            })();
+          `,
+          }}
+        />
       )}
 
       {isFailed && errorInfo?.actionButton && (
@@ -497,7 +545,10 @@ export const ImportProgressCard: FC<ImportProgressProps> = ({
               // Update progress bar
               const percent = data.progress.totalFiles 
                 ? Math.round((data.progress.processedFiles / data.progress.totalFiles) * 100)
-                : data.status === 'cloning' ? 10 : data.status === 'processing' ? 50 : 0;
+                : data.status === 'cloning' ? 10
+                : data.status === 'processing' ? 50
+                : data.status === 'syncing' ? 75
+                : 0;
               
               const fill = document.querySelector('.progress-fill');
               if (fill) fill.style.width = percent + '%';

--- a/src/ui/pages/repo.tsx
+++ b/src/ui/pages/repo.tsx
@@ -88,6 +88,12 @@ interface RepoProps {
     autoSyncEnabled?: boolean;
   };
   files: string[];
+  /**
+   * True when the repository listing could not be read (clone/auth/API failure)
+   * rather than genuinely being empty. Both cases arrive as `files: []`, but
+   * only the second means "this project has no content".
+   */
+  filesUnavailable?: boolean;
   log: Array<{ sha: string; message: string; author: string; timestamp: number }>;
   readme?: string | null;
   user?: { id: string; email: string; username: string } | null;
@@ -176,6 +182,7 @@ function truncateCommit(sha?: string): string {
 export const RepoPage: FC<RepoProps> = ({
   project,
   files,
+  filesUnavailable,
   log,
   readme,
   user,
@@ -191,6 +198,11 @@ export const RepoPage: FC<RepoProps> = ({
 }) => {
   const hasSource = !!project.sourceUrl;
   const currentRef = refName ?? defaultBranch;
+  // #304: an empty repo offered a live "Sync Now" button beside "Not synced"
+  // and an in-progress import badge — three claims that could not all be true.
+  // A failed listing also yields no files, but that is the one moment a user
+  // most needs Sync Now, so it must not be mistaken for an empty repo.
+  const hasContent = files.length > 0 || filesUnavailable === true;
   const isSyncing = project.lastSyncStatus === "in_progress";
   const hasUpdates = syncStatus?.hasUpdates;
   const syncFailed = project.lastSyncStatus === "failed";
@@ -198,7 +210,7 @@ export const RepoPage: FC<RepoProps> = ({
   return (
     <Layout title={project.name} user={user}>
       <ProjectHeader project={project} active="code" canWrite={canWrite ?? isOwner}>
-        {hasSource && canSync && (
+        {hasSource && canSync && hasContent && (
           <form
             method="post"
             action={`/api/projects/${project.namespace}/${project.slug}/sync`}

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -332,6 +332,7 @@ button.nav-auth-link {
 .badge-queued { background: var(--bg-raised); color: var(--text-muted); }
 .badge-cloning { background: var(--accent); color: var(--accent-text); }
 .badge-processing { background: var(--warning-surface); color: var(--warning-text); }
+.badge-syncing { background: var(--accent); color: var(--accent-text); }
 .badge-completed { background: var(--success-surface); color: var(--success-text); }
 .badge-failed { background: var(--danger-surface); color: var(--error-text); }
 .badge-cancelled { background: var(--bg-raised); color: var(--text-muted); }
@@ -518,6 +519,8 @@ button.nav-auth-link {
 .failed-actions { display: flex; gap: 0.5rem; }
 
 .retry-form { display: inline; }
+
+.delete-form { display: inline; }
 
 .technical-errors summary { color: var(--text-muted); cursor: pointer; padding: 0.5rem 0; font-size: 0.85rem; }
 

--- a/tests/backup-coverage.test.ts
+++ b/tests/backup-coverage.test.ts
@@ -1,6 +1,6 @@
-/// <reference types="vite/client" />
 import { describe, expect, it } from "vitest";
 import { BACKUP_EXCLUDED_TABLES, BACKUP_TABLES } from "../src/storage/d1-backup";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
 
 /**
  * Backup-coverage drift guard. `BACKUP_TABLES` is a hand-maintained allow-list,
@@ -8,23 +8,22 @@ import { BACKUP_EXCLUDED_TABLES, BACKUP_TABLES } from "../src/storage/d1-backup"
  * left out of every backup. This derives the real table set from migrations/
  * (the schema source of truth) and asserts every table is either backed up or
  * explicitly excluded — forcing that decision at PR time, not after data loss.
+ *
+ * The set comes from the schema the migrations actually build, not from a regex
+ * over their text: a table rebuild (migration 043) creates a scratch table and a
+ * `_new` table that it drops and renames away before finishing, and neither
+ * exists at runtime to be backed up.
  */
-const migrationModules = import.meta.glob("../migrations/*.sql", {
-  query: "?raw",
-  import: "default",
-  eager: true,
-}) as Record<string, string>;
-
 function tablesDefinedInMigrations(): Set<string> {
-  const names = new Set<string>();
-  const createTable = /CREATE TABLE (?:IF NOT EXISTS )?["'`]?([a-z_]+)/gi;
-  for (const sql of Object.values(migrationModules)) {
-    for (const match of sql.matchAll(createTable)) {
-      const table = match[1];
-      if (table) names.add(table.toLowerCase());
-    }
+  const { raw } = makeSqliteD1();
+  try {
+    const rows = raw
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
+      .all() as Array<{ name: string }>;
+    return new Set(rows.map((r) => r.name.toLowerCase()));
+  } finally {
+    raw.close();
   }
-  return names;
 }
 
 describe("backup coverage", () => {

--- a/tests/import-cleanup.test.ts
+++ b/tests/import-cleanup.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  cleanupOldImports,
+  createImportJob,
+  getImportById,
+  getLatestImportDepth,
+} from "../src/storage/imports";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
+
+const logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(function (this: unknown) {
+    return logger;
+  }),
+};
+
+async function seedFinished(
+  db: D1Database,
+  raw: ReturnType<typeof makeSqliteD1>["raw"],
+  id: string,
+  daysAgo: number,
+) {
+  await createImportJob(
+    db,
+    {
+      id,
+      projectId: "prj_1",
+      namespace: "@acme",
+      slug: id,
+      sourceUrl: "https://github.com/acme/widgets",
+      branch: "main",
+    },
+    logger,
+  );
+  // ISO-8601: cleanupOldImports binds an ISO cutoff, and the two timestamp
+  // formats do not compare correctly against each other.
+  const completedAt = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+  raw
+    .prepare("UPDATE import_jobs SET status = 'completed', completed_at = ? WHERE id = ?")
+    .run(completedAt, id);
+}
+
+/**
+ * `cleanupOldImports` existed but had no caller anywhere in src/, so nothing
+ * pruned import_jobs. The stall sweep pushes jobs into a terminal state far
+ * faster than before, which makes that gap matter — it is now wired into the
+ * daily housekeeping cron.
+ */
+describe("cleanupOldImports", () => {
+  it("removes jobs that finished before the retention cutoff", async () => {
+    const { db, raw } = makeSqliteD1();
+    // Two old jobs on one project: the older is prunable, the newest is the
+    // project's depth record and must survive.
+    await seedFinished(db, raw, "imp_old", 45);
+    await seedFinished(db, raw, "imp_older", 60);
+    raw
+      .prepare("UPDATE import_jobs SET slug = 'shared', started_at = ? WHERE id = 'imp_old'")
+      .run(new Date(Date.now() - 45 * 86_400_000).toISOString());
+    raw
+      .prepare("UPDATE import_jobs SET slug = 'shared', started_at = ? WHERE id = 'imp_older'")
+      .run(new Date(Date.now() - 60 * 86_400_000).toISOString());
+
+    const result = await cleanupOldImports(db, 30, logger);
+
+    expect(result.success && result.data).toBe(1);
+    const gone = await getImportById(db, "imp_older", logger);
+    expect(gone.success && gone.data).toBeNull();
+    raw.close();
+  });
+
+  // Retention must not undo what the delete route deliberately protects.
+  // The scenario raised in review: a full-history import that finished long ago,
+  // followed by a newer job. Retention deletes the older row, so the question is
+  // whether the depth survives. It does, because every sync carries the depth
+  // forward onto the row it creates (see getLatestImportDepth's callers), and
+  // the row retention protects is the same row that reader selects.
+  it("keeps the depth reachable when an older full-history import is pruned", async () => {
+    const { db, raw } = makeSqliteD1();
+    const day = 24 * 60 * 60 * 1000;
+
+    for (const [id, startedDaysAgo, depth] of [
+      ["imp_full", 60, 0],
+      ["imp_recent_sync", 40, 0],
+    ] as const) {
+      await createImportJob(
+        db,
+        {
+          id,
+          projectId: "prj_1",
+          namespace: "@acme",
+          slug: "widgets",
+          sourceUrl: "https://github.com/acme/widgets",
+          branch: "main",
+          depth,
+        },
+        logger,
+      );
+      raw
+        .prepare(
+          "UPDATE import_jobs SET status='completed', started_at=?, completed_at=? WHERE id=?",
+        )
+        .run(
+          new Date(Date.now() - startedDaysAgo * day).toISOString(),
+          new Date(Date.now() - startedDaysAgo * day).toISOString(),
+          id,
+        );
+    }
+
+    expect(await getLatestImportDepth(db, "@acme", "widgets", logger)).toBe(0);
+
+    const result = await cleanupOldImports(db, 30, logger);
+
+    // The older row is prunable; the newest is protected and still carries depth 0.
+    expect(result.success && result.data).toBe(1);
+    expect((await getImportById(db, "imp_full", logger)).success).toBe(true);
+    expect(await getLatestImportDepth(db, "@acme", "widgets", logger)).toBe(0);
+    raw.close();
+  });
+
+  it("prunes only within a project, never across projects", async () => {
+    const { db, raw } = makeSqliteD1();
+    for (const slug of ["alpha", "beta"]) {
+      for (const [id, daysAgo] of [
+        [`${slug}_old`, 90],
+        [`${slug}_new`, 45],
+      ] as const) {
+        await createImportJob(
+          db,
+          {
+            id,
+            projectId: "prj_1",
+            namespace: "@acme",
+            slug,
+            sourceUrl: "https://github.com/acme/x",
+            branch: "main",
+            depth: 0,
+          },
+          logger,
+        );
+        const at = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+        raw
+          .prepare(
+            "UPDATE import_jobs SET status='completed', started_at=?, completed_at=? WHERE id=?",
+          )
+          .run(at, at, id);
+      }
+    }
+
+    const result = await cleanupOldImports(db, 30, logger);
+
+    // One pruned per project, each project keeping its own newest row.
+    expect(result.success && result.data).toBe(2);
+    for (const slug of ["alpha", "beta"]) {
+      expect((await getImportById(db, `${slug}_old`, logger)).success).toBe(true);
+      const kept = await getImportById(db, `${slug}_new`, logger);
+      expect(kept.success && kept.data?.id).toBe(`${slug}_new`);
+      expect(await getLatestImportDepth(db, "@acme", slug, logger)).toBe(0);
+    }
+    raw.close();
+  });
+
+  it("always keeps the newest job so clone depth survives", async () => {
+    const { db, raw } = makeSqliteD1();
+    await seedFinished(db, raw, "imp_only", 400);
+    raw.prepare("UPDATE import_jobs SET depth = 0 WHERE id = 'imp_only'").run();
+
+    const result = await cleanupOldImports(db, 30, logger);
+
+    expect(result.success && result.data).toBe(0);
+    expect(await getLatestImportDepth(db, "@acme", "imp_only", logger)).toBe(0);
+    raw.close();
+  });
+
+  it("keeps jobs that finished inside the retention window", async () => {
+    const { db, raw } = makeSqliteD1();
+    await seedFinished(db, raw, "imp_recent", 5);
+
+    const result = await cleanupOldImports(db, 30, logger);
+
+    expect(result.success && result.data).toBe(0);
+    const kept = await getImportById(db, "imp_recent", logger);
+    expect(kept.success && kept.data?.id).toBe("imp_recent");
+    raw.close();
+  });
+
+  // completed_at is NULL while a job is still running; retention must never
+  // reap an import that has not finished, however old the row is.
+  it("never removes a job that has not completed", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(
+      db,
+      {
+        id: "imp_running",
+        projectId: "prj_1",
+        namespace: "@acme",
+        slug: "widgets",
+        sourceUrl: "https://github.com/acme/widgets",
+        branch: "main",
+      },
+      logger,
+    );
+    raw
+      .prepare("UPDATE import_jobs SET started_at = datetime('now', '-400 days') WHERE id = ?")
+      .run("imp_running");
+
+    const result = await cleanupOldImports(db, 30, logger);
+
+    expect(result.success && result.data).toBe(0);
+    const kept = await getImportById(db, "imp_running", logger);
+    expect(kept.success && kept.data?.id).toBe("imp_running");
+    raw.close();
+  });
+});

--- a/tests/import-delete-route.test.ts
+++ b/tests/import-delete-route.test.ts
@@ -1,0 +1,316 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../src/index";
+import type { Env, ImportProgress, ProjectEntry } from "../src/types";
+
+vi.mock("../src/storage/users", () => ({
+  getUserByToken: vi.fn(async (_: unknown, token: string) => {
+    if (token === "stratum_user_userA_token000000000000000000") {
+      return {
+        success: true,
+        data: {
+          id: "user_A",
+          email: "userA@example.com",
+          username: "userA",
+          tokenHash: "hashA",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      };
+    }
+    if (token === "stratum_user_userB_token000000000000000000") {
+      return {
+        success: true,
+        data: {
+          id: "user_B",
+          email: "userB@example.com",
+          username: "userB",
+          tokenHash: "hashB",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      };
+    }
+    return { success: false, error: { message: "User not found" } };
+  }),
+  getUser: vi.fn(async () => ({ success: false, error: { message: "User not found" } })),
+}));
+
+vi.mock("../src/storage/agents", () => ({
+  getAgentByToken: vi.fn(async () => ({
+    success: false,
+    error: { message: "Agent not found" },
+  })),
+}));
+
+/**
+ * Keyed by job id, not by namespace:slug — a project legitimately owns several
+ * import_jobs rows, and the delete route's whole contract is that it removes
+ * exactly one of them.
+ */
+const jobs = new Map<string, ImportProgress>();
+
+vi.mock("../src/storage/imports", () => ({
+  getImportProgress: vi.fn(async (_db: unknown, namespace: string, slug: string) => {
+    const matches = [...jobs.values()]
+      .filter((j) => j.namespace === namespace && j.slug === slug)
+      .sort((a, b) => (a.startedAt < b.startedAt ? 1 : -1));
+    return { success: true, data: matches[0] ?? null };
+  }),
+  deleteImportJobById: vi.fn(
+    async (_db: unknown, id: string, allowedStatuses: readonly string[]) => {
+      // Mirrors the real function's SQL guard: the status is re-checked at
+      // delete time, not trusted from the route's earlier read.
+      const job = jobs.get(id);
+      if (!job || !allowedStatuses.includes(job.status)) {
+        return { success: true, data: false };
+      }
+      jobs.delete(id);
+      return { success: true, data: true };
+    },
+  ),
+  deleteImportJob: vi.fn(async () => ({ success: true, data: undefined })),
+  createImportJob: vi.fn(async () => ({ success: false, error: { message: "unused" } })),
+  cancelImportJob: vi.fn(),
+  isImportCancelled: vi.fn(async () => false),
+  recoverStalledImport: vi.fn(async () => ({ success: true, data: false })),
+  updateImportStatus: vi.fn(async () => ({ success: true, data: null })),
+  getLatestImportDepth: vi.fn(async () => null),
+  getImportById: vi.fn(async (_db: unknown, id: string) => ({
+    success: true,
+    data: jobs.get(id) ?? null,
+  })),
+  listActiveImports: vi.fn(async () => ({ success: true, data: [] })),
+  STALLED_THRESHOLD_MS: 5 * 60 * 1000,
+}));
+
+// Recorded so the route's choice of limiter is assertable: the import limiter
+// takes a per-project lock that only the import paths release. Hoisted because
+// vi.mock factories are lifted above ordinary const declarations.
+const { limitersUsed } = vi.hoisted(() => ({ limitersUsed: [] as string[] }));
+
+vi.mock("../src/middleware/rate-limit", () => ({
+  rateLimitMiddleware: vi.fn(() => {
+    limitersUsed.push("rateLimitMiddleware");
+    return async (_c: unknown, next: () => Promise<void>) => {
+      await next();
+    };
+  }),
+  checkImportRateLimit: vi.fn(async () => ({ allowed: true })),
+  recordImportAttempt: vi.fn(),
+  releaseImportLock: vi.fn(async () => {}),
+  importRateLimitMiddleware: vi.fn(() => {
+    limitersUsed.push("importRateLimitMiddleware");
+    return async (_c: unknown, next: () => Promise<void>) => {
+      await next();
+    };
+  }),
+}));
+
+const USER_A_HEADERS = { Authorization: "Bearer stratum_user_userA_token000000000000000000" };
+const USER_B_HEADERS = { Authorization: "Bearer stratum_user_userB_token000000000000000000" };
+
+function makeKV(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    list: async () => ({ keys: [], list_complete: true, cursor: "" }),
+    getWithMetadata: async () => ({ value: null, metadata: null }),
+  } as unknown as KVNamespace;
+}
+
+function makeEnv(): Env {
+  return {
+    ARTIFACTS: {} as Env["ARTIFACTS"],
+    STATE: makeKV(),
+    DB: {} as D1Database,
+  } as Env;
+}
+
+function request(method: string, path: string, headers?: Record<string, string>): Request {
+  return new Request(`http://localhost${path}`, { method, headers: headers ?? {} });
+}
+
+async function seedProject(env: Env, namespace: string, slug: string): Promise<ProjectEntry> {
+  const project: ProjectEntry = {
+    id: crypto.randomUUID(),
+    name: slug,
+    slug,
+    namespace,
+    ownerId: "user_A",
+    ownerType: "user",
+    remote: `https://artifacts.example.com/repos/${slug}`,
+    createdAt: new Date().toISOString(),
+    visibility: "private",
+  };
+  await env.STATE.put(`project:${namespace}:${slug}`, JSON.stringify(project));
+  return project;
+}
+
+function seedJob(overrides: Partial<ImportProgress> & { id: string }): ImportProgress {
+  const now = new Date().toISOString();
+  const job: ImportProgress = {
+    projectId: "prj_1",
+    namespace: "@userA",
+    slug: "widgets",
+    status: "failed",
+    sourceUrl: "https://github.com/test/repo",
+    branch: "main",
+    startedAt: now,
+    updatedAt: now,
+    version: 1,
+    progress: { processedFiles: 0 },
+    errors: [],
+    logs: [],
+    ...overrides,
+  } as ImportProgress;
+  jobs.set(job.id, job);
+  return job;
+}
+
+describe("POST /import/delete", () => {
+  beforeEach(() => {
+    jobs.clear();
+  });
+
+  it("deletes a failed import", async () => {
+    const env = makeEnv();
+    await seedProject(env, "@userA", "widgets");
+    seedJob({ id: "imp_1", status: "failed" });
+
+    const res = await app.fetch(
+      request("POST", "/api/projects/@userA/widgets/import/delete", USER_A_HEADERS),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(jobs.has("imp_1")).toBe(false);
+  });
+
+  it("deletes a cancelled import", async () => {
+    const env = makeEnv();
+    await seedProject(env, "@userA", "widgets");
+    seedJob({ id: "imp_1", status: "cancelled" });
+
+    const res = await app.fetch(
+      request("POST", "/api/projects/@userA/widgets/import/delete", USER_A_HEADERS),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(jobs.has("imp_1")).toBe(false);
+  });
+
+  // A live consumer may still own the row; removing it would orphan the import.
+  for (const status of ["queued", "cloning", "processing", "syncing", "cancelling"] as const) {
+    it(`refuses to delete a job in '${status}' with 409`, async () => {
+      const env = makeEnv();
+      await seedProject(env, "@userA", "widgets");
+      seedJob({ id: "imp_1", status });
+
+      const res = await app.fetch(
+        request("POST", "/api/projects/@userA/widgets/import/delete", USER_A_HEADERS),
+        env,
+      );
+
+      expect(res.status).toBe(409);
+      expect(jobs.has("imp_1")).toBe(true);
+    });
+  }
+
+  // Deleting the completed record would take the clone-depth history with it.
+  it("refuses to delete a completed import with 409", async () => {
+    const env = makeEnv();
+    await seedProject(env, "@userA", "widgets");
+    seedJob({ id: "imp_1", status: "completed" });
+
+    const res = await app.fetch(
+      request("POST", "/api/projects/@userA/widgets/import/delete", USER_A_HEADERS),
+      env,
+    );
+
+    expect(res.status).toBe(409);
+    expect(jobs.has("imp_1")).toBe(true);
+  });
+
+  it("removes only the targeted job, leaving sibling rows intact", async () => {
+    const env = makeEnv();
+    await seedProject(env, "@userA", "widgets");
+    seedJob({ id: "imp_old", status: "completed", startedAt: "2020-01-01T00:00:00.000Z" });
+    seedJob({ id: "imp_recent", status: "failed", startedAt: "2026-01-01T00:00:00.000Z" });
+
+    const res = await app.fetch(
+      request("POST", "/api/projects/@userA/widgets/import/delete", USER_A_HEADERS),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(jobs.has("imp_recent")).toBe(false);
+    expect(jobs.has("imp_old")).toBe(true);
+  });
+
+  it("rejects a delete from another user's namespace", async () => {
+    const env = makeEnv();
+    await seedProject(env, "@userA", "widgets");
+    seedJob({ id: "imp_1", status: "failed" });
+
+    const res = await app.fetch(
+      request("POST", "/api/projects/@userA/widgets/import/delete", USER_B_HEADERS),
+      env,
+    );
+
+    expect(res.status).toBe(403);
+    expect(jobs.has("imp_1")).toBe(true);
+  });
+
+  it("requires authentication", async () => {
+    const env = makeEnv();
+    await seedProject(env, "@userA", "widgets");
+    seedJob({ id: "imp_1", status: "failed" });
+
+    const res = await app.fetch(request("POST", "/api/projects/@userA/widgets/import/delete"), env);
+
+    expect(res.status).toBe(401);
+    expect(jobs.has("imp_1")).toBe(true);
+  });
+
+  it("returns 404 when there is no import job", async () => {
+    const env = makeEnv();
+    await seedProject(env, "@userA", "widgets");
+
+    const res = await app.fetch(
+      request("POST", "/api/projects/@userA/widgets/import/delete", USER_A_HEADERS),
+      env,
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  // Regression: the route originally used importRateLimitMiddleware, which
+  // takes a per-project import lock with a TTL that only the import paths
+  // release — so clearing a dead job 429'd the retry the user was about to make.
+  it("does not take the import concurrency lock", () => {
+    expect(limitersUsed).toContain("rateLimitMiddleware");
+  });
+
+  it("is inert on a double submit", async () => {
+    const env = makeEnv();
+    await seedProject(env, "@userA", "widgets");
+    seedJob({ id: "imp_1", status: "failed" });
+
+    const first = await app.fetch(
+      request("POST", "/api/projects/@userA/widgets/import/delete", USER_A_HEADERS),
+      env,
+    );
+    const second = await app.fetch(
+      request("POST", "/api/projects/@userA/widgets/import/delete", USER_A_HEADERS),
+      env,
+    );
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(404);
+  });
+});

--- a/tests/import-job-by-id.test.ts
+++ b/tests/import-job-by-id.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createImportJob,
+  deleteImportJobById,
+  getImportById,
+  getImportProgress,
+  getLatestImportDepth,
+  updateImportProgressById,
+} from "../src/storage/imports";
+import type { ImportStatus } from "../src/types";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
+
+/** Mirrors the delete route's allow-list. */
+const DELETABLE: readonly ImportStatus[] = ["failed", "cancelled"];
+
+const logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(function (this: unknown) {
+    return logger;
+  }),
+};
+
+function jobParams(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    projectId: "prj_1",
+    namespace: "@acme",
+    slug: "widgets",
+    sourceUrl: "https://github.com/acme/widgets",
+    branch: "main",
+    ...overrides,
+  };
+}
+
+/**
+ * A project accumulates one import_jobs row per sync — there is no unique
+ * constraint on (namespace, slug) — so anything that has already selected a
+ * specific row must write back by primary key. These cover the id-scoped
+ * primitives the stall sweep and the delete action are built on.
+ */
+describe("updateImportProgressById", () => {
+  it("updates the selected row, not the newest one for the project", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(db, jobParams("imp_old"), logger);
+    await createImportJob(db, jobParams("imp_new"), logger);
+
+    // Make imp_new unambiguously the newest by started_at, which is what
+    // getImportProgress (and therefore updateImportProgress) resolves to.
+    raw
+      .prepare("UPDATE import_jobs SET started_at = '2020-01-01T00:00:00Z' WHERE id = 'imp_old'")
+      .run();
+
+    const old = await getImportById(db, "imp_old", logger);
+    expect(old.success && old.data).toBeTruthy();
+    const version = old.success && old.data ? old.data.version : -1;
+
+    const result = await updateImportProgressById(
+      db,
+      "imp_old",
+      version,
+      { status: "cancelled" },
+      logger,
+    );
+
+    expect(result.success && result.data.updated).toBe(true);
+
+    const reloadedOld = await getImportById(db, "imp_old", logger);
+    const reloadedNew = await getImportById(db, "imp_new", logger);
+    expect(reloadedOld.success && reloadedOld.data?.status).toBe("cancelled");
+    // The whole point: the newest row must be untouched.
+    expect(reloadedNew.success && reloadedNew.data?.status).toBe("queued");
+    raw.close();
+  });
+
+  it("reports a version mismatch as a conflict rather than an error", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(db, jobParams("imp_1"), logger);
+
+    const stale = await getImportById(db, "imp_1", logger);
+    const staleVersion = stale.success && stale.data ? stale.data.version : -1;
+
+    // Someone else advances the row first.
+    const first = await updateImportProgressById(
+      db,
+      "imp_1",
+      staleVersion,
+      { status: "processing" },
+      logger,
+    );
+    expect(first.success && first.data.updated).toBe(true);
+
+    const second = await updateImportProgressById(
+      db,
+      "imp_1",
+      staleVersion,
+      { status: "failed" },
+      logger,
+    );
+
+    expect(second.success).toBe(true);
+    expect(second.success && second.data.updated).toBe(false);
+    expect(second.success && !second.data.updated && second.data.reason).toBe("version-conflict");
+
+    const final = await getImportById(db, "imp_1", logger);
+    expect(final.success && final.data?.status).toBe("processing");
+    raw.close();
+  });
+
+  it("reports a missing job as not-found rather than an error", async () => {
+    const { db, raw } = makeSqliteD1();
+    const result = await updateImportProgressById(db, "nope", 1, { status: "failed" }, logger);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.updated).toBe(false);
+    expect(result.success && !result.data.updated && result.data.reason).toBe("not-found");
+    raw.close();
+  });
+
+  it("bumps the version so a second write with the same expectation cannot land", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(db, jobParams("imp_1"), logger);
+    const before = await getImportById(db, "imp_1", logger);
+    const version = before.success && before.data ? before.data.version : -1;
+
+    await updateImportProgressById(db, "imp_1", version, { status: "processing" }, logger);
+
+    const after = await getImportById(db, "imp_1", logger);
+    expect(after.success && after.data ? after.data.version : -1).toBe(version + 1);
+    raw.close();
+  });
+
+  it("appends errors without discarding existing ones", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(db, jobParams("imp_1"), logger);
+    const v0 = await getImportById(db, "imp_1", logger);
+
+    await updateImportProgressById(
+      db,
+      "imp_1",
+      v0.success && v0.data ? v0.data.version : -1,
+      {
+        status: "failed",
+        errors: [{ file: "_import", error: "stalled", timestamp: new Date().toISOString() }],
+      },
+      logger,
+    );
+
+    const after = await getImportById(db, "imp_1", logger);
+    expect(after.success && after.data?.errors).toHaveLength(1);
+    expect(after.success && after.data?.errors[0]?.error).toBe("stalled");
+    raw.close();
+  });
+});
+
+describe("deleteImportJobById", () => {
+  /** Puts a seeded job into a state the delete allow-list accepts. */
+  function markTerminal(raw: ReturnType<typeof makeSqliteD1>["raw"], id: string) {
+    raw.prepare("UPDATE import_jobs SET status = 'failed' WHERE id = ?").run(id);
+  }
+
+  it("removes exactly the named row and leaves siblings intact", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(db, jobParams("imp_1"), logger);
+    await createImportJob(db, jobParams("imp_2"), logger);
+    markTerminal(raw, "imp_1");
+    markTerminal(raw, "imp_2");
+
+    const deleted = await deleteImportJobById(db, "imp_1", DELETABLE, logger);
+    expect(deleted.success && deleted.data).toBe(true);
+
+    expect((await getImportById(db, "imp_1", logger)).success).toBe(true);
+    const gone = await getImportById(db, "imp_1", logger);
+    expect(gone.success && gone.data).toBeNull();
+
+    const kept = await getImportById(db, "imp_2", logger);
+    expect(kept.success && kept.data?.id).toBe("imp_2");
+    raw.close();
+  });
+
+  it("returns false when the row is already gone, so a double submit is inert", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(db, jobParams("imp_1"), logger);
+    markTerminal(raw, "imp_1");
+
+    expect((await deleteImportJobById(db, "imp_1", DELETABLE, logger)).success).toBe(true);
+    const second = await deleteImportJobById(db, "imp_1", DELETABLE, logger);
+    expect(second.success && second.data).toBe(false);
+    raw.close();
+  });
+
+  // Deleting a single finished job must not strip the depth history that the
+  // next sync reads; that is what a namespace+slug-wide delete would do.
+  it("preserves the clone depth recorded by a sibling job", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(db, jobParams("imp_full", { depth: 0 }), logger);
+    await createImportJob(db, jobParams("imp_failed"), logger);
+    markTerminal(raw, "imp_failed");
+    raw
+      .prepare("UPDATE import_jobs SET started_at = '2020-01-01T00:00:00Z' WHERE id = 'imp_failed'")
+      .run();
+
+    await deleteImportJobById(db, "imp_failed", DELETABLE, logger);
+
+    expect(await getLatestImportDepth(db, "@acme", "widgets", logger)).toBe(0);
+    const remaining = await getImportProgress(db, "@acme", "widgets", logger);
+    expect(remaining.success && remaining.data?.id).toBe("imp_full");
+    raw.close();
+  });
+
+  // The status is enforced in the DELETE itself, so a retry that re-queues the
+  // job between the route's status check and this call cannot orphan a live
+  // import.
+  it("refuses to delete a job whose status left the allow-list", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(db, jobParams("imp_1"), logger);
+    raw.prepare("UPDATE import_jobs SET status = 'cloning' WHERE id = 'imp_1'").run();
+
+    const result = await deleteImportJobById(db, "imp_1", DELETABLE, logger);
+
+    expect(result.success && result.data).toBe(false);
+    const kept = await getImportById(db, "imp_1", logger);
+    expect(kept.success && kept.data?.id).toBe("imp_1");
+    raw.close();
+  });
+});

--- a/tests/import-stall-recovery.test.ts
+++ b/tests/import-stall-recovery.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  STALLED_THRESHOLD_MS,
+  createImportJob,
+  getImportById,
+  recoverStalledImport,
+} from "../src/storage/imports";
+import type { ImportStatus } from "../src/types";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
+
+const logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(function (this: unknown) {
+    return logger;
+  }),
+};
+
+async function seed(
+  db: D1Database,
+  raw: ReturnType<typeof makeSqliteD1>["raw"],
+  status: ImportStatus,
+  minutesSinceUpdate: number,
+) {
+  await createImportJob(
+    db,
+    {
+      id: "imp_1",
+      projectId: "prj_1",
+      namespace: "@acme",
+      slug: "widgets",
+      sourceUrl: "https://github.com/acme/widgets",
+      branch: "main",
+    },
+    logger,
+  );
+  // ISO-8601, matching what the storage layer writes — see the note in
+  // tests/import-sweep.test.ts.
+  const updatedAt = new Date(Date.now() - minutesSinceUpdate * 60_000).toISOString();
+  raw
+    .prepare("UPDATE import_jobs SET status = ?, updated_at = ? WHERE id = 'imp_1'")
+    .run(status, updatedAt);
+}
+
+/**
+ * The on-demand half of #304. `recoverStalledImport` always matched
+ * 'cancelling' in SQL, but the progress route's guard listed only the active
+ * statuses, so a wedged cancel was never handed to it — the case that produced
+ * a CANCELLING badge lasting months.
+ */
+describe("recoverStalledImport", () => {
+  it("recovers a stale 'cancelling' job to 'cancelled'", async () => {
+    const { db, raw } = makeSqliteD1();
+    await seed(db, raw, "cancelling", 60);
+
+    const result = await recoverStalledImport(db, "@acme", "widgets", STALLED_THRESHOLD_MS, logger);
+
+    expect(result.success && result.data).toBe(true);
+    const job = await getImportById(db, "imp_1", logger);
+    expect(job.success && job.data?.status).toBe("cancelled");
+    raw.close();
+  });
+
+  it("recovers a stale 'syncing' job to 'failed'", async () => {
+    const { db, raw } = makeSqliteD1();
+    await seed(db, raw, "syncing", 60);
+
+    const result = await recoverStalledImport(db, "@acme", "widgets", STALLED_THRESHOLD_MS, logger);
+
+    expect(result.success && result.data).toBe(true);
+    const job = await getImportById(db, "imp_1", logger);
+    expect(job.success && job.data?.status).toBe("failed");
+    raw.close();
+  });
+
+  it("leaves a job that is still progressing alone", async () => {
+    const { db, raw } = makeSqliteD1();
+    await seed(db, raw, "cancelling", 1);
+
+    const result = await recoverStalledImport(db, "@acme", "widgets", STALLED_THRESHOLD_MS, logger);
+
+    expect(result.success && result.data).toBe(false);
+    const job = await getImportById(db, "imp_1", logger);
+    expect(job.success && job.data?.status).toBe("cancelling");
+    raw.close();
+  });
+
+  // The function selects the stalest matching row but used to write back via
+  // namespace+slug, which `updateImportProgress` resolves to the NEWEST row for
+  // the project. Since a project owns one row per sync, that combination failed
+  // a healthy in-flight job and left the wedged one untouched — the opposite of
+  // the intent.
+  it("recovers the stalled row and leaves a newer healthy job alone", async () => {
+    const { db, raw } = makeSqliteD1();
+    for (const id of ["imp_wedged", "imp_live"]) {
+      await createImportJob(
+        db,
+        {
+          id,
+          projectId: "prj_1",
+          namespace: "@acme",
+          slug: "widgets",
+          sourceUrl: "https://github.com/acme/widgets",
+          branch: "main",
+        },
+        logger,
+      );
+    }
+
+    const stale = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    raw
+      .prepare(
+        "UPDATE import_jobs SET status = 'cancelling', updated_at = ?, started_at = ? WHERE id = 'imp_wedged'",
+      )
+      .run(stale, "2020-01-01T00:00:00.000Z");
+    raw
+      .prepare(
+        "UPDATE import_jobs SET status = 'processing', updated_at = ?, started_at = ? WHERE id = 'imp_live'",
+      )
+      .run(new Date().toISOString(), new Date().toISOString());
+
+    const result = await recoverStalledImport(db, "@acme", "widgets", STALLED_THRESHOLD_MS, logger);
+
+    expect(result.success && result.data).toBe(true);
+    const wedged = await getImportById(db, "imp_wedged", logger);
+    const live = await getImportById(db, "imp_live", logger);
+    expect(wedged.success && wedged.data?.status).toBe("cancelled");
+    expect(live.success && live.data?.status).toBe("processing");
+    raw.close();
+  });
+
+  it("does nothing for a job already in a terminal state", async () => {
+    const { db, raw } = makeSqliteD1();
+    await seed(db, raw, "failed", 500);
+
+    const result = await recoverStalledImport(db, "@acme", "widgets", STALLED_THRESHOLD_MS, logger);
+
+    expect(result.success && result.data).toBe(false);
+    raw.close();
+  });
+});

--- a/tests/import-status-persistence.test.ts
+++ b/tests/import-status-persistence.test.ts
@@ -1,0 +1,292 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it, vi } from "vitest";
+import { createImportJob, getImportProgress, updateImportStatus } from "../src/storage/imports";
+import type { ImportStatus } from "../src/types";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
+
+const logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(function (this: unknown) {
+    return logger;
+  }),
+};
+
+function jobParams(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "imp_1",
+    projectId: "prj_1",
+    namespace: "@acme",
+    slug: "widgets",
+    sourceUrl: "https://github.com/acme/widgets",
+    branch: "main",
+    ...overrides,
+  };
+}
+
+/**
+ * Regression cover for #304. The status CHECK constraint in migration 010
+ * omitted 'syncing' and 'checking' while `ImportStatus` and the queue consumer
+ * both used 'syncing', so the consumer's status write failed with SQLite error
+ * 19 on every sync and the row silently kept its previous status. Nothing
+ * caught it because no test ever wrote those statuses against the real schema.
+ */
+describe("import status persistence against the real schema", () => {
+  const ALL_STATUSES: ImportStatus[] = [
+    "queued",
+    "cloning",
+    "processing",
+    "completed",
+    "failed",
+    "cancelled",
+    "cancelling",
+    "syncing",
+    "checking",
+  ];
+
+  for (const status of ALL_STATUSES) {
+    it(`persists the '${status}' status`, async () => {
+      const { db, raw } = makeSqliteD1();
+      await createImportJob(db, jobParams(), logger);
+
+      const updated = await updateImportStatus(db, "@acme", "widgets", status, logger);
+      expect(updated.success).toBe(true);
+
+      const read = await getImportProgress(db, "@acme", "widgets", logger);
+      expect(read.success && read.data?.status).toBe(status);
+      raw.close();
+    });
+  }
+
+  // The specific write at src/queue/import-queue.ts that was failing.
+  it("records 'syncing' when the consumer enters its sync phase", async () => {
+    const { db, raw } = makeSqliteD1();
+    await createImportJob(db, jobParams(), logger);
+
+    const result = await updateImportStatus(
+      db,
+      "@acme",
+      "widgets",
+      "syncing",
+      logger,
+      "Syncing repository",
+    );
+
+    expect(result.success).toBe(true);
+    const read = await getImportProgress(db, "@acme", "widgets", logger);
+    expect(read.success && read.data?.status).toBe("syncing");
+    raw.close();
+  });
+});
+
+describe("migration 043 schema shape", () => {
+  it("indexes (status, updated_at) so the stall sweep does not scan", () => {
+    const { raw } = makeSqliteD1();
+    const indexes = raw
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='import_jobs' AND name NOT LIKE 'sqlite_%'",
+      )
+      .all() as Array<{ name: string }>;
+
+    expect(indexes.map((i) => i.name)).toContain("idx_import_jobs_status_updated_at");
+    raw.close();
+  });
+
+  it("keeps every index the rebuild was responsible for recreating", () => {
+    const { raw } = makeSqliteD1();
+    const names = (
+      raw
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='import_jobs' AND name NOT LIKE 'sqlite_%'",
+        )
+        .all() as Array<{ name: string }>
+    ).map((i) => i.name);
+
+    for (const expected of [
+      "idx_import_jobs_ns_slug",
+      "idx_import_jobs_status",
+      "idx_import_jobs_completed_at",
+      "idx_import_jobs_project_id",
+      "idx_import_jobs_version",
+    ]) {
+      expect(names).toContain(expected);
+    }
+    raw.close();
+  });
+});
+
+/**
+ * These apply the migrations by hand, stopping before 043, so the upgrade is
+ * genuinely exercised against pre-043 data. `makeSqliteD1` applies every
+ * migration at construction, which would make the assertions vacuous.
+ */
+describe("migration 043 upgrade path", () => {
+  const migrationSql = import.meta.glob("../migrations/*.sql", {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }) as Record<string, string>;
+
+  function sortedMigrations(): Array<[string, string]> {
+    return Object.entries(migrationSql)
+      .map(([path, sql]) => [path.split("/").pop() ?? path, sql] as [string, string])
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  }
+
+  function dbAtPre043(): DatabaseSync {
+    const raw = new DatabaseSync(":memory:");
+    for (const [name, sql] of sortedMigrations()) {
+      if (name.startsWith("043")) continue;
+      raw.exec(sql);
+    }
+    return raw;
+  }
+
+  function apply043(raw: DatabaseSync): void {
+    const entry = sortedMigrations().find(([name]) => name.startsWith("043"));
+    if (!entry) throw new Error("migration 043 not found");
+    raw.exec(entry[1]);
+  }
+
+  // Proves the bug the migration exists to fix, so the test fails loudly if
+  // anyone reintroduces the narrow constraint.
+  it("rejects 'syncing' before the migration and accepts it after", () => {
+    const raw = dbAtPre043();
+    const insertSyncing = () =>
+      raw
+        .prepare(
+          `INSERT INTO import_jobs (id, project_id, namespace, slug, status, source_url, branch)
+           VALUES ('imp_s','prj_1','@acme','widgets','syncing','https://x/y','main')`,
+        )
+        .run();
+
+    expect(insertSyncing).toThrow(/CHECK constraint failed/);
+
+    apply043(raw);
+    expect(insertSyncing).not.toThrow();
+    raw.close();
+  });
+
+  it("carries existing job rows through the rebuild, including depth 0", () => {
+    const raw = dbAtPre043();
+    raw
+      .prepare(
+        `INSERT INTO import_jobs (id, project_id, namespace, slug, status, source_url, branch, depth)
+         VALUES ('imp_kept','prj_1','@acme','widgets','processing','https://x/y','main',0)`,
+      )
+      .run();
+
+    apply043(raw);
+
+    const rows = raw.prepare("SELECT id, status, depth FROM import_jobs").all() as Array<{
+      id: string;
+      status: string;
+      depth: number | null;
+    }>;
+    expect(rows).toEqual([{ id: "imp_kept", status: "processing", depth: 0 }]);
+    raw.close();
+  });
+
+  // The rebuild drops import_jobs, which fires ON DELETE SET NULL across
+  // failed_imports.import_id (foreign keys are enforced in both node:sqlite and
+  // D1, and defer_foreign_keys does not suppress delete actions). The migration
+  // snapshots and restores the linkage; without it every historical failure
+  // record is orphaned from the job it describes.
+  it("preserves failed_imports linkage across the rebuild", () => {
+    const raw = dbAtPre043();
+    raw
+      .prepare(
+        `INSERT INTO import_jobs (id, project_id, namespace, slug, status, source_url, branch)
+         VALUES ('imp_kept','prj_1','@acme','widgets','failed','https://x/y','main')`,
+      )
+      .run();
+    raw
+      .prepare(
+        `INSERT INTO failed_imports (import_id, namespace, slug, error_type, error_message)
+         VALUES ('imp_kept','@acme','widgets','CLONE_FAILED','boom')`,
+      )
+      .run();
+
+    apply043(raw);
+
+    const rows = raw.prepare("SELECT import_id FROM failed_imports").all() as Array<{
+      import_id: string | null;
+    }>;
+    expect(rows[0]?.import_id).toBe("imp_kept");
+    raw.close();
+  });
+
+  // A row written outside the storage layer takes the CURRENT_TIMESTAMP
+  // default, which is 'YYYY-MM-DD HH:MM:SS'. Mixed with the ISO strings the
+  // storage layer writes, TEXT range comparisons break in both directions
+  // ('T' 0x54 sorts after ' ' 0x20), which is what stopped stall detection from
+  // ever matching. The rebuild normalises the column so one format is possible.
+  it("normalises legacy SQLite-format timestamps to ISO", () => {
+    const raw = dbAtPre043();
+    raw
+      .prepare(
+        `INSERT INTO import_jobs (id, project_id, namespace, slug, status, source_url, branch,
+                                  started_at, updated_at, completed_at)
+         VALUES ('imp_legacy','prj_1','@acme','widgets','failed','https://x/y','main',
+                 datetime('now', '-2 days'), datetime('now', '-1 days'), datetime('now', '-1 days'))`,
+      )
+      .run();
+
+    const before = raw.prepare("SELECT updated_at FROM import_jobs").get() as {
+      updated_at: string;
+    };
+    expect(before.updated_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+
+    apply043(raw);
+
+    const after = raw
+      .prepare("SELECT started_at, updated_at, completed_at FROM import_jobs")
+      .get() as { started_at: string; updated_at: string; completed_at: string };
+    const iso = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+    expect(after.started_at).toMatch(iso);
+    expect(after.updated_at).toMatch(iso);
+    expect(after.completed_at).toMatch(iso);
+    raw.close();
+  });
+
+  it("leaves a NULL completed_at alone while normalising the others", () => {
+    const raw = dbAtPre043();
+    raw
+      .prepare(
+        `INSERT INTO import_jobs (id, project_id, namespace, slug, status, source_url, branch, updated_at)
+         VALUES ('imp_running','prj_1','@acme','widgets','processing','https://x/y','main',
+                 datetime('now', '-10 minutes'))`,
+      )
+      .run();
+
+    apply043(raw);
+
+    const row = raw.prepare("SELECT updated_at, completed_at FROM import_jobs").get() as {
+      updated_at: string;
+      completed_at: string | null;
+    };
+    expect(row.completed_at).toBeNull();
+    expect(row.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    raw.close();
+  });
+
+  it("leaves no scratch table behind", () => {
+    const raw = dbAtPre043();
+    apply043(raw);
+
+    const tables = (
+      raw.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{
+        name: string;
+      }>
+    ).map((t) => t.name);
+
+    expect(tables).not.toContain("import_jobs_fk_backup");
+    expect(tables).not.toContain("import_jobs_new");
+    expect(tables).toContain("import_jobs");
+    raw.close();
+  });
+});

--- a/tests/import-sweep.test.ts
+++ b/tests/import-sweep.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it, vi } from "vitest";
+import { runImportSweep } from "../src/queue/import-sweep";
+import {
+  QUEUED_GRACE_MS,
+  STALLED_THRESHOLD_MS,
+  createImportJob,
+  getImportById,
+  updateImportStatus,
+} from "../src/storage/imports";
+import type { Env, ImportStatus } from "../src/types";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
+
+const logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(function (this: unknown) {
+    return logger;
+  }),
+};
+
+/**
+ * Exercised against a real SQLite engine rather than the namespace:slug Map
+ * mock used elsewhere: that mock can only hold one job per project, which is
+ * precisely the assumption the sweep must not make.
+ */
+function setup() {
+  const { db, raw } = makeSqliteD1();
+  return { db, raw, env: { DB: db } as unknown as Env };
+}
+
+/** The status values the sweep binds before its two cutoffs. */
+const ACTIVE_STATUS_NAMES = ["cloning", "processing", "syncing", "checking", "cancelling"];
+
+async function seedJob(
+  db: D1Database,
+  raw: ReturnType<typeof makeSqliteD1>["raw"],
+  opts: {
+    id: string;
+    status: ImportStatus;
+    minutesSinceUpdate: number;
+    slug?: string;
+  },
+) {
+  await createImportJob(
+    db,
+    {
+      id: opts.id,
+      projectId: "prj_1",
+      namespace: "@acme",
+      slug: opts.slug ?? "widgets",
+      sourceUrl: "https://github.com/acme/widgets",
+      branch: "main",
+    },
+    logger,
+  );
+  // Ages the row in ISO-8601, which is what the storage layer actually writes.
+  // Seeding SQLite's `datetime()` format instead would exercise a shape
+  // production never produces — and would hide a format mismatch in the
+  // sweep's own predicate, since the two sort differently as TEXT.
+  const updatedAt = new Date(Date.now() - opts.minutesSinceUpdate * 60_000).toISOString();
+  raw
+    .prepare("UPDATE import_jobs SET status = ?, updated_at = ? WHERE id = ?")
+    .run(opts.status, updatedAt, opts.id);
+}
+
+describe("runImportSweep", () => {
+  it("moves a wedged 'cancelling' job to 'cancelled'", async () => {
+    const { db, raw, env } = setup();
+    await seedJob(db, raw, { id: "imp_1", status: "cancelling", minutesSinceUpdate: 60 });
+
+    const result = await runImportSweep(env, logger);
+
+    expect(result).toMatchObject({ scanned: 1, reaped: 1, conflicted: 0, errored: 0 });
+    const job = await getImportById(db, "imp_1", logger);
+    expect(job.success && job.data?.status).toBe("cancelled");
+    expect(job.success && job.data?.completedAt).toBeTruthy();
+    raw.close();
+  });
+
+  it("moves a stalled active job to 'failed' with an explanatory error", async () => {
+    const { db, raw, env } = setup();
+    await seedJob(db, raw, { id: "imp_1", status: "processing", minutesSinceUpdate: 60 });
+
+    const result = await runImportSweep(env, logger);
+
+    expect(result.reaped).toBe(1);
+    const job = await getImportById(db, "imp_1", logger);
+    expect(job.success && job.data?.status).toBe("failed");
+    expect(job.success && job.data?.errors[0]?.file).toBe("_import");
+    expect(job.success && job.data?.errors[0]?.error).toMatch(/stalled/i);
+    raw.close();
+  });
+
+  it("reaps a job stuck in 'syncing', which only became storable in migration 043", async () => {
+    const { db, raw, env } = setup();
+    await seedJob(db, raw, { id: "imp_1", status: "syncing", minutesSinceUpdate: 60 });
+
+    expect((await runImportSweep(env, logger)).reaped).toBe(1);
+    const job = await getImportById(db, "imp_1", logger);
+    expect(job.success && job.data?.status).toBe("failed");
+    raw.close();
+  });
+
+  it("leaves a job that is still reporting progress alone", async () => {
+    const { db, raw, env } = setup();
+    await seedJob(db, raw, { id: "imp_1", status: "processing", minutesSinceUpdate: 1 });
+
+    const result = await runImportSweep(env, logger);
+
+    expect(result).toMatchObject({ scanned: 0, reaped: 0 });
+    const job = await getImportById(db, "imp_1", logger);
+    expect(job.success && job.data?.status).toBe("processing");
+    raw.close();
+  });
+
+  it("never touches jobs already in a terminal state", async () => {
+    const { db, raw, env } = setup();
+    await seedJob(db, raw, { id: "imp_done", status: "completed", minutesSinceUpdate: 500 });
+    await seedJob(db, raw, {
+      id: "imp_failed",
+      status: "failed",
+      minutesSinceUpdate: 500,
+      slug: "w2",
+    });
+
+    expect((await runImportSweep(env, logger)).scanned).toBe(0);
+    raw.close();
+  });
+
+  // The central correctness requirement: writes are keyed by job id, so a stale
+  // row is reaped without disturbing a healthy newer job on the same project.
+  it("reaps the stale job and leaves a newer healthy job for the same project untouched", async () => {
+    const { db, raw, env } = setup();
+    await seedJob(db, raw, { id: "imp_wedged", status: "cancelling", minutesSinceUpdate: 500 });
+    await seedJob(db, raw, { id: "imp_live", status: "processing", minutesSinceUpdate: 0 });
+    raw
+      .prepare("UPDATE import_jobs SET started_at = '2020-01-01T00:00:00Z' WHERE id = 'imp_wedged'")
+      .run();
+
+    const result = await runImportSweep(env, logger);
+
+    expect(result).toMatchObject({ scanned: 1, reaped: 1 });
+    const wedged = await getImportById(db, "imp_wedged", logger);
+    const live = await getImportById(db, "imp_live", logger);
+    expect(wedged.success && wedged.data?.status).toBe("cancelled");
+    expect(live.success && live.data?.status).toBe("processing");
+    raw.close();
+  });
+
+  describe("queued jobs", () => {
+    it("leaves a recently queued job alone even past the active threshold", async () => {
+      const { db, raw, env } = setup();
+      // Past the active threshold but well inside the queued grace period, so
+      // only the status distinction keeps this job alive.
+      const minutes = STALLED_THRESHOLD_MS / 60_000 + 10;
+      expect(minutes * 60_000).toBeLessThan(QUEUED_GRACE_MS);
+      await seedJob(db, raw, { id: "imp_1", status: "queued", minutesSinceUpdate: minutes });
+
+      expect((await runImportSweep(env, logger)).scanned).toBe(0);
+      const job = await getImportById(db, "imp_1", logger);
+      expect(job.success && job.data?.status).toBe("queued");
+      raw.close();
+    });
+
+    it("fails a job that was never picked up, and says so", async () => {
+      const { db, raw, env } = setup();
+      await seedJob(db, raw, {
+        id: "imp_1",
+        status: "queued",
+        minutesSinceUpdate: QUEUED_GRACE_MS / 60_000 + 30,
+      });
+
+      expect((await runImportSweep(env, logger)).reaped).toBe(1);
+      const job = await getImportById(db, "imp_1", logger);
+      expect(job.success && job.data?.status).toBe("failed");
+      expect(job.success && job.data?.errors[0]?.error).toMatch(/never picked up/i);
+      raw.close();
+    });
+  });
+
+  it("bounds the batch so a large backlog drains across runs", async () => {
+    const { db, raw, env } = setup();
+    for (let i = 0; i < 105; i++) {
+      await seedJob(db, raw, {
+        id: `imp_${i}`,
+        status: "processing",
+        minutesSinceUpdate: 60,
+        slug: `widgets-${i}`,
+      });
+    }
+
+    const first = await runImportSweep(env, logger);
+    expect(first.scanned).toBe(100);
+    expect(first.reaped).toBe(100);
+
+    const second = await runImportSweep(env, logger);
+    expect(second.reaped).toBe(5);
+    raw.close();
+  });
+
+  // Ordering matters under a backlog: with more stale rows than the batch
+  // limit, the oldest must drain first rather than being starved by newer ones.
+  // Asserting on the reaped rows' final status alone would pass whatever the
+  // order was, so this checks the actual sequence the sweep worked in.
+  it("processes the oldest jobs first", async () => {
+    const { db, raw, env } = setup();
+    const ages = [30, 500, 90, 240];
+    for (const [index, minutes] of ages.entries()) {
+      await seedJob(db, raw, {
+        id: `imp_${minutes}`,
+        status: "processing",
+        minutesSinceUpdate: minutes,
+        slug: `w${index}`,
+      });
+    }
+
+    logger.info.mockClear();
+    await runImportSweep(env, logger);
+
+    const reapedOrder = logger.info.mock.calls
+      .filter(([message]) => message === "Reaped stalled import")
+      .map(([, meta]) => (meta as { importId: string }).importId);
+
+    expect(reapedOrder).toEqual(["imp_500", "imp_240", "imp_90", "imp_30"]);
+    raw.close();
+  });
+
+  // Regression guard. `updated_at` is written as ISO-8601 by the storage layer,
+  // but the sweep originally compared it against `datetime('now', ?)`, which
+  // yields 'YYYY-MM-DD HH:MM:SS'. As TEXT, 'T' (0x54) sorts after ' ' (0x20),
+  // so the predicate was false for every real row until the UTC date rolled
+  // over — the sweep looked correct and reaped nothing for up to a day.
+  describe("timestamp format", () => {
+    it("reaps a job aged through the storage layer's own writer", async () => {
+      const { db, raw, env } = setup();
+      await createImportJob(
+        db,
+        {
+          id: "imp_1",
+          projectId: "prj_1",
+          namespace: "@acme",
+          slug: "widgets",
+          sourceUrl: "https://github.com/acme/widgets",
+          branch: "main",
+        },
+        logger,
+      );
+      // Drive the status through the real update path, then age only the clock.
+      await updateImportStatus(db, "@acme", "widgets", "cancelling", logger);
+      raw
+        .prepare("UPDATE import_jobs SET updated_at = ? WHERE id = 'imp_1'")
+        .run(new Date(Date.now() - 60 * 60 * 1000).toISOString());
+
+      const result = await runImportSweep(env, logger);
+
+      expect(result.reaped).toBe(1);
+      const job = await getImportById(db, "imp_1", logger);
+      expect(job.success && job.data?.status).toBe("cancelled");
+      raw.close();
+    });
+
+    // Behavioural coverage alone is time-of-day dependent: the old comparison
+    // happened to work for rows whose UTC date already differed from the
+    // cutoff's, so a suite running just after midnight would go green. Pin the
+    // contract itself — the cutoff must be an ISO instant, never a
+    // `datetime()` modifier like '-300 seconds'.
+    it("binds ISO instants as the staleness cutoffs", async () => {
+      const bindings: unknown[][] = [];
+      const probeEnv = {
+        DB: {
+          prepare: (sql: string) => ({
+            bind: (...args: unknown[]) => {
+              if (sql.includes("FROM import_jobs")) bindings.push(args);
+              return { all: async () => ({ results: [] }) };
+            },
+          }),
+        },
+      } as unknown as Env;
+
+      await runImportSweep(probeEnv, logger);
+
+      const cutoffs = (bindings[0] ?? []).filter(
+        (arg): arg is string => typeof arg === "string" && !ACTIVE_STATUS_NAMES.includes(arg),
+      );
+      expect(cutoffs).toHaveLength(2);
+      for (const cutoff of cutoffs) {
+        expect(cutoff).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      }
+    });
+
+    // The sweep relies on every stored timestamp being ISO — mixing formats in
+    // one column breaks the range query in both directions. That invariant is
+    // established by migration 043 and covered in
+    // tests/import-status-persistence.test.ts, not here.
+  });
+
+  it("reports a query failure without throwing", async () => {
+    const brokenEnv = {
+      DB: {
+        prepare: () => {
+          throw new Error("d1 unavailable");
+        },
+      },
+    } as unknown as Env;
+
+    const result = await runImportSweep(brokenEnv, logger);
+
+    expect(result).toEqual({ scanned: 0, reaped: 0, conflicted: 0, errored: 0 });
+  });
+
+  it("counts a row it could not write as errored and still finishes the batch", async () => {
+    const { db, raw, env } = setup();
+    await seedJob(db, raw, { id: "imp_1", status: "processing", minutesSinceUpdate: 60 });
+    await seedJob(db, raw, {
+      id: "imp_2",
+      status: "processing",
+      minutesSinceUpdate: 61,
+      slug: "w2",
+    });
+
+    let call = 0;
+    const realPrepare = db.prepare.bind(db);
+    const flaky = {
+      ...env,
+      DB: {
+        ...db,
+        prepare: (sql: string) => {
+          // Let the SELECT through, then fail the first row's read-back.
+          if (sql.includes("SELECT * FROM import_jobs WHERE id")) {
+            call++;
+            if (call === 1) throw new Error("transient");
+          }
+          return realPrepare(sql);
+        },
+      },
+    } as unknown as Env;
+
+    const result = await runImportSweep(flaky, logger);
+
+    expect(result.scanned).toBe(2);
+    expect(result.errored).toBe(1);
+    expect(result.reaped).toBe(1);
+    raw.close();
+  });
+});

--- a/tests/import-terminal-state-ui.test.tsx
+++ b/tests/import-terminal-state-ui.test.tsx
@@ -1,0 +1,143 @@
+import { renderToString } from "hono/jsx/dom/server";
+import { describe, expect, it } from "vitest";
+import type { ImportStatus } from "../src/types";
+import { ImportProgressCard } from "../src/ui/components/import-progress";
+import { RepoPage } from "../src/ui/pages/repo";
+
+const baseProject = {
+  name: "my-repo",
+  namespace: "@alice",
+  slug: "my-repo",
+  remote: "git@stratum:alice/my-repo.git",
+  createdAt: "2024-01-01T00:00:00Z",
+};
+
+const baseRepoProps = {
+  files: [],
+  log: [],
+  readme: null,
+  user: null,
+  importProgress: null,
+  syncStatus: null,
+  canSync: false,
+  nonce: "test-nonce",
+};
+
+/**
+ * #304: an empty repo showed a live "Sync Now" button next to "Not synced" and
+ * an in-progress import badge. Content is the gate that makes those claims
+ * consistent — the same one the pull-request card already used.
+ */
+describe("RepoPage — Sync Now content gate", () => {
+  const syncable = {
+    ...baseProject,
+    sourceUrl: "https://github.com/acme/api",
+    sourceProvider: "github" as const,
+  };
+
+  it("offers Sync Now when the repo has content", () => {
+    const html = renderToString(
+      <RepoPage {...baseRepoProps} project={syncable} canSync={true} files={["README.md"]} />,
+    );
+    expect(html).toContain("Sync Now");
+  });
+
+  it("hides Sync Now on an empty repo even when the project is syncable", () => {
+    const html = renderToString(
+      <RepoPage {...baseRepoProps} project={syncable} canSync={true} files={[]} />,
+    );
+    expect(html).not.toContain("Sync Now");
+  });
+
+  // A failed listing yields no files too, but that is when a user most needs
+  // the retry path — it must not be mistaken for an empty repository.
+  it("keeps Sync Now when the file listing failed rather than the repo being empty", () => {
+    const html = renderToString(
+      <RepoPage
+        {...baseRepoProps}
+        project={syncable}
+        canSync={true}
+        files={[]}
+        filesUnavailable={true}
+      />,
+    );
+    expect(html).toContain("Sync Now");
+  });
+
+  it("still hides Sync Now when the user lacks sync permission", () => {
+    const html = renderToString(
+      <RepoPage {...baseRepoProps} project={syncable} canSync={false} files={["README.md"]} />,
+    );
+    expect(html).not.toContain("Sync Now");
+  });
+});
+
+function renderImport(status: ImportStatus): string {
+  return renderToString(
+    <ImportProgressCard
+      namespace="@alice"
+      slug="my-repo"
+      status={status}
+      progress={{ processedFiles: 0 }}
+      logs={[]}
+      errors={[]}
+      sourceUrl="https://github.com/acme/api"
+      branch="main"
+      nonce="test-nonce"
+    />,
+  );
+}
+
+// Before migration 043 the 'syncing' status could not be stored, so the card
+// never had to render it. Now that the consumer's sync-phase write lands, a
+// syncing job must read as active — otherwise it shows no spinner, no Cancel,
+// and no live refresh, which looks exactly like the wedge this PR fixes.
+describe("ImportProgressCard — active statuses", () => {
+  for (const status of ["queued", "cloning", "processing", "syncing"] as const) {
+    it(`renders '${status}' as an in-progress import`, () => {
+      const html = renderImport(status);
+      expect(html).toContain("Cancel Import");
+      expect(html).toContain("/import/cancel");
+    });
+  }
+
+  it("shows progress for a syncing job rather than an empty bar", () => {
+    expect(renderImport("syncing")).toContain("75%");
+  });
+
+  for (const status of ["completed", "failed", "cancelled"] as const) {
+    it(`does not offer Cancel for a '${status}' job`, () => {
+      expect(renderImport(status)).not.toContain("Cancel Import");
+    });
+  }
+});
+
+describe("ImportProgressCard — Delete import action", () => {
+  for (const status of ["failed", "cancelled"] as const) {
+    it(`offers Delete import for a '${status}' job`, () => {
+      const html = renderImport(status);
+      expect(html).toContain("Delete import");
+      expect(html).toContain("/import/delete");
+    });
+  }
+
+  // Not terminal: the queue consumer may still own the row.
+  it("does not offer Delete import while a cancel is still in flight", () => {
+    const html = renderImport("cancelling");
+    expect(html).not.toContain("Delete import");
+    expect(html).toContain("Retry import");
+  });
+
+  for (const status of ["queued", "cloning", "processing", "syncing"] as const) {
+    it(`does not offer Delete import for an active '${status}' job`, () => {
+      const html = renderImport(status);
+      expect(html).not.toContain("Delete import");
+    });
+  }
+
+  it("keeps Retry available alongside Delete", () => {
+    const html = renderImport("failed");
+    expect(html).toContain("Retry import");
+    expect(html).toContain("Delete import");
+  });
+});

--- a/tests/namespace-routes.test.ts
+++ b/tests/namespace-routes.test.ts
@@ -116,6 +116,7 @@ vi.mock("../src/storage/provenance", () => ({
 // Mock imports storage
 const mockImportProgress: Record<string, Record<string, unknown>> = {};
 vi.mock("../src/storage/imports", () => ({
+  STALLED_THRESHOLD_MS: 5 * 60 * 1000,
   getImportProgress: vi.fn(async (_kv, namespace: string, slug: string) => {
     const key = `${namespace}:${slug}`;
     if (mockImportProgress[key]) {

--- a/tests/scheduled.test.ts
+++ b/tests/scheduled.test.ts
@@ -8,9 +8,11 @@ import type { Logger } from "../src/utils/logger";
 const noopRunners: JobRunners = {
   "event-sweep": () => Promise.resolve(),
   "deletion-sweep": () => Promise.resolve(),
+  "import-sweep": () => Promise.resolve(),
   backup: () => Promise.resolve(),
   "ttl-sweep": () => Promise.resolve(),
   "project-sync": () => Promise.resolve(),
+  "import-cleanup": () => Promise.resolve(),
 };
 
 describe("jobsForCron", () => {
@@ -22,12 +24,19 @@ describe("jobsForCron", () => {
 
   it("runs housekeeping (no backup) on the 0 6 trigger", () => {
     const jobs = jobsForCron("0 6 * * *");
-    expect(jobs).toEqual(["ttl-sweep", "project-sync"]);
+    expect(jobs).toEqual(["ttl-sweep", "project-sync", "import-cleanup"]);
     expect(jobs).not.toContain("backup");
   });
 
-  it("runs the event + deletion sweeps on the */5 trigger", () => {
-    expect(jobsForCron("*/5 * * * *")).toEqual(["event-sweep", "deletion-sweep"]);
+  it("runs the event, deletion and import sweeps on the */5 trigger", () => {
+    expect(jobsForCron("*/5 * * * *")).toEqual(["event-sweep", "deletion-sweep", "import-sweep"]);
+  });
+
+  // #304: a wedged import must reach a terminal state without anyone loading
+  // the project page, so the sweep belongs on the frequent tick, not the daily one.
+  it("sweeps stalled imports frequently rather than once a day", () => {
+    expect(jobsForCron("*/5 * * * *")).toContain("import-sweep");
+    expect(jobsForCron("0 6 * * *")).not.toContain("import-sweep");
   });
 
   it("returns nothing for an unknown cron", () => {
@@ -47,9 +56,10 @@ describe("runScheduledJobs", () => {
   });
 
   it("registers a SEPARATE waitUntil per job (not one batched Promise.all)", () => {
-    // The 06:00 cron has two jobs; each must be its own waitUntil so one failing
-    // job can't reject the other — a single Promise.all would show up as length 1.
-    expect(collect("0 6 * * *")).toHaveLength(2);
+    // The 06:00 cron has three jobs; each must be its own waitUntil so one
+    // failing job can't reject the others — a single Promise.all would show up
+    // as length 1.
+    expect(collect("0 6 * * *")).toHaveLength(3);
   });
 
   it("registers nothing for an unknown cron", () => {

--- a/tests/ui-route-sync-props.test.ts
+++ b/tests/ui-route-sync-props.test.ts
@@ -175,7 +175,27 @@ vi.mock("../src/storage/provenance", () => ({
   listProvenance: vi.fn(async () => ({ success: true, data: [] })),
 }));
 
+// Give the page content: "Sync Now" is gated on the repo actually having files
+// (#304), so a project with an empty tree would hide the button for a reason
+// unrelated to the canSync plumbing these tests cover.
+vi.mock("../src/storage/repo-snapshot", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/storage/repo-snapshot")>();
+  return {
+    ...actual,
+    readRepoSnapshot: vi.fn(async () => ({
+      success: true,
+      data: {
+        files: ["src/index.ts"],
+        commits: [],
+        readme: null,
+        capturedAt: "2026-01-01T00:00:00.000Z",
+      },
+    })),
+  };
+});
+
 vi.mock("../src/storage/imports", () => ({
+  STALLED_THRESHOLD_MS: 5 * 60 * 1000,
   getImportProgress: vi.fn(async () => ({ success: true, data: null })),
   createImportJob: vi.fn(async () => ({ success: true, data: { id: "import-001" } })),
   updateImportStatus: vi.fn(async () => ({ success: true, data: undefined })),

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -109,8 +109,10 @@ retry_delay = 30    # Wait 30 seconds between retries
 
 # "0 4 * * *"   — daily backup, on its OWN trigger so the ~15-min invocation
 #                 budget is never shared with (and starved by) the sync/TTL work
-# "0 6 * * *"   — daily housekeeping: workspace TTL sweep + auto-sync
-# "*/5 * * * *" — event outbox sweep: re-enqueue stale pending events
+# "0 6 * * *"   — daily housekeeping: workspace TTL sweep + auto-sync +
+#                 pruning import jobs that finished outside the retention window
+# "*/5 * * * *" — event outbox sweep (re-enqueue stale pending events) and the
+#                 import stall sweep (move wedged import jobs to a terminal state)
 [triggers]
 crons = ["0 4 * * *", "0 6 * * *", "*/5 * * * *"]
 


### PR DESCRIPTION
Closes #304 — the remaining half. #317 shipped the UI changes; this is the backend recovery the follow-up comment listed as still open, plus two root causes found on the way.

## The reported problem

A project displayed "Import in Progress" with a `CANCELLING` badge for four months, beside "Not synced", a PR card, and a live Sync Now button — on a repo with zero commits and zero files. Recovery only ever ran when somebody opened the progress page, so a project nobody visited stayed wedged indefinitely.

## Two root causes underneath it

Both made the *existing* recovery path silently inert, which is likely why the badge survived four months rather than five minutes.

**1. Stall detection never matched a real row.** It compared `updated_at` against SQLite's `datetime('now', …)`, which formats as `2026-08-29 23:54:06`, while every job row stores `new Date().toISOString()` → `2026-08-29T23:54:06.326Z`. Compared as TEXT, `'T'` (0x54) sorts after `' '` (0x20), so the `<` was false for every row until the UTC *date* rolled over — delaying recovery by 5 minutes to ~24 hours depending on time of day. Reproduced directly: an hour-old `cancelling` job returned `{ scanned: 0, reaped: 0 }`.

This affected the pre-existing `recoverStalledImport` too, so the on-demand path was broken before this PR. Both now bind ISO instants, which also keeps the new index usable (wrapping the column in `datetime()`/`julianday()` would not).

**2. The `syncing` status was never storable.** It was missing from the `import_jobs` CHECK constraint, so the write the consumer makes when a sync begins failed with constraint error 19 on *every* sync — and the `Result` was discarded, so the row silently kept its previous status. A job the consumer had picked up still read as `queued`.

## What this adds

- **Scheduled sweep** (`src/queue/import-sweep.ts`) on the `*/5` cron. Bounded to 100 rows, per-row fault isolated, reports `{ scanned, reaped, conflicted, errored }`. `cancelling → cancelled`; anything else → `failed` with an explanatory error. Jobs never picked up off the queue are reaped under a longer grace period.
- **Writes are scoped by job id.** There is no unique constraint on `(namespace, slug)` — every sync creates a row — and `getImportProgress` resolves to the *newest*. A namespace-scoped write would have failed a healthy in-flight job while leaving the wedged one alone. New `updateImportProgressById` is a true compare-and-swap on the primary key.
- **Migration 041** widens the status CHECK, adds `(status, updated_at)`, normalises legacy timestamps to ISO, makes `version` NOT NULL, and snapshots/restores the `failed_imports` FK linkage that `DROP TABLE` would otherwise null out via `ON DELETE SET NULL` (`defer_foreign_keys` does not suppress delete actions).
- **Delete import**, for `failed`/`cancelled` only, removing that row alone so the clone depth the next sync reads survives. Status is re-checked in the `DELETE` itself to close a TOCTOU against a concurrent retry.
- **Sync Now gated on content**, but still rendered when the listing merely *failed* — both produce `files: []`, and that is the moment the button is most needed.
- **Retention wired up** (`cleanupOldImports` had zero callers), always keeping the newest finished job per project for the same depth reason.
- **`isImportCancelled` now recognises `cancelled`.** Otherwise a slow consumer would see a swept cancellation as an unrecognised status, take its failure branch, email the user about a failure they never had, and — on the sync path — `msg.retry()` the work they cancelled.

## Threshold choice

`STALLED_THRESHOLD_MS` is 20 minutes, not 5. The consumer writes `cloning` and then makes no progress write for the duration of the clone, and a queue consumer invocation may run up to 15 minutes ([Workers limits](https://developers.cloudflare.com/workers/platform/limits/)). Anything at or below that ceiling would let the sweep mark healthy long clones `failed`. Heartbeating `updated_at` during the clone would allow a tighter bound — a change to the consumer, not the sweep.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run release:check` — all clean
- `npm test` — **2364 passing**, +60 tests across 7 new files
- The 43 failures in `tests/issues.test.ts` / `tests/issues-comment-body-limit.test.ts` are **pre-existing on `origin/main`** (confirmed by running them in a detached worktree at `af6a1e5`) and touch nothing this PR modifies

Test fixtures deliberately age rows using `new Date(...).toISOString()`, the shape production writes. Seeding SQLite's format is what hid root cause #1 — the suite was green against a shape that cannot occur. There is also a contract test asserting the bound cutoffs are ISO, because behavioural coverage alone is time-of-day dependent and would pass just after UTC midnight.

## Known gap, not fixed here

A wedged **sync** leaves `lastSyncStatus: "in_progress"` in KV and nothing resets it: the sweep terminalises the `import_jobs` row, but the project still reports a sync in flight, so new syncs are rejected and a "Syncing…" badge persists. Same class of contradictory state, but it lives in project KV state rather than import jobs and needs its own staleness rule. Worth a follow-up issue rather than bolting onto this sweep.

## Incidental

- `package-lock.json` had drifted from the v0.2.0 release (still `0.1.0`, missing `engines`); `npm install` corrected it.
- `tests/backup-coverage.test.ts` now derives its table set from the built schema instead of a regex over migration text — a table rebuild defeats the regex. That made the never-existing `change_reviews_new` a phantom entry in `BACKUP_EXCLUDED_TABLES`, so it's removed; migration 041 needs no such entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pf51T6gQy5G3NvSnf9TaT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live “Syncing” progress status with improved progress reporting.
  * Added deletion controls for failed and cancelled imports.
  * Added automatic recovery for stalled imports and retention cleanup for completed imports.
  * Improved Sync Now availability when repository files cannot be loaded.

* **Bug Fixes**
  * Improved cancellation handling and import-status persistence.
  * Prevented newer or unrelated import jobs from being affected during recovery.
  * Normalized import timestamps for more reliable processing.

* **Documentation**
  * Updated changelog, architecture, and import-state documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->