### PR TITLE
Bound PR-Agent review runs and stop auto-improve from wedging

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -136,11 +136,12 @@ jobs:
           # Ticket-compliance analysis emits a block per referenced issue, and our PRs
           # routinely cite several — a lot of output for a section nobody reads.
           pr_reviewer.require_ticket_analysis_review: "false"
-          # Packaging ("safe preset"): quality-score row, walkthrough posted as a
-          # comment (never edits the author's description).
-          # Committable ```suggestion blocks stay OFF by documented security
-          # decision — suggestions render in a table only.
+          # Packaging ("safe preset"): quality-score row on the review. Committable
+          # ```suggestion blocks stay OFF by documented security decision —
+          # suggestions render in a table only.
           pr_reviewer.require_score_review: "true"
+          # These govern /describe when it is invoked by comment; auto_describe is
+          # off, so they do not apply to the automatic run.
           pr_description.publish_description_as_comment: "true"
           # The walkthrough comment sits under the description — don't echo it back,
           # and keep it lean: no PR-type row, no mermaid diagram.
@@ -148,7 +149,10 @@ jobs:
           pr_description.enable_pr_type: "false"
           pr_description.enable_pr_diagram: "false"
           github_action_config.auto_review: "true"
-          github_action_config.auto_describe: "true"
+          # Off: the walkthrough comment restated the author's own description back
+          # at them plus a file-by-file table, on a repo where PR descriptions are
+          # written by hand. Available on demand as a /describe comment.
+          github_action_config.auto_describe: "false"
           # Off until long generations can clear the TTFB wall: both of /improve's
           # calls exceeded it on every run, so auto-improve cost ~2h of runner time
           # per PR and never posted a suggestion. Still available on demand as an

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -7,6 +7,11 @@
 #   -> workers-ai/@cf/zai-org/glm-5.3-flash
 #   -> openai/gpt-5.6-terra          (via unified billing, Cloudflare-managed credentials)
 #
+# Timeouts: AI Gateway bounds a request on time-to-first-byte, and PR-Agent does not
+# stream, so TTFB is the entire generation. Long outputs hit that wall and come back
+# 408, which LiteLLM surfaces as a Timeout. The bounds below keep a wedged call to
+# minutes instead of hours — see docs/runbooks/ai-review.md#timeouts.
+#
 # Required repository secrets (see docs/runbooks/ai-review.md for setup):
 #   AI_GATEWAY_COMPAT_BASE - https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_id>/compat
 #   CLOUDFLARE_AI_TOKEN    - Cloudflare API token with AI Gateway Run permission
@@ -52,6 +57,9 @@ jobs:
                   github.event.comment.author_association) &&
          startsWith(github.event.comment.body, '/')))
     runs-on: ubuntu-latest
+    # Backstop. The default job timeout is 360 minutes; a wedged model call burned
+    # ~2h of runner time per PR before the fallback chain gave up.
+    timeout-minutes: 20
     permissions:
       issues: write
       pull-requests: write
@@ -98,14 +106,38 @@ jobs:
           config.fallback_models: '["openai/workers-ai/@cf/zai-org/glm-5.3-flash","openai/openai/gpt-5.6-terra"]'
           # Gateway models are absent from LiteLLM's token registry; cap explicitly.
           config.custom_model_max_tokens: "131072"
-          # GLM-5.3 is a reasoning model; a full review takes minutes. The default
-          # 120s timeout kills it mid-generation and retries forever.
-          config.ai_timeout: "600"
+          # /improve makes two sequential model calls: generate suggestions, then a
+          # self-reflection pass that re-ranks them. That second call is mandatory in
+          # 0.41.0 (pr_code_suggestions.py) and defaults to config.model, so without
+          # this it is a second full reasoning generation.
+          config.model_reasoning: "openai/workers-ai/@cf/zai-org/glm-5.3-flash"
+          # Per-attempt bound, ~2x the slowest healthy call we have measured (a full
+          # /review at ~222s). LiteLLM only enforces this on its httpx path — the
+          # aiohttp transport ignores it, which is how a call ran 1800s against a
+          # nominal 600s limit — so the transport is disabled alongside it.
+          config.ai_timeout: "420"
+          DISABLE_AIOHTTP_TRANSPORT: "True"
+          # Same bound server-side, so the gateway answers instead of holding the
+          # connection open. cf-aig-max-attempts pins gateway retries to 1 so they
+          # cannot multiply against PR-Agent's own 2-attempts-per-model.
+          litellm.extra_headers: '{"cf-aig-request-timeout": "420000", "cf-aig-max-attempts": "1"}'
           github_action_config.pr_actions: '["opened", "reopened", "ready_for_review"]'
-          # Strictness dials (CodeRabbit-ish): inline code suggestions on, more findings.
-          pr_reviewer.num_max_findings: "8"
-          # Packaging ("safe preset"): quality-score row, walkthrough + changes
-          # diagram posted as a comment (never edits the author's description).
+          # Generated files, excluded from the diff the model sees. ~1MB of the repo is
+          # machine-written (worker-configuration.d.ts from `npm run cf-typegen`, five
+          # package-lock.json files); a single dep bump or typegen refresh would other-
+          # wise dominate the prompt and crowd out the code actually worth reviewing.
+          # Globs are matched against the repo-relative path, and a "**/" prefix also
+          # covers the root-level file.
+          ignore.glob: '["**/package-lock.json", "**/worker-configuration.d.ts"]'
+          # Strictness dials. num_max_findings drives output length, and output length
+          # is what pushes a call past the gateway's TTFB wall; 5 splits the difference
+          # between the 0.41.0 default of 3 and the 8 we started with.
+          pr_reviewer.num_max_findings: "5"
+          # Ticket-compliance analysis emits a block per referenced issue, and our PRs
+          # routinely cite several — a lot of output for a section nobody reads.
+          pr_reviewer.require_ticket_analysis_review: "false"
+          # Packaging ("safe preset"): quality-score row, walkthrough posted as a
+          # comment (never edits the author's description).
           # Committable ```suggestion blocks stay OFF by documented security
           # decision — suggestions render in a table only.
           pr_reviewer.require_score_review: "true"
@@ -117,4 +149,8 @@ jobs:
           pr_description.enable_pr_diagram: "false"
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "true"
-          github_action_config.auto_improve: "true"
+          # Off until long generations can clear the TTFB wall: both of /improve's
+          # calls exceeded it on every run, so auto-improve cost ~2h of runner time
+          # per PR and never posted a suggestion. Still available on demand as an
+          # /improve comment. See docs/runbooks/ai-review.md#timeouts.
+          github_action_config.auto_improve: "false"

--- a/docs/runbooks/ai-review.md
+++ b/docs/runbooks/ai-review.md
@@ -55,10 +55,10 @@ pass-through. Verify actuals in AI Gateway analytics after the first week.
   `/` (ordinary discussion comments never start a run): `/review`, `/describe`, `/improve`,
   `/ask <question>`. `/review` also works on fork PRs (comment events run with base-repo
   secrets).
-- **Comment-triggered runs use the workflow file from the default branch**, not from the PR
-  branch — `issue_comment` is not a `pull_request` event, so GitHub reads `main`'s copy. A PR
-  that edits this workflow therefore cannot be tested with a `/review` comment on itself: the
-  comment runs the old settings. Only the automatic on-open run uses the PR's own version.
+- **Workflow version depends on the trigger:** automatic `pull_request` runs use the workflow
+  file from the PR's merge ref, while comment-triggered `issue_comment` runs use the default
+  branch's workflow file. A PR that edits this workflow therefore cannot test those edits with a
+  `/review` comment on itself: the comment runs the old settings.
 - The `-i` in `/review -i` is matched exactly (`pr_reviewer.py`, `arg == "-i"`). `/review -I`
   is not an error — it silently runs a full review.
 - A PR event posts one artifact: the reviewer guide (up to 5 findings + quality score +

--- a/docs/runbooks/ai-review.md
+++ b/docs/runbooks/ai-review.md
@@ -55,6 +55,12 @@ pass-through. Verify actuals in AI Gateway analytics after the first week.
   `/` (ordinary discussion comments never start a run): `/review`, `/describe`, `/improve`,
   `/ask <question>`. `/review` also works on fork PRs (comment events run with base-repo
   secrets).
+- **Comment-triggered runs use the workflow file from the default branch**, not from the PR
+  branch — `issue_comment` is not a `pull_request` event, so GitHub reads `main`'s copy. A PR
+  that edits this workflow therefore cannot be tested with a `/review` comment on itself: the
+  comment runs the old settings. Only the automatic on-open run uses the PR's own version.
+- The `-i` in `/review -i` is matched exactly (`pr_reviewer.py`, `arg == "-i"`). `/review -I`
+  is not an error — it silently runs a full review.
 - A PR event posts one artifact: the reviewer guide (up to 5 findings + quality score +
   effort/security labels). The walkthrough (`auto_describe`) and the code-suggestions table
   (`auto_improve`) are both off — comment `/describe` or `/improve` to request either on
@@ -105,8 +111,10 @@ review runs 10–14K tokens against a 32K cap. Revisit only if reviews start cli
 
 Two things need to be true first:
 
-1. **`/improve` completes at all.** Comment `/improve` on a real PR and confirm both calls
-   land inside 420s now that self-reflection runs on flash.
+1. **`/improve` completes at all.** Comment `/improve` on a real PR **after these settings are
+   on `main`** — comment runs read the default branch's workflow, so testing from a PR branch
+   silently measures the old config — and confirm both calls land inside 420s now that
+   self-reflection runs on flash.
 2. **The chain has a working last resort.** `openai/gpt-5.6-terra` currently returns
    `400 Chat completion bad format` from the gateway, immediately after PR-Agent logs
    `Using reasoning_effort='medium' for GPT-5 model`. 0.41.0 injects that parameter for any

--- a/docs/runbooks/ai-review.md
+++ b/docs/runbooks/ai-review.md
@@ -1,8 +1,8 @@
 # AI code review (PR-Agent via Cloudflare AI Gateway)
 
 `.github/workflows/pr-agent.yml` runs [PR-Agent](https://github.com/qodo-ai/pr-agent) on every
-non-draft, non-fork PR (opened / reopened / ready_for_review / synchronize). It posts a review
-comment with findings; it never blocks a merge.
+non-draft, non-fork PR (opened / reopened / ready_for_review). It posts a review comment with
+findings; it never blocks a merge.
 
 All LLM traffic goes through **Cloudflare AI Gateway's OpenAI-compatible `/compat` endpoint**
 with unified billing: one Cloudflare API token, one Cloudflare bill, no third-party model
@@ -22,6 +22,10 @@ API errors or context overflow — not on review quality:
 
 Kimi K3 was considered and dropped: Moonshot is not a Cloudflare-billable provider, so keeping
 it would have required a third-party account — the thing this setup exists to avoid.
+
+`config.model_reasoning` points flash at one specific call: `/improve`'s self-reflection pass,
+which re-ranks the generated suggestions. PR-Agent 0.41.0 makes that pass mandatory and defaults
+it to `config.model`, so `/improve` is otherwise two full GLM-5.3 generations back to back.
 
 Typical PR review ≈ 15–40K input + a few K output tokens → **roughly $0.03–0.08 per review** on
 GLM-5.3. Unified billing adds a 5% fee on credit *purchases*; per-token rates are provider
@@ -51,12 +55,67 @@ pass-through. Verify actuals in AI Gateway analytics after the first week.
   `/` (ordinary discussion comments never start a run): `/review`, `/describe`, `/improve`,
   `/ask <question>`. `/review` also works on fork PRs (comment events run with base-repo
   secrets).
-- Each PR event posts three artifacts: the reviewer guide (up to 8 findings + quality score +
-  effort/security labels), a walkthrough comment with a changes diagram (`auto_describe`,
-  as a comment — the bot never edits the author's description), and a code-suggestions table
-  (`auto_improve`). Committable ` ```suggestion ` blocks remain off by security decision.
-  Turn dials down if the bot gets noisy.
+- Each PR event posts two artifacts: the reviewer guide (up to 5 findings + quality score +
+  effort/security labels) and a walkthrough comment (`auto_describe`, as a comment — the bot
+  never edits the author's description). The code-suggestions table (`auto_improve`) is off by
+  default; comment `/improve` to request one. Committable ` ```suggestion ` blocks remain off
+  by security decision. Turn dials down if the bot gets noisy.
 - To change models, edit the workflow env — one line per model; no code involved.
+
+## Timeouts
+
+AI Gateway bounds a request on **time-to-first-byte**, not total duration. PR-Agent sends
+`stream: false`, so TTFB is the entire generation — prefill, every reasoning token, every
+output token. A long answer therefore trips a bound meant for an unresponsive provider.
+
+That is what `/improve` did on every run: the gateway returned `408 / AiError 3046` after
+~30 minutes, LiteLLM mapped the 408 to `litellm.Timeout`, and the fallback chain retried it
+twice per model. Roughly two hours of runner time per PR, no suggestions posted. `/review`
+survived only because it is shorter (~222s).
+
+The bounds now in place, outermost first:
+
+| Bound | Value | What it catches |
+|---|---|---|
+| `timeout-minutes` (job) | 20 min | anything that escapes the bounds below |
+| `config.ai_timeout` | 420s | a slow call, client-side |
+| `DISABLE_AIOHTTP_TRANSPORT` | `True` | makes the line above actually fire |
+| `cf-aig-request-timeout` | 420000 ms | a slow call, at the gateway |
+| `cf-aig-max-attempts` | 1 | gateway retries multiplying PR-Agent's own |
+
+`DISABLE_AIOHTTP_TRANSPORT` is not incidental. LiteLLM's aiohttp transport ignores the
+per-request timeout, so `config.ai_timeout` was silently unenforced — the logs read
+`timeout value=600.0, time taken=1801.57 seconds`. It only holds on the httpx path.
+
+Output length is the lever that keeps calls under the wall, so `pr_reviewer.num_max_findings`
+and the `require_*` toggles are cost controls as much as noise controls.
+
+Input size is the secondary lever. `ignore.glob` drops generated files from the diff the model
+sees — `worker-configuration.d.ts` (476 KB, from `npm run cf-typegen`) and the five committed
+`package-lock.json` files are together about a megabyte, so a dependency bump or a typegen
+refresh would otherwise crowd out the code worth reviewing. Extend the glob list when you
+commit something else that a machine writes.
+
+We deliberately have *not* trimmed `patch_extra_lines_before` (5) or `allow_dynamic_context`.
+Those are the surrounding lines the model reads to understand a hunk, so cutting them buys
+input tokens at the cost of review quality — and input is not the binding constraint: a typical
+review runs 10–14K tokens against a 32K cap. Revisit only if reviews start clipping.
+
+### Re-enabling auto_improve
+
+Two things need to be true first:
+
+1. **`/improve` completes at all.** Comment `/improve` on a real PR and confirm both calls
+   land inside 420s now that self-reflection runs on flash.
+2. **The chain has a working last resort.** `openai/gpt-5.6-terra` currently returns
+   `400 Chat completion bad format` from the gateway, immediately after PR-Agent logs
+   `Using reasoning_effort='medium' for GPT-5 model`. 0.41.0 injects that parameter for any
+   `gpt-5*` model with no setting to suppress it. Verify with a direct `curl` to the compat
+   endpoint, with and without `reasoning_effort`, before trusting the fallback.
+
+The real fix is streaming, which sidesteps a TTFB bound entirely. PR-Agent's
+`litellm.force_streaming_api_base_substrings` does exactly this, but as of v0.43.0 it is
+unreleased (`main` only), so it is not reachable from a digest-pinned image yet.
 
 ## Security posture & abuse bounds
 
@@ -93,6 +152,8 @@ rate limits / spend caps on the Cloudflare gateway are the backstop.
 
 - Fallback chain is availability-based, not quality-based; if GLM-5.3 errors persistently you
   are silently reviewed by flash-tier — check gateway logs when reviews look shallow.
+- `auto_improve` is off; code suggestions are on-demand via an `/improve` comment. See
+  [Timeouts](#timeouts).
 - Draft PRs are skipped until marked ready for review.
 - A build-your-own alternative (a Cloudflare Worker reviewer with a custom rubric) was specced
   and shelved in favor of PR-Agent; revisit as a Stratum-native feature once the project

--- a/docs/runbooks/ai-review.md
+++ b/docs/runbooks/ai-review.md
@@ -55,11 +55,11 @@ pass-through. Verify actuals in AI Gateway analytics after the first week.
   `/` (ordinary discussion comments never start a run): `/review`, `/describe`, `/improve`,
   `/ask <question>`. `/review` also works on fork PRs (comment events run with base-repo
   secrets).
-- Each PR event posts two artifacts: the reviewer guide (up to 5 findings + quality score +
-  effort/security labels) and a walkthrough comment (`auto_describe`, as a comment — the bot
-  never edits the author's description). The code-suggestions table (`auto_improve`) is off by
-  default; comment `/improve` to request one. Committable ` ```suggestion ` blocks remain off
-  by security decision. Turn dials down if the bot gets noisy.
+- A PR event posts one artifact: the reviewer guide (up to 5 findings + quality score +
+  effort/security labels). The walkthrough (`auto_describe`) and the code-suggestions table
+  (`auto_improve`) are both off — comment `/describe` or `/improve` to request either on
+  demand. Committable ` ```suggestion ` blocks remain off by security decision. Turn dials
+  down if the bot gets noisy.
 - To change models, edit the workflow env — one line per model; no code involved.
 
 ## Timeouts
@@ -154,6 +154,10 @@ rate limits / spend caps on the Cloudflare gateway are the backstop.
   are silently reviewed by flash-tier — check gateway logs when reviews look shallow.
 - `auto_improve` is off; code suggestions are on-demand via an `/improve` comment. See
   [Timeouts](#timeouts).
+- `auto_describe` is off. Its walkthrough comment restated the author's own description plus a
+  file-by-file table, which is noise on a repo where descriptions are written by hand. It also
+  never edited the description, so nothing downstream depended on it. Run `/describe` when a
+  generated summary is genuinely wanted — the `pr_description.*` settings still govern it.
 - Draft PRs are skipped until marked ready for review.
 - A build-your-own alternative (a Cloudflare Worker reviewer with a custom rubric) was specced
   and shelved in favor of PR-Agent; revisit as a Stratum-native feature once the project


### PR DESCRIPTION
## What was happening

Auto-review runs were taking **~2 hours** and posting no code suggestions. Example: [run 33282224516](https://github.com/stratum-eng/stratum/actions/runs/33282224516) (2h05m, green).

Actual work in that run was about 5 minutes:

| Phase | Duration |
|---|---|
| `/describe` | 29s |
| `/review` | 3m42s |
| `/improve` glm-5.3 ×2 attempts | **60m → timeout** |
| `/improve` glm-5.3-flash ×2 attempts | **60m → timeout** |
| `/improve` gpt-5.6-terra ×2 | 0.5s → HTTP 400 |
| → `Failed to generate code suggestions` | |

Same shape in runs `33283161537`, `33281838631`, `33281094304`.

## Why

AI Gateway bounds a request on **time-to-first-byte**, and PR-Agent sends `stream: false`, so TTFB is the entire generation — prefill, every reasoning token, every output token. `/improve` asks a reasoning model for a long structured YAML and never produces a first byte in time, so the gateway returns `408 / AiError 3046` and LiteLLM maps that to `litellm.Timeout`. `/review` survives only because it is shorter.

Nothing bounded it:

- `config.ai_timeout: 600` was **silently unenforced** — LiteLLM's aiohttp transport ignores the per-request timeout. The logs are self-contradicting: `timeout value=600.0, time taken=1801.57 seconds`, with `Unclosed client session: <aiohttp.ClientSession>` at the end as the tell.
- The job had no `timeout-minutes`, so it inherited GitHub's 360-minute default.
- The last-resort fallback is broken independently: `gpt-5.6-terra` returns `400 Chat completion bad format`, immediately after PR-Agent logs `Using reasoning_effort='medium' for GPT-5 model`. 0.41.0 injects that for any `gpt-5*` model with no way to suppress it. So the chain had no working member for `/improve`.

## Changes

Bounds, outermost first:

| Bound | Value |
|---|---|
| `timeout-minutes` (job) | 20 min |
| `config.ai_timeout` | 420s |
| `DISABLE_AIOHTTP_TRANSPORT` | `True` — makes the line above actually fire |
| `cf-aig-request-timeout` | 420000 ms |
| `cf-aig-max-attempts` | 1 — so gateway retries don't multiply PR-Agent's own |

420s is ~2× the slowest healthy call measured (`/review` at 222s).

Then reduce what has to fit inside them:

- **`auto_improve: false`.** It has never once succeeded, and has no working fallback. Still available on demand as an `/improve` comment.
- **`config.model_reasoning` → flash.** `/improve` is two sequential calls: generate, then a self-reflection pass that re-ranks. That second call is mandatory in 0.41.0 (`pr_code_suggestions.py:412`) and defaults to `config.model`, so it was a second full reasoning generation.
- **`num_max_findings` 8 → 5** (0.41.0 default is 3) and **ticket-compliance analysis off** — it emits a block per referenced issue, and our PRs routinely cite several. Output length is the thing that pushes a call past the wall, and `/review` at 222s had little headroom.
- **`auto_describe: false`.** Its walkthrough comment restated the author's own description back at them plus a file-by-file table — duplication on a repo where descriptions are written by hand. It never edited the description field, so nothing downstream depended on it. Available as a `/describe` comment.
- **`ignore.glob`** for `package-lock.json` and `worker-configuration.d.ts` — ~1MB of generated content that would crowd out real code on a dep bump or typegen refresh.

Deliberately **not** changed: `patch_extra_lines_before` and `allow_dynamic_context`. Those are the surrounding lines the model reads to understand a hunk; trimming them buys input tokens at the cost of review quality, and input is not the constraint (a typical review is 10–14K against a 32K cap).

## Verification

- Workflow parses as valid YAML; every env key resolves to the intended value (`ignore.glob` and `config.fallback_models` both arrive as real lists — Dynaconf parses the JSON-array form, as today's fallback chain already demonstrates in the logs).
- `DISABLE_AIOHTTP_TRANSPORT` confirmed real in LiteLLM: `http_handler.py:1069`, `str_to_bool(os.getenv("DISABLE_AIOHTTP_TRANSPORT", "False"))`.
- `litellm.extra_headers` confirmed present in the pinned 0.41.0 image (`litellm_ai_handler.py:597`) — it is not a `main`-only setting.
- Glob semantics confirmed against `file_filter.py`: `fnmatch.translate` matched on the repo-relative path, and a `**/` prefix also generates a root-level variant.
- No CHANGELOG entry: CI-only change, consistent with #328 which added this workflow.
- Not verified by running — the real proof is the next auto-review on this PR. It should finish in single-digit minutes with a review comment only — no walkthrough, no suggestions table.

## Follow-up (not in this PR)

The real fix for `/improve` is streaming, which sidesteps a TTFB bound entirely. PR-Agent's `litellm.force_streaming_api_base_substrings` does exactly that, but as of v0.43.0 it is unreleased (`main` only) and so unreachable from a digest-pinned image. The runbook's new Timeouts section carries the re-enable checklist, including a `curl` to isolate the terra 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwNDMevcvpygY3mfuVvNYN



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards to limit automated review duration and gateway retries.
  * Improved control over review triggers, input size, model selection, and generated-file exclusions.
  * Retained on-demand description and improvement commands.

* **Documentation**
  * Updated the AI review runbook with timeout behavior, command usage, trigger rules, limitations, and re-enablement guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->