### PR TITLE
Require public docs updates alongside user-facing changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,8 @@
 ## Checklist
 
 - [ ] Tests added or updated for the change (coverage thresholds still pass)
-- [ ] Docs updated where the change makes them inaccurate
+- [ ] `CHANGELOG.md` updated (`## [Unreleased]`) if this is user-visible
+- [ ] Public docs (`website/src/content/docs/`) updated if this changes user-facing config, API
+      shape, or evaluator/policy behavior — internal `docs/` is not enough, see AGENTS.md
 - [ ] No secrets, tokens, or personal data committed
 - [ ] The web UI change (if any) stays server-rendered with no client-side JavaScript

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,11 @@ Mirror lint → typecheck → test locally before pushing.
 - **Every user-visible change gets a `CHANGELOG.md` entry** under `## [Unreleased]`, in the same
   PR, under a Keep a Changelog group. That text ships verbatim as the release notes; the release
   tooling infers the version bump from which groups are present (`docs/developer/releasing.md`).
+- **A change to user-facing config, API shape, or evaluator/policy behavior also updates the public
+  docs** (`website/src/content/docs/`, `docs.usestratum.dev`) in the same PR — not just
+  `CHANGELOG.md`. `docs/` is internal (developer, API reference, ADRs, runbooks); `website/` is what
+  a self-hoster or agent operator actually reads to configure `.stratum/policy.yaml` or use the API,
+  and it goes stale silently since nothing fails a build over it.
 - Highlight.js / type gotchas and the full ship flow live in `docs/developer/`.
 
 ## Operational rules (do not violate)


### PR DESCRIPTION
## Summary
- AGENTS.md now distinguishes `docs/` (internal) from `website/` (public, docs.usestratum.dev) and requires a same-PR update to `website/src/content/docs/` for any change to user-facing config, API shape, or evaluator/policy behavior.
- PR template's single generic "docs updated" checkbox is split into two specific ones: `CHANGELOG.md` and public docs.

## Related issues
Follow-up from #339, which shipped a breaking sandbox-evaluator config change (`totalBudgetMs`, `allowInstallScripts`) with a CHANGELOG entry but no public docs update — the policy.yaml walkthrough on docs.usestratum.dev went stale silently.

## Type of change
- [x] Documentation
- [ ] Other:

## How was this verified?
Docs-only change to AGENTS.md and the PR template; no code paths affected.

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`

## Checklist
- [x] No secrets, tokens, or personal data committed