### PR TITLE
Let Google sign-in work outside production, and return to where sign-in started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a change that passed before this release may fail on re-evaluation.
 
 ### Fixed
+- **Google sign-in works outside production.** Only `[env.production.vars]` declared
+  `GOOGLE_REDIRECT_URI`, and the Google routes require it, so `/auth/google` answered
+  501 on staging and under `wrangler dev` however the secrets were set — named
+  environments replace top-level `[vars]` rather than inheriting them. Staging and
+  local now declare their own callback.
+- **A sign-in returns to the page it started from.** `/auth/github` and `/auth/google`
+  accept `?next=`, carried through the flow on the OAuth state record and honoured by
+  both callbacks. The GitHub callback previously read `next` from its own query string,
+  where it could never arrive: an authorization server echoes back `code` and `state`
+  and drops everything else, so every sign-in landed on `/`. Off-origin destinations
+  are still refused, at both ends of the round trip.
 - Approvals are dismissed when the evaluated **base** moves, not only when the
   tip does. A change re-evaluated against a newer base kept approvals that were
   granted against different code.

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -280,9 +280,21 @@ npx wrangler d1 execute stratum --remote --command "<rollback SQL>"
 
 **Production:**
 ```bash
-# GitHub OAuth
+# GitHub OAuth — an OAuth App (Settings -> Developer settings -> OAuth Apps),
+# NOT a GitHub App. Its "Authorization callback URL" must equal this env's
+# OAUTH_REDIRECT_URI exactly. GitHub allows one callback per app, so production,
+# staging, and local each need their own app.
 npx wrangler secret put GITHUB_CLIENT_ID
 npx wrangler secret put GITHUB_CLIENT_SECRET
+
+# Google OAuth — a Web application client in Google Cloud console (APIs &
+# Services -> Credentials), with GOOGLE_REDIRECT_URI listed under "Authorized
+# redirect URIs". One client can serve every environment: unlike GitHub, Google
+# accepts multiple redirect URIs. The requested scopes are openid/email/profile
+# only, so the consent screen stays in the non-sensitive tier — but it must be
+# Published, since a client in Testing mode admits only listed test users.
+npx wrangler secret put GOOGLE_CLIENT_ID
+npx wrangler secret put GOOGLE_CLIENT_SECRET
 
 # Email
 npx wrangler secret put EMAIL_FROM_ADDRESS
@@ -319,7 +331,23 @@ npx wrangler secret put BACKUP_ENCRYPTION_SECRET
 ```bash
 npx wrangler secret put GITHUB_CLIENT_ID --env=staging
 npx wrangler secret put GITHUB_CLIENT_SECRET --env=staging
+npx wrangler secret put GOOGLE_CLIENT_ID --env=staging
+npx wrangler secret put GOOGLE_CLIENT_SECRET --env=staging
 ```
+
+Each provider is independent: `/auth/github` and `/auth/google` answer `501
+{"error": "... is not configured"}` until *their own* pair of secrets and the
+matching redirect-URI var are present, and neither blocks magic-link sign-in.
+
+Staging runs with `BETA_GATE = "1"`, which makes OAuth **login-only** there: an
+account that matches neither an existing GitHub id nor a verified email is sent
+to `/auth/signup?error=invite_required`. Signing in to staging with a brand-new
+Google or GitHub account is expected to bounce — that is the invite gate doing
+its job, not a misconfigured provider. Production sets `BETA_GATE = "0"`, where
+first-time OAuth sign-in creates the account.
+
+For local `wrangler dev`, put the four secrets in a gitignored `.dev.vars`
+rather than in `wrangler.toml`.
 
 ### Viewing Secrets
 
@@ -501,12 +529,21 @@ Set in `wrangler.toml`:
 [vars]
 POSTHOG_HOST = "https://app.posthog.com"
 OAUTH_REDIRECT_URI = "https://your-instance.workers.dev/auth/github/callback"
+GOOGLE_REDIRECT_URI = "https://your-instance.workers.dev/auth/google/callback"
 STRATUM_TELEMETRY_DISABLED = "false"
 
 [env.staging.vars]
 OAUTH_REDIRECT_URI = "https://your-instance-staging.workers.dev/auth/github/callback"
+GOOGLE_REDIRECT_URI = "https://your-instance-staging.workers.dev/auth/google/callback"
 STRATUM_TELEMETRY_DISABLED = "true"
 ```
+
+`OAUTH_REDIRECT_URI` is the **GitHub** callback and `GOOGLE_REDIRECT_URI` the
+Google one; the names are asymmetric for backwards compatibility. Because named
+environments replace top-level `[vars]` rather than inheriting them, each
+`[env.<name>.vars]` block you deploy must declare both — a missing
+`GOOGLE_REDIRECT_URI` disables Google sign-in in that environment even when the
+secrets are set.
 
 > **Named environments do not inherit top-level `[vars]` — they replace them.**
 > Setting `STRATUM_TELEMETRY_DISABLED` only under `[vars]` has no effect on

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -23,15 +23,42 @@ function timingSafeEqual(a: string, b: string): boolean {
 }
 
 /**
+ * Reduce a caller-supplied `?next=` to a same-origin path, or undefined.
+ *
+ * Parsing against a dummy base makes an absolute or protocol-relative target
+ * ("https://evil.example/x", "//evil.example/x") resolve to a foreign hostname,
+ * which is rejected — only a relative path keeps the base's host and survives.
+ */
+function sanitizeNextPath(next: unknown): string | undefined {
+  if (typeof next !== "string" || next === "") return undefined;
+  try {
+    const url = new URL(next, "http://localhost");
+    if (url.hostname !== "localhost" && url.hostname !== "") return undefined;
+    return url.pathname + url.search;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Mint an OAuth state, persist it in KV (replay prevention), and bind it to
  * the initiating browser via a short-lived cookie (login-CSRF prevention).
+ *
+ * The post-login destination rides along as the KV *value*: an authorization
+ * server echoes back only `code` and `state`, never the extra query params the
+ * sign-in link carried, so `next` cannot survive the round trip on the URL.
  */
 async function issueOAuthState(
   c: Parameters<typeof setCookie>[0],
   kv: KVNamespace,
+  next?: string,
 ): Promise<string> {
   const state = crypto.randomUUID().replace(/-/g, "");
-  await kv.put(`oauth_state:${state}`, "1", { expirationTtl: OAUTH_STATE_TTL_SECONDS });
+  // "1" is the no-destination marker (and what states minted before this
+  // carried, so one in flight across a deploy still validates).
+  await kv.put(`oauth_state:${state}`, sanitizeNextPath(next) ?? "1", {
+    expirationTtl: OAUTH_STATE_TTL_SECONDS,
+  });
   setCookie(c, OAUTH_STATE_COOKIE, state, {
     httpOnly: true,
     secure: true,
@@ -44,24 +71,27 @@ async function issueOAuthState(
 
 /**
  * Validate a callback's state: it must match the browser's state cookie
- * (constant-time) AND exist in KV. Consumes both on success.
+ * (constant-time) AND exist in KV. Consumes both on success, returning the
+ * post-login destination the state was minted with.
  */
 async function consumeOAuthState(
   c: Parameters<typeof getCookie>[0] & Parameters<typeof deleteCookie>[0],
   kv: KVNamespace,
   state: string,
-): Promise<boolean> {
+): Promise<{ ok: boolean; next?: string }> {
   const cookieState = getCookie(c, OAUTH_STATE_COOKIE);
   if (!cookieState || !timingSafeEqual(cookieState, state)) {
-    return false;
+    return { ok: false };
   }
   deleteCookie(c, OAUTH_STATE_COOKIE, { path: "/auth" });
 
   const stateKey = `oauth_state:${state}`;
   const stored = await kv.get(stateKey);
-  if (!stored) return false;
+  if (!stored) return { ok: false };
   await kv.delete(stateKey);
-  return true;
+  // Re-sanitize on the way out: KV is trusted, but the value round-tripped
+  // through storage and the redirect below must not be widened by accident.
+  return { ok: true, next: stored === "1" ? undefined : sanitizeNextPath(stored) };
 }
 
 app.get("/github", async (c) => {
@@ -79,7 +109,7 @@ app.get("/github", async (c) => {
     return c.json({ error: "GitHub OAuth is not configured" }, 501);
   }
 
-  const state = await issueOAuthState(c, c.env.STATE);
+  const state = await issueOAuthState(c, c.env.STATE, c.req.query("next"));
 
   const params = new URLSearchParams({
     client_id: clientId,
@@ -108,14 +138,15 @@ app.get("/github/callback", async (c) => {
     return c.json({ error: "GitHub OAuth is not configured" }, 501);
   }
 
-  const { code, state, next } = c.req.query();
+  const { code, state } = c.req.query();
 
   if (!state) {
     logger.warn("Missing state parameter");
     return c.json({ error: "Missing state parameter" }, 400);
   }
 
-  if (!(await consumeOAuthState(c, c.env.STATE, state))) {
+  const consumed = await consumeOAuthState(c, c.env.STATE, state);
+  if (!consumed.ok) {
     logger.warn("Invalid, expired, or unbound state", { statePrefix: state.slice(0, 8) });
     return c.json({ error: "Invalid or expired state" }, 400);
   }
@@ -252,19 +283,7 @@ app.get("/github/callback", async (c) => {
 
   sessionLogger.info("GitHub OAuth successful, session created");
 
-  let redirectTo = "/";
-  if (next && typeof next === "string") {
-    try {
-      const url = new URL(next, "http://localhost");
-      if (url.hostname === "localhost" || url.hostname === "") {
-        redirectTo = url.pathname + url.search;
-      }
-    } catch {
-      // invalid next param — fall back to /
-    }
-  }
-
-  return c.redirect(redirectTo);
+  return c.redirect(consumed.next ?? "/");
 });
 
 app.get("/google", async (c) => {
@@ -282,7 +301,7 @@ app.get("/google", async (c) => {
     return c.json({ error: "Google OAuth is not configured" }, 501);
   }
 
-  const state = await issueOAuthState(c, c.env.STATE);
+  const state = await issueOAuthState(c, c.env.STATE, c.req.query("next"));
 
   const params = new URLSearchParams({
     client_id: clientId,
@@ -317,7 +336,8 @@ app.get("/google/callback", async (c) => {
   if (!state) {
     return c.json({ error: "Missing state parameter" }, 400);
   }
-  if (!(await consumeOAuthState(c, c.env.STATE, state))) {
+  const consumed = await consumeOAuthState(c, c.env.STATE, state);
+  if (!consumed.ok) {
     logger.warn("Invalid, expired, or unbound state", { statePrefix: state.slice(0, 8) });
     return c.json({ error: "Invalid or expired state" }, 400);
   }
@@ -412,7 +432,7 @@ app.get("/google/callback", async (c) => {
   });
 
   sessionLogger.info("Google OAuth successful, session created");
-  return c.redirect("/");
+  return c.redirect(consumed.next ?? "/");
 });
 
 // Logout is state-changing, so it happens on POST (the nav renders a form and

--- a/tests/oauth-return-path.test.ts
+++ b/tests/oauth-return-path.test.ts
@@ -1,0 +1,242 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { authRouter } from "../src/routes/auth";
+import type { Env } from "../src/types";
+
+vi.mock("../src/storage/users", () => ({
+  createUser: vi.fn(),
+  getUserByEmail: vi.fn(),
+  getUserByGitHubId: vi.fn(),
+  upsertGitHubUser: vi.fn(),
+}));
+
+vi.mock("../src/storage/sessions", () => ({
+  createSession: vi.fn(),
+  deleteSession: vi.fn(),
+  getSession: vi.fn(),
+}));
+
+vi.mock("../src/storage/audit", () => ({
+  recordAudit: vi.fn().mockResolvedValue({ success: true, data: undefined }),
+}));
+
+import { createSession } from "../src/storage/sessions";
+import { getUserByEmail, upsertGitHubUser } from "../src/storage/users";
+
+const fetchMock = vi.fn();
+
+function makeApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.route("/auth", authRouter);
+  return app;
+}
+
+/** In-memory KV that also exposes the raw store, so a test can read the state value. */
+function makeKv(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  const kv = {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+  } as unknown as KVNamespace;
+  return { kv, store };
+}
+
+function makeEnv(state: KVNamespace): Env {
+  return {
+    ARTIFACTS: {} as Env["ARTIFACTS"],
+    STATE: state,
+    DB: {} as D1Database,
+    GITHUB_CLIENT_ID: "gh-client",
+    GITHUB_CLIENT_SECRET: "gh-secret",
+    OAUTH_REDIRECT_URI: "https://app.example.com/auth/github/callback",
+    GOOGLE_CLIENT_ID: "google-client",
+    GOOGLE_CLIENT_SECRET: "google-secret",
+    GOOGLE_REDIRECT_URI: "https://app.example.com/auth/google/callback",
+  } as Env;
+}
+
+/** The `state` an authorize redirect minted, read back off its Location header. */
+function stateFrom(res: Response): string {
+  const location = res.headers.get("Location") ?? "";
+  const state = new URL(location).searchParams.get("state");
+  if (!state) throw new Error(`No state in ${location}`);
+  return state;
+}
+
+function mockGoogleIdentity() {
+  fetchMock.mockImplementation(async (url: string) => {
+    if (url.startsWith("https://oauth2.googleapis.com/token")) {
+      return new Response(JSON.stringify({ access_token: "t" }), { status: 200 });
+    }
+    if (url.startsWith("https://www.googleapis.com/oauth2/v3/userinfo")) {
+      return new Response(
+        JSON.stringify({ sub: "g-1", email: "user@example.com", email_verified: true }),
+        { status: 200 },
+      );
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  vi.mocked(getUserByEmail).mockResolvedValue({
+    success: true,
+    data: {
+      id: "usr_1",
+      email: "user@example.com",
+      username: "user",
+      tokenHash: "h",
+      createdAt: "",
+    },
+  });
+}
+
+function mockGitHubIdentity() {
+  fetchMock.mockImplementation(async (url: string) => {
+    if (url.startsWith("https://github.com/login/oauth/access_token")) {
+      return new Response(JSON.stringify({ access_token: "t" }), { status: 200 });
+    }
+    if (url === "https://api.github.com/user") {
+      return new Response(JSON.stringify({ id: 42, login: "octocat" }), { status: 200 });
+    }
+    if (url === "https://api.github.com/user/emails") {
+      return new Response(
+        JSON.stringify([{ email: "user@example.com", primary: true, verified: true }]),
+        { status: 200 },
+      );
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  vi.mocked(upsertGitHubUser).mockResolvedValue({
+    success: true,
+    data: {
+      id: "usr_1",
+      email: "user@example.com",
+      username: "octocat",
+      tokenHash: "h",
+      createdAt: "",
+    },
+  });
+}
+
+describe("OAuth post-login return path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(createSession).mockResolvedValue({
+      success: true,
+      data: { id: "sess_1", userId: "usr_1", expiresAt: "2099-01-01T00:00:00.000Z" },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // The destination cannot ride the URL: an authorization server echoes back
+  // only `code` and `state`, so it has to be carried by the state record.
+  it.each([
+    ["github", "/auth/github"],
+    ["google", "/auth/google"],
+  ])("stores the requested destination alongside the %s state", async (_provider, path) => {
+    const { kv, store } = makeKv();
+    const res = await makeApp().fetch(
+      new Request(`http://localhost${path}?next=/projects/acme%2Fweb`),
+      makeEnv(kv),
+    );
+
+    expect(store.get(`oauth_state:${stateFrom(res)}`)).toBe("/projects/acme/web");
+  });
+
+  it("returns a GitHub sign-in to the page it started from", async () => {
+    mockGitHubIdentity();
+    const { kv } = makeKv();
+    const env = makeEnv(kv);
+    const app = makeApp();
+
+    const start = await app.fetch(new Request("http://localhost/auth/github?next=/settings"), env);
+    const state = stateFrom(start);
+
+    const res = await app.fetch(
+      new Request(`http://localhost/auth/github/callback?code=ok&state=${state}`, {
+        headers: { Cookie: `stratum_oauth_state=${state}` },
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/settings");
+  });
+
+  it("returns a Google sign-in to the page it started from", async () => {
+    mockGoogleIdentity();
+    const { kv } = makeKv();
+    const env = makeEnv(kv);
+    const app = makeApp();
+
+    const start = await app.fetch(new Request("http://localhost/auth/google?next=/settings"), env);
+    const state = stateFrom(start);
+
+    const res = await app.fetch(
+      new Request(`http://localhost/auth/google/callback?code=ok&state=${state}`, {
+        headers: { Cookie: `stratum_oauth_state=${state}` },
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/settings");
+  });
+
+  // An open redirect out of the sign-in flow is a credible phishing primitive:
+  // the victim lands on the attacker's page having just authenticated for real.
+  it.each(["https://evil.example/pwn", "//evil.example/pwn", "http://evil.example"])(
+    "refuses to carry the off-origin destination %s",
+    async (next) => {
+      const { kv, store } = makeKv();
+      const res = await makeApp().fetch(
+        new Request(`http://localhost/auth/google?next=${encodeURIComponent(next)}`),
+        makeEnv(kv),
+      );
+
+      expect(store.get(`oauth_state:${stateFrom(res)}`)).toBe("1");
+    },
+  );
+
+  it("sends a sign-in that asked for nothing to the home page", async () => {
+    mockGoogleIdentity();
+    const { kv } = makeKv();
+    const env = makeEnv(kv);
+    const app = makeApp();
+
+    const state = stateFrom(await app.fetch(new Request("http://localhost/auth/google"), env));
+
+    const res = await app.fetch(
+      new Request(`http://localhost/auth/google/callback?code=ok&state=${state}`, {
+        headers: { Cookie: `stratum_oauth_state=${state}` },
+      }),
+      env,
+    );
+
+    expect(res.headers.get("Location")).toBe("/");
+  });
+
+  // A state minted by the previous revision holds the literal "1"; one still in
+  // flight when this deploy lands must validate rather than 400.
+  it("accepts a state minted before destinations were carried", async () => {
+    mockGoogleIdentity();
+    const { kv } = makeKv({ "oauth_state:legacy": "1" });
+
+    const res = await makeApp().fetch(
+      new Request("http://localhost/auth/google/callback?code=ok&state=legacy", {
+        headers: { Cookie: "stratum_oauth_state=legacy" },
+      }),
+      makeEnv(kv),
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/");
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -137,7 +137,7 @@ REPO_DO_ENABLED = "false"
 # Set these to your own host when self-hosting (and register the callback URLs
 # in your GitHub/Google OAuth apps):
 OAUTH_REDIRECT_URI = "http://localhost:8787/auth/github/callback"
-# GOOGLE_REDIRECT_URI = "https://your-app.example.com/auth/google/callback"
+GOOGLE_REDIRECT_URI = "http://localhost:8787/auth/google/callback"
 # Closed-beta gate (hosted-only; leave unset/commented for ungated self-hosting).
 # The gate turns ON only when BETA_GATE = "1" AND REFERRAL_SERVICE_URL is set.
 # BETA_GATE = "1"
@@ -390,6 +390,7 @@ REPO_DO_ENABLED = "true"
 # flip production once validated end-to-end against real Artifacts.
 GIT_PUSH_GATED_ENABLED = "true"
 OAUTH_REDIRECT_URI = "https://staging.app.usestratum.dev/auth/github/callback"
+GOOGLE_REDIRECT_URI = "https://staging.app.usestratum.dev/auth/google/callback"
 EMAIL_FROM_ADDRESS = "noreply@staging.app.usestratum.dev"
 # Closed beta — validate the invite gate on staging before prod. Points at the
 # live stratum-landing Worker (see [env.production.vars] cutover note).


### PR DESCRIPTION
Two configuration-shaped gaps kept the OAuth support that already exists from
being usable once its providers are configured.

Only [env.production.vars] declared GOOGLE_REDIRECT_URI, which the Google
routes require, so /auth/google answered 501 on staging and under `wrangler
dev` no matter which secrets were set: named environments replace top-level
[vars] rather than inheriting them, and staging never re-declared it while the
top-level copy stayed commented out pointing at an example host. Both now
declare their own callback next to the GitHub one.

The GitHub callback read `next` from its own query string, where it could not
arrive — an authorization server echoes back `code` and `state` and drops
whatever else the sign-in link carried — so the destination was silently lost
and every sign-in landed on /. The destination now rides on the state record
in KV, which does survive the round trip, and both callbacks honour it. States
minted before this hold the literal "1", the no-destination marker, so one in
flight across the deploy still validates.

Off-origin destinations are refused at both ends: a target that resolves to a
foreign host when parsed against a dummy base is dropped when the state is
minted, and again when it is read back. An open redirect out of a sign-in flow
is worth the second check — the victim lands on the attacker's page having
just authenticated for real.

Also documents the Google client secrets, which the deployment guide had never
mentioned, along with the asymmetric redirect-URI var names and staging's
invite gate making OAuth login-only there.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X1sowhUZET4CztHchPxngC