### PR TITLE
Add a profile page, and make invite codes retrievable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Minting an agent token from the settings form requires a browser session.**
+  `POST /settings/agents` and `POST /settings/agents/:id/delete` loaded the user
+  but never checked *how* they authenticated, so a scoped `read_write` API token
+  could post to the form and receive a fresh agent token — a credential that
+  outlives the token that minted it, which is exactly the circularity #254 closed
+  for `/settings/tokens`. Both are now behind the same session-only guard.
+  This closes the browser form only: `POST /api/agents` and
+  `DELETE /api/agents/:id` still accept any authenticated caller, so the
+  capability is not gone. Closing that too is a breaking change for automation
+  that provisions agents with an API token, and is left as a deliberate decision
+  rather than folded into this change.
+
 ### Added
 - **A profile page, and invite codes you can actually find.** `/profile` (linked
   from the header, next to settings) shows your account identity — username,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate was on stay visible to their owners after signups reopen, and an
   unreachable service reports itself as such instead of rendering as "you have no
   codes". Requires the referral service to serve
-  `GET /api/referral/codes?userId=…` (contract in `wrangler.toml`); the page is
-  not rendered at all on instances with no referral service, which is every
-  ungated self-hosted deployment. Like `/settings`, it is session-only: an API
-  token cannot enumerate your codes.
+  `GET /api/referral/codes?userId=…` (contract in `wrangler.toml`). On an
+  instance with no referral service — every ungated self-hosted deployment — the
+  page still renders its account details, just without the invite section. Like
+  `/settings`, it is session-only: an API token cannot enumerate your codes.
 - **CLI and MCP server guides.** Dedicated documentation for `@stratum/cli`
   (`docs/user-guide/cli.md`) and `@stratum/mcp` (`docs/user-guide/mcp.md`),
   published at `/guides/cli/` and `/guides/mcp/` — installation from source,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **A profile page, and invite codes you can actually find.** `/profile` (linked
+  from the header, next to settings) shows your account identity — username,
+  email, member since, and any linked GitHub account — plus the invite codes
+  issued to your account, each with a share link and whether it has been
+  redeemed. Codes previously existed only in the one email sent at signup, which
+  is best-effort and skipped entirely when the instance has no email binding
+  configured, so a lost or never-sent email meant unreachable codes; they can now
+  be read back from the referral service on demand. The listing keys off
+  `REFERRAL_SERVICE_URL` alone rather than `BETA_GATE`, so codes minted while the
+  gate was on stay visible to their owners after signups reopen, and an
+  unreachable service reports itself as such instead of rendering as "you have no
+  codes". Requires the referral service to serve
+  `GET /api/referral/codes?userId=…` (contract in `wrangler.toml`); the page is
+  not rendered at all on instances with no referral service, which is every
+  ungated self-hosted deployment. Like `/settings`, it is session-only: an API
+  token cannot enumerate your codes.
 - **CLI and MCP server guides.** Dedicated documentation for `@stratum/cli`
   (`docs/user-guide/cli.md`) and `@stratum/mcp` (`docs/user-guide/mcp.md`),
   published at `/guides/cli/` and `/guides/mcp/` — installation from source,

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -221,6 +221,28 @@ Events also carry identity attribution: the `distinctId` is the acting user or
 agent id (or `server` for unattributed requests, which are marked personless) so
 usage can be counted per account.
 
+## Where are my invite codes?
+
+Open **`/profile`** (the *profile* link in the header). If your account was
+issued invite codes, they are listed there with a share link for each one and
+whether it has been redeemed yet — codes you can still give away are marked
+*Available*.
+
+Codes are issued only on an instance running the optional closed-beta gate, and
+only to accounts that joined through it. If you signed up while signups were
+open, you have no codes and the page says so. The hosted instance
+(`app.usestratum.dev`) has open signup, so most accounts there hold none.
+
+Send someone the share link rather than the bare code: it carries `?ref=<code>`,
+which fills the code in for them on the signup form. Each code admits one
+person, and a redeemed code cannot be reused.
+
+The page also stays useful after the gate is switched off — codes minted while
+it was on remain listed and redeemable, so the listing keys off the invite
+service being configured rather than off the gate. If the page says your codes
+could not be loaded, that is a temporary problem reaching the invite service;
+nothing has been lost, and a reload once it recovers shows them again.
+
 ## What if my policy file has a mistake in it?
 
 A present-but-malformed `.stratum/policy.yaml` fails closed: the merge gate

--- a/src/beta/gate.ts
+++ b/src/beta/gate.ts
@@ -9,6 +9,7 @@
  * - betaGateEnabled: is the gate switched on and pointed at a service?
  * - validateInviteCode: is this code redeemable? (pre-createUser check)
  * - admitUser: record the redemption + mint the user's 5 codes (post-createUser)
+ * - fetchInviteCodes: read back the codes a user already holds (profile page)
  */
 import type { Env } from "../types";
 import type { Logger } from "../utils/logger";
@@ -114,5 +115,98 @@ export async function admitUser(
       userId: params.userId,
     });
     return { codes: [], referrerUserId: null };
+  }
+}
+
+/**
+ * One of the caller's own invite codes, with whatever the service knows about
+ * its redemption. `redeemedAt === null` means the code is still spendable.
+ */
+export interface InviteCodeStatus {
+  code: string;
+  redeemedAt: string | null;
+  /** Display name of whoever redeemed it, when the service reports one. */
+  redeemedBy: string | null;
+}
+
+/**
+ * "No codes" and "we could not ask" are different answers and must not render
+ * the same: telling someone their code list is empty when the service is down
+ * reads as "your codes are gone".
+ */
+export type InviteCodesResult =
+  | { status: "ok"; codes: InviteCodeStatus[] }
+  | { status: "unavailable" };
+
+/** The service holds codes minted under the gate; they outlive the gate itself. */
+export function referralServiceConfigured(env: Env): boolean {
+  return !!env.REFERRAL_SERVICE_URL;
+}
+
+/**
+ * Normalize one entry of the service's `codes` array. `/admit` returns bare
+ * strings, so both shapes are accepted rather than making the two endpoints
+ * disagree. Anything else is dropped — a malformed entry must not render as a
+ * blank code someone might try to share.
+ */
+function parseCodeEntry(entry: unknown): InviteCodeStatus | null {
+  if (typeof entry === "string") {
+    const code = entry.trim();
+    return code ? { code, redeemedAt: null, redeemedBy: null } : null;
+  }
+  if (typeof entry !== "object" || entry === null) return null;
+  const record = entry as Record<string, unknown>;
+  const code = typeof record.code === "string" ? record.code.trim() : "";
+  if (!code) return null;
+  return {
+    code,
+    redeemedAt: typeof record.redeemedAt === "string" ? record.redeemedAt : null,
+    redeemedBy: typeof record.redeemedBy === "string" ? record.redeemedBy : null,
+  };
+}
+
+/**
+ * Fetch the invite codes minted for a user, so they can be shown in-app rather
+ * than living only in the one email sent at signup (which is best-effort and
+ * silently skipped when no email binding is configured).
+ *
+ * Read-only and never on the signup path, so unlike `validateInviteCode` this
+ * fails *open-ended* rather than closed: an outage reports "unavailable" and
+ * the page says so, because withholding a shareable code is not a security
+ * boundary and a wrong "you have none" is the worse answer.
+ */
+export async function fetchInviteCodes(
+  env: Env,
+  userId: string,
+  logger: Logger,
+): Promise<InviteCodesResult> {
+  if (!referralServiceConfigured(env)) return { status: "ok", codes: [] };
+
+  try {
+    const url = `${serviceUrl(env, "/api/referral/codes")}?userId=${encodeURIComponent(userId)}`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${env.REFERRAL_SERVICE_SECRET ?? ""}` },
+      signal: AbortSignal.timeout(REFERRAL_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      logger.warn("Invite code lookup returned non-OK", { status: res.status, userId });
+      return { status: "unavailable" };
+    }
+    const data = (await res.json()) as { codes?: unknown };
+    if (!Array.isArray(data.codes)) {
+      logger.warn("Invite code lookup returned no code list", { userId });
+      return { status: "unavailable" };
+    }
+    const codes: InviteCodeStatus[] = [];
+    for (const entry of data.codes) {
+      const parsed = parseCodeEntry(entry);
+      if (parsed) codes.push(parsed);
+    }
+    return { status: "ok", codes };
+  } catch (error) {
+    logger.error("Invite code lookup failed", error instanceof Error ? error : undefined, {
+      userId,
+    });
+    return { status: "unavailable" };
   }
 }

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
+import { fetchInviteCodes, referralServiceConfigured } from "../beta/gate";
 import { isScopedTokenCaller } from "../middleware/auth";
 import { createAgent, deleteAgent, getAgent, listAgents } from "../storage/agents";
 import {
@@ -61,6 +62,7 @@ import { FileViewerPage } from "../ui/pages/file-viewer";
 import { HomePage } from "../ui/pages/home";
 import { IssueDetailPage, IssuesPage, NewIssuePage } from "../ui/pages/issues";
 import { NewProjectPage } from "../ui/pages/new-project";
+import { ProfilePage } from "../ui/pages/profile";
 import { ProjectSettingsPage } from "../ui/pages/project-settings";
 import { RepoPage } from "../ui/pages/repo";
 import { type FreshCredential, type SettingsNotice, SettingsPage } from "../ui/pages/settings";
@@ -212,35 +214,54 @@ async function loadAgentSummaries(
   }));
 }
 
-type SettingsUser = { id: string; email: string; username: string };
+/**
+ * The account pages need more of the user row than the page header does:
+ * `createdAt` and the linked GitHub handle for the profile, plus the telemetry
+ * preference (#257) for settings.
+ */
+type AccountUser = {
+  id: string;
+  email: string;
+  username: string;
+  createdAt: string;
+  githubUsername?: string;
+};
 
 /**
- * The settings page needs the telemetry preference (#257) on top of the page
- * identity `getCurrentUser` returns. Both come off the same row, so this reads
- * it once rather than widening `PageUser` — which is threaded through every
- * page header — or paying a second lookup for one checkbox.
+ * Every field above comes off the same row, so this reads it once rather than
+ * widening `PageUser` — which is threaded through every page header — or paying
+ * a second lookup per extra field.
  */
-async function getSettingsUser(
+async function getAccountUser(
   c: { get: (key: "userId") => string | undefined; env: { DB: D1Database } },
   logger: ReturnType<typeof createLogger>,
-): Promise<{ user: SettingsUser; telemetryOptOut: boolean } | null> {
+): Promise<{ user: AccountUser; telemetryOptOut: boolean } | null> {
   const userId = c.get("userId");
   if (!userId) return null;
   const result = await getUser(c.env.DB, userId, logger);
   if (!result.success) return null;
 
-  const { id, email, username, telemetryOptOut } = result.data;
-  return { user: { id, email, username }, telemetryOptOut: telemetryOptOut === true };
+  const { id, email, username, createdAt, githubUsername, telemetryOptOut } = result.data;
+  return {
+    user: {
+      id,
+      email,
+      username,
+      createdAt,
+      ...(githubUsername !== undefined ? { githubUsername } : {}),
+    },
+    telemetryOptOut: telemetryOptOut === true,
+  };
 }
 
 const sessionRequiredError = () => (
   <div style="padding:2rem;font-family:monospace;color:#f87171;">
-    Settings require a signed-in browser session, not an API token.
+    Account pages require a signed-in browser session, not an API token.
   </div>
 );
 
 /**
- * Resolves the settings caller, insisting on a browser SESSION (#254).
+ * Resolves the caller of an account page, insisting on a browser SESSION (#254).
  *
  * These pages mint, revoke, and disable credentials, so the rule the JSON
  * routes enforce (`requireSession` in `routes/users.ts`) has to hold here too:
@@ -250,17 +271,20 @@ const sessionRequiredError = () => (
  * replacement. A read-only token never reaches the POSTs — `authMiddleware`
  * refuses it on method — but it could still read this listing, so the check is
  * on the session, not on the scope.
+ *
+ * `/profile` is behind the same guard: it lists shareable invite codes, and a
+ * leaked read-only token must not be able to enumerate and spend them.
  */
-async function requireSettingsSession(
+async function requireAccountSession(
   c: Context<{ Bindings: Env }>,
   logger: ReturnType<typeof createLogger>,
 ): Promise<
-  { user: SettingsUser; telemetryOptOut: boolean } | { response: Response | Promise<Response> }
+  { user: AccountUser; telemetryOptOut: boolean } | { response: Response | Promise<Response> }
 > {
-  const loaded = await getSettingsUser(c, logger);
+  const loaded = await getAccountUser(c, logger);
   if (!loaded) return { response: c.redirect("/auth/email") };
   if (c.get("authVia") !== "session") {
-    logger.warn("Settings rejected - not a session caller", {});
+    logger.warn("Account page rejected - not a session caller", {});
     return { response: c.html(sessionRequiredError(), 403) };
   }
   return loaded;
@@ -288,7 +312,7 @@ async function loadApiTokens(
 /** The settings page plus everything it lists, in one round of loads. */
 async function renderSettings(
   c: Context<{ Bindings: Env }>,
-  user: SettingsUser,
+  user: AccountUser,
   telemetryOptOut: boolean,
   logger: ReturnType<typeof createLogger>,
   extras: { freshToken?: FreshCredential; notice?: SettingsNotice } = {},
@@ -332,10 +356,35 @@ const SETTINGS_NOTICES: Record<string, SettingsNotice> = {
   },
 };
 
+// GET /profile — Account identity and the caller's own invite codes
+app.get("/profile", async (c) => {
+  const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
+  const access = await requireAccountSession(c, logger);
+  if ("response" in access) return access.response;
+
+  // Keyed off the service URL alone, not `betaGateEnabled`: codes minted while
+  // the gate was on stay redeemable after it is switched off, so gating the
+  // listing on the gate would hide real codes from the users holding them.
+  const invites = referralServiceConfigured(c.env)
+    ? await fetchInviteCodes(c.env, access.user.id, logger)
+    : undefined;
+
+  return c.html(
+    <ProfilePage
+      user={access.user}
+      {...(invites !== undefined ? { invites } : {})}
+      {...(c.env.REFERRAL_SERVICE_URL !== undefined
+        ? { shareBaseUrl: c.env.REFERRAL_SERVICE_URL }
+        : {})}
+      nonce={c.get("cspNonce") ?? ""}
+    />,
+  );
+});
+
 // GET /settings — Account, privacy, API token, and agent token management
 app.get("/settings", async (c) => {
   const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
-  const access = await requireSettingsSession(c, logger);
+  const access = await requireAccountSession(c, logger);
   if ("response" in access) return access.response;
 
   // Own keys only: a bare index lookup would resolve `?notice=constructor`
@@ -384,7 +433,7 @@ function parseTokenForm(
 // POST /settings/tokens — Mint a named API token; renders the plaintext once
 app.post("/settings/tokens", async (c) => {
   const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
-  const access = await requireSettingsSession(c, logger);
+  const access = await requireAccountSession(c, logger);
   if ("response" in access) return access.response;
   const user = access.user;
 
@@ -444,7 +493,7 @@ app.post("/settings/tokens", async (c) => {
 // POST /settings/tokens/:id/revoke — Revoke one of the caller's own tokens
 app.post("/settings/tokens/:id/revoke", async (c) => {
   const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
-  const access = await requireSettingsSession(c, logger);
+  const access = await requireAccountSession(c, logger);
   if ("response" in access) return access.response;
 
   const { id } = c.req.param();
@@ -479,7 +528,7 @@ app.post("/settings/tokens/:id/revoke", async (c) => {
 // POST /settings/legacy-token/disable — Turn off the pre-scopes credential
 app.post("/settings/legacy-token/disable", async (c) => {
   const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
-  const access = await requireSettingsSession(c, logger);
+  const access = await requireAccountSession(c, logger);
   if ("response" in access) return access.response;
 
   const disableResult = await disableLegacyToken(c.env.DB, access.user.id, logger);
@@ -501,13 +550,13 @@ app.post("/settings/legacy-token/disable", async (c) => {
 
 // POST /settings/telemetry — Set the per-user product-analytics preference
 //
-// Not behind `requireSettingsSession`: this changes the caller's own analytics
+// Not behind `requireAccountSession`: this changes the caller's own analytics
 // preference, it does not mint or revoke a credential, so the circularity that
 // makes the token routes session-only does not apply. A read-only token is
 // already refused on method by `authMiddleware`.
 app.post("/settings/telemetry", async (c) => {
   const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
-  const loaded = await getSettingsUser(c, logger);
+  const loaded = await getAccountUser(c, logger);
   if (!loaded) return c.redirect("/auth/login");
   const { user } = loaded;
 
@@ -547,11 +596,11 @@ app.post("/settings/telemetry", async (c) => {
 // POST /settings/rotate-token — Rotate the API key; renders the new key once
 app.post("/settings/rotate-token", async (c) => {
   const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
-  const loaded = await getSettingsUser(c, logger);
+  const loaded = await getAccountUser(c, logger);
   if (!loaded) return c.redirect("/auth/login");
   const { user, telemetryOptOut } = loaded;
 
-  // Not `requireSettingsSession`: the legacy key must keep rotating for callers
+  // Not `requireAccountSession`: the legacy key must keep rotating for callers
   // that predate #254. Only a SCOPED token is refused, because the key it would
   // mint never expires and survives revocation of the token that minted it.
   if (isScopedTokenCaller(c)) {
@@ -582,7 +631,7 @@ app.post("/settings/rotate-token", async (c) => {
 // POST /settings/agents — Create an agent token; renders it once
 app.post("/settings/agents", async (c) => {
   const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
-  const loaded = await getSettingsUser(c, logger);
+  const loaded = await getAccountUser(c, logger);
   if (!loaded) return c.redirect("/auth/login");
   const { user, telemetryOptOut } = loaded;
 

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -629,11 +629,18 @@ app.post("/settings/rotate-token", async (c) => {
 });
 
 // POST /settings/agents — Create an agent token; renders it once
+//
+// Behind `requireAccountSession` for the same reason as `/settings/tokens`: an
+// agent token is a long-lived credential that outlives the credential that
+// minted it, so letting a scoped `read_write` token mint one would leave
+// "revoke the lost laptop" incomplete. Note this closes the browser form only —
+// `POST /api/agents` still accepts any authenticated caller, so the capability
+// is not gone, just no longer reachable by two doors with different rules.
 app.post("/settings/agents", async (c) => {
   const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
-  const loaded = await getAccountUser(c, logger);
-  if (!loaded) return c.redirect("/auth/login");
-  const { user, telemetryOptOut } = loaded;
+  const access = await requireAccountSession(c, logger);
+  if ("response" in access) return access.response;
+  const { user, telemetryOptOut } = access;
 
   const form = await c.req.parseBody();
   const name = typeof form.name === "string" ? form.name.trim().slice(0, 100) : "";
@@ -664,10 +671,15 @@ app.post("/settings/agents", async (c) => {
 });
 
 // POST /settings/agents/:id/delete — Revoke an agent token
+//
+// Session-only alongside its create counterpart: revocation is half of the
+// same credential-management surface, and a token that could revoke its owner's
+// agents can lock them out of their own automation.
 app.post("/settings/agents/:id/delete", async (c) => {
   const logger = createLogger({ path: c.req.path, userId: c.get("userId") });
-  const user = await getCurrentUser(c, logger);
-  if (!user) return c.redirect("/auth/login");
+  const access = await requireAccountSession(c, logger);
+  if ("response" in access) return access.response;
+  const { user } = access;
 
   const { id } = c.req.param();
   const agentResult = await getAgent(c.env.DB, id, logger);

--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -36,6 +36,9 @@ export const Layout: FC<LayoutProps> = ({ title, user, refreshSeconds, children 
                 <a href="/new" class="nav-auth-link">
                   new project
                 </a>
+                <a href="/profile" class="nav-auth-link">
+                  profile
+                </a>
                 <a href="/settings" class="nav-auth-link">
                   settings
                 </a>

--- a/src/ui/pages/profile.tsx
+++ b/src/ui/pages/profile.tsx
@@ -1,0 +1,226 @@
+import type { FC } from "hono/jsx";
+import type { InviteCodeStatus, InviteCodesResult } from "../../beta/gate";
+import { Layout } from "../layout";
+
+interface ProfileUser {
+  id: string;
+  email: string;
+  username: string;
+  createdAt: string;
+  githubUsername?: string;
+}
+
+interface ProfilePageProps {
+  user: ProfileUser;
+  /**
+   * Absent when no referral service is configured (every self-hosted instance,
+   * and any deployment that never ran the closed beta) — the invite section is
+   * then not rendered at all rather than rendered empty.
+   */
+  invites?: InviteCodesResult;
+  /** Origin for share links, e.g. https://referral.usestratum.dev. */
+  shareBaseUrl?: string;
+  /** Per-request CSP nonce for the copy-button script. */
+  nonce?: string;
+}
+
+function formatDate(iso: string): string {
+  const parsed = new Date(iso);
+  // Show the raw value rather than "Invalid Date": it is at least evidence of
+  // what is stored. Same rule as the settings page.
+  return Number.isNaN(parsed.getTime()) ? iso : parsed.toLocaleDateString();
+}
+
+function shareLink(base: string | undefined, code: string): string | null {
+  if (!base) return null;
+  return `${base.replace(/\/$/, "")}/?ref=${encodeURIComponent(code)}`;
+}
+
+/**
+ * Copies the text of the element named by `data-copy-target`. One delegated
+ * listener rather than a script per row, and the value is read out of the DOM
+ * instead of being interpolated into JS — a code must never reach a script
+ * body, where escaping it correctly is a fresh chance to get it wrong.
+ */
+const COPY_CODE_SCRIPT = `
+(function () {
+  var buttons = document.querySelectorAll('[data-copy-target]');
+  Array.prototype.forEach.call(buttons, function (btn) {
+    var target = document.getElementById(btn.getAttribute('data-copy-target'));
+    if (!target) return;
+    var label = btn.textContent;
+    btn.addEventListener('click', function () {
+      // Clipboard API can be missing (insecure context) or blocked by policy;
+      // fall back to selecting the value so a manual Ctrl/Cmd+C still works.
+      var fallback = function () {
+        var range = document.createRange();
+        range.selectNodeContents(target);
+        var sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+        btn.textContent = 'Ctrl/Cmd+C';
+        setTimeout(function () { btn.textContent = label; }, 3000);
+      };
+      if (!navigator.clipboard || !navigator.clipboard.writeText) {
+        fallback();
+        return;
+      }
+      navigator.clipboard.writeText(target.textContent).then(function () {
+        btn.textContent = 'Copied';
+        setTimeout(function () { btn.textContent = label; }, 2000);
+      }, fallback);
+    });
+  });
+})();
+`;
+
+const InviteCodeRow: FC<{ entry: InviteCodeStatus; index: number; shareBaseUrl?: string }> = ({
+  entry,
+  index,
+  shareBaseUrl,
+}) => {
+  const redeemed = entry.redeemedAt !== null;
+  const link = shareLink(shareBaseUrl, entry.code);
+  // The id only has to be unique within the page; the code itself is not used,
+  // so a code containing characters illegal in an id cannot break the wiring.
+  const linkId = `invite-link-${index}`;
+  const codeId = `invite-code-${index}`;
+  return (
+    <tr>
+      <td>
+        <code class="mono" id={codeId}>
+          {entry.code}
+        </code>
+      </td>
+      <td>
+        {link === null ? (
+          <span class="text-muted">—</span>
+        ) : (
+          <code class="mono invite-share-link" id={linkId}>
+            {link}
+          </code>
+        )}
+      </td>
+      <td>
+        {redeemed ? (
+          <span class="badge badge-merged">
+            Redeemed {entry.redeemedAt === null ? "" : formatDate(entry.redeemedAt)}
+            {entry.redeemedBy === null ? "" : ` by ${entry.redeemedBy}`}
+          </span>
+        ) : (
+          <span class="badge badge-open">Available</span>
+        )}
+      </td>
+      <td>
+        {redeemed ? (
+          <span class="text-muted">—</span>
+        ) : (
+          <button
+            type="button"
+            class="btn btn-small"
+            data-copy-target={link === null ? codeId : linkId}
+          >
+            Copy
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+};
+
+const InviteCodesCard: FC<{
+  invites: InviteCodesResult;
+  shareBaseUrl?: string;
+  nonce?: string;
+}> = ({ invites, shareBaseUrl, nonce }) => {
+  const codes = invites.status === "ok" ? invites.codes : [];
+  const available = codes.filter((entry) => entry.redeemedAt === null).length;
+  return (
+    <div class="card">
+      <h3 style={{ marginTop: 0 }}>Invite codes</h3>
+      {invites.status === "unavailable" ? (
+        <p class="settings-help" style={{ color: "#f87171" }}>
+          Your invite codes could not be loaded right now. This is a temporary problem reaching the
+          invite service — your codes have not been lost. Try again shortly.
+        </p>
+      ) : codes.length === 0 ? (
+        <p class="settings-help">
+          You have no invite codes. Codes are issued when you join through the closed beta; if you
+          signed up while signups were open, there is nothing to share here.
+        </p>
+      ) : (
+        <>
+          <p class="settings-help">
+            Each code lets one person create an account. Send someone the share link and their code
+            is filled in for them at signup. {available} of {codes.length}{" "}
+            {codes.length === 1 ? "code is" : "codes are"} still available.
+          </p>
+          <div class="table-scroll">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Code</th>
+                  <th>Share link</th>
+                  <th>Status</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {codes.map((entry, index) => (
+                  <InviteCodeRow
+                    key={entry.code}
+                    entry={entry}
+                    index={index}
+                    {...(shareBaseUrl !== undefined ? { shareBaseUrl } : {})}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {nonce !== undefined && (
+            <script nonce={nonce} dangerouslySetInnerHTML={{ __html: COPY_CODE_SCRIPT }} />
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export const ProfilePage: FC<ProfilePageProps> = ({ user, invites, shareBaseUrl, nonce }) => (
+  <Layout title="Profile" user={user}>
+    <div class="page-header">
+      <h1>Profile</h1>
+    </div>
+
+    <div class="card">
+      <h3 style={{ marginTop: 0 }}>Account</h3>
+      <dl class="detail-list">
+        <dt>Username</dt>
+        <dd>@{user.username}</dd>
+        <dt>Email</dt>
+        <dd>{user.email}</dd>
+        <dt>Member since</dt>
+        <dd>{formatDate(user.createdAt)}</dd>
+        {user.githubUsername !== undefined && (
+          <>
+            <dt>GitHub</dt>
+            <dd>
+              <a href={`https://github.com/${user.githubUsername}`}>@{user.githubUsername}</a>
+            </dd>
+          </>
+        )}
+      </dl>
+      <p class="settings-help">
+        Credentials, API tokens, and privacy live in <a href="/settings">settings</a>.
+      </p>
+    </div>
+
+    {invites !== undefined && (
+      <InviteCodesCard
+        invites={invites}
+        {...(shareBaseUrl !== undefined ? { shareBaseUrl } : {})}
+        {...(nonce !== undefined ? { nonce } : {})}
+      />
+    )}
+  </Layout>
+);

--- a/src/ui/pages/settings.tsx
+++ b/src/ui/pages/settings.tsx
@@ -192,6 +192,10 @@ export const SettingsPage: FC<SettingsPageProps> = ({
           <dt>Email</dt>
           <dd>{user.email}</dd>
         </dl>
+        <p class="settings-help">
+          Your <a href="/profile">profile</a> has your account details and any invite codes you
+          hold.
+        </p>
       </div>
 
       <div class="card">

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -918,6 +918,10 @@ ${NAV_CSS}
 .token-reveal-row { display: flex; gap: 0.5rem; align-items: stretch; flex-wrap: wrap; }
 .token-reveal-row .settings-token { flex: 1; min-width: 240px; }
 
+/* Profile: invite codes. The share link is the long column, so it is the one
+   allowed to wrap; the code itself stays on one line to stay readable. */
+.invite-share-link { word-break: break-all; font-size: 0.8rem; color: var(--accent-text); }
+
 /* New project form: CSS-only mode toggle (script only re-points the action) */
 .mode-toggle { display: flex; gap: 0.5rem; margin-bottom: 1.25rem; flex-wrap: wrap; }
 .mode-toggle label {

--- a/tests/beta-gate.test.ts
+++ b/tests/beta-gate.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { admitUser, betaGateEnabled, validateInviteCode } from "../src/beta/gate";
+import {
+  admitUser,
+  betaGateEnabled,
+  fetchInviteCodes,
+  referralServiceConfigured,
+  validateInviteCode,
+} from "../src/beta/gate";
 import type { Env } from "../src/types";
 import type { Logger } from "../src/utils/logger";
 
@@ -124,5 +130,103 @@ describe("admitUser", () => {
       noopLogger,
     );
     expect(result).toEqual({ codes: [], referrerUserId: null });
+  });
+});
+
+describe("referralServiceConfigured", () => {
+  it("is false with no service URL", () => {
+    expect(referralServiceConfigured(env())).toBe(false);
+  });
+
+  // The gate and the service are deliberately decoupled: codes minted while the
+  // gate was on must stay listable after it is switched off (production runs
+  // BETA_GATE = "0" with the service still pointed at).
+  it("is true from the URL alone, whatever BETA_GATE says", () => {
+    expect(referralServiceConfigured(env({ REFERRAL_SERVICE_URL: "https://x.dev" }))).toBe(true);
+    expect(
+      referralServiceConfigured(env({ BETA_GATE: "0", REFERRAL_SERVICE_URL: "https://x.dev" })),
+    ).toBe(true);
+  });
+});
+
+describe("fetchInviteCodes", () => {
+  const e = env({ REFERRAL_SERVICE_URL: "https://x.dev/", REFERRAL_SERVICE_SECRET: "s3cret" });
+
+  it("returns an empty list without calling the service when none is configured", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    expect(await fetchInviteCodes(env(), "usr_1", noopLogger)).toEqual({ status: "ok", codes: [] });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("sends the shared secret and the user id, against a single-slash URL", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ codes: [] }), { status: 200 }));
+    await fetchInviteCodes(e, "usr 1", noopLogger);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+      "https://x.dev/api/referral/codes?userId=usr%201",
+    );
+    const init = fetchSpy.mock.calls[0]?.[1];
+    expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer s3cret");
+  });
+
+  it("parses full entries and bare strings, and drops malformed ones", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          codes: [
+            { code: "AAA111", redeemedAt: "2026-01-02T00:00:00Z", redeemedBy: "bob" },
+            { code: " BBB222 " },
+            "CCC333",
+            { code: "   " },
+            { redeemedAt: "2026-01-02T00:00:00Z" },
+            42,
+            null,
+            "",
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    const result = await fetchInviteCodes(e, "usr_1", noopLogger);
+    expect(result).toEqual({
+      status: "ok",
+      codes: [
+        { code: "AAA111", redeemedAt: "2026-01-02T00:00:00Z", redeemedBy: "bob" },
+        { code: "BBB222", redeemedAt: null, redeemedBy: null },
+        { code: "CCC333", redeemedAt: null, redeemedBy: null },
+      ],
+    });
+  });
+
+  // "Unavailable" and "you have none" must stay distinguishable: the page says
+  // something different for each, and conflating them reads as "codes lost".
+  it("reports unavailable on a non-OK response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 404 }));
+    expect(await fetchInviteCodes(e, "usr_1", noopLogger)).toEqual({ status: "unavailable" });
+  });
+
+  it("reports unavailable when the service throws", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("down"));
+    expect(await fetchInviteCodes(e, "usr_1", noopLogger)).toEqual({ status: "unavailable" });
+  });
+
+  it("reports unavailable on a body with no code list", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    expect(await fetchInviteCodes(e, "usr_1", noopLogger)).toEqual({ status: "unavailable" });
+  });
+
+  it("reports unavailable on an unparseable body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("<html>", { status: 200 }));
+    expect(await fetchInviteCodes(e, "usr_1", noopLogger)).toEqual({ status: "unavailable" });
+  });
+
+  it("distinguishes an empty list from an outage", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ codes: [] }), { status: 200 }),
+    );
+    expect(await fetchInviteCodes(e, "usr_1", noopLogger)).toEqual({ status: "ok", codes: [] });
   });
 });

--- a/tests/profile-page.test.tsx
+++ b/tests/profile-page.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * `GET /profile`: account identity plus the caller's own invite codes.
+ *
+ * Before this page the only copy of a user's codes was the one best-effort
+ * email sent at signup — an email that is skipped entirely when no email
+ * binding is configured. These assertions cover the whole route: the session
+ * guard, the referral lookup, and the three states the code list can be in
+ * (codes, none, service unreachable).
+ *
+ * `vitest.config.ts` restricts coverage to `src/**\/*.ts`, so the `.tsx` route
+ * and page contribute nothing to the ratchet — these assertions are the only
+ * thing policing them.
+ */
+import { Hono } from "hono";
+import { renderToString } from "hono/jsx/dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../src/types";
+import { ProfilePage } from "../src/ui/pages/profile";
+
+vi.mock("../src/storage/users", () => ({
+  getUser: vi.fn(),
+  rotateUserToken: vi.fn(),
+  disableLegacyToken: vi.fn(),
+  setUserTelemetryOptOut: vi.fn(),
+}));
+vi.mock("../src/storage/agents", () => ({
+  listAgents: vi.fn(async () => ({ success: true, data: [] })),
+  createAgent: vi.fn(),
+  deleteAgent: vi.fn(),
+  getAgent: vi.fn(),
+}));
+
+import { uiRouter } from "../src/routes/ui";
+import { getUser } from "../src/storage/users";
+
+const liveUser = {
+  id: "usr_1",
+  email: "a@b.com",
+  username: "alice",
+  tokenHash: "h",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    ARTIFACTS: {} as Env["ARTIFACTS"],
+    STATE: {} as KVNamespace,
+    DB: {} as D1Database,
+    ...overrides,
+  } as Env;
+}
+
+// `null`, not `undefined`, marks the anonymous case: `undefined` would trigger
+// the default parameter and silently authenticate the request.
+function makeApp(userId: string | null = "usr_1", via: "session" | "token" = "session") {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", async (c, next) => {
+    if (userId) {
+      c.set("userId", userId);
+      c.set("authVia", via);
+    }
+    await next();
+  });
+  app.route("/", uiRouter);
+  return app;
+}
+
+const get = () => new Request("http://localhost/profile");
+
+function codesResponse(codes: unknown[]): Response {
+  return new Response(JSON.stringify({ codes }), { status: 200 });
+}
+
+describe("GET /profile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: liveUser });
+  });
+
+  it("sends an anonymous visitor to sign in", async () => {
+    const res = await makeApp(null).fetch(get(), makeEnv());
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/auth/email");
+  });
+
+  // Same rule as /settings (#254): the page lists shareable codes, so a leaked
+  // read-only API token must not be able to enumerate and spend them.
+  it("refuses an API-token caller", async () => {
+    const res = await makeApp("usr_1", "token").fetch(get(), makeEnv());
+    expect(res.status).toBe(403);
+  });
+
+  it("shows account identity", async () => {
+    const res = await makeApp().fetch(get(), makeEnv());
+    const html = await res.text();
+    expect(res.status).toBe(200);
+    expect(html).toContain("@alice");
+    expect(html).toContain("a@b.com");
+    expect(html).toContain("Member since");
+  });
+
+  it("omits the invite section entirely when no referral service is configured", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const html = await (await makeApp().fetch(get(), makeEnv())).text();
+    expect(html).not.toContain("Invite codes");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("lists codes with share links and redemption status", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      codesResponse([
+        { code: "AAA111" },
+        { code: "BBB222", redeemedAt: "2026-02-03T00:00:00Z", redeemedBy: "bob" },
+      ]),
+    );
+    const html = await (
+      await makeApp().fetch(get(), makeEnv({ REFERRAL_SERVICE_URL: "https://ref.example" }))
+    ).text();
+
+    expect(html).toContain("AAA111");
+    expect(html).toContain("https://ref.example/?ref=AAA111");
+    expect(html).toContain("Available");
+    expect(html).toContain("bob");
+    expect(html).toContain("1 of 2 codes are still available");
+  });
+
+  // The gate being off does not retract codes already minted: production runs
+  // BETA_GATE = "0" with the service still configured, and those users' codes
+  // must remain visible to them.
+  it("lists codes even when the beta gate is switched off", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(codesResponse(["AAA111"]));
+    const html = await (
+      await makeApp().fetch(
+        get(),
+        makeEnv({ BETA_GATE: "0", REFERRAL_SERVICE_URL: "https://ref.example" }),
+      )
+    ).text();
+    expect(html).toContain("AAA111");
+  });
+
+  it("says 'no codes' only when the service actually answered with none", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(codesResponse([]));
+    const html = await (
+      await makeApp().fetch(get(), makeEnv({ REFERRAL_SERVICE_URL: "https://ref.example" }))
+    ).text();
+    expect(html).toContain("You have no invite codes");
+    expect(html).not.toContain("could not be loaded");
+  });
+
+  it("says the codes could not be loaded — not that there are none — on an outage", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("down"));
+    const html = await (
+      await makeApp().fetch(get(), makeEnv({ REFERRAL_SERVICE_URL: "https://ref.example" }))
+    ).text();
+    expect(html).toContain("could not be loaded");
+    expect(html).toContain("have not been lost");
+    expect(html).not.toContain("You have no invite codes");
+  });
+
+  it("still renders the page when the referral service is down", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("down"));
+    const res = await makeApp().fetch(
+      get(),
+      makeEnv({ REFERRAL_SERVICE_URL: "https://ref.example" }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("@alice");
+  });
+});
+
+describe("ProfilePage rendering", () => {
+  const user = {
+    id: "usr_1",
+    email: "a@b.com",
+    username: "alice",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("offers a copy button only for codes that are still available", () => {
+    const html = renderToString(
+      <ProfilePage
+        user={user}
+        invites={{
+          status: "ok",
+          codes: [
+            { code: "AAA111", redeemedAt: null, redeemedBy: null },
+            { code: "BBB222", redeemedAt: "2026-02-03T00:00:00Z", redeemedBy: "bob" },
+          ],
+        }}
+        shareBaseUrl="https://ref.example"
+        nonce="n1"
+      />,
+    );
+    expect([...html.matchAll(/data-copy-target=/g)]).toHaveLength(1);
+  });
+
+  it("shows the bare code when there is no share origin to build a link from", () => {
+    const html = renderToString(
+      <ProfilePage
+        user={user}
+        invites={{ status: "ok", codes: [{ code: "AAA111", redeemedAt: null, redeemedBy: null }] }}
+        nonce="n1"
+      />,
+    );
+    expect(html).toContain("AAA111");
+    expect(html).not.toContain("?ref=");
+  });
+
+  it("links a connected GitHub account and omits the row otherwise", () => {
+    const withGitHub = renderToString(
+      <ProfilePage user={{ ...user, githubUsername: "alice-gh" }} />,
+    );
+    expect(withGitHub).toContain("https://github.com/alice-gh");
+    expect(renderToString(<ProfilePage user={user} />)).not.toContain("github.com");
+  });
+
+  // #161: with `script-src 'nonce-…'`, an un-nonced script and any inline
+  // handler are both blocked outright.
+  it("carries the CSP nonce on its script and uses no inline handlers", () => {
+    const html = renderToString(
+      <ProfilePage
+        user={user}
+        invites={{ status: "ok", codes: [{ code: "AAA111", redeemedAt: null, redeemedBy: null }] }}
+        shareBaseUrl="https://ref.example"
+        nonce="n1"
+      />,
+    );
+    const scripts = [...html.matchAll(/<script\b[^>]*>/g)].map((m) => m[0]);
+    expect(scripts.length).toBeGreaterThan(0);
+    expect(scripts.filter((tag) => !tag.includes('nonce="n1"'))).toEqual([]);
+    expect([...html.matchAll(/\son[a-z]+="/g)]).toEqual([]);
+  });
+
+  // The copy script reads the value out of the DOM; a code must never be
+  // interpolated into a script body, where one escaping slip is an XSS.
+  it("keeps codes out of the script body and escapes them in markup", () => {
+    const html = renderToString(
+      <ProfilePage
+        user={user}
+        invites={{
+          status: "ok",
+          codes: [{ code: "</script><img src=x>", redeemedAt: null, redeemedBy: null }],
+        }}
+        shareBaseUrl="https://ref.example"
+        nonce="n1"
+      />,
+    );
+    const scriptBody = html.slice(html.indexOf("<script"));
+    expect(scriptBody).not.toContain("<img src=x>");
+    expect(html).not.toContain("<img src=x>");
+  });
+});

--- a/tests/settings-tokens-ui.test.tsx
+++ b/tests/settings-tokens-ui.test.tsx
@@ -48,6 +48,7 @@ vi.mock("../src/storage/agents", () => ({
 }));
 
 import { uiRouter } from "../src/routes/ui";
+import { createAgent, deleteAgent, getAgent } from "../src/storage/agents";
 import { createApiToken, listApiTokens, revokeApiToken } from "../src/storage/api-tokens";
 import { recordAudit } from "../src/storage/audit";
 import { disableLegacyToken, rotateUserToken } from "../src/storage/users";
@@ -362,6 +363,11 @@ describe("the settings surfaces require a browser session", () => {
     { label: "create", call: (id) => post("/settings/tokens", { name: "ci" }, id) },
     { label: "revoke", call: (id) => post("/settings/tokens/tok_ci/revoke", {}, id) },
     { label: "legacy disable", call: (id) => post("/settings/legacy-token/disable", {}, id) },
+    // An agent token outlives the credential that minted it, so the same rule
+    // has to cover these two: a `read_write` token that could mint one would
+    // leave "revoke the lost laptop" incomplete.
+    { label: "agent create", call: (id) => post("/settings/agents", { name: "bot" }, id) },
+    { label: "agent revoke", call: (id) => post("/settings/agents/agt_1/delete", {}, id) },
   ];
 
   it.each(routes)("403s an API-token caller on $label", async ({ call }) => {
@@ -372,6 +378,8 @@ describe("the settings surfaces require a browser session", () => {
     expect(revokeApiToken).not.toHaveBeenCalled();
     expect(disableLegacyToken).not.toHaveBeenCalled();
     expect(listApiTokens).not.toHaveBeenCalled();
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(deleteAgent).not.toHaveBeenCalled();
   });
 
   it.each(routes)("sends an unauthenticated caller to sign in on $label", async ({ call }) => {
@@ -381,6 +389,53 @@ describe("the settings surfaces require a browser session", () => {
     expect(createApiToken).not.toHaveBeenCalled();
     expect(revokeApiToken).not.toHaveBeenCalled();
     expect(disableLegacyToken).not.toHaveBeenCalled();
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(deleteAgent).not.toHaveBeenCalled();
+  });
+
+  // A scoped token is the case #254 was written for; it must be refused here
+  // too, not merely the legacy credential.
+  it.each(routes)("403s a scoped-token caller on $label", async ({ call }) => {
+    const res = await call(SCOPED_TOKEN);
+    expect(res.status).toBe(403);
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(deleteAgent).not.toHaveBeenCalled();
+  });
+});
+
+describe("the agent surfaces still work for a browser session", () => {
+  it("mints an agent token and shows the plaintext once, uncached", async () => {
+    vi.mocked(createAgent).mockResolvedValue({
+      success: true,
+      data: { agent: { id: "agt_1" }, plaintext: "stratum_agent_fresh" },
+    } as unknown as Awaited<ReturnType<typeof createAgent>>);
+    const res = await post("/settings/agents", { name: "bot" }, SESSION);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(await res.text()).toContain("stratum_agent_fresh");
+  });
+
+  it("revokes an agent the caller owns", async () => {
+    vi.mocked(getAgent).mockResolvedValue({
+      success: true,
+      data: { id: "agt_1", ownerId: "usr_1" },
+    } as unknown as Awaited<ReturnType<typeof getAgent>>);
+    vi.mocked(deleteAgent).mockResolvedValue({
+      success: true,
+      data: undefined,
+    } as unknown as Awaited<ReturnType<typeof deleteAgent>>);
+    const res = await post("/settings/agents/agt_1/delete", {}, SESSION);
+    expect(res.status).toBe(302);
+    expect(deleteAgent).toHaveBeenCalled();
+  });
+
+  it("does not revoke an agent owned by someone else", async () => {
+    vi.mocked(getAgent).mockResolvedValue({
+      success: true,
+      data: { id: "agt_1", ownerId: "usr_other" },
+    } as unknown as Awaited<ReturnType<typeof getAgent>>);
+    await post("/settings/agents/agt_1/delete", {}, SESSION);
+    expect(deleteAgent).not.toHaveBeenCalled();
   });
 });
 

--- a/website/src/content/docs/guides/faq.md
+++ b/website/src/content/docs/guides/faq.md
@@ -225,6 +225,28 @@ Events also carry identity attribution: the `distinctId` is the acting user or
 agent id (or `server` for unattributed requests, which are marked personless) so
 usage can be counted per account.
 
+## Where are my invite codes?
+
+Open **`/profile`** (the *profile* link in the header). If your account was
+issued invite codes, they are listed there with a share link for each one and
+whether it has been redeemed yet — codes you can still give away are marked
+*Available*.
+
+Codes are issued only on an instance running the optional closed-beta gate, and
+only to accounts that joined through it. If you signed up while signups were
+open, you have no codes and the page says so. The hosted instance
+(`app.usestratum.dev`) has open signup, so most accounts there hold none.
+
+Send someone the share link rather than the bare code: it carries `?ref=<code>`,
+which fills the code in for them on the signup form. Each code admits one
+person, and a redeemed code cannot be reused.
+
+The page also stays useful after the gate is switched off — codes minted while
+it was on remain listed and redeemable, so the listing keys off the invite
+service being configured rather than off the gate. If the page says your codes
+could not be loaded, that is a temporary problem reaching the invite service;
+nothing has been lost, and a reload once it recovers shows them again.
+
 ## What if my policy file has a mistake in it?
 
 A present-but-malformed `.stratum/policy.yaml` fails closed: the merge gate

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -140,6 +140,16 @@ OAUTH_REDIRECT_URI = "http://localhost:8787/auth/github/callback"
 # GOOGLE_REDIRECT_URI = "https://your-app.example.com/auth/google/callback"
 # Closed-beta gate (hosted-only; leave unset/commented for ungated self-hosting).
 # The gate turns ON only when BETA_GATE = "1" AND REFERRAL_SERVICE_URL is set.
+#
+# The referral service must serve three endpoints:
+#   POST /api/referral/validate  {code}                 -> {valid, referrerUserId}
+#   POST /api/referral/admit     {userId,email,code,source} -> {codes[], referrerUserId}
+#   GET  /api/referral/codes?userId=…                   -> {codes: [{code, redeemedAt, redeemedBy}]}
+# The last two authenticate with `Authorization: Bearer $REFERRAL_SERVICE_SECRET`.
+# `/codes` backs the invite list on /profile; a bare string per entry is also
+# accepted, matching what /admit returns. REFERRAL_SERVICE_URL alone (without
+# BETA_GATE) still enables that listing, so codes minted while the gate was on
+# stay visible to their owners after it is switched off.
 # BETA_GATE = "1"
 # REFERRAL_SERVICE_URL = "https://your-referral-service.example.com"
 


### PR DESCRIPTION
Invite codes existed in exactly one place a user could reach: the email
sent once at signup. That send is best-effort by design (a referral
hiccup must never break a just-created account) and is skipped entirely
when the instance has no email binding, so a lost or never-sent email
left codes unreachable — the service still held them, but nothing in the
app would ask for them.

- `fetchInviteCodes` reads a user's codes back from the referral service
  (`GET /api/referral/codes`). Unlike `validateInviteCode` it does not
  fail closed: withholding a shareable code is not a security boundary,
  and "you have none" is the worse wrong answer, so an outage reports
  itself as unavailable and the page says so.
- `/profile` shows account identity plus those codes, each with a share
  link and its redemption status. Linked from the header and from the
  settings Account card.
- The listing keys off REFERRAL_SERVICE_URL alone, not BETA_GATE: codes
  minted while the gate was on stay redeemable after it is switched off
  (production runs BETA_GATE = "0" with the service still configured),
  and gating the listing on the gate would hide real codes from the
  users holding them. Instances with no referral service — every ungated
  self-hosted deployment — render no invite section at all.
- Behind the same session-only guard as /settings (#254), renamed from
  requireSettingsSession to requireAccountSession now that it guards
  more than settings: a leaked read-only token must not be able to
  enumerate and spend someone's codes.

The referral service must now serve `GET /api/referral/codes?userId=…`;
the contract for all three endpoints is documented in wrangler.toml.
Until it does, the page reports the codes as temporarily unavailable
rather than misreporting them as absent.

Verified: typecheck, lint, and the full unit suite (2899 passing) green;
coverage thresholds hold with src/beta at 100% line coverage.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CBbLcmBS1HPrzPYkWvt5Cw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an authenticated profile page showing account details and optional GitHub information.
  - Eligible users can view, copy, and share invite codes, including redemption status.
  - Added profile navigation and a settings link to account details.
  - Invite-code availability is independent of the closed-beta setting.
- **Bug Fixes**
  - Added clear states for unavailable services, empty results, and loading failures.
  - Improved handling of malformed invite-code data and temporary service outages.
  - Restricted agent-token creation and deletion to browser sessions.
- **Documentation**
  - Added FAQs and configuration guidance for invite-code eligibility, sharing, redemption, persistence, and service errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->