### PR TITLE
Let the MCP consent redirect through the CSP, and slim the consent page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   user), so an agent's feedback channel is change comments.
 
 ### Changed
+- **The MCP consent screen is shorter.** It leads with the question (allow
+  *this application* to access Stratum as *you*), the permissions it is asking
+  for, and the two buttons, with the host it returns you to on one line. The
+  full redirect address, the note that application names are self-declared, and
+  where to disconnect later are under a collapsible **Where this request came
+  from** instead of above the buttons.
 - **The MCP request body is capped at 8 MB**, below the REST API's 25 MB commit
   limit. A tool call is buffered, parsed, re-serialized into an internal request
   and parsed again, so a body near the REST limit would cost more than a Workers
@@ -193,6 +199,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a change that passed before this release may fail on re-evaluation.
 
 ### Fixed
+- **Approving an MCP connection in Chrome, Edge or Safari now completes it.**
+  The consent screen shipped the site-wide `form-action 'self'` policy, and
+  those browsers enforce that directive against the redirect that answers the
+  consent form, not just against the form's own action. Clicking Allow minted
+  an authorization code the browser then refused to deliver to the client, so
+  the page sat there and the connector never connected. Firefox does not check
+  redirects, which is why the flow appeared to work in one browser and not
+  another. The consent page now names the client's registered redirect origin
+  in its own `form-action`; every other response keeps `'self'`.
+- **The MCP `401` challenge names the scopes the endpoint needs**
+  (`scope="mcp:read mcp:write"`, RFC 6750 §3). A client that takes its scope
+  from the challenge asks for read and write up front rather than authorizing
+  read-only and failing on its first commit. A client that asks for nothing
+  still gets `mcp:read`.
 - Approvals are dismissed when the evaluated **base** moves, not only when the
   tip does. A change re-evaluated against a newer base kept approvals that were
   granted against different code.

--- a/docs/user-guide/mcp.md
+++ b/docs/user-guide/mcp.md
@@ -30,6 +30,13 @@ configure by hand.
      twice — and tells a self-hoster to point their client at someone else's
      instance. The wording above is correct in both copies. -->
 
+Claude (web, desktop and mobile), as a connector: **Settings → Connectors →
+Add custom connector**. Name it, paste `https://app.usestratum.dev/mcp` as the
+URL, and leave the advanced OAuth client id and secret blank — Stratum registers
+the client itself. Click **Connect** on the new connector and approve the
+consent screen that opens; the tools are then available in any conversation
+where the connector is enabled.
+
 Claude Code:
 
 ```bash
@@ -49,10 +56,11 @@ Any MCP client that supports remote servers:
 }
 ```
 
-The first tool call opens your browser, asks you to sign in if you are not
-already, and shows a consent screen naming the application and what it is asking
-for. Approve it once; the client stores the tokens and refreshes them on its
-own.
+Connecting opens your browser, asks you to sign in if you are not already, and
+shows a consent screen: which application is asking, what it will be able to do,
+and the host it returns you to. The full redirect address and where to
+disconnect later are one click away under **Where this request came from**.
+Approve it once; the client stores the tokens and refreshes them on its own.
 
 You never paste a Stratum credential into your editor's configuration, and you
 can withdraw access at any time from **Settings → Connected applications**
@@ -81,7 +89,8 @@ The endpoint is an OAuth 2.1 protected resource, and Stratum is the
 authorization server. A client bootstraps the whole flow from the URL alone:
 
 1. It calls `/mcp` with no credential. The `401` carries a `WWW-Authenticate`
-   header naming `/.well-known/oauth-protected-resource`.
+   header naming `/.well-known/oauth-protected-resource` and the scopes full
+   use of the endpoint needs (`scope="mcp:read mcp:write"`).
 2. That document points at `/.well-known/oauth-authorization-server`.
 3. The client registers itself at `/oauth/register`
    ([RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591) dynamic client
@@ -110,9 +119,12 @@ instance advertises itself with nothing to configure.
 | `mcp:read` | Read projects, files, changes, evaluations and issues. Exactly a read-only API token. |
 | `mcp:write` | The above, plus workspaces, commits, changes, merges, reviews and issue management. Exactly a read-write API token. |
 
-A client that asks for no scope gets `mcp:read`. A read-only grant is refused in
-the middleware, before routing, on any write request — so no route has to
-remember the rule.
+A client that asks for no scope gets `mcp:read`. Most clients do ask: the `401`
+challenge and the protected-resource metadata both list `mcp:read mcp:write`,
+and a client that follows either requests both. The consent screen spells out
+what the grant covers, so a read-only connection is a choice you can see being
+made. A read-only grant is refused in the middleware, before routing, on any
+write request — so no route has to remember the rule.
 
 The one place the check is deferred is `/mcp` itself, and only because the HTTP
 method there says nothing about the operation: every MCP call is a POST,

--- a/docs/user-guide/mcp.md
+++ b/docs/user-guide/mcp.md
@@ -119,9 +119,11 @@ instance advertises itself with nothing to configure.
 | `mcp:read` | Read projects, files, changes, evaluations and issues. Exactly a read-only API token. |
 | `mcp:write` | The above, plus workspaces, commits, changes, merges, reviews and issue management. Exactly a read-write API token. |
 
-A client that asks for no scope gets `mcp:read`. Most clients do ask: the `401`
-challenge and the protected-resource metadata both list `mcp:read mcp:write`,
-and a client that follows either requests both. The consent screen spells out
+A client that asks for no scope gets `mcp:read`. Most clients ask for more: the
+`401` challenge names `mcp:read mcp:write` as what full use of the endpoint
+needs, and the protected-resource metadata lists both scopes as supported, so a
+client that follows either discovery path can request both. Neither obliges it
+to: a client may still ask for `mcp:read` alone. The consent screen spells out
 what the grant covers, so a read-only connection is a choice you can see being
 made. A read-only grant is refused in the middleware, before routing, on any
 write request — so no route has to remember the rule.

--- a/src/middleware/security-headers.ts
+++ b/src/middleware/security-headers.ts
@@ -27,6 +27,24 @@ export function generateCspNonce(): string {
   return btoa(binary);
 }
 
+export interface CspOptions {
+  /**
+   * Extra `form-action` sources beyond `'self'`, or `null` to omit the
+   * directive entirely.
+   *
+   * Exists for one page: the OAuth consent screen (`/oauth/authorize`). Its
+   * form POSTs to us, but the RESPONSE to that POST is a redirect to the
+   * client's registered callback, and Chromium and WebKit enforce the
+   * submitting page's `form-action` against that redirect target as well as
+   * against the form's own action (the CSP spec leaves this open —
+   * w3c/webappsec-csp#8 — and Firefox does not check redirects). Under the
+   * site-wide `'self'`, clicking Allow mints an authorization code that the
+   * browser then refuses to deliver, and the page just sits there. Every other
+   * page keeps the default.
+   */
+  formAction?: string[] | null;
+}
+
 /**
  * CSP for the server-rendered UI and API, parameterized by the per-request
  * script nonce. Built in ONE place so the request middleware and the error
@@ -44,8 +62,19 @@ export function generateCspNonce(): string {
  *   scripts; the UI loads no external scripts and injects none, so granting
  *   transitive trust would only widen the policy.
  */
-export function contentSecurityPolicy(nonce: string): string {
-  return `frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-src 'none'; script-src 'nonce-${nonce}'`;
+export function contentSecurityPolicy(nonce: string, options: CspOptions = {}): string {
+  const formAction =
+    options.formAction === null
+      ? []
+      : [`form-action ${["'self'", ...(options.formAction ?? [])].join(" ")}`];
+  return [
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    ...formAction,
+    "frame-src 'none'",
+    `script-src 'nonce-${nonce}'`,
+  ].join("; ");
 }
 
 /**
@@ -56,7 +85,7 @@ export function contentSecurityPolicy(nonce: string): string {
  * already stamped, and both calls must emit the SAME policy string. HSTS is
  * applied separately — it is conditional on HTTPS.
  */
-export function setHtmlSecurityHeaders(c: Context<{ Bindings: Env }>): void {
+export function setHtmlSecurityHeaders(c: Context<{ Bindings: Env }>, options?: CspOptions): void {
   let nonce = c.get("cspNonce");
   if (nonce === undefined) {
     nonce = generateCspNonce();
@@ -65,7 +94,7 @@ export function setHtmlSecurityHeaders(c: Context<{ Bindings: Env }>): void {
   c.header("X-Content-Type-Options", "nosniff");
   c.header("X-Frame-Options", "DENY");
   c.header("Referrer-Policy", "strict-origin-when-cross-origin");
-  c.header("Content-Security-Policy", contentSecurityPolicy(nonce));
+  c.header("Content-Security-Policy", contentSecurityPolicy(nonce, options));
 }
 
 /**

--- a/src/routes/mcp-oauth.tsx
+++ b/src/routes/mcp-oauth.tsx
@@ -21,6 +21,7 @@
  */
 import type { Context } from "hono";
 import { Hono } from "hono";
+import { setHtmlSecurityHeaders } from "../middleware/security-headers";
 import { recordAudit } from "../storage/audit";
 import {
   SCOPE_WRITE,
@@ -428,7 +429,7 @@ const CONSENT_CSS = `
     padding: 2rem;
   }
   .consent-title { margin: 0 0 0.5rem; font-size: 1.25rem; }
-  .consent-detail { color: var(--text-secondary); font-size: 0.9rem; line-height: 1.5; }
+  .consent-detail { margin: 0 0 0.75rem; color: var(--text-secondary); font-size: 0.9rem; line-height: 1.5; }
   .consent-client {
     display: block;
     font-family: monospace;
@@ -447,15 +448,15 @@ const CONSENT_CSS = `
     font-size: 0.9rem;
   }
   .consent-scopes li:last-child { border-bottom: none; }
-  .consent-warn {
-    background: var(--bg-primary);
-    border-left: 3px solid var(--accent, #7ca9f7);
-    padding: 0.65rem 0.85rem;
-    margin: 0 0 1.25rem;
+  .consent-more {
+    margin-top: 1.25rem;
     font-size: 0.82rem;
     color: var(--text-secondary);
     line-height: 1.45;
   }
+  .consent-more summary { cursor: pointer; color: var(--text-muted, var(--text-secondary)); }
+  .consent-more p { margin: 0.6rem 0 0; }
+  .consent-more .consent-client { margin: 0.35rem 0 0; }
   .consent-actions { display: flex; gap: 0.75rem; }
   .consent-actions button { flex: 1; padding: 0.6rem 1rem; border-radius: 6px; cursor: pointer; font-size: 0.92rem; }
   .consent-allow { background: var(--accent, #7ca9f7); color: #0d0d0d; border: none; font-weight: 600; }
@@ -500,6 +501,15 @@ app.get("/oauth/authorize", async (c) => {
   if (!clientResult.success) {
     return renderAuthorizeError(c, "Unknown client", "This application is no longer registered.");
   }
+  const clientName = clientResult.data.clientName;
+
+  // The redirect URI is verified against the registered list by now, so the
+  // browser must be allowed to follow the redirect that answers the consent
+  // POST. Chromium and WebKit check this page's `form-action` against that
+  // redirect, and under the site-wide `'self'` they refuse it — the code is
+  // minted and never delivered, and clicking Allow visibly does nothing. See
+  // `CspOptions`.
+  setHtmlSecurityHeaders(c, { formAction: consentFormAction(params.redirectUri) });
 
   return c.html(
     <html lang="en">
@@ -513,28 +523,23 @@ app.get("/oauth/authorize", async (c) => {
       <body>
         <div class="consent-page">
           <div class="consent-card">
-            <h1 class="consent-title">Connect an application</h1>
+            <h1 class="consent-title">
+              Allow <strong>{clientName}</strong> to access Stratum?
+            </h1>
+            {/* The host it returns to is the one signal a person can actually
+                check against a self-asserted name, so it stays above the fold;
+                the full URI and the rest of the fine print are one click away. */}
             <p class="consent-detail">
-              An application calling itself <strong>{clientResult.data.clientName}</strong> wants to
-              act on Stratum as <strong>{userResult.data.username}</strong>.
+              Signed in as <strong>{userResult.data.username}</strong>. Returns you to{" "}
+              <strong>{new URL(params.redirectUri).host}</strong> when done.
             </p>
-            <p class="consent-detail">It will be sent back to:</p>
-            <code class="consent-client">{params.redirectUri}</code>
 
-            <p class="consent-detail">If you allow this, it will be able to:</p>
+            <p class="consent-detail">It will be able to:</p>
             <ul class="consent-scopes">
               {describeScope(params.scope).map((line) => (
                 <li key={line}>{line}</li>
               ))}
             </ul>
-
-            {/* Anyone can register a client under any name. Saying so is the
-                only defence against a client registered as "Stratum Official". */}
-            <p class="consent-warn">
-              Any application can register itself under any name. Only continue if you just started
-              this from <strong>{clientResult.data.clientName}</strong> yourself, and the address
-              above is one you recognise.
-            </p>
 
             <form method="post" action="/oauth/authorize">
               <input type="hidden" name="client_id" value={params.clientId} />
@@ -556,12 +561,43 @@ app.get("/oauth/authorize", async (c) => {
                 </button>
               </div>
             </form>
+
+            {/* Anyone can register a client under any name. Saying so is the
+                only defence against a client registered as "Stratum Official". */}
+            <details class="consent-more">
+              <summary>Where this request came from</summary>
+              <p>
+                Application names are self-declared: any application can register itself under any
+                name. Only continue if you started this connection from{" "}
+                <strong>{clientName}</strong> yourself.
+              </p>
+              <p>After you allow, your browser is sent to:</p>
+              <code class="consent-client">{params.redirectUri}</code>
+              <p>
+                You can disconnect it at any time from{" "}
+                <a href="/settings">Settings → Connected applications</a>.
+              </p>
+            </details>
           </div>
         </div>
       </body>
     </html>,
   );
 });
+
+/**
+ * The `form-action` sources the consent page needs: `'self'` plus the client's
+ * registered origin, which is where the post-consent redirect goes.
+ *
+ * CSP's host-source grammar has no spelling for an IPv6 literal, so a client
+ * listening on `[::1]` cannot be named; for that one case the directive is
+ * dropped on this page rather than emitted in a form the browser would discard
+ * as invalid (and then enforce as if absent — or, in Chromium, as if `'none'`).
+ */
+function consentFormAction(redirectUri: string): string[] | null {
+  const origin = new URL(redirectUri).origin;
+  return origin.includes("[") ? null : [origin];
+}
 
 app.post("/oauth/authorize", async (c) => {
   const logger = createLogger({ path: c.req.path, method: c.req.method });

--- a/src/utils/oauth-challenge.ts
+++ b/src/utils/oauth-challenge.ts
@@ -9,10 +9,13 @@
  * configured — so this header is load-bearing UX, not decoration.
  */
 
+import { SUPPORTED_SCOPES } from "../storage/oauth";
+
 /** The MCP endpoint's path.
  *
- * Lives here, in a module that imports nothing, because `authMiddleware` needs
- * it and `src/routes/mcp.ts` imports the middleware (through the dispatcher) —
+ * Lives here, in a module that imports nothing from the route or middleware
+ * layers, because `authMiddleware` needs it and `src/routes/mcp.ts` imports the
+ * middleware (through the dispatcher) —
  * defining it there and reading it from the middleware is an import cycle that
  * leaves `authMiddleware` undefined at module-init time inside the dispatcher,
  * which fails as an unauthenticated sub-request rather than as a loud error.
@@ -56,6 +59,13 @@ export function mcpResourceIdentifier(requestUrl: string): string {
  * assembled from our own message strings today, but stripping means a future
  * caller that passes something client-controlled cannot inject a second
  * auth-param, and losing a character from an English sentence costs nothing.
+ *
+ * `scope` (RFC 6750 §3) names what full use of the endpoint needs. Clients that
+ * follow the MCP authorization guidance take the scopes they request from this
+ * attribute first and from the protected-resource metadata second; a client
+ * that consults neither still gets `mcp:read` by default. Without the hint, a
+ * connector authorizes read-only and fails on its first commit with no
+ * indication that the fix is to re-authorize.
  */
 export function buildAuthenticateChallenge(
   requestUrl: string,
@@ -68,6 +78,7 @@ export function buildAuthenticateChallenge(
     [
       `error=${quoted(error)}`,
       `error_description=${quoted(description)}`,
+      `scope=${quoted(SUPPORTED_SCOPES.join(" "))}`,
       `resource_metadata=${quoted(protectedResourceMetadataUrl(requestUrl))}`,
     ].join(", "),
   ].join(" ");

--- a/tests/mcp-endpoint.test.ts
+++ b/tests/mcp-endpoint.test.ts
@@ -99,6 +99,10 @@ describe("authentication", () => {
     expect(challenge).toContain(
       `resource_metadata="${ORIGIN}/.well-known/oauth-protected-resource"`,
     );
+    // RFC 6750 §3: the scopes full use of the endpoint needs, so a client that
+    // takes its scope from the challenge asks for write access up front rather
+    // than authorizing read-only and failing on its first commit.
+    expect(challenge).toContain('scope="mcp:read mcp:write"');
 
     // And the body is a JSON-RPC error, so a client that hands the body to its
     // RPC layer before checking the status gets something parseable.

--- a/tests/mcp-oauth-flow.test.ts
+++ b/tests/mcp-oauth-flow.test.ts
@@ -16,6 +16,7 @@ import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authMiddleware } from "../src/middleware/auth";
 import { csrfMiddleware } from "../src/middleware/csrf";
+import { securityHeadersMiddleware } from "../src/middleware/security-headers";
 import { mcpOAuthRouter } from "../src/routes/mcp-oauth";
 import { createSession } from "../src/storage/sessions";
 import type { Env } from "../src/types";
@@ -133,6 +134,7 @@ beforeEach(async () => {
   CHALLENGE = await pkceChallenge(VERIFIER);
 
   app = new Hono<{ Bindings: Env }>();
+  app.use("*", securityHeadersMiddleware);
   app.use("*", authMiddleware);
   app.use("*", csrfMiddleware);
   app.route("/", mcpOAuthRouter);
@@ -230,6 +232,35 @@ describe("authorization", () => {
     expect(html).toContain("Create workspaces, commit files");
     // And the screen must say the name is self-asserted.
     expect(html).toContain("register itself under any name");
+  });
+
+  it("lets the browser follow the post-consent redirect to the client", async () => {
+    // Chromium and WebKit enforce the consent page's `form-action` against the
+    // redirect that answers its form POST. Under the site-wide `'self'`,
+    // clicking Allow minted a code the browser then refused to deliver, so this
+    // page — and only this page — has to name the client's origin. The
+    // middleware sets the site-wide policy first; the route must win.
+    const { json } = await register();
+    const url = `${ORIGIN}/oauth/authorize?response_type=code&client_id=${json.client_id}&redirect_uri=${encodeURIComponent(REDIRECT)}&code_challenge=${CHALLENGE}&code_challenge_method=S256`;
+    const consentPage = await app.fetch(
+      new Request(url, { headers: { Cookie: sessionCookie } }),
+      env,
+    );
+    expect(consentPage.status).toBe(200);
+    expect(consentPage.headers.get("Content-Security-Policy")).toContain(
+      "form-action 'self' http://127.0.0.1:9876;",
+    );
+
+    // The error page redirects nowhere, so it keeps the default.
+    const errorPage = await app.fetch(
+      new Request(
+        `${ORIGIN}/oauth/authorize?response_type=code&client_id=${json.client_id}&redirect_uri=${encodeURIComponent("https://attacker.example/steal")}&code_challenge=${CHALLENGE}&code_challenge_method=S256`,
+        { headers: { Cookie: sessionCookie } },
+      ),
+      env,
+    );
+    expect(errorPage.status).toBe(400);
+    expect(errorPage.headers.get("Content-Security-Policy")).toContain("form-action 'self';");
   });
 
   it("RENDERS rather than redirects when the redirect URI is not registered", async () => {

--- a/tests/security-headers.test.ts
+++ b/tests/security-headers.test.ts
@@ -90,6 +90,27 @@ describe("SEC-7: security headers", () => {
     expect(csp).toContain("frame-src 'none'");
   });
 
+  it("contentSecurityPolicy can widen or drop form-action for a page that redirects off-origin", () => {
+    // The OAuth consent page's form POST is answered with a redirect to the
+    // client, and Chromium checks form-action against that redirect too.
+    expect(contentSecurityPolicy("n", { formAction: ["https://claude.ai"] })).toContain(
+      "form-action 'self' https://claude.ai;",
+    );
+    expect(contentSecurityPolicy("n", { formAction: null })).not.toContain("form-action");
+    // Every other directive survives either way.
+    for (const csp of [
+      contentSecurityPolicy("n", { formAction: ["https://claude.ai"] }),
+      contentSecurityPolicy("n", { formAction: null }),
+    ]) {
+      expect(csp).toContain("frame-ancestors 'none'");
+      expect(csp).toContain("script-src 'nonce-n'");
+    }
+    // And the default is byte-for-byte what it was.
+    expect(contentSecurityPolicy("n")).toBe(
+      "frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-src 'none'; script-src 'nonce-n'",
+    );
+  });
+
   it("applies the same CSP to 500 error responses (error boundary parity)", async () => {
     // GET / renders the dashboard, which throws under the bare test env and hits
     // the error boundary — the 500 must carry the identical hardened policy.

--- a/website/src/content/docs/guides/mcp.md
+++ b/website/src/content/docs/guides/mcp.md
@@ -123,9 +123,11 @@ instance advertises itself with nothing to configure.
 | `mcp:read` | Read projects, files, changes, evaluations and issues. Exactly a read-only API token. |
 | `mcp:write` | The above, plus workspaces, commits, changes, merges, reviews and issue management. Exactly a read-write API token. |
 
-A client that asks for no scope gets `mcp:read`. Most clients do ask: the `401`
-challenge and the protected-resource metadata both list `mcp:read mcp:write`,
-and a client that follows either requests both. The consent screen spells out
+A client that asks for no scope gets `mcp:read`. Most clients ask for more: the
+`401` challenge names `mcp:read mcp:write` as what full use of the endpoint
+needs, and the protected-resource metadata lists both scopes as supported, so a
+client that follows either discovery path can request both. Neither obliges it
+to: a client may still ask for `mcp:read` alone. The consent screen spells out
 what the grant covers, so a read-only connection is a choice you can see being
 made. A read-only grant is refused in the middleware, before routing, on any
 write request — so no route has to remember the rule.

--- a/website/src/content/docs/guides/mcp.md
+++ b/website/src/content/docs/guides/mcp.md
@@ -34,6 +34,13 @@ configure by hand.
      twice — and tells a self-hoster to point their client at someone else's
      instance. The wording above is correct in both copies. -->
 
+Claude (web, desktop and mobile), as a connector: **Settings → Connectors →
+Add custom connector**. Name it, paste `https://app.usestratum.dev/mcp` as the
+URL, and leave the advanced OAuth client id and secret blank — Stratum registers
+the client itself. Click **Connect** on the new connector and approve the
+consent screen that opens; the tools are then available in any conversation
+where the connector is enabled.
+
 Claude Code:
 
 ```bash
@@ -53,10 +60,11 @@ Any MCP client that supports remote servers:
 }
 ```
 
-The first tool call opens your browser, asks you to sign in if you are not
-already, and shows a consent screen naming the application and what it is asking
-for. Approve it once; the client stores the tokens and refreshes them on its
-own.
+Connecting opens your browser, asks you to sign in if you are not already, and
+shows a consent screen: which application is asking, what it will be able to do,
+and the host it returns you to. The full redirect address and where to
+disconnect later are one click away under **Where this request came from**.
+Approve it once; the client stores the tokens and refreshes them on its own.
 
 You never paste a Stratum credential into your editor's configuration, and you
 can withdraw access at any time from **Settings → Connected applications**
@@ -85,7 +93,8 @@ The endpoint is an OAuth 2.1 protected resource, and Stratum is the
 authorization server. A client bootstraps the whole flow from the URL alone:
 
 1. It calls `/mcp` with no credential. The `401` carries a `WWW-Authenticate`
-   header naming `/.well-known/oauth-protected-resource`.
+   header naming `/.well-known/oauth-protected-resource` and the scopes full
+   use of the endpoint needs (`scope="mcp:read mcp:write"`).
 2. That document points at `/.well-known/oauth-authorization-server`.
 3. The client registers itself at `/oauth/register`
    ([RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591) dynamic client
@@ -114,9 +123,12 @@ instance advertises itself with nothing to configure.
 | `mcp:read` | Read projects, files, changes, evaluations and issues. Exactly a read-only API token. |
 | `mcp:write` | The above, plus workspaces, commits, changes, merges, reviews and issue management. Exactly a read-write API token. |
 
-A client that asks for no scope gets `mcp:read`. A read-only grant is refused in
-the middleware, before routing, on any write request — so no route has to
-remember the rule.
+A client that asks for no scope gets `mcp:read`. Most clients do ask: the `401`
+challenge and the protected-resource metadata both list `mcp:read mcp:write`,
+and a client that follows either requests both. The consent screen spells out
+what the grant covers, so a read-only connection is a choice you can see being
+made. A read-only grant is refused in the middleware, before routing, on any
+write request — so no route has to remember the rule.
 
 The one place the check is deferred is `/mcp` itself, and only because the HTTP
 method there says nothing about the operation: every MCP call is a POST,


### PR DESCRIPTION
## Summary

Approving an MCP connection from Claude (or any client) never completed in Chrome, Edge or Safari. The consent page shipped the site-wide `form-action 'self'` Content Security Policy, and those browsers enforce that directive against the **redirect that answers the consent form**, not only against the form's own action. Clicking Allow minted an authorization code the browser then refused to deliver to `claude.ai/api/mcp/auth_callback`, so the page sat there and the connector never connected. Firefox does not check redirects, which is why the flow could look fine in one browser and dead in another.

Reproduced in headless Chromium before changing anything: a page under `form-action 'self'` whose POST answers with an off-origin 302 stays put with `Refused to send form data …`; the same page with the target origin added to the directive lands on the callback.

**Fix**
- `contentSecurityPolicy()` / `setHtmlSecurityHeaders()` take an optional `formAction` (extra sources, or `null` to omit the directive). The consent page sets `form-action 'self' <registered redirect origin>` for itself, using the origin already verified against the client's registered list. Every other response keeps `'self'` byte-for-byte. An IPv6 loopback client cannot be spelled in CSP host-source grammar, so for that one case the directive is omitted on the consent page rather than emitted invalid.
- The `/mcp` 401 challenge now carries `scope="mcp:read mcp:write"` (RFC 6750 §3). A client that takes its scopes from the challenge asks for write access up front instead of authorizing read-only and failing on its first commit. A client that asks for nothing still gets `mcp:read`.

**Consent page**
- Shorter: the question ("Allow *Claude* to access Stratum?"), one line with who you are signed in as and the host it returns you to, the permission list, and the two buttons. The full redirect URI, the self-declared-name caveat and the disconnect link sit under a collapsible **Where this request came from** (`<details>`, no JS).

**Docs**
- MCP guide: how to add Stratum as a Claude connector (Settings → Connectors → Add custom connector, leave the OAuth id/secret blank), the shorter consent-screen description, and the scope hint. Docs-site mirror regenerated.

## Related issues

Follow-up to #350.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` (185 files, 3043 tests passing)
- [x] `npm run lint`
- `npm run release:check` and `cd website && npm run check:guides` pass.
- Headless Chromium reproduction of the `form-action` redirect block, before and after the directive change.
- The real `/oauth/authorize` route rendered for a client registered as "Claude" with redirect `https://claude.ai/api/mcp/auth_callback` emits `form-action 'self' https://claude.ai`; screenshots of the rendered page were reviewed.
- Not run: the end-to-end flow against a live Claude connector, which needs a deploy.

New tests: the consent page names the client origin in its CSP while the error page keeps the default (`tests/mcp-oauth-flow.test.ts`, which now also mounts `securityHeadersMiddleware`); the CSP helper's new option and unchanged default (`tests/security-headers.test.ts`); the `scope` attribute on the challenge (`tests/mcp-endpoint.test.ts`).

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] `CHANGELOG.md` updated (`## [Unreleased]`) if this is user-visible
- [x] Public docs updated if this changes user-facing config, API shape, or evaluator/policy
      behavior — edit the canonical page under `docs/user-guide/` or `docs/api/`, then
      `cd website && npm run sync:guides` and commit the regenerated mirrors (see AGENTS.md)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yzLNZm4typZvS5DzKh94e

---
_Generated by [Claude Code](https://claude.ai/code/session_012yzLNZm4typZvS5DzKh94e)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved MCP consent screens to prominently display authorization questions, permissions, signed-in user details, and controls.
  - Added collapsible details for redirect and disconnect information.
  - MCP authentication challenges now request read and write permissions by default, while preserving read-only access for clients without a specified scope.

- **Bug Fixes**
  - Improved MCP OAuth approval compatibility in Chrome, Edge, and Safari.
  - Consent submissions now work with registered OAuth redirect destinations.

- **Documentation**
  - Added guidance for connecting Claude using a custom connector.
  - Updated OAuth, permissions, consent, and disconnect documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->