### PR TITLE
Accept localhost loopback redirects and any loopback port for MCP OAuth clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `isScopedTokenCaller` is now `cannotMintLegacyCredential`, and covers OAuth
   grants as well as scoped tokens.
 
+### Fixed
+- **Claude Code can connect to the MCP server.** `claude mcp add` registers
+  `http://localhost:<port>/callback` as its OAuth redirect, and the
+  authorization server refused the name outright — only the loopback IP
+  literals were accepted — so every registration from the CLI failed with
+  `invalid_redirect_uri` before a browser ever opened. `localhost` is now
+  accepted as loopback (every current browser resolves it internally, without
+  DNS), and a loopback redirect may use a different port at authorization time
+  than the one it registered with, as RFC 8252 §7.3 requires of a server that
+  serves native apps. Nothing else about redirect matching is relaxed: host,
+  path, query and scheme are still compared exactly, and `localhost` and
+  `127.0.0.1` do not stand in for each other.
+
 ### Removed
 - **The standalone `mcp/` package (`@stratum/mcp`).** It was a stdio process
   that wrapped the REST API over the network — 609 lines holding no state,

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -3614,9 +3614,10 @@ paths:
                   maxItems: 10
                   items: { type: string }
                   description: |
-                    Exact URIs. `https`, or `http` on a loopback IP literal
-                    (`127.0.0.1`, `[::1]`) for native apps. No fragment, no
-                    embedded credentials.
+                    `https`, or `http` on loopback (`localhost`, `127.0.0.1`,
+                    `[::1]`) for native apps. No fragment, no embedded
+                    credentials. Matched exactly at authorization time, except
+                    that a loopback redirect may use any port (RFC 8252 §7.3).
                 scope: { type: string, example: "mcp:read mcp:write" }
                 token_endpoint_auth_method:
                   type: string

--- a/docs/user-guide/mcp.md
+++ b/docs/user-guide/mcp.md
@@ -106,7 +106,7 @@ Details worth knowing:
 | Authorization code lifetime | 60 seconds, single use. A replayed code revokes every token issued from it — but a redemption that merely *fails validation* (wrong client, wrong verifier, wrong redirect URI) leaves the code untouched, so observing one is not enough to disrupt the real client. |
 | Access token lifetime | 1 hour |
 | Refresh token lifetime | 30 days, **rotated** on every use |
-| Redirect URIs | Matched exactly against the registered list. `https`, or `http` on a loopback IP literal for native apps. |
+| Redirect URIs | `https`, or plaintext `http` on loopback (`localhost`, `127.0.0.1`, `[::1]`) for native apps. Matched exactly against the registered list, except that a loopback redirect may use any port, which RFC 8252 requires because a native app binds whatever port is free when it starts. |
 | Scopes | `mcp:read`, `mcp:write` |
 
 Every metadata document is built from the request's own origin, so a self-hosted

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,17 +1,15 @@
 /**
  * The Stratum API surface the MCP tools call.
  *
- * This is a port of the client the standalone stdio server used to carry, with
- * one substitution: where that one issued `fetch` calls across the internet to
- * `app.usestratum.dev`, this one hands the request to a dispatcher that runs
- * the SAME Hono routers in-process. The paths, payloads and error mapping are
- * unchanged, deliberately — the point of routing through the real handlers is
- * that MCP callers get exactly the REST API's behaviour, including its
- * authorization checks, its evaluation gates and its refusals, rather than a
- * parallel implementation that has to be kept in agreement with it.
+ * Every tool call is handed to a dispatcher that runs the SAME Hono routers
+ * in-process, with the REST API's own paths, payloads and error mapping. The
+ * point of routing through the real handlers is that MCP callers get exactly
+ * the REST API's behaviour, including its authorization checks, its evaluation
+ * gates and its refusals, rather than a parallel implementation that has to be
+ * kept in agreement with it.
  *
- * There is no request timeout here, unlike the network client. A dispatched
- * request never leaves the isolate, so there is no socket to hang: the bound is
+ * There is no request timeout here. A dispatched request never leaves the
+ * isolate, so there is no socket to hang: the bound is
  * the Worker's own wall-clock limit, and an AbortController racing it would
  * only turn a clean platform error into a confusing one. `stratum_create_change`
  * is the long pole — it runs the whole evaluation suite synchronously — and it

--- a/src/mcp/schema.ts
+++ b/src/mcp/schema.ts
@@ -7,9 +7,8 @@
  * exceptional one. Both halves have to agree, or a model reads one contract and
  * is judged against another.
  *
- * Rather than carry a validator library plus a schema converter (the stdio
- * server this replaces used zod and let the MCP SDK derive the JSON Schema),
- * the field spec here IS the schema: `toJsonSchema` and `validate` are two
+ * Rather than carry a validator library plus a schema converter, the field
+ * spec here IS the schema: `toJsonSchema` and `validate` are two
  * readings of the same declaration, so they cannot drift. The tool surface only
  * needs strings, enums, integers, booleans and one string map, which is far
  * less than a general validator would give us and exactly what a hand-written

--- a/src/routes/mcp-oauth.tsx
+++ b/src/routes/mcp-oauth.tsx
@@ -33,6 +33,7 @@ import {
   issueTokens,
   parseScope,
   readAuthorizationCode,
+  redirectUriMatches,
   registerClient,
   revokeGrantsForClientUser,
   revokeToken,
@@ -306,10 +307,12 @@ async function validateAuthorizeRequest(
   }
   const client = clientResult.data;
 
-  // EXACT match against the registered list. No prefix matching, no
-  // subdirectory allowance, no ignoring the query string — every relaxation of
-  // this comparison is a published way to steal authorization codes.
-  if (redirectUri === "" || !client.redirectUris.includes(redirectUri)) {
+  // Exact match against the registered list, with the single RFC 8252 §7.3
+  // exception for a loopback redirect's port (see `redirectUriMatches`). No
+  // prefix matching, no subdirectory allowance, no ignoring the query string —
+  // every other relaxation of this comparison is a published way to steal
+  // authorization codes.
+  if (redirectUri === "" || !redirectUriMatches(client.redirectUris, redirectUri)) {
     logger.warn("Authorization rejected - redirect_uri not registered", { clientId });
     return {
       response: await renderAuthorizeError(

--- a/src/storage/oauth.ts
+++ b/src/storage/oauth.ts
@@ -220,32 +220,78 @@ function rowToClient(row: OAuthClientRow): OAuthClient {
  * Is this a redirect URI we will ever hand an authorization code to?
  *
  * MCP clients are overwhelmingly native apps that listen on an ephemeral
- * loopback port, so `http://127.0.0.1:<port>/…` has to be allowed — that is
- * what RFC 8252 prescribes for native apps, and it is safe precisely because
- * loopback cannot be reached off the machine. Everything else must be https.
+ * loopback port, so plaintext `http` has to be allowed there — RFC 8252 §7.3
+ * prescribes it for native apps, and it is safe precisely because loopback
+ * cannot be reached off the machine. Everything else must be https.
+ *
+ * `localhost` is accepted alongside the IP literals. RFC 8252 §8.3 prefers the
+ * literals because a hostname nominally goes through DNS, but every current
+ * browser resolves `localhost` to loopback internally without consulting a
+ * resolver (RFC 6761 §6.3 requires it), and the clients that matter use the
+ * name: Claude Code registers `http://localhost:<port>/callback` and offers no
+ * way to change it. Refusing the name locked those clients out at registration
+ * for no security gained.
  *
  * Rejected outright: a fragment (the redirect target would be rewritten),
  * credentials in the authority, and any non-loopback plaintext http.
  */
 export function isAllowedRedirectUri(value: string): boolean {
   if (value.length > MAX_REDIRECT_URI_LENGTH) return false;
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    return false;
-  }
+  const url = parseUrl(value);
+  if (url === null) return false;
   if (url.hash !== "") return false;
   if (url.username !== "" || url.password !== "") return false;
   if (url.protocol === "https:") return true;
-  if (url.protocol === "http:") {
-    // Note: `localhost` is deliberately NOT accepted alongside the literals.
-    // It resolves through DNS, so on a compromised resolver it is not loopback
-    // at all — RFC 8252 §8.3 says to use the IP literals for exactly this
-    // reason.
-    return url.hostname === "127.0.0.1" || url.hostname === "[::1]" || url.hostname === "::1";
+  return url.protocol === "http:" && isLoopbackHost(url.hostname);
+}
+
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
   }
-  return false;
+}
+
+/** The WHATWG parser keeps the brackets on an IPv6 hostname, hence both forms. */
+const LOOPBACK_HOSTS: ReadonlySet<string> = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+function isLoopbackHost(hostname: string): boolean {
+  return LOOPBACK_HOSTS.has(hostname);
+}
+
+/**
+ * Does a presented `redirect_uri` match one the client registered?
+ *
+ * Exact string equality, with one deliberate exception: a plaintext loopback
+ * redirect may differ from its registration in PORT only. RFC 8252 §7.3
+ * requires this of an authorization server — a native app binds whatever
+ * ephemeral port is free when it starts, so the port in its registration is
+ * merely the one it happened to get that day — and the relaxation is safe
+ * because every loopback port on the user's machine is equally theirs.
+ *
+ * Nothing else is relaxed. Scheme, host, path and query must be identical;
+ * `localhost` and `127.0.0.1` do not stand in for each other; an https URI
+ * matches only itself; and the presented URI must still pass
+ * `isAllowedRedirectUri`, so a fragment cannot ride in on the port exception.
+ * Every broader comparison — prefix, subdirectory, ignored query — is a
+ * published way to steal authorization codes.
+ */
+export function redirectUriMatches(registered: readonly string[], presented: string): boolean {
+  if (registered.includes(presented)) return true;
+  if (!isAllowedRedirectUri(presented)) return false;
+  const url = parseUrl(presented);
+  if (url === null || url.protocol !== "http:" || !isLoopbackHost(url.hostname)) return false;
+  return registered.some((candidate) => {
+    const reg = parseUrl(candidate);
+    return (
+      reg !== null &&
+      reg.protocol === "http:" &&
+      reg.hostname === url.hostname &&
+      reg.pathname === url.pathname &&
+      reg.search === url.search
+    );
+  });
 }
 
 export interface RegisteredClient {

--- a/src/storage/oauth.ts
+++ b/src/storage/oauth.ts
@@ -245,6 +245,7 @@ export function isAllowedRedirectUri(value: string): boolean {
   return url.protocol === "http:" && isLoopbackHost(url.hostname);
 }
 
+/** `new URL` without the throw: the callers treat unparseable input as a policy failure, not an exception. */
 function parseUrl(value: string): URL | null {
   try {
     return new URL(value);
@@ -256,6 +257,7 @@ function parseUrl(value: string): URL | null {
 /** The WHATWG parser keeps the brackets on an IPv6 hostname, hence both forms. */
 const LOOPBACK_HOSTS: ReadonlySet<string> = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
 
+/** Is this WHATWG-parsed hostname one of the loopback forms `isAllowedRedirectUri` admits over plaintext http? */
 function isLoopbackHost(hostname: string): boolean {
   return LOOPBACK_HOSTS.has(hostname);
 }

--- a/src/storage/oauth.ts
+++ b/src/storage/oauth.ts
@@ -342,7 +342,7 @@ export async function registerClient(
     if (!isAllowedRedirectUri(uri)) {
       return err(
         new AppError(
-          `redirect_uri '${uri}' must be https, or http on a loopback IP literal, with no fragment or credentials`,
+          `redirect_uri '${uri}' must be https, or http on loopback (localhost, 127.0.0.1 or [::1]), with no fragment or credentials`,
           "INVALID_REDIRECT_URI",
           400,
         ),

--- a/src/storage/oauth.ts
+++ b/src/storage/oauth.ts
@@ -257,7 +257,9 @@ function parseUrl(value: string): URL | null {
 /** The WHATWG parser keeps the brackets on an IPv6 hostname, hence both forms. */
 const LOOPBACK_HOSTS: ReadonlySet<string> = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
 
-/** Is this WHATWG-parsed hostname one of the loopback forms `isAllowedRedirectUri` admits over plaintext http? */
+/** One predicate shared by registration and authorization, so the two can never disagree about
+ * what counts as loopback: it is the only thing that lets plaintext http through at all, and
+ * the only thing that unlocks the port-only match exception. */
 function isLoopbackHost(hostname: string): boolean {
   return LOOPBACK_HOSTS.has(hostname);
 }

--- a/tests/mcp-oauth-flow.test.ts
+++ b/tests/mcp-oauth-flow.test.ts
@@ -401,6 +401,55 @@ describe("authorization", () => {
 });
 
 describe("token endpoint", () => {
+  it("completes the flow for a Claude Code style localhost redirect on a different port", async () => {
+    // Claude Code registers `http://localhost:<port>/callback` and binds whatever
+    // ephemeral port is free on each run, so the port at authorization time is
+    // routinely not the one in the registration. RFC 8252 §7.3.
+    const { status, json } = await register({
+      redirect_uris: ["http://localhost:9876/callback"],
+    });
+    expect(status).toBe(201);
+    const used = "http://localhost:41234/callback";
+
+    const consented = await consent({
+      client_id: json.client_id,
+      redirect_uri: used,
+      scope: "mcp:read mcp:write",
+      code_challenge: CHALLENGE,
+      state: "xyz",
+    });
+    const location = new URL(consented.headers.get("location") ?? "");
+    expect(location.origin).toBe("http://localhost:41234");
+    expect(location.pathname).toBe("/callback");
+    const code = location.searchParams.get("code");
+    expect(code).not.toBeNull();
+
+    // The token request presents the URI the code was actually bound to.
+    const response = await exchange({
+      grant_type: "authorization_code",
+      code: code as string,
+      code_verifier: VERIFIER,
+      redirect_uri: used,
+      client_id: json.client_id,
+    });
+    expect(response.status).toBe(200);
+  });
+
+  it("does not let the loopback port exception cross to a different host", async () => {
+    const { json } = await register({
+      redirect_uris: ["http://localhost:9876/callback"],
+    });
+    const response = await consent({
+      client_id: json.client_id,
+      redirect_uri: "http://127.0.0.1:9876/callback",
+      scope: "mcp:read",
+      code_challenge: CHALLENGE,
+    });
+    expect(response.status).toBe(400);
+    expect(response.headers.get("location")).toBeNull();
+    expect(await response.text()).toContain("Redirect URI mismatch");
+  });
+
   it("completes the authorization_code grant with a valid verifier", async () => {
     const { json } = await register();
     const code = await codeFor(json.client_id);

--- a/tests/mcp-oauth-storage.test.ts
+++ b/tests/mcp-oauth-storage.test.ts
@@ -26,6 +26,7 @@ import {
   narrowOAuthScope,
   parseScope,
   readAuthorizationCode,
+  redirectUriMatches,
   registerClient,
   resolveOAuthAccessToken,
   revokeGrantForUser,
@@ -117,18 +118,58 @@ describe("scope handling", () => {
   });
 });
 
+describe("redirect URI matching", () => {
+  const registered = ["http://localhost:9876/callback", "https://editor.example/cb"];
+
+  it("matches a registered URI exactly", () => {
+    expect(redirectUriMatches(registered, "http://localhost:9876/callback")).toBe(true);
+    expect(redirectUriMatches(registered, "https://editor.example/cb")).toBe(true);
+  });
+
+  it("lets a loopback redirect use any port, as RFC 8252 §7.3 requires", () => {
+    expect(redirectUriMatches(registered, "http://localhost:41234/callback")).toBe(true);
+    expect(redirectUriMatches(registered, "http://localhost/callback")).toBe(true);
+    expect(redirectUriMatches(["http://127.0.0.1:1/cb"], "http://127.0.0.1:65000/cb")).toBe(true);
+    expect(redirectUriMatches(["http://[::1]:1/cb"], "http://[::1]:2/cb")).toBe(true);
+  });
+
+  it("relaxes only the port: host, path, query and scheme still have to be identical", () => {
+    // `localhost` and `127.0.0.1` are both loopback, but they are not each other.
+    expect(redirectUriMatches(registered, "http://127.0.0.1:9876/callback")).toBe(false);
+    expect(redirectUriMatches(registered, "http://localhost:9876/callback/")).toBe(false);
+    expect(redirectUriMatches(registered, "http://localhost:9876/other")).toBe(false);
+    expect(redirectUriMatches(registered, "http://localhost:9876/callback?x=1")).toBe(false);
+    expect(redirectUriMatches(["http://localhost:1/cb?x=1"], "http://localhost:2/cb?x=2")).toBe(
+      false,
+    );
+    expect(redirectUriMatches(registered, "https://localhost:9876/callback")).toBe(false);
+    // An https registration never gets the port exception.
+    expect(redirectUriMatches(registered, "https://editor.example:8443/cb")).toBe(false);
+  });
+
+  it("never admits a URI the registration policy would have refused", () => {
+    expect(redirectUriMatches(registered, "http://localhost:1/callback#frag")).toBe(false);
+    expect(redirectUriMatches(registered, "http://user:pw@localhost:1/callback")).toBe(false);
+    expect(redirectUriMatches(registered, "not a url")).toBe(false);
+    expect(redirectUriMatches([], "http://localhost:1/callback")).toBe(false);
+  });
+});
+
 describe("redirect URI policy", () => {
-  it("accepts https and loopback IP literals", () => {
+  it("accepts https and plaintext http on loopback, by IP literal or by name", () => {
     expect(isAllowedRedirectUri("https://editor.example/cb")).toBe(true);
     expect(isAllowedRedirectUri("http://127.0.0.1:1234/cb")).toBe(true);
     expect(isAllowedRedirectUri("http://[::1]:1234/cb")).toBe(true);
+    // Claude Code registers exactly this shape and cannot be told otherwise.
+    expect(isAllowedRedirectUri("http://localhost:1234/cb")).toBe(true);
+    expect(isAllowedRedirectUri("http://localhost/cb")).toBe(true);
   });
 
-  it("rejects plaintext http on a resolvable host, including localhost", () => {
-    // RFC 8252 §8.3: `localhost` goes through DNS, so it is not reliably
-    // loopback. Only the IP literals are.
-    expect(isAllowedRedirectUri("http://localhost:1234/cb")).toBe(false);
+  it("rejects plaintext http on any resolvable host that is not loopback", () => {
     expect(isAllowedRedirectUri("http://editor.example/cb")).toBe(false);
+    expect(isAllowedRedirectUri("http://localhost.example/cb")).toBe(false);
+    expect(isAllowedRedirectUri("http://127.0.0.2/cb")).toBe(false);
+    expect(isAllowedRedirectUri("http://10.0.0.1:1234/cb")).toBe(false);
   });
 
   it("rejects fragments, embedded credentials, and non-http schemes", () => {

--- a/website/src/content/docs/guides/mcp.md
+++ b/website/src/content/docs/guides/mcp.md
@@ -110,7 +110,7 @@ Details worth knowing:
 | Authorization code lifetime | 60 seconds, single use. A replayed code revokes every token issued from it — but a redemption that merely *fails validation* (wrong client, wrong verifier, wrong redirect URI) leaves the code untouched, so observing one is not enough to disrupt the real client. |
 | Access token lifetime | 1 hour |
 | Refresh token lifetime | 30 days, **rotated** on every use |
-| Redirect URIs | Matched exactly against the registered list. `https`, or `http` on a loopback IP literal for native apps. |
+| Redirect URIs | `https`, or plaintext `http` on loopback (`localhost`, `127.0.0.1`, `[::1]`) for native apps. Matched exactly against the registered list, except that a loopback redirect may use any port, which RFC 8252 requires because a native app binds whatever port is free when it starts. |
 | Scopes | `mcp:read`, `mcp:write` |
 
 Every metadata document is built from the request's own origin, so a self-hosted


### PR DESCRIPTION
## Summary

`claude mcp add --transport http stratum https://app.usestratum.dev/mcp` could never connect. Claude Code registers `http://localhost:<port>/callback` as its OAuth redirect (the template is in the CLI binary; there is no option to change it), and `isAllowedRedirectUri` accepted plaintext `http` only on the loopback IP literals `127.0.0.1` and `[::1]`. Dynamic client registration therefore failed with `invalid_redirect_uri` before a browser ever opened, reproducible against production. The web connector was unaffected because it registers an `https://claude.ai/...` callback.

**Registration policy.** `localhost` is now accepted as loopback. RFC 8252 §8.3 prefers the IP literals because a hostname nominally goes through DNS, but every current browser resolves `localhost` internally to loopback without consulting a resolver (RFC 6761 §6.3 requires it), so the concern the rule guards against does not arise, and refusing the name locked out the main MCP client for no gain. `http://localhost.example/`, `http://127.0.0.2/` and other non-loopback plaintext hosts stay refused.

**Port matching.** New `redirectUriMatches` in `src/storage/oauth.ts` implements RFC 8252 §7.3: a plaintext loopback redirect may differ from its registration in **port only**, because a native app binds whatever ephemeral port is free on each run. Nothing else is relaxed — scheme, host, path and query are compared exactly, `localhost` and `127.0.0.1` do not stand in for each other, an https URI matches only itself, and the presented URI must still pass `isAllowedRedirectUri` so a fragment or userinfo cannot ride in on the exception. The authorize route (GET and the consent POST, which share the validator) uses it. The token endpoint is unchanged and still requires the exact URI the code was bound to (RFC 6749 §4.1.3).

**Stdio cleanup.** The standalone stdio package was already deleted in #350; the only traces left were two module comments in `src/mcp/client.ts` and `src/mcp/schema.ts` describing the code as a port of it. Those are rewritten to describe the code as it is.

Docs: the redirect URI row of the MCP guide's authorization table, its website mirror, and a Fixed entry in the changelog.

## Related issues

Follow-up to #353 and #355 (Claude web connector); this one is the Claude Code CLI path.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test` — 187 files, 3099 tests passing
- [x] `npm run lint`
- `cd website && npm run check:guides` — mirrors in sync.
- Reproduced the failure first: `POST /oauth/register` on production with `redirect_uris: ["http://localhost:53421/callback"]` returns `400 invalid_redirect_uri`. Confirmed the CLI's redirect template by inspecting the installed `claude` binary (2.1.259), which carries `http://localhost:<port>/callback`.
- New tests in `tests/mcp-oauth-storage.test.ts`: `localhost` accepted, non-loopback plaintext hosts refused, and a `redirectUriMatches` suite covering exact match, any-port loopback for all three host forms, and every relaxation that must NOT happen (host, path, trailing slash, query, scheme, https port, fragment, userinfo, empty registration).
- New end-to-end tests in `tests/mcp-oauth-flow.test.ts`: register with `http://localhost:9876/callback`, consent with `http://localhost:41234/callback`, receive the code on the presented port and exchange it for tokens; and the negative case where `127.0.0.1` on the registered port is refused with the rendered "Redirect URI mismatch" page rather than a redirect.
- Not run: the live `claude mcp add` flow, which needs this deployed.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] `CHANGELOG.md` updated (`## [Unreleased]`) if this is user-visible
- [x] Public docs updated if this changes user-facing config, API shape, or evaluator/policy
      behavior — edit the canonical page under `docs/user-guide/` or `docs/api/`, then
      `cd website && npm run sync:guides` and commit the regenerated mirrors (see AGENTS.md)
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yzLNZm4typZvS5DzKh94e

---
_Generated by [Claude Code](https://claude.ai/code/session_012yzLNZm4typZvS5DzKh94e)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MCP OAuth support for native applications using loopback redirects.
  - Authorization now permits different ports for registered loopback HTTP redirects on `localhost`, `127.0.0.1`, and `[::1]`.
  - Redirect validation remains strict for the scheme, host, path, query, fragments, and credentials.
  - Prevented invalid host changes, such as switching between `localhost` and `127.0.0.1`.
  - Invalid redirect URLs are rejected.

- **Documentation**
  - Updated MCP OAuth guidance and API documentation to explain loopback redirect behavior and port flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->