### PR TITLE
Authenticate the CLI through the browser with `stratum login`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,11 @@ jobs:
         with:
           node-version: "22"
 
-      - name: CLI — install, typecheck, test, build
+      - name: CLI — install, lint, typecheck, test, build
         working-directory: cli
         run: |
           npm install
+          npm run lint
           npm run typecheck
           npm test
           npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,14 @@ jobs:
           path: coverage/
 
   packages:
-    name: CLI & Agent Packages
+    name: CLI & Agent Packages (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The floor each package declares in `engines`, and the version most
+        # contributors run. Testing only the latter lets the floor rot.
+        node: ["20", "22"]
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -45,16 +51,19 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "22"
+          node-version: ${{ matrix.node }}
 
-      - name: CLI — install, lint, typecheck, test, build
+      # Lint runs last, per AGENTS.md: Biome autofixes formatting, so putting it
+      # ahead of the correctness gates just reports style on code that may not
+      # compile.
+      - name: CLI — install, typecheck, test, build, lint
         working-directory: cli
         run: |
           npm install
-          npm run lint
           npm run typecheck
           npm test
           npm run build
+          npm run lint
 
       - name: Agent — install, typecheck, test, build
         working-directory: agent

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,10 +22,11 @@ jobs:
         with:
           node-version: "22"
 
-      - name: CLI — install, typecheck, test, build
+      - name: CLI — install, lint, typecheck, test, build
         working-directory: cli
         run: |
           npm install
+          npm run lint
           npm run typecheck
           npm test
           npm run build

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,8 +11,14 @@ concurrency:
 
 jobs:
   packages:
-    name: CLI & Agent Packages
+    name: CLI & Agent Packages (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The floor each package declares in `engines`, and the version most
+        # contributors run. Testing only the latter lets the floor rot.
+        node: ["20", "22"]
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -20,16 +26,19 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "22"
+          node-version: ${{ matrix.node }}
 
-      - name: CLI — install, lint, typecheck, test, build
+      # Lint runs last, per AGENTS.md: Biome autofixes formatting, so putting it
+      # ahead of the correctness gates just reports style on code that may not
+      # compile.
+      - name: CLI — install, typecheck, test, build, lint
         working-directory: cli
         run: |
           npm install
-          npm run lint
           npm run typecheck
           npm test
           npm run build
+          npm run lint
 
       - name: Agent — install, typecheck, test, build
         working-directory: agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   user), so an agent's feedback channel is change comments.
 
 ### Changed
+
+- **`stratum login --host <url>` without `--key` now opens a browser** instead of
+  prompting for a key. Scripts that piped a key into the prompt must pass
+  `--key` (or set `STRATUM_HOST` and `STRATUM_API_KEY`). Without a TTY the
+  command now refuses with a message naming both, rather than spawning a browser
+  nobody can see or hanging on a prompt nobody can answer.
+- **A lone `STRATUM_HOST` no longer retargets a browser session.** It still
+  overrides the host for an API-token credential, but an OAuth grant belongs to
+  the server that issued it, so pointing one at a different host is now refused
+  with an explanatory error instead of sending that host a token it did not
+  issue. Set `STRATUM_API_KEY` alongside it, or run `stratum login --host …`.
+- **`cli/` requires Node 20+** (was 18). The loopback listener relies on
+  `server.close()` dropping idle keep-alive connections, which is Node 19+
+  behaviour; 18 was declared but never tested.
 - **Profile is folded into Settings.** The two pages opened with the same
   Account card and each pointed at the other for the rest. Settings now holds
   everything — identity, invite codes, privacy, tokens, connected apps, agents,
@@ -252,6 +266,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collapsed into one row, so only one of their reasons survived — a rejection
   sharing a name with a valid entry could even take that entry's row and stop it
   deploying. Every rejected entry now gets its own `failed` row.
+
+- **The CLI credential file is now `0600` in a `0700` directory on existing
+  installs, not only new ones.** It holds a bearer token in plaintext, and
+  earlier releases left it world-readable at `0644`. Passing `mode` to
+  `writeFile`/`mkdir` does not fix an existing file — POSIX honours `mode` only
+  when the call creates the node — so the write now goes through a temp file and
+  `rename`, which replaces the inode and carries the right permissions with it.
+- **A `stratum` session can no longer be destroyed by running two commands at
+  once.** Refresh tokens rotate on every use, and presenting a retired one is
+  treated as theft: the server revokes the whole grant, logging you out
+  everywhere. Two processes refreshing concurrently both held the same token, so
+  parallel commands after an idle hour would systematically do exactly that.
+  Rotation now takes a cross-process lock and re-reads the stored credential
+  inside it, so a process that waited adopts the winner's token instead of
+  replaying its own.
+- **A crash or `^C` while the CLI wrote its credential no longer loses the
+  session.** The file was truncated in place, and after a rotation the new
+  refresh token exists only on disk, so a torn write was unrecoverable. Writes
+  are now atomic.
+- **The CLI refuses to send credentials over plaintext or off-origin.** `--host`
+  must be `https` (loopback excepted), and every endpoint named in a host's
+  OAuth discovery document must share that host's origin, so a tampered document
+  cannot redirect the authorization code or refresh token elsewhere.
+- **OAuth requests no longer hang indefinitely.** Every call in the login and
+  refresh path carries a timeout; without one, an unreachable host hung not just
+  `login` but every command, because a refresh re-enters discovery.
+- **A stray request to the CLI's loopback port no longer cancels a login.** Any
+  page open in the browser can reach `127.0.0.1`; a request with a mismatched
+  `state` is now ignored and the listener keeps waiting, per RFC 8252.
+- **A failed token refresh reports its actual cause.** A network failure was
+  reported as `session expired`, sending users to re-authenticate over a problem
+  that re-authenticating could not fix.
 - **The header fits a phone.** Signed in, the nav's five links were laid out in
   one unwrappable row, so below about 460px the row ran past the viewport, the
   page scrolled sideways, and the wordmark and "logout" were clipped off either

--- a/cli/README.md
+++ b/cli/README.md
@@ -5,6 +5,11 @@ CLI for Stratum — code hosting for the AI engineering era. Wraps the Stratum R
 ## Setup
 
 ```bash
+stratum login                    # opens your browser, no token to copy
+stratum login --read-only        # request a read-only session
+stratum logout                   # revoke this machine's session
+
+# Headless (CI, containers): an API token instead of the browser.
 stratum login --host https://your-stratum-instance --key stratum_user_…
 # or set STRATUM_HOST and STRATUM_API_KEY (these override the config file)
 ```
@@ -36,6 +41,7 @@ stratum issue list <ns/slug> [--status closed]
 stratum issue close <ns/slug> <number>
 
 stratum status                                  # who am I
+stratum logout                                  # revoke and clear this session
 stratum account delete --confirm <username>     # irreversible account erasure
 ```
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -15,12 +15,177 @@
         "stratum": "dist/index.js"
       },
       "devDependencies": {
+        "@biomejs/biome": "^1.9.4",
         "@types/node": "^22.0.0",
         "typescript": "^5.4.0",
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.9.4",
+        "@biomejs/cli-darwin-x64": "1.9.4",
+        "@biomejs/cli-linux-arm64": "1.9.4",
+        "@biomejs/cli-linux-arm64-musl": "1.9.4",
+        "@biomejs/cli-linux-x64": "1.9.4",
+        "@biomejs/cli-linux-x64-musl": "1.9.4",
+        "@biomejs/cli-win32-arm64": "1.9.4",
+        "@biomejs/cli-win32-x64": "1.9.4"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stratum/cli",
   "version": "0.2.0",
-  "description": "CLI for Stratum — code hosting for the AI engineering era",
+  "description": "CLI for Stratum \u2014 code hosting for the AI engineering era",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,15 +9,23 @@
     "directory": "cli"
   },
   "type": "module",
-  "bin": { "stratum": "./dist/index.js" },
-  "files": ["dist"],
-  "publishConfig": { "access": "public" },
+  "bin": {
+    "stratum": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json",
+    "prepublishOnly": "npm run build",
+    "lint": "biome check src tests",
+    "lint:fix": "biome check --write src tests"
   },
   "dependencies": {
     "commander": "^12.0.0"
@@ -27,5 +35,7 @@
     "typescript": "^5.4.0",
     "vitest": "^3.0.0"
   },
-  "engines": { "node": ">=18" }
+  "engines": {
+    "node": ">=20"
+  }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -31,6 +31,7 @@
     "commander": "^12.0.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "@types/node": "^22.0.0",
     "typescript": "^5.4.0",
     "vitest": "^3.0.0"

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -85,17 +85,68 @@ export interface ActivityEvent {
 // the deadline must comfortably exceed a slow LLM + sandbox run.
 const DEFAULT_TIMEOUT_MS = 120_000;
 
+/**
+ * A credential that can be presented and, if the server rejects it, renewed.
+ * A bare string is an API key: presented as-is, never renewable.
+ */
+export interface ClientCredential {
+  token(): Promise<string>;
+  refresh(): Promise<string | null>;
+}
+
+function asCredential(auth: string | ClientCredential): ClientCredential {
+  if (typeof auth !== "string") return auth;
+  return { token: async () => auth, refresh: async () => null };
+}
+
+/** An API error that kept its status code, so callers can act on a 401. */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
 export class StratumClient {
+  private readonly credential: ClientCredential;
+
   constructor(
     private host: string,
-    private apiKey: string,
+    auth: string | ClientCredential,
     private opts: { timeoutMs?: number } = {},
-  ) {}
+  ) {
+    this.credential = asCredential(auth);
+  }
 
+  /**
+   * One retry, and only on a 401 that a refresh could plausibly fix: an access
+   * token can expire mid-session (they last an hour), and re-running the whole
+   * command is not something a user should have to do for that.
+   */
   async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const token = await this.credential.token();
+    try {
+      return await this.send<T>(method, path, token, body);
+    } catch (err) {
+      if (!(err instanceof ApiError) || err.status !== 401) throw err;
+      // A refresh that fails for its own reason — the network is down, the host
+      // is unreachable — must surface that reason. Reporting it as the original
+      // 401 sends the user to re-authenticate over a problem login cannot fix.
+      const renewed = await this.credential.refresh().catch((refreshErr: unknown) => {
+        throw refreshErr instanceof Error ? refreshErr : err;
+      });
+      if (renewed === null) throw err;
+      return this.send<T>(method, path, renewed, body);
+    }
+  }
+
+  private async send<T>(method: string, path: string, token: string, body?: unknown): Promise<T> {
     const url = `${this.host.replace(/\/$/, "")}${path}`;
     const headers: Record<string, string> = {
-      Authorization: `Bearer ${this.apiKey}`,
+      Authorization: `Bearer ${token}`,
     };
     if (body !== undefined) headers["Content-Type"] = "application/json";
 
@@ -126,10 +177,22 @@ export class StratumClient {
         } catch {
           message = response.statusText || message;
         }
-        throw new Error(message);
+        throw new ApiError(message, response.status);
       }
 
-      return (await response.json()) as T;
+      // The error path above is already defensive; the success path was not.
+      // A 200 with an empty body (a delete) or an HTML body (a proxy, a captive
+      // portal) otherwise surfaces as a raw `Unexpected token '<'`.
+      const text = await response.text();
+      if (text === "") return undefined as T;
+      try {
+        return JSON.parse(text) as T;
+      } catch {
+        throw new ApiError(
+          `${url} returned a non-JSON body (HTTP ${response.status})`,
+          response.status,
+        );
+      }
     } finally {
       clearTimeout(timer);
     }
@@ -252,8 +315,6 @@ export class StratumClient {
     const params = new URLSearchParams();
     if (opts?.force) params.set("force", "true");
     if (opts?.strategy) params.set("strategy", opts.strategy);
-    // params.size needs Node >= 18.16; the serialized string works on every
-    // release the engines field allows.
     const serialized = params.toString();
     const query = serialized ? `?${serialized}` : "";
     return this.request<{

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,45 +1,442 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import { chmod, mkdir, open, readFile, rename, rm, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import {
+  type AuthServerMetadata,
+  type OAuthTokens,
+  discover,
+  normalizeHost,
+  refreshTokens,
+} from "./oauth.js";
 
-export interface StratumConfig {
-  host: string;
+/**
+ * An OAuth grant from `stratum login`. The refresh token rotates on every use,
+ * so this record is rewritten each time it is refreshed.
+ */
+export interface OAuthCredential {
+  kind: "oauth";
+  clientId: string;
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: string;
+  scope: string;
+}
+
+/** A long-lived API token, from `stratum login --key` or the environment. */
+export interface ApiKeyCredential {
+  kind: "apiKey";
   apiKey: string;
 }
 
+export type Credential = OAuthCredential | ApiKeyCredential;
+
+export interface StratumConfig {
+  host: string;
+  credential: Credential;
+}
+
+/**
+ * On-disk shape. `apiKey` at the top level is the format every previous
+ * release wrote and the one the docs describe, so it is read and written
+ * unchanged; OAuth grants live under their own key rather than overloading it.
+ */
+interface ConfigFile {
+  host?: string;
+  apiKey?: string;
+  oauth?: Partial<Omit<OAuthCredential, "kind">>;
+}
+
+function configDir(): string {
+  return join(homedir(), ".stratum");
+}
+
 function configPath(): string {
-  return join(homedir(), ".stratum", "config.json");
+  return join(configDir(), "config.json");
 }
 
 export async function readConfig(): Promise<StratumConfig | null> {
+  let raw: string;
   try {
-    const raw = await readFile(configPath(), "utf-8");
-    return JSON.parse(raw) as StratumConfig;
+    raw = await readFile(configPath(), "utf-8");
+  } catch (err) {
+    // Absence is the "not logged in" case and the only one worth answering with
+    // null. A permissions or I/O failure answered the same way becomes "Not
+    // configured. Run: stratum login" — advice that cannot work — and, worse,
+    // lets rotateGuarded believe nobody else has rotated.
+    if (isErrnoCode(err, "ENOENT")) return null;
+    throw new Error(
+      `could not read ${configPath()}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  try {
+    return fromFile(JSON.parse(raw) as ConfigFile);
   } catch {
+    throw new Error(`${configPath()} is not valid JSON. Run: stratum login`);
+  }
+}
+
+export function fromFile(parsed: ConfigFile): StratumConfig | null {
+  if (!parsed.host) return null;
+  const oauth = parsed.oauth;
+  if (oauth?.accessToken && oauth.refreshToken && oauth.clientId) {
+    return {
+      host: parsed.host,
+      credential: {
+        kind: "oauth",
+        clientId: oauth.clientId,
+        accessToken: oauth.accessToken,
+        refreshToken: oauth.refreshToken,
+        expiresAt: oauth.expiresAt ?? new Date(0).toISOString(),
+        scope: oauth.scope ?? "",
+      },
+    };
+  }
+  if (parsed.apiKey) {
+    return { host: parsed.host, credential: { kind: "apiKey", apiKey: parsed.apiKey } };
+  }
+  return null;
+}
+
+export function toFile(config: StratumConfig): ConfigFile {
+  if (config.credential.kind === "apiKey") {
+    return { host: config.host, apiKey: config.credential.apiKey };
+  }
+  const { kind: _kind, ...oauth } = config.credential;
+  return { host: config.host, oauth };
+}
+
+function lockPath(): string {
+  return join(configDir(), "config.lock");
+}
+
+/**
+ * Write the credential file atomically, and leave it readable only by its owner.
+ *
+ * Two properties, one mechanism. Writing a temp file and `rename`ing it over the
+ * target means a reader never observes a half-written file and a crash mid-write
+ * leaves the previous credential intact — which matters more than it looks,
+ * because after a rotation the new refresh token exists ONLY here, so a torn
+ * write is a permanently lost session.
+ *
+ * The rename also fixes the permissions of an existing install. `mode` on
+ * `writeFile`/`mkdir` is honoured only when the call actually creates the node,
+ * so rewriting a file an older release left at 0644 keeps 0644 — the token stays
+ * world-readable. Because `rename` replaces the inode, the file inherits the
+ * temp file's 0600 no matter what the old one had.
+ */
+export async function writeConfig(config: StratumConfig): Promise<void> {
+  const dir = configDir();
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  // Same reasoning as above: mkdir's mode is a no-op on a directory that already
+  // exists, so an upgraded install needs this explicitly.
+  await chmod(dir, 0o700).catch((err: unknown) => {
+    process.stderr.write(
+      `Warning: could not restrict ${dir} to owner-only: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  });
+
+  const temp = join(dir, `.config.${process.pid}.${randomBytes(6).toString("hex")}.tmp`);
+  try {
+    const handle = await open(temp, "wx", 0o600);
+    try {
+      await handle.writeFile(`${JSON.stringify(toFile(config), null, 2)}\n`, "utf-8");
+      // `rename` is atomic against other processes but says nothing about
+      // durability: after a power cut the rename can survive while the data
+      // blocks do not, leaving an empty config and — post-rotation, when the
+      // refresh token exists nowhere else — an unrecoverable session.
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await rename(temp, configPath());
+  } catch (err) {
+    await rm(temp, { force: true });
+    throw new Error(
+      `could not write ${configPath()}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Both thresholds must clear the worst-case time spent holding the lock, which
+ * is a discovery round trip plus a token round trip — two 30s timeouts, so 60s.
+ * A stale threshold at or below that lets a HEALTHY holder be declared dead,
+ * and two processes then present the same refresh token, which the server reads
+ * as theft and answers by revoking the whole grant.
+ */
+const LOCK_TIMEOUT_MS = 90_000;
+const LOCK_STALE_MS = 180_000;
+const LOCK_POLL_MS = 50;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isErrnoCode(err: unknown, code: string): boolean {
+  return typeof err === "object" && err !== null && (err as { code?: string }).code === code;
+}
+
+/** Raised when another process held the lock for longer than we will wait. */
+export class LockTimeoutError extends Error {
+  constructor(path: string) {
+    super(`timed out waiting for another stratum process to refresh the session (${path})`);
+    this.name = "LockTimeoutError";
+  }
+}
+
+/**
+ * Delete the lock only if we still hold it.
+ *
+ * An unconditional `rm` in the release path is worse than no lock at all: once
+ * any holder has been broken as stale, its exit deletes the *next* holder's
+ * lock, and from then on every process can enter at once. The nonce is what
+ * makes release idempotent and safe.
+ */
+async function releaseLock(path: string, nonce: string): Promise<void> {
+  const held = await readFile(path, "utf-8").catch(() => null);
+  if (held === null || held.trim() === nonce) await rm(path, { force: true });
+}
+
+/**
+ * Hold an exclusive, cross-process lock for the duration of `action`.
+ *
+ * `wx` fails when the file exists, which is the whole mechanism: it is one
+ * atomic filesystem operation, so two processes cannot both believe they hold
+ * the lock. A stale lock is broken on age rather than by trusting a recorded
+ * pid, because a pid can be recycled.
+ *
+ * Acquisition failures and failures raised by `action` are deliberately handled
+ * apart. Folding them together means an errno that happens to be EEXIST from
+ * inside `action` — `mkdir` on a path that exists as a regular file raises
+ * exactly that — is mistaken for a busy lock, and the critical section runs a
+ * second time with a refresh token the first attempt already retired.
+ */
+export async function withConfigLock<T>(action: () => Promise<T>): Promise<T> {
+  const path = lockPath();
+  const nonce = randomBytes(16).toString("hex");
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  await mkdir(configDir(), { recursive: true, mode: 0o700 });
+
+  for (;;) {
+    let handle: Awaited<ReturnType<typeof open>>;
+    try {
+      handle = await open(path, "wx", 0o600);
+    } catch (err) {
+      if (!isErrnoCode(err, "EEXIST")) throw err;
+      const info = await stat(path).catch(() => null);
+      // `open(dir, "wx")` also reports EEXIST, and a plain `rm` of a directory
+      // then throws EISDIR — which would wedge every future command behind an
+      // error that names neither the cause nor the cure.
+      if (info?.isDirectory()) {
+        throw new Error(`${path} is a directory; remove it and retry`);
+      }
+      const age = info === null ? Number.POSITIVE_INFINITY : Date.now() - info.mtimeMs;
+      if (age > LOCK_STALE_MS) {
+        await rm(path, { force: true });
+        continue;
+      }
+      if (Date.now() >= deadline) throw new LockTimeoutError(path);
+      await delay(LOCK_POLL_MS);
+      continue;
+    }
+
+    try {
+      await handle.writeFile(nonce, "utf-8");
+      return await action();
+    } finally {
+      await handle.close().catch(() => {});
+      await releaseLock(path, nonce);
+    }
+  }
+}
+
+export async function clearConfig(): Promise<void> {
+  await rm(configPath(), { force: true });
+}
+
+/** Refresh this far before the token actually expires, to cover a slow request. */
+const REFRESH_SKEW_MS = 60_000;
+
+export function isExpired(expiresAt: string, now = Date.now()): boolean {
+  const at = Date.parse(expiresAt);
+  if (Number.isNaN(at)) return true;
+  return at - REFRESH_SKEW_MS <= now;
+}
+
+/**
+ * Supplies the bearer token for each request, and knows whether a 401 is worth
+ * retrying. An API key is a constant; an OAuth grant rotates under us.
+ */
+export interface TokenProvider {
+  token(): Promise<string>;
+  /** New token, or null when this credential cannot be renewed. */
+  refresh(): Promise<string | null>;
+}
+
+class ApiKeyProvider implements TokenProvider {
+  constructor(private readonly key: string) {}
+  async token(): Promise<string> {
+    return this.key;
+  }
+  async refresh(): Promise<null> {
     return null;
   }
 }
 
-export async function writeConfig(config: StratumConfig): Promise<void> {
-  await mkdir(join(homedir(), ".stratum"), { recursive: true });
-  await writeFile(configPath(), JSON.stringify(config, null, 2), "utf-8");
+/**
+ * Raised when the stored credential was replaced while we waited to rotate.
+ * Rotating anyway would overwrite whatever the user just did — a fresh
+ * `login --key`, or a `logout` — and in the logout case would resurrect a
+ * credential file they deliberately deleted.
+ */
+class CredentialChangedError extends Error {
+  constructor(detail: string) {
+    super(`the stored credential changed while refreshing (${detail}); rerun the command`);
+    this.name = "CredentialChangedError";
+  }
+}
+
+class OAuthProvider implements TokenProvider {
+  /** Collapses refreshes *within* this process; the lockfile handles the rest. */
+  private inFlight: Promise<string> | null = null;
+  /** Cached so a refresh does not re-run discovery on every renewal. */
+  private metadata: AuthServerMetadata | null = null;
+
+  constructor(
+    private readonly host: string,
+    private credential: OAuthCredential,
+    private readonly persist: boolean,
+  ) {}
+
+  async token(): Promise<string> {
+    if (isExpired(this.credential.expiresAt)) return this.refresh();
+    return this.credential.accessToken;
+  }
+
+  async refresh(): Promise<string> {
+    this.inFlight ??= this.rotateGuarded().finally(() => {
+      this.inFlight = null;
+    });
+    return this.inFlight;
+  }
+
+  /**
+   * Rotation is not merely a race — it is destructive when lost.
+   *
+   * The server treats a retired refresh token as evidence of theft: presenting
+   * one matches `previous_refresh_token_hash` and revokes the ENTIRE grant
+   * (OAuth 2.1 §4.3.1). So two `stratum` processes that both hold token R do not
+   * just duplicate work; the loser's replay of R logs the user out of every
+   * terminal. An in-process promise cannot prevent that, because the competitors
+   * are separate processes — hence a filesystem lock, and a re-read inside it so
+   * a process that waited adopts the winner's token instead of replaying its own.
+   */
+  private async rotateGuarded(): Promise<string> {
+    if (!this.persist) return this.rotate(this.credential.refreshToken);
+    try {
+      return await withConfigLock(async () => this.rotateWithStored());
+    } catch (err) {
+      // The winner may have finished a moment after we gave up waiting. Its
+      // token is on disk and perfectly usable; failing the command because our
+      // patience ran out would be gratuitous.
+      if (err instanceof LockTimeoutError) {
+        const adopted = await this.adoptStored();
+        if (adopted !== null) return adopted;
+      }
+      throw err;
+    }
+  }
+
+  /** The stored credential, if it is a live grant for THIS host and not ours. */
+  private async adoptStored(): Promise<string | null> {
+    const stored = await this.storedCredential();
+    if (stored === null || stored.refreshToken === this.credential.refreshToken) return null;
+    this.credential = stored;
+    return isExpired(stored.expiresAt) ? null : stored.accessToken;
+  }
+
+  /**
+   * Read the credential this host's grant is stored under, refusing anything
+   * that is not one. `readConfig` carries a host, and ignoring it is how a
+   * concurrent `login --host other` ends with one host's refresh token being
+   * POSTed to another.
+   */
+  private async storedCredential(): Promise<OAuthCredential | null> {
+    const fresh = await readConfig();
+    if (fresh === null) throw new CredentialChangedError("it was removed, or you logged out");
+    if (normalizeHost(fresh.host) !== normalizeHost(this.host)) {
+      throw new CredentialChangedError(`it now belongs to ${fresh.host}`);
+    }
+    if (fresh.credential.kind !== "oauth") {
+      throw new CredentialChangedError("it is now an API token");
+    }
+    return fresh.credential;
+  }
+
+  private async rotateWithStored(): Promise<string> {
+    const adopted = await this.adoptStored();
+    if (adopted !== null) return adopted;
+    return this.rotate(this.credential.refreshToken);
+  }
+
+  private async rotate(refreshToken: string): Promise<string> {
+    this.metadata ??= await discover(this.host);
+    const tokens: OAuthTokens = await refreshTokens(this.host, {
+      clientId: this.credential.clientId,
+      refreshToken,
+      metadata: this.metadata,
+    });
+    this.credential = {
+      kind: "oauth",
+      clientId: tokens.clientId,
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      expiresAt: tokens.expiresAt,
+      scope: tokens.scope || this.credential.scope,
+    };
+    // The presented refresh token is spent, so losing this write means losing
+    // the session — it is awaited, not fired and forgotten.
+    if (this.persist) await writeConfig({ host: this.host, credential: this.credential });
+    return this.credential.accessToken;
+  }
+}
+
+export function providerFor(config: StratumConfig, persist = true): TokenProvider {
+  return config.credential.kind === "apiKey"
+    ? new ApiKeyProvider(config.credential.apiKey)
+    : new OAuthProvider(config.host, config.credential, persist);
 }
 
 /**
- * Resolve configuration: STRATUM_HOST / STRATUM_API_KEY environment variables
- * override the config file (useful in CI and agents).
+ * Resolve configuration. `STRATUM_HOST` + `STRATUM_API_KEY` override the config
+ * file entirely (CI and agents); a lone `STRATUM_HOST` retargets a stored
+ * credential, which is only meaningful for an API key — an OAuth grant belongs
+ * to the host that issued it, so pointing it elsewhere is refused rather than
+ * silently sending someone's token to another server.
  */
 export async function getConfig(): Promise<StratumConfig> {
   const envHost = process.env.STRATUM_HOST;
   const envKey = process.env.STRATUM_API_KEY;
-  if (envHost && envKey) return { host: envHost, apiKey: envKey };
+  if (envHost && envKey) {
+    return { host: envHost, credential: { kind: "apiKey", apiKey: envKey } };
+  }
 
   const config = await readConfig();
   if (!config) {
     throw new Error("Not configured. Run: stratum login (or set STRATUM_HOST and STRATUM_API_KEY)");
   }
-  return {
-    host: envHost ?? config.host,
-    apiKey: envKey ?? config.apiKey,
-  };
+  if (envKey) {
+    return { host: envHost ?? config.host, credential: { kind: "apiKey", apiKey: envKey } };
+  }
+  if (envHost && normalizeHost(envHost) !== normalizeHost(config.host)) {
+    if (config.credential.kind === "oauth") {
+      throw new Error(
+        `STRATUM_HOST is ${envHost} but the stored session belongs to ${config.host}. ` +
+          `Run: stratum login --host ${envHost} (or set STRATUM_API_KEY too).`,
+      );
+    }
+    return { host: envHost, credential: config.credential };
+  }
+  return config;
 }

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -111,6 +111,31 @@ function lockPath(): string {
 }
 
 /**
+ * Flush the directory entry `rename` just created.
+ *
+ * Syncing the temp file's contents is only half of durability: the rename
+ * itself lives in the parent directory, and after a power cut that entry can be
+ * missing even though the data blocks were flushed. Post-rotation that is a
+ * lost session, because the refresh token exists nowhere else.
+ *
+ * Best effort — opening a directory for sync is not portable (Windows refuses),
+ * and a platform that cannot do it should not fail an otherwise good write.
+ */
+async function syncDirectory(dir: string): Promise<void> {
+  try {
+    const handle = await open(dir, "r");
+    try {
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    // Durability improves where the platform allows it and is unchanged where
+    // it does not; either way the credential is already renamed into place.
+  }
+}
+
+/**
  * Write the credential file atomically, and leave it readable only by its owner.
  *
  * Two properties, one mechanism. Writing a temp file and `rename`ing it over the
@@ -150,6 +175,7 @@ export async function writeConfig(config: StratumConfig): Promise<void> {
       await handle.close();
     }
     await rename(temp, configPath());
+    await syncDirectory(dir);
   } catch (err) {
     await rm(temp, { force: true });
     throw new Error(
@@ -159,14 +185,20 @@ export async function writeConfig(config: StratumConfig): Promise<void> {
 }
 
 /**
- * Both thresholds must clear the worst-case time spent holding the lock, which
- * is a discovery round trip plus a token round trip — two 30s timeouts, so 60s.
- * A stale threshold at or below that lets a HEALTHY holder be declared dead,
- * and two processes then present the same refresh token, which the server reads
- * as theft and answers by revoking the whole grant.
+ * Two ordering rules, and both matter:
+ *
+ * `LOCK_STALE_MS` > the worst-case hold — a discovery round trip plus a token
+ * round trip, two 30s timeouts, so 60s. A stale threshold at or below that lets
+ * a HEALTHY holder be declared dead, and two processes then present the same
+ * refresh token, which the server reads as theft and revokes the whole grant.
+ *
+ * `LOCK_TIMEOUT_MS` > `LOCK_STALE_MS` — a waiter has to outlive the staleness
+ * threshold to be the one that breaks an abandoned lock. Inverted, a process
+ * killed mid-rotation wedges every later command: waiters give up before the
+ * lock is old enough to remove, so nothing ever clears it.
  */
-const LOCK_TIMEOUT_MS = 90_000;
-const LOCK_STALE_MS = 180_000;
+const LOCK_STALE_MS = 120_000;
+const LOCK_TIMEOUT_MS = 150_000;
 const LOCK_POLL_MS = 50;
 
 function delay(ms: number): Promise<void> {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,8 +2,9 @@
 import { createInterface } from "node:readline";
 import { Command } from "commander";
 import { parseProjectRef } from "./client.js";
-import { writeConfig } from "./config.js";
+import { clearConfig, readConfig, writeConfig } from "./config.js";
 import { getStagedContent, getStagedFiles } from "./git.js";
+import { assertSecureHost, browserLogin, normalizeHost, revokeToken } from "./oauth.js";
 import { print, withClient } from "./run.js";
 
 const program = new Command();
@@ -25,37 +26,151 @@ function prompt(question: string): Promise<string> {
 
 // ── login ─────────────────────────────────────────────────────────────────
 
+const DEFAULT_HOST = "https://app.usestratum.dev";
+
+/** A readline prompt in a pipe either hangs or reads EOF; neither is an answer. */
+function isInteractive(): boolean {
+  return process.stdin.isTTY === true && process.stdout.isTTY === true;
+}
+
+async function promptHost(): Promise<string> {
+  const answer = await prompt(`Stratum host [${DEFAULT_HOST}]: `);
+  return answer === "" ? DEFAULT_HOST : answer;
+}
+
+/** `login` verifies a key by calling an endpoint every host exposes. */
+async function healthCheck(host: string, apiKey: string): Promise<string | null> {
+  const response = await fetch(`${normalizeHost(host)}/health`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  }).catch((err: unknown) => {
+    return `could not connect to ${host}: ${err instanceof Error ? err.message : String(err)}`;
+  });
+  if (typeof response === "string") return response;
+  if (!response.ok) return `health check failed: HTTP ${response.status}`;
+  return null;
+}
+
 program
   .command("login")
   .description("Authenticate with a Stratum instance")
-  .option("--host <url>", "Stratum host URL")
-  .option("--key <key>", "API key")
-  .action(async (opts: { host?: string; key?: string }) => {
-    const host = opts.host ?? (await prompt("Stratum host (e.g. https://stratum.example.com): "));
-    const apiKey = opts.key ?? (await prompt("API key: "));
-    if (!host || !apiKey) {
-      process.stderr.write("Error: host and key are required\n");
-      process.exitCode = 1;
+  .option("--host <url>", `Stratum host URL (default: ${DEFAULT_HOST})`)
+  .option("--key <key>", "Authenticate with an API token instead of the browser")
+  .option("--read-only", "Request a read-only session")
+  .action(async (opts: { host?: string; key?: string; readOnly?: boolean }) => {
+    // Headless path: an API token, for CI and anywhere without a browser.
+    // Kept explicit — passing --key is how you say "do not open a browser".
+    if (opts.key !== undefined) {
+      try {
+        const resolvedHost = opts.host ?? (isInteractive() ? await promptHost() : DEFAULT_HOST);
+        // An API token never expires on its own, so putting one on a plaintext
+        // wire is strictly worse than doing it with an OAuth grant — which the
+        // browser path already refuses.
+        assertSecureHost(resolvedHost);
+        const failure = await healthCheck(resolvedHost, opts.key);
+        if (failure !== null) {
+          process.stderr.write(`Error: ${failure}\n`);
+          process.exitCode = 1;
+          return;
+        }
+        await writeConfig({ host: resolvedHost, credential: { kind: "apiKey", apiKey: opts.key } });
+        print(`Logged in to ${resolvedHost}`);
+      } catch (err) {
+        // Commander does not await this action, so without a boundary here a
+        // filesystem failure escapes as an unhandled rejection and a raw stack.
+        process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+        process.exitCode = 1;
+      }
       return;
     }
-    const response = await fetch(`${host.replace(/\/$/, "")}/health`, {
-      headers: { Authorization: `Bearer ${apiKey}` },
-    }).catch((err: unknown) => {
+
+    // Without a terminal there is nobody to approve the consent screen, and the
+    // browser flow would burn its five-minute timeout before failing. Say so now
+    // and name the two paths that do work unattended.
+    if (!isInteractive()) {
       process.stderr.write(
-        `Error: could not connect to ${host}: ${err instanceof Error ? err.message : String(err)}\n`,
+        "Error: stratum login needs a terminal to open a browser.\n" +
+          "  Use: stratum login --key <token>  (or set STRATUM_HOST and STRATUM_API_KEY)\n",
       );
       process.exitCode = 1;
-      return null;
-    });
-    if (!response) return;
-    if (!response.ok) {
-      process.stderr.write(`Error: health check failed: HTTP ${response.status}\n`);
-      process.exitCode = 1;
       return;
     }
-    await writeConfig({ host, apiKey });
-    print(`Logged in to ${host}`);
+
+    const host = normalizeHost(opts.host ?? DEFAULT_HOST);
+    // Reuse the client registration from a previous login on this host, so a
+    // user does not collect a new entry under Settings > Connected
+    // applications every time they sign in.
+    const existing = await readConfig();
+    const cachedClientId =
+      existing !== null &&
+      normalizeHost(existing.host) === host &&
+      existing.credential.kind === "oauth"
+        ? existing.credential.clientId
+        : undefined;
+
+    try {
+      const tokens = await browserLogin(host, {
+        cachedClientId,
+        ...(opts.readOnly ? { readOnly: true } : {}),
+        notify: print,
+      });
+      await writeConfig({
+        host,
+        credential: {
+          kind: "oauth",
+          clientId: tokens.clientId,
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+          expiresAt: tokens.expiresAt,
+          scope: tokens.scope,
+        },
+      });
+      // The GRANTED scope, never the requested one: a server may narrow it, and
+      // hiding that is how `--key` used to let a read-only credential look fine
+      // until the first write failed.
+      print(`Logged in to ${host}${tokens.scope ? ` (scope: ${tokens.scope})` : ""}`);
+    } catch (err) {
+      process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exitCode = 1;
+    }
   });
+
+program
+  .command("logout")
+  .description("Revoke this machine's session and clear stored credentials")
+  .action(async () => {
+    try {
+      await runLogout();
+    } catch (err) {
+      process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exitCode = 1;
+    }
+  });
+
+async function runLogout(): Promise<void> {
+  {
+    const config = await readConfig();
+    if (config === null) {
+      print("Not logged in.");
+      return;
+    }
+    if (config.credential.kind === "oauth") {
+      // Best effort in the strict sense: the local credential is cleared either
+      // way, and even a delivered request proves nothing, because RFC 7009 §2.2
+      // has the server answer 200 whether or not anything matched. So this
+      // reports delivery, never confirmed revocation.
+      const delivered = await revokeToken(config.host, {
+        clientId: config.credential.clientId,
+        token: config.credential.refreshToken,
+      });
+      if (!delivered) {
+        print(`Could not reach ${config.host} to revoke the session — clearing it locally.`);
+        print("Revoke it from Settings > Connected applications when you are back online.");
+      }
+    }
+    await clearConfig();
+    print(`Logged out of ${config.host}`);
+  }
+}
 
 // ── projects ──────────────────────────────────────────────────────────────
 
@@ -374,6 +489,13 @@ program
     withClient(async (client) => {
       const user = await client.me();
       print(`Authenticated as ${user.email} (${user.id})`);
+      // Scope decides whether the next write succeeds, so it belongs in the
+      // answer to "who am I" rather than in a 403 later.
+      const config = await readConfig();
+      if (config?.credential.kind === "oauth") {
+        print(`Host: ${config.host}`);
+        if (config.credential.scope) print(`Scope: ${config.credential.scope}`);
+      }
     }),
   );
 

--- a/cli/src/oauth.ts
+++ b/cli/src/oauth.ts
@@ -1,0 +1,575 @@
+/**
+ * Browser-based login: OAuth 2.1 authorization code + PKCE, run the way RFC
+ * 8252 tells a native app to run it.
+ *
+ * The CLI is a *public* client. It ships no secret (anything in an npm tarball
+ * is not a secret), so it registers itself on first use via RFC 7591 dynamic
+ * registration and proves possession of the authorization code with PKCE
+ * instead. The code comes back to a loopback HTTP server this process starts
+ * on an ephemeral port — the one redirect target a program on someone's laptop
+ * can actually own.
+ *
+ * Everything here talks to endpoints the Worker already serves for MCP
+ * clients; nothing is CLI-specific on the server side.
+ */
+import { spawn } from "node:child_process";
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+
+/** Shown on the consent screen, so make it the name a user would recognise. */
+const CLIENT_NAME = "Stratum CLI";
+
+/** The user has to find the browser, maybe sign in, then read the screen. */
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Every OAuth round trip is bounded. Without this a black-holed host hangs not
+ * just `login` but every ordinary command, because a token refresh re-enters
+ * discovery on its way to the token endpoint.
+ */
+const OAUTH_TIMEOUT_MS = 30_000;
+
+const SCOPE_READ = "mcp:read";
+const SCOPE_WRITE = "mcp:write";
+
+export interface OAuthTokens {
+  clientId: string;
+  accessToken: string;
+  refreshToken: string;
+  /** Absolute ISO instant, computed from `expires_in` at the moment of issue. */
+  expiresAt: string;
+  /** The scope the server GRANTED, which may be narrower than the one asked for. */
+  scope: string;
+}
+
+export interface AuthServerMetadata {
+  issuer?: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint?: string;
+  revocation_endpoint?: string;
+}
+
+/** A token pair the caller can use without re-checking its own fields. */
+interface IssuedTokenPair {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: unknown;
+  scope: string | undefined;
+}
+
+function describeOAuthError(body: Record<string, unknown>, status: number): string {
+  const detail = body.error_description ?? body.error;
+  return typeof detail === "string" && detail !== "" ? detail : `HTTP ${status}`;
+}
+
+/**
+ * A token endpoint answers with credentials, so its fields are validated rather
+ * than asserted: a numeric `access_token` cast to `string` is persisted as a
+ * JSON number and later sent as `Bearer 12345`.
+ */
+function readTokenPair(body: Record<string, unknown>): IssuedTokenPair | null {
+  const accessToken = body.access_token;
+  const refreshToken = body.refresh_token;
+  if (typeof accessToken !== "string" || accessToken === "") return null;
+  if (typeof refreshToken !== "string" || refreshToken === "") return null;
+  return {
+    accessToken,
+    refreshToken,
+    expiresIn: body.expires_in,
+    scope: typeof body.scope === "string" ? body.scope : undefined,
+  };
+}
+
+export function normalizeHost(host: string): string {
+  return host.replace(/\/$/, "");
+}
+
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+const LOOPBACK_HOSTS: ReadonlySet<string> = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+/**
+ * Refuse to run the flow over plaintext.
+ *
+ * Everything that follows — the authorization code, the PKCE verifier, the
+ * refresh token — is a bearer credential, and `http://` puts all of it on the
+ * wire in the clear. Loopback is the sole exception, because there is no wire.
+ */
+export function assertSecureHost(host: string): URL {
+  const url = parseUrl(host);
+  if (url === null) throw new Error(`'${host}' is not a valid URL`);
+  if (url.protocol === "https:") return url;
+  if (url.protocol === "http:" && LOOPBACK_HOSTS.has(url.hostname)) return url;
+  throw new Error(`refusing to send credentials to ${host} over plaintext — use an https:// host`);
+}
+
+/**
+ * A discovery document names the URLs this process is about to POST the
+ * authorization code and the refresh token to. Trusting it blindly means a
+ * hostile or tampered-with document can redirect those credentials to a server
+ * of its choosing, so every endpoint must belong to the host the user named.
+ */
+function assertSameOrigin(endpoint: string, origin: string, field: string): void {
+  const url = parseUrl(endpoint);
+  if (url === null || url.origin !== origin) {
+    throw new Error(
+      `discovery document for ${origin} points ${field} at ${endpoint} — refusing to send credentials off-origin`,
+    );
+  }
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit = {}): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new Error(`request to ${url} timed out`)),
+    OAUTH_TIMEOUT_MS,
+  );
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * `response.json()` on a host that answers HTML — a proxy error page, a captive
+ * portal, an SPA catch-all — throws a parser error naming a stray `<`, which
+ * tells the user nothing. Every OAuth response goes through here so the failure
+ * names the actual problem.
+ */
+async function readJson(response: Response, context: string): Promise<Record<string, unknown>> {
+  const body = await response.text();
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (parsed === null || typeof parsed !== "object") throw new Error("not an object");
+    return parsed as Record<string, unknown>;
+  } catch {
+    throw new Error(`${context} did not return JSON (HTTP ${response.status})`);
+  }
+}
+
+function base64Url(bytes: Buffer): string {
+  return bytes.toString("base64url");
+}
+
+/**
+ * RFC 7636 §4.1: 43–128 characters from the unreserved set. 32 random bytes
+ * base64url-encode to 43, the shortest length the spec allows and already 256
+ * bits of entropy.
+ */
+export function createPkcePair(): { verifier: string; challenge: string } {
+  const verifier = base64Url(randomBytes(32));
+  const challenge = base64Url(createHash("sha256").update(verifier).digest());
+  return { verifier, challenge };
+}
+
+/** Constant-time, because `state` is the CSRF defence for the callback. */
+function stateMatches(expected: string, presented: string): boolean {
+  const a = Buffer.from(expected);
+  const b = Buffer.from(presented);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export async function discover(host: string): Promise<AuthServerMetadata> {
+  const origin = assertSecureHost(host).origin;
+  // Built from the origin, not concatenated onto the raw host: a host carrying a
+  // query or path suffix would otherwise bury the well-known path inside it.
+  const url = new URL("/.well-known/oauth-authorization-server", origin).toString();
+  const response = await fetchWithTimeout(url).catch((err: unknown) => {
+    throw new Error(`could not reach ${host}: ${err instanceof Error ? err.message : String(err)}`);
+  });
+  if (!response.ok) {
+    throw new Error(
+      `${host} does not advertise OAuth (HTTP ${response.status} from ${url}). Use \`stratum login --key <token>\` against this host.`,
+    );
+  }
+  const metadata = (await readJson(response, `${host} OAuth discovery`).catch(() => {
+    throw new Error(
+      `${host} does not advertise OAuth (its discovery endpoint did not return JSON). Use \`stratum login --key <token>\` against this host.`,
+    );
+  })) as Partial<AuthServerMetadata>;
+
+  if (!metadata.authorization_endpoint || !metadata.token_endpoint) {
+    throw new Error(`${host} returned incomplete OAuth metadata`);
+  }
+  // RFC 8414 §3.3: the issuer must be the host we asked, or the document is
+  // describing somebody else's authorization server.
+  if (metadata.issuer !== undefined && parseUrl(metadata.issuer)?.origin !== origin) {
+    throw new Error(`discovery document for ${origin} claims issuer ${metadata.issuer}`);
+  }
+  assertSameOrigin(metadata.authorization_endpoint, origin, "authorization_endpoint");
+  assertSameOrigin(metadata.token_endpoint, origin, "token_endpoint");
+  if (metadata.registration_endpoint) {
+    assertSameOrigin(metadata.registration_endpoint, origin, "registration_endpoint");
+  }
+  if (metadata.revocation_endpoint) {
+    assertSameOrigin(metadata.revocation_endpoint, origin, "revocation_endpoint");
+  }
+  return metadata as AuthServerMetadata;
+}
+
+/** RFC 7591 dynamic registration. Public client: no secret, PKCE mandatory. */
+async function registerClient(
+  metadata: AuthServerMetadata,
+  redirectUri: string,
+  scope: string,
+): Promise<string> {
+  const endpoint = metadata.registration_endpoint;
+  if (!endpoint) {
+    throw new Error("This host does not support dynamic client registration");
+  }
+  const response = await fetchWithTimeout(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_name: CLIENT_NAME,
+      redirect_uris: [redirectUri],
+      token_endpoint_auth_method: "none",
+      scope,
+    }),
+  });
+  const body = await readJson(response, "client registration");
+  const clientId = typeof body.client_id === "string" ? body.client_id : null;
+  if (!response.ok || clientId === null) {
+    throw new Error(`client registration failed: ${describeOAuthError(body, response.status)}`);
+  }
+  return clientId;
+}
+
+/**
+ * Is a cached client_id still usable on this host?
+ *
+ * The token endpoint authenticates the client *before* it looks at the grant,
+ * so a deliberately junk refresh grant separates the two cases: `invalid_client`
+ * means the row is gone, anything else means it is still there. Worth the one
+ * request — the alternative is discovering it in the browser, where an unknown
+ * client is a dead-end HTML page rather than something the CLI can recover from.
+ *
+ * Fails CLOSED. Only a well-formed JSON answer proves the client exists; a 5xx,
+ * a WAF interstitial, or a dropped connection proves nothing, and re-registering
+ * costs one spare row while guessing wrong costs the user a dead end.
+ */
+async function cachedClientUsable(
+  metadata: AuthServerMetadata,
+  clientId: string,
+): Promise<boolean> {
+  const response = await fetchWithTimeout(metadata.token_endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: "probe",
+      client_id: clientId,
+    }).toString(),
+  }).catch(() => null);
+  if (response === null) return false;
+  const body = await readJson(response, "client probe").catch(() => null);
+  if (body === null) return false;
+  return body.error !== "invalid_client";
+}
+
+/**
+ * Hand the URL to the user's browser. Best-effort by design: the URL is always
+ * printed too, so a headless box, an unusual desktop, or a missing `open`
+ * degrades to copy-and-paste rather than to a failed login.
+ */
+function openBrowser(url: string): void {
+  const [command, args] =
+    process.platform === "darwin"
+      ? (["open", [url]] as const)
+      : process.platform === "win32"
+        ? (["cmd", ["/c", "start", "", url]] as const)
+        : (["xdg-open", [url]] as const);
+  try {
+    const child = spawn(command, [...args], { stdio: "ignore", detached: true });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // Printed URL is the fallback.
+  }
+}
+
+const DONE_STYLE =
+  "font:16px/1.5 system-ui,sans-serif;margin:0;display:grid;place-items:center;height:100vh";
+
+const DONE_PAGE = (heading: string, detail: string): string =>
+  `<!doctype html><meta charset="utf-8"><title>Stratum CLI</title><body style="${DONE_STYLE}"><div style="text-align:center"><h1 style="font-size:1.25rem;margin:0 0 .5rem">${heading}</h1><p style="margin:0;color:#555">${detail}</p></div>`;
+
+interface CallbackResult {
+  code: string;
+}
+
+export interface CallbackListener {
+  port: number;
+  /** The interface actually bound, so tests can pin the loopback-only property. */
+  address: string;
+  code: Promise<CallbackResult>;
+  close: () => void;
+}
+
+/**
+ * Start the loopback listener and return the port plus a promise for the code.
+ *
+ * The listener is started *before* registration so the redirect URI we register
+ * is the one we will actually present. (The server also implements RFC 8252
+ * §7.3 port relaxation, which is what lets a *cached* client_id keep working on
+ * a different ephemeral port next time.)
+ *
+ * Anything the browser sends that is not a valid callback is answered and then
+ * IGNORED, and the listener keeps waiting. Every page the user has open can
+ * reach a loopback port, so treating a stray or mismatched request as fatal
+ * would let any of them cancel a login in progress.
+ */
+export function listenForCallback(expectedState: string): Promise<CallbackListener> {
+  const server = createServer();
+  let settle: ((result: CallbackResult) => void) | null = null;
+  let fail: ((err: Error) => void) | null = null;
+  const code = new Promise<CallbackResult>((resolve, reject) => {
+    settle = resolve;
+    fail = reject;
+  });
+
+  server.on("request", (req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    if (url.pathname !== "/callback") {
+      res.writeHead(404).end();
+      return;
+    }
+    const params = url.searchParams;
+    const presentedState = params.get("state") ?? "";
+    // The state gate comes first: without a matching state this request did not
+    // originate from the authorization we started, whatever else it carries.
+    if (!stateMatches(expectedState, presentedState)) {
+      res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(DONE_PAGE("Not this login", "This request did not match a login in progress."));
+      return;
+    }
+
+    const error = params.get("error");
+    if (error !== null) {
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(DONE_PAGE("Authorization declined", "You can close this window."));
+      fail?.(new Error(`${error}: ${params.get("error_description") ?? "authorization denied"}`));
+      return;
+    }
+
+    const authCode = params.get("code") ?? "";
+    if (authCode === "") {
+      res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(DONE_PAGE("Login failed", "No authorization code was returned."));
+      return;
+    }
+
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(
+      DONE_PAGE("Signed in to Stratum", "You can close this window and return to the terminal."),
+    );
+    settle?.({ code: authCode });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.on("error", reject);
+    // Loopback only: this listener accepts an authorization code, and nothing
+    // outside this machine has any business reaching it.
+    server.listen(0, "127.0.0.1", () => {
+      const bound = server.address() as AddressInfo;
+      resolve({
+        port: bound.port,
+        address: bound.address,
+        code,
+        close: () => server.close(),
+      });
+    });
+  });
+}
+
+async function exchangeCode(
+  metadata: AuthServerMetadata,
+  params: { clientId: string; code: string; verifier: string; redirectUri: string },
+): Promise<IssuedTokenPair> {
+  const response = await fetchWithTimeout(metadata.token_endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code: params.code,
+      redirect_uri: params.redirectUri,
+      client_id: params.clientId,
+      code_verifier: params.verifier,
+    }).toString(),
+  });
+  const body = await readJson(response, "token exchange");
+  const tokens = response.ok ? readTokenPair(body) : null;
+  if (tokens === null) {
+    throw new Error(`token exchange failed: ${describeOAuthError(body, response.status)}`);
+  }
+  return tokens;
+}
+
+/**
+ * `expires_in` is whatever the server sent, not necessarily a number. A string,
+ * an object, or 1e18 all reach `new Date(...)` and throw `Invalid time value` —
+ * and this runs *after* the token endpoint has already retired the refresh
+ * token we presented, so throwing here loses the rotated token before it can be
+ * written and logs the user out with an error about dates.
+ *
+ * An unusable value is therefore treated as absent, which the design already
+ * handles: the credential looks expired and costs one extra refresh.
+ */
+export function expiresAtFrom(expiresIn: unknown, now = Date.now()): string {
+  const seconds =
+    typeof expiresIn === "number" && Number.isFinite(expiresIn) && expiresIn >= 0
+      ? Math.min(expiresIn, MAX_EXPIRES_IN_SECONDS)
+      : 0;
+  return new Date(now + seconds * 1000).toISOString();
+}
+
+/** A year. Anything beyond this is a broken server, not a long-lived token. */
+const MAX_EXPIRES_IN_SECONDS = 366 * 24 * 60 * 60;
+
+export interface BrowserLoginOptions {
+  /** Reuse a client_id from a previous login on this host, if still valid. */
+  cachedClientId?: string | undefined;
+  readOnly?: boolean;
+  /** Where progress lines go; the caller owns stdout formatting. */
+  notify?: (line: string) => void;
+}
+
+/**
+ * Run the whole browser flow and return tokens ready to persist.
+ */
+export async function browserLogin(
+  host: string,
+  opts: BrowserLoginOptions = {},
+): Promise<OAuthTokens> {
+  const notify = opts.notify ?? (() => {});
+  const requestedScope = opts.readOnly ? SCOPE_READ : `${SCOPE_READ} ${SCOPE_WRITE}`;
+  const metadata = await discover(host);
+
+  const state = base64Url(randomBytes(24));
+  const { verifier, challenge } = createPkcePair();
+  const listener = await listenForCallback(state);
+  const redirectUri = `http://127.0.0.1:${listener.port}/callback`;
+
+  try {
+    let clientId = opts.cachedClientId;
+    if (clientId && !(await cachedClientUsable(metadata, clientId))) clientId = undefined;
+    if (!clientId) clientId = await registerClient(metadata, redirectUri, requestedScope);
+
+    const authorizeUrl = new URL(metadata.authorization_endpoint);
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("client_id", clientId);
+    authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+    authorizeUrl.searchParams.set("scope", requestedScope);
+    authorizeUrl.searchParams.set("state", state);
+    authorizeUrl.searchParams.set("code_challenge", challenge);
+    authorizeUrl.searchParams.set("code_challenge_method", "S256");
+
+    notify("Opening your browser to authorize the Stratum CLI…");
+    notify(`If it does not open, visit:\n  ${authorizeUrl.toString()}`);
+    openBrowser(authorizeUrl.toString());
+
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("timed out waiting for authorization (5 minutes)")),
+        LOGIN_TIMEOUT_MS,
+      ).unref(),
+    );
+    const { code } = await Promise.race([listener.code, timeout]);
+
+    const tokens = await exchangeCode(metadata, { clientId, code, verifier, redirectUri });
+    return {
+      clientId,
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      expiresAt: expiresAtFrom(tokens.expiresIn),
+      // What the server granted, not what we asked for. The two can differ, and
+      // recording the request would hide a narrower grant until the first write.
+      scope: tokens.scope ?? requestedScope,
+    };
+  } finally {
+    // `unref` on the timer is not what releases the event loop — the HTTP
+    // server is. This close is load-bearing.
+    listener.close();
+  }
+}
+
+/** Distinguishes "this session is over" from "the network is down". */
+export class SessionExpiredError extends Error {
+  constructor(detail: string) {
+    super(`session expired (${detail}). Run: stratum login`);
+    this.name = "SessionExpiredError";
+  }
+}
+
+/**
+ * Rotate an access token. Stratum rotates the refresh token on every use, so
+ * the caller MUST persist what comes back — the presented refresh token is
+ * dead the moment this returns, and replaying it later reads as theft and
+ * revokes the whole grant.
+ */
+export async function refreshTokens(
+  host: string,
+  params: { clientId: string; refreshToken: string; metadata?: AuthServerMetadata },
+): Promise<OAuthTokens> {
+  const metadata = params.metadata ?? (await discover(host));
+  const response = await fetchWithTimeout(metadata.token_endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: params.refreshToken,
+      client_id: params.clientId,
+    }).toString(),
+  });
+  const body = await readJson(response, "token refresh");
+  const tokens = response.ok ? readTokenPair(body) : null;
+  if (tokens === null) {
+    const detail = describeOAuthError(body, response.status);
+    // Only the grant-level errors mean re-authenticating would help. A 429 or a
+    // 503 reported as "session expired" sends the user to log in again over a
+    // problem that logging in cannot fix — the same misreporting the 401 path
+    // one layer up goes out of its way to avoid.
+    const code = body.error;
+    if (code === "invalid_grant" || code === "invalid_client") {
+      throw new SessionExpiredError(detail);
+    }
+    throw new Error(`could not refresh the session: ${detail}`);
+  }
+  return {
+    clientId: params.clientId,
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    expiresAt: expiresAtFrom(tokens.expiresIn),
+    scope: tokens.scope ?? "",
+  };
+}
+
+/**
+ * RFC 7009 revocation.
+ *
+ * Returns whether the request was *delivered*, which is the most this can
+ * honestly report: §2.2 has the server answer 200 whether or not anything
+ * matched, so a `true` here never proves the grant is gone.
+ */
+export async function revokeToken(
+  host: string,
+  params: { clientId: string; token: string },
+): Promise<boolean> {
+  const metadata = await discover(host).catch(() => null);
+  if (!metadata?.revocation_endpoint) return false;
+  const response = await fetchWithTimeout(metadata.revocation_endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ token: params.token, client_id: params.clientId }).toString(),
+  }).catch(() => null);
+  return response?.ok ?? false;
+}

--- a/cli/src/oauth.ts
+++ b/cli/src/oauth.ts
@@ -126,14 +126,27 @@ function assertSameOrigin(endpoint: string, origin: string, field: string): void
   }
 }
 
-async function fetchWithTimeout(url: string, init: RequestInit = {}): Promise<Response> {
+/** A response whose body has already been read, so nothing is left to stall on. */
+interface TimedResponse {
+  ok: boolean;
+  status: number;
+  text: string;
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit = {}): Promise<TimedResponse> {
   const controller = new AbortController();
   const timer = setTimeout(
     () => controller.abort(new Error(`request to ${url} timed out`)),
     OAUTH_TIMEOUT_MS,
   );
   try {
-    return await fetch(url, { ...init, signal: controller.signal });
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    // The body is read while the timer is still armed. Clearing it as soon as
+    // the headers land leaves a server free to send `200 OK` and then stall the
+    // body forever — which would hang not just `login` but every command, since
+    // a token refresh runs through here.
+    const text = await response.text();
+    return { ok: response.ok, status: response.status, text };
   } finally {
     clearTimeout(timer);
   }
@@ -145,10 +158,9 @@ async function fetchWithTimeout(url: string, init: RequestInit = {}): Promise<Re
  * tells the user nothing. Every OAuth response goes through here so the failure
  * names the actual problem.
  */
-async function readJson(response: Response, context: string): Promise<Record<string, unknown>> {
-  const body = await response.text();
+function readJson(response: TimedResponse, context: string): Record<string, unknown> {
   try {
-    const parsed: unknown = JSON.parse(body);
+    const parsed: unknown = JSON.parse(response.text);
     if (parsed === null || typeof parsed !== "object") throw new Error("not an object");
     return parsed as Record<string, unknown>;
   } catch {
@@ -191,11 +203,14 @@ export async function discover(host: string): Promise<AuthServerMetadata> {
       `${host} does not advertise OAuth (HTTP ${response.status} from ${url}). Use \`stratum login --key <token>\` against this host.`,
     );
   }
-  const metadata = (await readJson(response, `${host} OAuth discovery`).catch(() => {
+  let metadata: Partial<AuthServerMetadata>;
+  try {
+    metadata = readJson(response, `${host} OAuth discovery`) as Partial<AuthServerMetadata>;
+  } catch {
     throw new Error(
       `${host} does not advertise OAuth (its discovery endpoint did not return JSON). Use \`stratum login --key <token>\` against this host.`,
     );
-  })) as Partial<AuthServerMetadata>;
+  }
 
   if (!metadata.authorization_endpoint || !metadata.token_endpoint) {
     throw new Error(`${host} returned incomplete OAuth metadata`);
@@ -271,9 +286,12 @@ async function cachedClientUsable(
     }).toString(),
   }).catch(() => null);
   if (response === null) return false;
-  const body = await readJson(response, "client probe").catch(() => null);
-  if (body === null) return false;
-  return body.error !== "invalid_client";
+  try {
+    return readJson(response, "client probe").error !== "invalid_client";
+  } catch {
+    // Unparseable is inconclusive, and inconclusive fails closed.
+    return false;
+  }
 }
 
 /**
@@ -282,14 +300,24 @@ async function cachedClientUsable(
  * degrades to copy-and-paste rather than to a failed login.
  */
 function openBrowser(url: string): void {
+  // Windows deliberately avoids `cmd /c start`: cmd re-parses its argument and
+  // treats `&`, `|` and `^` as syntax, so a host whose authorization_endpoint
+  // carries those characters — same-origin is enforced, the path and query are
+  // not — could turn opening a browser into running a command. `rundll32` takes
+  // the URL as a single argument and never goes through a shell.
   const [command, args] =
     process.platform === "darwin"
       ? (["open", [url]] as const)
       : process.platform === "win32"
-        ? (["cmd", ["/c", "start", "", url]] as const)
+        ? (["rundll32", ["url.dll,FileProtocolHandler", url]] as const)
         : (["xdg-open", [url]] as const);
   try {
-    const child = spawn(command, [...args], { stdio: "ignore", detached: true });
+    const child = spawn(command, [...args], {
+      stdio: "ignore",
+      detached: true,
+      // Explicit: `spawn` must never hand these arguments to a shell.
+      shell: false,
+    });
     child.on("error", () => {});
     child.unref();
   } catch {

--- a/cli/src/run.ts
+++ b/cli/src/run.ts
@@ -1,5 +1,5 @@
 import { StratumClient } from "./client.js";
-import { getConfig } from "./config.js";
+import { getConfig, providerFor } from "./config.js";
 
 /**
  * Shared command wrapper: resolves config, runs the action, and converts
@@ -9,7 +9,7 @@ export async function withClient(action: (client: StratumClient) => Promise<void
   let client: StratumClient;
   try {
     const config = await getConfig();
-    client = new StratumClient(config.host, config.apiKey);
+    client = new StratumClient(config.host, providerFor(config));
   } catch (err) {
     process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
     process.exitCode = 1;

--- a/cli/tests/auth.test.ts
+++ b/cli/tests/auth.test.ts
@@ -1,0 +1,188 @@
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError, StratumClient } from "../src/client.js";
+import { fromFile, isExpired, toFile } from "../src/config.js";
+import { createPkcePair, expiresAtFrom, normalizeHost } from "../src/oauth.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("PKCE", () => {
+  it("derives an S256 challenge from the verifier", () => {
+    const { verifier, challenge } = createPkcePair();
+    expect(challenge).toBe(createHash("sha256").update(verifier).digest("base64url"));
+  });
+
+  it("uses a verifier within the length RFC 7636 allows", () => {
+    const { verifier } = createPkcePair();
+    expect(verifier.length).toBeGreaterThanOrEqual(43);
+    expect(verifier.length).toBeLessThanOrEqual(128);
+    expect(verifier).toMatch(/^[A-Za-z0-9\-._~]+$/);
+  });
+
+  it("is different every time", () => {
+    expect(createPkcePair().verifier).not.toBe(createPkcePair().verifier);
+  });
+});
+
+describe("config file format", () => {
+  it("reads the legacy flat apiKey file", () => {
+    const config = fromFile({ host: "https://s.example", apiKey: "stratum_user_x" });
+    expect(config).toEqual({
+      host: "https://s.example",
+      credential: { kind: "apiKey", apiKey: "stratum_user_x" },
+    });
+  });
+
+  it("round-trips an api key without inventing an oauth block", () => {
+    const config = fromFile({ host: "https://s.example", apiKey: "k" });
+    expect(config).not.toBeNull();
+    expect(toFile(config as NonNullable<typeof config>)).toEqual({
+      host: "https://s.example",
+      apiKey: "k",
+    });
+  });
+
+  it("reads an oauth grant", () => {
+    const config = fromFile({
+      host: "https://s.example",
+      oauth: {
+        clientId: "c1",
+        accessToken: "stratum_mcp_a",
+        refreshToken: "stratum_mcprt_r",
+        expiresAt: "2030-01-01T00:00:00.000Z",
+        scope: "mcp:read mcp:write",
+      },
+    });
+    expect(config?.credential).toMatchObject({ kind: "oauth", clientId: "c1" });
+  });
+
+  it("prefers the oauth grant when a stale apiKey is also present", () => {
+    const config = fromFile({
+      host: "https://s.example",
+      apiKey: "stratum_user_old",
+      oauth: {
+        clientId: "c1",
+        accessToken: "stratum_mcp_a",
+        refreshToken: "stratum_mcprt_r",
+        expiresAt: "2030-01-01T00:00:00.000Z",
+        scope: "mcp:read",
+      },
+    });
+    expect(config?.credential.kind).toBe("oauth");
+  });
+
+  it("rejects a half-written oauth block rather than using it", () => {
+    const config = fromFile({
+      host: "https://s.example",
+      oauth: { clientId: "c1", accessToken: "a" },
+    });
+    expect(config).toBeNull();
+  });
+
+  it("returns null without a host", () => {
+    expect(fromFile({ apiKey: "k" })).toBeNull();
+  });
+});
+
+describe("expiry", () => {
+  it("treats a token inside the refresh skew as expired", () => {
+    const now = Date.parse("2030-01-01T00:00:00.000Z");
+    expect(isExpired(new Date(now + 30_000).toISOString(), now)).toBe(true);
+    expect(isExpired(new Date(now + 300_000).toISOString(), now)).toBe(false);
+  });
+
+  it("treats an unparseable expiry as expired", () => {
+    expect(isExpired("not a date")).toBe(true);
+  });
+
+  it("treats a missing expires_in as immediately expired", () => {
+    const now = Date.parse("2030-01-01T00:00:00.000Z");
+    expect(isExpired(expiresAtFrom(undefined, now), now)).toBe(true);
+    expect(isExpired(expiresAtFrom(3600, now), now)).toBe(false);
+  });
+});
+
+describe("normalizeHost", () => {
+  it("drops exactly one trailing slash", () => {
+    expect(normalizeHost("https://s.example/")).toBe("https://s.example");
+    expect(normalizeHost("https://s.example")).toBe("https://s.example");
+  });
+});
+
+describe("401 refresh and retry", () => {
+  function jsonResponse(status: number, body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("refreshes once and replays the request", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(401, { error: "Invalid token" }))
+      .mockResolvedValueOnce(jsonResponse(200, { projects: [] }));
+
+    const credential = {
+      token: vi.fn().mockResolvedValue("old"),
+      refresh: vi.fn().mockResolvedValue("new"),
+    };
+    const client = new StratumClient("https://s.example", credential);
+
+    await expect(client.request("GET", "/api/projects")).resolves.toEqual({ projects: [] });
+    expect(credential.refresh).toHaveBeenCalledTimes(1);
+
+    const second = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    expect((second.headers as Record<string, string>).Authorization).toBe("Bearer new");
+  });
+
+  it("does not retry when the credential cannot be renewed", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(401, { error: "Invalid token" }));
+    const client = new StratumClient("https://s.example", "stratum_user_x");
+
+    await expect(client.request("GET", "/api/projects")).rejects.toThrow("Invalid token");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after one retry rather than looping", async () => {
+    // A fresh Response per call: a body can only be read once, and the retry
+    // reads its own.
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => jsonResponse(401, { error: "Invalid token" }));
+    const credential = {
+      token: vi.fn().mockResolvedValue("old"),
+      refresh: vi.fn().mockResolvedValue("new"),
+    };
+    const client = new StratumClient("https://s.example", credential);
+
+    await expect(client.request("GET", "/api/projects")).rejects.toThrow("Invalid token");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(credential.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refresh on a 403, which a new token would not fix", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(403, { error: "This OAuth grant is read-only." }));
+    const credential = {
+      token: vi.fn().mockResolvedValue("old"),
+      refresh: vi.fn().mockResolvedValue("new"),
+    };
+    const client = new StratumClient("https://s.example", credential);
+
+    await expect(client.request("GET", "/api/projects")).rejects.toThrow("read-only");
+    expect(credential.refresh).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries the status code on the error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(404, { error: "Not found" }));
+    const client = new StratumClient("https://s.example", "k");
+    await expect(client.request("GET", "/api/projects")).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/cli/tests/credential-store.test.ts
+++ b/cli/tests/credential-store.test.ts
@@ -1,0 +1,267 @@
+import { chmod, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { StratumConfig } from "../src/config.js";
+
+/**
+ * `config.ts` resolves its path from `homedir()` at call time, so each test gets
+ * a throwaway home and the real `~/.stratum` is never touched.
+ */
+let home: string;
+
+async function loadConfigModule() {
+  vi.resetModules();
+  vi.doMock("node:os", async () => {
+    const actual = await vi.importActual<typeof import("node:os")>("node:os");
+    return { ...actual, homedir: () => home };
+  });
+  return import("../src/config.js");
+}
+
+beforeEach(async () => {
+  home = join(tmpdir(), `stratum-cfg-${Math.random().toString(36).slice(2)}`);
+  await mkdir(home, { recursive: true });
+});
+
+afterEach(async () => {
+  vi.doUnmock("node:os");
+  vi.resetModules();
+  await rm(home, { recursive: true, force: true });
+});
+
+const oauthConfig = {
+  host: "https://s.example",
+  credential: {
+    kind: "oauth" as const,
+    clientId: "c1",
+    accessToken: "stratum_mcp_a",
+    refreshToken: "stratum_mcprt_r",
+    expiresAt: "2030-01-01T00:00:00.000Z",
+    scope: "mcp:read mcp:write",
+  },
+};
+
+async function modeOf(path: string): Promise<string> {
+  return ((await stat(path)).mode & 0o777).toString(8);
+}
+
+describe("credential file permissions", () => {
+  it("writes a new credential file 0600 in a 0700 directory", async () => {
+    const { writeConfig } = await loadConfigModule();
+    await writeConfig(oauthConfig);
+    expect(await modeOf(join(home, ".stratum", "config.json"))).toBe("600");
+    expect(await modeOf(join(home, ".stratum"))).toBe("700");
+  });
+
+  it("hardens an existing world-readable file and directory", async () => {
+    // The upgrade path: a previous release left 0644/0755 behind. Passing `mode`
+    // to writeFile/mkdir does NOT fix this, because POSIX honours it only when
+    // the call creates the node — which is why the write goes via rename.
+    const dir = join(home, ".stratum");
+    await mkdir(dir, { recursive: true });
+    await chmod(dir, 0o755);
+    await writeFile(join(dir, "config.json"), '{"host":"x","apiKey":"k"}', { mode: 0o644 });
+    expect(await modeOf(join(dir, "config.json"))).toBe("644");
+
+    const { writeConfig } = await loadConfigModule();
+    await writeConfig(oauthConfig);
+
+    expect(await modeOf(join(dir, "config.json"))).toBe("600");
+    expect(await modeOf(dir)).toBe("700");
+  });
+});
+
+describe("atomic credential writes", () => {
+  it("leaves the previous credential intact when the write fails", async () => {
+    const { writeConfig, readConfig } = await loadConfigModule();
+    await writeConfig(oauthConfig);
+
+    const rotated = {
+      ...oauthConfig,
+      credential: { ...oauthConfig.credential, refreshToken: "stratum_mcprt_r2" },
+    };
+    // A circular value fails inside JSON.stringify, before anything is renamed
+    // over the live file — the shape of any mid-write crash.
+    const poisoned = { ...rotated, credential: { ...rotated.credential } } as Record<
+      string,
+      unknown
+    >;
+    (poisoned.credential as Record<string, unknown>).self = poisoned;
+
+    await expect(writeConfig(poisoned as unknown as StratumConfig)).rejects.toThrow();
+
+    const survivor = await readConfig();
+    expect(survivor?.credential).toMatchObject({ refreshToken: "stratum_mcprt_r" });
+  });
+
+  it("leaves no temp files behind on success or failure", async () => {
+    const { writeConfig } = await loadConfigModule();
+    await writeConfig(oauthConfig);
+    const { readdir } = await import("node:fs/promises");
+    const entries = await readdir(join(home, ".stratum"));
+    expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([]);
+  });
+
+  it("never exposes a partially written file to a reader", async () => {
+    const { writeConfig, readConfig } = await loadConfigModule();
+    await writeConfig(oauthConfig);
+    const raw = await readFile(join(home, ".stratum", "config.json"), "utf-8");
+    expect(() => JSON.parse(raw)).not.toThrow();
+    expect((await readConfig())?.host).toBe("https://s.example");
+  });
+});
+
+describe("cross-process refresh lock", () => {
+  it("serialises holders so only one runs at a time", async () => {
+    const { withConfigLock } = await loadConfigModule();
+    let active = 0;
+    let maxActive = 0;
+    const body = async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 20));
+      active -= 1;
+      return true;
+    };
+    await Promise.all([withConfigLock(body), withConfigLock(body), withConfigLock(body)]);
+    expect(maxActive).toBe(1);
+  });
+
+  it("releases the lock when the action throws", async () => {
+    const { withConfigLock } = await loadConfigModule();
+    await expect(withConfigLock(async () => Promise.reject(new Error("boom")))).rejects.toThrow(
+      "boom",
+    );
+    await expect(withConfigLock(async () => "recovered")).resolves.toBe("recovered");
+  });
+
+  it("breaks a stale lock left by a dead process", async () => {
+    const { withConfigLock } = await loadConfigModule();
+    const dir = join(home, ".stratum");
+    await mkdir(dir, { recursive: true });
+    const lock = join(dir, "config.lock");
+    await writeFile(lock, "");
+    const old = new Date(Date.now() - 5 * 60_000);
+    const { utimes } = await import("node:fs/promises");
+    await utimes(lock, old, old);
+
+    await expect(withConfigLock(async () => "proceeded")).resolves.toBe("proceeded");
+  });
+});
+
+describe("rotation under contention", () => {
+  it("adopts the winner's token instead of replaying a retired one", async () => {
+    // Replaying a retired refresh token is what makes the server revoke the whole
+    // grant, so a provider that waited on the lock must re-read and use what it
+    // finds rather than the token it started with.
+    const { writeConfig, providerFor, readConfig } = await loadConfigModule();
+    await writeConfig({
+      ...oauthConfig,
+      credential: { ...oauthConfig.credential, expiresAt: "2020-01-01T00:00:00.000Z" },
+    });
+
+    // Simulate the winner having already rotated and persisted.
+    await writeConfig({
+      ...oauthConfig,
+      credential: {
+        ...oauthConfig.credential,
+        refreshToken: "stratum_mcprt_WINNER",
+        accessToken: "stratum_mcp_WINNER",
+        expiresAt: "2030-01-01T00:00:00.000Z",
+      },
+    });
+
+    expect(await readConfig()).not.toBeNull();
+    // The regression path would POST to s.example. Stub it so that path fails
+    // instantly and offline, instead of waiting on a real DNS lookup.
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("no network in unit tests"));
+    const provider = providerFor({
+      host: oauthConfig.host,
+      credential: { ...oauthConfig.credential, expiresAt: "2020-01-01T00:00:00.000Z" },
+    });
+
+    // Resolving at all is the proof: the stale credential is expired, so any
+    // path that did NOT adopt the stored token would call the real token
+    // endpoint at s.example and fail rather than return the winner's token.
+    await expect(provider.token()).resolves.toBe("stratum_mcp_WINNER");
+  });
+});
+
+describe("lock ownership", () => {
+  it("does not delete a lock it no longer owns", async () => {
+    // Without an ownership check, a holder that was broken as stale deletes the
+    // NEXT holder's lock on its way out, and mutual exclusion is gone for good.
+    const { withConfigLock } = await loadConfigModule();
+    const dir = join(home, ".stratum");
+    await mkdir(dir, { recursive: true });
+    const lock = join(dir, "config.lock");
+
+    let observed: string | null = null;
+    await withConfigLock(async () => {
+      // Simulate being broken as stale: someone replaces our lock with theirs.
+      await writeFile(lock, "another-processes-nonce");
+      observed = await readFile(lock, "utf-8");
+    });
+
+    expect(observed).toBe("another-processes-nonce");
+    // Ours released without destroying theirs.
+    await expect(readFile(lock, "utf-8")).resolves.toBe("another-processes-nonce");
+    await rm(lock, { force: true });
+  });
+
+  it("reports a directory at the lock path instead of wedging forever", async () => {
+    const { withConfigLock } = await loadConfigModule();
+    const dir = join(home, ".stratum");
+    await mkdir(join(dir, "config.lock"), { recursive: true });
+    await expect(withConfigLock(async () => "unreachable")).rejects.toThrow(/is a directory/);
+  });
+
+  it("does not re-run the action when the action itself raises EEXIST", async () => {
+    // mkdir on a path that exists as a file raises EEXIST — the same errno as a
+    // busy lock. Conflating them re-runs a rotation with a spent refresh token.
+    const { withConfigLock } = await loadConfigModule();
+    let runs = 0;
+    const failing = async () => {
+      runs += 1;
+      const err = new Error("EEXIST: file already exists") as Error & { code: string };
+      err.code = "EEXIST";
+      throw err;
+    };
+    await expect(withConfigLock(failing)).rejects.toThrow(/EEXIST/);
+    expect(runs).toBe(1);
+  });
+});
+
+describe("credential replaced while refreshing", () => {
+  async function providerAgainstStored(stored: unknown) {
+    const mod = await loadConfigModule();
+    const dir = join(home, ".stratum");
+    await mkdir(dir, { recursive: true });
+    if (stored !== null) {
+      await writeFile(join(dir, "config.json"), JSON.stringify(stored), { mode: 0o600 });
+    }
+    return mod.providerFor({
+      host: "https://s.example",
+      credential: { ...oauthConfig.credential, expiresAt: "2020-01-01T00:00:00.000Z" },
+    });
+  }
+
+  it("refuses to rotate after a logout instead of recreating the file", async () => {
+    const provider = await providerAgainstStored(null);
+    await expect(provider.token()).rejects.toThrow(/removed, or you logged out/);
+  });
+
+  it("refuses to rotate when the stored credential is now an API token", async () => {
+    const provider = await providerAgainstStored({ host: "https://s.example", apiKey: "k" });
+    await expect(provider.token()).rejects.toThrow(/now an API token/);
+  });
+
+  it("refuses to send this host's refresh token to a different host", async () => {
+    const provider = await providerAgainstStored({
+      host: "https://other.example",
+      oauth: { ...oauthConfig.credential, kind: undefined },
+    });
+    await expect(provider.token()).rejects.toThrow(/now belongs to https:\/\/other\.example/);
+  });
+});

--- a/cli/tests/credential-store.test.ts
+++ b/cli/tests/credential-store.test.ts
@@ -27,6 +27,10 @@ beforeEach(async () => {
 afterEach(async () => {
   vi.doUnmock("node:os");
   vi.resetModules();
+  // `resetModules` does not undo `vi.spyOn(globalThis, "fetch")`, and no config
+  // enables `restoreMocks`. Without this a stubbed fetch leaks into later tests
+  // and hides real regressions.
+  vi.restoreAllMocks();
   await rm(home, { recursive: true, force: true });
 });
 
@@ -95,15 +99,23 @@ describe("atomic credential writes", () => {
     expect(survivor?.credential).toMatchObject({ refreshToken: "stratum_mcprt_r" });
   });
 
-  it("leaves no temp files behind on success or failure", async () => {
+  it("leaves no temp files behind, on success or on a failed write", async () => {
     const { writeConfig } = await loadConfigModule();
-    await writeConfig(oauthConfig);
     const { readdir } = await import("node:fs/promises");
+    await writeConfig(oauthConfig);
+
+    const poisoned = { ...oauthConfig, credential: { ...oauthConfig.credential } } as Record<
+      string,
+      unknown
+    >;
+    (poisoned.credential as Record<string, unknown>).self = poisoned;
+    await expect(writeConfig(poisoned as unknown as StratumConfig)).rejects.toThrow();
+
     const entries = await readdir(join(home, ".stratum"));
     expect(entries.filter((name) => name.endsWith(".tmp"))).toEqual([]);
   });
 
-  it("never exposes a partially written file to a reader", async () => {
+  it("leaves parseable JSON once a write completes", async () => {
     const { writeConfig, readConfig } = await loadConfigModule();
     await writeConfig(oauthConfig);
     const raw = await readFile(join(home, ".stratum", "config.json"), "utf-8");

--- a/cli/tests/oauth-flow.test.ts
+++ b/cli/tests/oauth-flow.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { assertSecureHost, discover, expiresAtFrom, listenForCallback } from "../src/oauth.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const validMetadata = {
+  issuer: "https://s.example",
+  authorization_endpoint: "https://s.example/oauth/authorize",
+  token_endpoint: "https://s.example/oauth/token",
+  registration_endpoint: "https://s.example/oauth/register",
+  revocation_endpoint: "https://s.example/oauth/revoke",
+};
+
+describe("transport security", () => {
+  it("accepts https", () => {
+    expect(assertSecureHost("https://s.example").origin).toBe("https://s.example");
+  });
+
+  it("accepts plaintext loopback, where there is no wire to sniff", () => {
+    expect(() => assertSecureHost("http://127.0.0.1:8787")).not.toThrow();
+    expect(() => assertSecureHost("http://localhost:8787")).not.toThrow();
+  });
+
+  it("refuses plaintext to a remote host", () => {
+    expect(() => assertSecureHost("http://s.example")).toThrow(/plaintext/);
+  });
+
+  it("refuses a malformed host", () => {
+    expect(() => assertSecureHost("not a url")).toThrow(/not a valid URL/);
+  });
+});
+
+describe("discovery document validation", () => {
+  it("accepts a well-formed same-origin document", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(validMetadata));
+    await expect(discover("https://s.example")).resolves.toMatchObject({
+      token_endpoint: "https://s.example/oauth/token",
+    });
+  });
+
+  it("refuses a token endpoint on another origin", async () => {
+    // The credential-exfiltration case: this endpoint receives the auth code,
+    // the PKCE verifier and the refresh token.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ ...validMetadata, token_endpoint: "https://evil.example/oauth/token" }),
+    );
+    await expect(discover("https://s.example")).rejects.toThrow(/off-origin/);
+  });
+
+  it("refuses an off-origin authorization endpoint", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ ...validMetadata, authorization_endpoint: "https://evil.example/go" }),
+    );
+    await expect(discover("https://s.example")).rejects.toThrow(/off-origin/);
+  });
+
+  it("refuses a document claiming a different issuer", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ ...validMetadata, issuer: "https://evil.example" }),
+    );
+    await expect(discover("https://s.example")).rejects.toThrow(/claims issuer/);
+  });
+
+  it("reports a helpful error when the host answers HTML, not a JSON parse error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("<!doctype html><title>Login</title>", {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      }),
+    );
+    const failure = await discover("https://s.example").catch((err: Error) => err);
+    expect((failure as Error).message).toMatch(/does not advertise OAuth/);
+    // Not a raw parser error naming a stray "<", which tells the user nothing.
+    expect((failure as Error).message).not.toMatch(/Unexpected token/);
+  });
+
+  it("names --key when the host has no OAuth at all", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ error: "nope" }, 404));
+    await expect(discover("https://s.example")).rejects.toThrow(/--key/);
+  });
+});
+
+describe("loopback callback listener", () => {
+  // `Connection: close` keeps undici from holding a keep-alive socket open past
+  // server.close(), which surfaces as a spurious parser error after the test.
+  async function get(port: number, path: string): Promise<number> {
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+      headers: { Connection: "close" },
+    });
+    await response.arrayBuffer();
+    return response.status;
+  }
+
+  it("accepts a matching state and yields the code", async () => {
+    const listener = await listenForCallback("st4te");
+    try {
+      await get(listener.port, "/callback?code=abc&state=st4te");
+      await expect(listener.code).resolves.toEqual({ code: "abc" });
+    } finally {
+      listener.close();
+    }
+  });
+
+  it("ignores a stray request instead of aborting the login", async () => {
+    // Any page the user has open can hit a loopback port. Treating that as fatal
+    // would let any of them cancel a login in progress.
+    const listener = await listenForCallback("st4te");
+    try {
+      expect(await get(listener.port, "/callback?code=evil&state=wrong")).toBe(400);
+      expect(await get(listener.port, "/callback")).toBe(400);
+      expect(await get(listener.port, "/somewhere-else")).toBe(404);
+
+      // Still listening: the real callback still completes.
+      await get(listener.port, "/callback?code=real&state=st4te");
+      await expect(listener.code).resolves.toEqual({ code: "real" });
+    } finally {
+      listener.close();
+    }
+  });
+
+  it("surfaces an explicit denial", async () => {
+    const listener = await listenForCallback("st4te");
+    try {
+      // Attach the handler BEFORE the request lands: the rejection happens while
+      // `get` is in flight, and an unobserved rejection trips Node's handler.
+      const rejected = expect(listener.code).rejects.toThrow(/access_denied/);
+      await get(listener.port, "/callback?error=access_denied&state=st4te");
+      await rejected;
+    } finally {
+      listener.close();
+    }
+  });
+
+  it("does not let a mismatched state deliver a denial either", async () => {
+    const listener = await listenForCallback("st4te");
+    try {
+      expect(await get(listener.port, "/callback?error=access_denied&state=wrong")).toBe(400);
+      await get(listener.port, "/callback?code=real&state=st4te");
+      await expect(listener.code).resolves.toEqual({ code: "real" });
+    } finally {
+      listener.close();
+    }
+  });
+
+  it("binds loopback only", async () => {
+    const listener = await listenForCallback("st4te");
+    try {
+      expect(listener.port).toBeGreaterThan(0);
+    } finally {
+      listener.close();
+    }
+  });
+});
+
+describe("expiry arithmetic", () => {
+  it("treats a missing expires_in as already expired", () => {
+    const now = Date.parse("2030-01-01T00:00:00.000Z");
+    expect(expiresAtFrom(undefined, now)).toBe(new Date(now).toISOString());
+  });
+});
+
+describe("token response validation", () => {
+  it("keeps a junk expires_in from throwing after the token is already rotated", () => {
+    // This runs after the server has retired the presented refresh token, so a
+    // throw here loses the rotated one and silently ends the session.
+    for (const junk of ["not-a-number", {}, [], null, Number.NaN, 1e18, -5]) {
+      expect(() => expiresAtFrom(junk)).not.toThrow();
+    }
+    expect(expiresAtFrom("not-a-number", 0)).toBe(new Date(0).toISOString());
+  });
+
+  it("honours a sane expires_in", () => {
+    expect(expiresAtFrom(3600, 0)).toBe(new Date(3_600_000).toISOString());
+  });
+
+  it("clamps an absurd expires_in instead of producing an invalid date", () => {
+    expect(() => new Date(expiresAtFrom(1e18, 0)).toISOString()).not.toThrow();
+  });
+});
+
+describe("loopback binding", () => {
+  it("binds 127.0.0.1, not every interface", async () => {
+    const listener = await listenForCallback("st4te");
+    try {
+      expect(listener.address).toBe("127.0.0.1");
+    } finally {
+      listener.close();
+    }
+  });
+});

--- a/cli/tests/oauth-flow.test.ts
+++ b/cli/tests/oauth-flow.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { assertSecureHost, discover, expiresAtFrom, listenForCallback } from "../src/oauth.js";
+import {
+  SessionExpiredError,
+  assertSecureHost,
+  discover,
+  expiresAtFrom,
+  listenForCallback,
+  refreshTokens,
+} from "../src/oauth.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -127,6 +134,17 @@ describe("loopback callback listener", () => {
     }
   });
 
+  it("keeps listening after a matching state with no code", async () => {
+    const listener = await listenForCallback("st4te");
+    try {
+      expect(await get(listener.port, "/callback?state=st4te")).toBe(400);
+      await get(listener.port, "/callback?code=real&state=st4te");
+      await expect(listener.code).resolves.toEqual({ code: "real" });
+    } finally {
+      listener.close();
+    }
+  });
+
   it("surfaces an explicit denial", async () => {
     const listener = await listenForCallback("st4te");
     try {
@@ -195,5 +213,63 @@ describe("loopback binding", () => {
     } finally {
       listener.close();
     }
+  });
+});
+
+describe("refresh failure classification", () => {
+  const metadata = {
+    issuer: "https://s.example",
+    authorization_endpoint: "https://s.example/oauth/authorize",
+    token_endpoint: "https://s.example/oauth/token",
+  };
+  const params = { clientId: "c1", refreshToken: "stratum_mcprt_r", metadata };
+
+  function tokenEndpoint(body: unknown, status: number): void {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(body, status));
+  }
+
+  it("treats invalid_grant as an expired session", async () => {
+    tokenEndpoint({ error: "invalid_grant" }, 400);
+    await expect(refreshTokens("https://s.example", params)).rejects.toBeInstanceOf(
+      SessionExpiredError,
+    );
+  });
+
+  it("treats invalid_client as an expired session", async () => {
+    tokenEndpoint({ error: "invalid_client" }, 401);
+    await expect(refreshTokens("https://s.example", params)).rejects.toBeInstanceOf(
+      SessionExpiredError,
+    );
+  });
+
+  it("does NOT tell the user to log in again after a transient 503", async () => {
+    // Re-authenticating cannot fix a server fault, and "session expired" sends
+    // the user to do exactly that.
+    tokenEndpoint({ error: "temporarily_unavailable" }, 503);
+    const failure = await refreshTokens("https://s.example", params).catch((err: Error) => err);
+    expect(failure).not.toBeInstanceOf(SessionExpiredError);
+    expect((failure as Error).message).toMatch(/could not refresh/);
+  });
+
+  it("does NOT tell the user to log in again after a 429", async () => {
+    tokenEndpoint({ error: "slow_down" }, 429);
+    const failure = await refreshTokens("https://s.example", params).catch((err: Error) => err);
+    expect(failure).not.toBeInstanceOf(SessionExpiredError);
+  });
+
+  it("rejects a non-string access_token rather than sending `Bearer 12345`", async () => {
+    tokenEndpoint({ access_token: 12345, refresh_token: 678, expires_in: 3600 }, 200);
+    await expect(refreshTokens("https://s.example", params)).rejects.toThrow(/could not refresh/);
+  });
+
+  it("accepts a well-formed rotation", async () => {
+    tokenEndpoint(
+      { access_token: "stratum_mcp_new", refresh_token: "stratum_mcprt_new", expires_in: 3600 },
+      200,
+    );
+    await expect(refreshTokens("https://s.example", params)).resolves.toMatchObject({
+      accessToken: "stratum_mcp_new",
+      refreshToken: "stratum_mcprt_new",
+    });
   });
 });

--- a/cli/tsconfig.test.json
+++ b/cli/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src", "tests"]
+}

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -112,14 +112,27 @@ it mints never expires and cannot be revoked one at a time, so letting either
 rotate it would mean revoking them contained nothing — the credential could have
 issued itself a permanent replacement on the way out.
 
-## MCP OAuth grants
+## OAuth grants
 
-The remote MCP endpoint at `/mcp` is an OAuth 2.1 protected resource, and
-Stratum is the authorization server. An MCP client registers itself
+Stratum is an OAuth 2.1 authorization server, and the remote MCP endpoint at
+`/mcp` is a protected resource. A client registers itself
 ([RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591)), sends the user to a
 consent screen, and receives an access token — so a user connects an editor
-without ever pasting a credential into it. See
-[the MCP guide](../user-guide/mcp.md) for the full flow.
+without ever pasting a credential into it.
+
+Two first-party clients use this flow, and the grants they receive are the same
+kind of credential:
+
+- **MCP clients** (editors, agent frameworks) — see
+  [the MCP guide](../user-guide/mcp.md).
+- **The CLI**, since `stratum login` — see [the CLI guide](../user-guide/cli.md).
+  It registers as a public client with a loopback redirect
+  ([RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252)) rather than an
+  https one, because it runs on the user's own machine.
+
+An OAuth access token authenticates **everywhere a user token does**, which is
+what keeps the MCP tools from drifting away from the API they wrap — with the
+carve-outs listed below.
 
 | | |
 |---|---|

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -22,30 +22,103 @@ npm link          # puts the `stratum` binary on your PATH
 ## Authentication
 
 ```bash
+stratum login
+```
+
+That is the whole thing: `login` opens your browser, you approve the CLI on
+Stratum's consent screen, and the tokens land in `~/.stratum/config.json`.
+There is no token to create by hand and none to paste.
+
+Under the hood it is the OAuth 2.1 authorization-code flow that native apps
+use (RFC 8252): the CLI registers itself as a public client
+([RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591)), proves possession of the code with
+PKCE, and receives the redirect on a loopback listener bound to an ephemeral
+port on `127.0.0.1`. Nothing is minted that you have to store, and the grant
+shows up under **Settings → Connected applications** alongside your editors,
+where it can be revoked like any other.
+
+The **granted** scope is printed at login and by `stratum status`, so a grant
+narrower than you asked for is visible immediately rather than at the first
+write that fails. By default the session is read **and** write, because most
+commands write. For a session that cannot change anything:
+
+```bash
+stratum login --read-only
+```
+
+Sign out, which asks the host to revoke the grant and then clears the local
+credential — and still clears it locally if the host is unreachable:
+
+```bash
+stratum logout
+```
+
+`logout` reports that the revocation request was *delivered*, not that the grant
+is gone: [RFC 7009 §2.2](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2)
+has the server answer `200` whether or not anything matched. To confirm, check
+**Settings → Connected applications**.
+
+### Headless: CI, containers, and anywhere without a browser
+
+Without a terminal, `stratum login` refuses rather than opening a browser nobody
+can see. Two options:
+
+```bash
 stratum login --host https://app.usestratum.dev --key stratum_user_xxxxx
 ```
 
-Run it with no flags to be prompted for both values. Two things to know:
+or set `STRATUM_HOST` and `STRATUM_API_KEY`, which override the config file.
+`STRATUM_API_KEY` overrides on its own; `STRATUM_HOST` on its own retargets a
+stored **API token** only. With a browser session it is refused, because an
+OAuth grant belongs to the server that issued it and is worthless — and unsafe —
+anywhere else. Passing `--key` is also how you say "do not open a
+browser" on a machine that has one. Create the token from
+**Settings → API tokens**; token management deliberately requires a browser
+session, so a token can never mint another token.
 
-- **Credentials land in `~/.stratum/config.json` as plaintext JSON.** Treat
-  that file like the token itself. In CI, skip the file entirely and set
-  `STRATUM_HOST` and `STRATUM_API_KEY` — the environment variables override
-  the config file, each independently.
-- **`login` verifies the key exists, not what it can do.** It calls the
+> **Changed:** `stratum login --host <url>` *without* `--key` now opens a
+> browser instead of prompting for a key. A script that piped a key into that
+> prompt must pass `--key` or use the environment variables.
+
+Two things to know either way:
+
+- **Credentials land in `~/.stratum/config.json`.** The file is `0600` in a
+  `0700` directory — including on installs upgraded from a release that left it
+  world-readable — and is written atomically, so an interrupted write cannot
+  destroy a session. It is still plaintext: treat it like the token itself. In
+  CI, skip the file entirely and use the environment variables.
+- **`login --key` verifies the key exists, not what it can do.** It calls the
   host's `/health` endpoint with your key, and an invalid or mistyped key
-  fails there with `HTTP 401` before anything is saved. What login does *not*
+  fails there with `HTTP 401` before anything is saved. What it does *not*
   check is **scope**: a `read`-scoped token logs in fine and only fails on
-  the first write. `stratum status` confirms which account you are:
+  the first write. The browser flow has no such gap — you choose the scope at
+  login and `--read-only` is the only way to end up with less than you need.
+
+`stratum status` confirms which account you are:
 
 ```bash
 stratum status
 # Authenticated as you@example.com (usr_...)
 ```
 
-Most commands write, so use a `read_write` [API token](../api/authentication.md).
-A `read`-scoped token works for the listing commands but is refused with
-`403 TOKEN_SCOPE_INSUFFICIENT` on anything else. The CLI has no commands for
-creating or revoking tokens — that surface is deliberately
+### Sessions renew themselves
+
+An OAuth access token is good for an hour and the CLI refreshes it silently
+when it expires, rotating the stored refresh token each time. You stay signed
+in for up to 30 days of inactivity, and 180 days in total, after which
+`stratum login` asks for approval again. An API token, by contrast, lives
+until it expires or is revoked.
+
+Rotation is coordinated across processes with a lock file
+(`~/.stratum/config.lock`), so running several `stratum` commands at once is
+safe. It has to be: presenting a refresh token that has already been rotated is
+indistinguishable from a stolen one, and the server responds by revoking the
+whole grant.
+
+A read-only session — `--read-only`, or a `read`-scoped API token — is refused
+on every request that is not a `GET` or a `HEAD`, with
+`403 TOKEN_SCOPE_INSUFFICIENT`. Beyond `logout`, the CLI has no commands for
+creating or revoking API tokens: that surface is deliberately
 [session-only](../api/authentication.md#managing-tokens-requires-a-session), so
 it lives in the settings UI.
 

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -10,7 +10,7 @@ agent frameworks already understand.
 ## Installation
 
 The package is **not yet published to npm** — install it from the `cli/`
-directory of the repository (Node 18+):
+directory of the repository (Node 20+):
 
 ```bash
 git clone https://github.com/stratum-eng/stratum.git

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -339,7 +339,10 @@ git clone https://github.com/stratum-eng/stratum.git
 cd stratum/cli && npm install && npm run build
 npm link   # puts the `stratum` binary on your PATH
 
-stratum login --host https://app.usestratum.dev --key stratum_user_xxxxx
+stratum login          # opens your browser; no token to create or paste
+
+# Headless (CI, containers), where there is no browser:
+# stratum login --host https://app.usestratum.dev --key stratum_user_xxxxx
 # or: export STRATUM_HOST=... STRATUM_API_KEY=...   (env overrides the config file)
 
 stratum status        # who am I

--- a/website/src/content/docs/guides/cli.md
+++ b/website/src/content/docs/guides/cli.md
@@ -26,30 +26,103 @@ npm link          # puts the `stratum` binary on your PATH
 ## Authentication
 
 ```bash
+stratum login
+```
+
+That is the whole thing: `login` opens your browser, you approve the CLI on
+Stratum's consent screen, and the tokens land in `~/.stratum/config.json`.
+There is no token to create by hand and none to paste.
+
+Under the hood it is the OAuth 2.1 authorization-code flow that native apps
+use (RFC 8252): the CLI registers itself as a public client
+([RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591)), proves possession of the code with
+PKCE, and receives the redirect on a loopback listener bound to an ephemeral
+port on `127.0.0.1`. Nothing is minted that you have to store, and the grant
+shows up under **Settings → Connected applications** alongside your editors,
+where it can be revoked like any other.
+
+The **granted** scope is printed at login and by `stratum status`, so a grant
+narrower than you asked for is visible immediately rather than at the first
+write that fails. By default the session is read **and** write, because most
+commands write. For a session that cannot change anything:
+
+```bash
+stratum login --read-only
+```
+
+Sign out, which asks the host to revoke the grant and then clears the local
+credential — and still clears it locally if the host is unreachable:
+
+```bash
+stratum logout
+```
+
+`logout` reports that the revocation request was *delivered*, not that the grant
+is gone: [RFC 7009 §2.2](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2)
+has the server answer `200` whether or not anything matched. To confirm, check
+**Settings → Connected applications**.
+
+### Headless: CI, containers, and anywhere without a browser
+
+Without a terminal, `stratum login` refuses rather than opening a browser nobody
+can see. Two options:
+
+```bash
 stratum login --host https://app.usestratum.dev --key stratum_user_xxxxx
 ```
 
-Run it with no flags to be prompted for both values. Two things to know:
+or set `STRATUM_HOST` and `STRATUM_API_KEY`, which override the config file.
+`STRATUM_API_KEY` overrides on its own; `STRATUM_HOST` on its own retargets a
+stored **API token** only. With a browser session it is refused, because an
+OAuth grant belongs to the server that issued it and is worthless — and unsafe —
+anywhere else. Passing `--key` is also how you say "do not open a
+browser" on a machine that has one. Create the token from
+**Settings → API tokens**; token management deliberately requires a browser
+session, so a token can never mint another token.
 
-- **Credentials land in `~/.stratum/config.json` as plaintext JSON.** Treat
-  that file like the token itself. In CI, skip the file entirely and set
-  `STRATUM_HOST` and `STRATUM_API_KEY` — the environment variables override
-  the config file, each independently.
-- **`login` verifies the key exists, not what it can do.** It calls the
+> **Changed:** `stratum login --host <url>` *without* `--key` now opens a
+> browser instead of prompting for a key. A script that piped a key into that
+> prompt must pass `--key` or use the environment variables.
+
+Two things to know either way:
+
+- **Credentials land in `~/.stratum/config.json`.** The file is `0600` in a
+  `0700` directory — including on installs upgraded from a release that left it
+  world-readable — and is written atomically, so an interrupted write cannot
+  destroy a session. It is still plaintext: treat it like the token itself. In
+  CI, skip the file entirely and use the environment variables.
+- **`login --key` verifies the key exists, not what it can do.** It calls the
   host's `/health` endpoint with your key, and an invalid or mistyped key
-  fails there with `HTTP 401` before anything is saved. What login does *not*
+  fails there with `HTTP 401` before anything is saved. What it does *not*
   check is **scope**: a `read`-scoped token logs in fine and only fails on
-  the first write. `stratum status` confirms which account you are:
+  the first write. The browser flow has no such gap — you choose the scope at
+  login and `--read-only` is the only way to end up with less than you need.
+
+`stratum status` confirms which account you are:
 
 ```bash
 stratum status
 # Authenticated as you@example.com (usr_...)
 ```
 
-Most commands write, so use a `read_write` [API token](/reference/authentication/).
-A `read`-scoped token works for the listing commands but is refused with
-`403 TOKEN_SCOPE_INSUFFICIENT` on anything else. The CLI has no commands for
-creating or revoking tokens — that surface is deliberately
+### Sessions renew themselves
+
+An OAuth access token is good for an hour and the CLI refreshes it silently
+when it expires, rotating the stored refresh token each time. You stay signed
+in for up to 30 days of inactivity, and 180 days in total, after which
+`stratum login` asks for approval again. An API token, by contrast, lives
+until it expires or is revoked.
+
+Rotation is coordinated across processes with a lock file
+(`~/.stratum/config.lock`), so running several `stratum` commands at once is
+safe. It has to be: presenting a refresh token that has already been rotated is
+indistinguishable from a stolen one, and the server responds by revoking the
+whole grant.
+
+A read-only session — `--read-only`, or a `read`-scoped API token — is refused
+on every request that is not a `GET` or a `HEAD`, with
+`403 TOKEN_SCOPE_INSUFFICIENT`. Beyond `logout`, the CLI has no commands for
+creating or revoking API tokens: that surface is deliberately
 [session-only](/reference/authentication/#managing-tokens-requires-a-session), so
 it lives in the settings UI.
 

--- a/website/src/content/docs/guides/cli.md
+++ b/website/src/content/docs/guides/cli.md
@@ -14,7 +14,7 @@ agent frameworks already understand.
 ## Installation
 
 The package is **not yet published to npm** — install it from the `cli/`
-directory of the repository (Node 18+):
+directory of the repository (Node 20+):
 
 ```bash
 git clone https://github.com/stratum-eng/stratum.git

--- a/website/src/content/docs/guides/getting-started.md
+++ b/website/src/content/docs/guides/getting-started.md
@@ -343,7 +343,10 @@ git clone https://github.com/stratum-eng/stratum.git
 cd stratum/cli && npm install && npm run build
 npm link   # puts the `stratum` binary on your PATH
 
-stratum login --host https://app.usestratum.dev --key stratum_user_xxxxx
+stratum login          # opens your browser; no token to create or paste
+
+# Headless (CI, containers), where there is no browser:
+# stratum login --host https://app.usestratum.dev --key stratum_user_xxxxx
 # or: export STRATUM_HOST=... STRATUM_API_KEY=...   (env overrides the config file)
 
 stratum status        # who am I

--- a/website/src/content/docs/reference/authentication.md
+++ b/website/src/content/docs/reference/authentication.md
@@ -116,14 +116,27 @@ it mints never expires and cannot be revoked one at a time, so letting either
 rotate it would mean revoking them contained nothing — the credential could have
 issued itself a permanent replacement on the way out.
 
-## MCP OAuth grants
+## OAuth grants
 
-The remote MCP endpoint at `/mcp` is an OAuth 2.1 protected resource, and
-Stratum is the authorization server. An MCP client registers itself
+Stratum is an OAuth 2.1 authorization server, and the remote MCP endpoint at
+`/mcp` is a protected resource. A client registers itself
 ([RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591)), sends the user to a
 consent screen, and receives an access token — so a user connects an editor
-without ever pasting a credential into it. See
-[the MCP guide](/guides/mcp/) for the full flow.
+without ever pasting a credential into it.
+
+Two first-party clients use this flow, and the grants they receive are the same
+kind of credential:
+
+- **MCP clients** (editors, agent frameworks) — see
+  [the MCP guide](/guides/mcp/).
+- **The CLI**, since `stratum login` — see [the CLI guide](/guides/cli/).
+  It registers as a public client with a loopback redirect
+  ([RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252)) rather than an
+  https one, because it runs on the user's own machine.
+
+An OAuth access token authenticates **everywhere a user token does**, which is
+what keeps the MCP tools from drifting away from the API they wrap — with the
+carve-outs listed below.
 
 | | |
 |---|---|


### PR DESCRIPTION
## Why

`stratum login` accepted only `--key`, and getting that token was an out-of-band errand: open the settings UI, mint a token, paste it into a terminal. The guard that forces this is deliberate — token management requires a browser session, so a token can never mint another token — but it left the CLI unable to log you in.

**The server already had everything needed.** Stratum runs an OAuth 2.1 authorization server for MCP clients (RFC 7591 dynamic registration, mandatory PKCE, `authorization_code` + `refresh_token`); #356 added loopback redirects with RFC 8252 §7.3 port relaxation, which exists precisely for native apps binding an ephemeral port; and `src/middleware/auth.ts` resolves OAuth access tokens as a peer of API tokens on every route, by explicit design — *"the MCP endpoint reuses the real API handlers, so an OAuth credential has to authenticate everywhere a user token does, or the tools would diverge from the API they wrap."*

The CLI simply never asked. **This is the client half only — zero server changes.**

## What

```bash
stratum login              # opens your browser; nothing to create or paste
stratum login --read-only  # narrower grant
stratum logout             # revokes, then clears
```

The **granted** scope — not the requested one — is printed at login and by `stratum status`, so a narrowed grant is visible immediately rather than at the first write that 403s. That was the `--key` path's quiet failure mode: it validates against `/health`, which authenticates but does not report scope.

`--key` and `STRATUM_HOST`/`STRATUM_API_KEY` still work for CI. One breaking change, in the CHANGELOG: `--host` *without* `--key` now opens a browser instead of prompting, and without a TTY the command refuses rather than hanging.

## The delicate part

Refresh tokens rotate, and the server treats a retired one as theft — presenting it revokes the **entire** grant (`storage/oauth.ts:765`, OAuth 2.1 §4.3.1). Adversarial review found three defects here, each reproduced before being fixed:

| Defect | Consequence |
|---|---|
| `mode` on `writeFile` is honoured only when the call *creates* the file | Everyone upgrading kept a world-readable refresh token at `0644` |
| Two concurrent commands both held the same refresh token | The loser's replay revoked the grant — logged out of every terminal |
| A junk `expires_in` threw *after* the server had retired our token | Rotated token never persisted; silent logout reading `Invalid time value` |

Fixes: writes go through a temp file + `rename` (which replaces the inode and carries `0600` with it) and are fsynced; rotation takes a cross-process lock with an ownership nonce and re-reads the stored credential inside it, aborting rather than rotating if another `login`/`logout` changed it — including one for a *different host*, which would otherwise have sent one host's token to another; and a malformed `expires_in` is coerced rather than thrown.

Also hardened: credentials refused over plaintext and to off-origin endpoints named by a discovery document; timeouts on every OAuth call (a refresh re-enters discovery, so an unreachable host hung *every* command); a stray request to the loopback port is ignored rather than cancelling the login; token fields validated instead of cast (`access_token: 12345` was reachable); only `invalid_grant`/`invalid_client` report as an expired session.

## Verification

- `cli`: **64 tests** (from 11), typecheck, lint — all pass.
- Against **production**: three concurrent commands needing a refresh → one rotation, session intact, no lock or temp files left. Before the fix that exact command revoked the grant.
- Root typecheck passes; `src/` untouched.
- Two gates did not exist and now do: `cli/tests/` was never typechecked (which is what let two `as never` escapes through), and `cli/` was never linted in CI.

## Note for reviewers

`npm test` at the repo root has **43 pre-existing failures on `main`** (`tests/issues.test.ts`, `tests/issues-comment-body-limit.test.ts`). Confirmed by stashing this branch and re-running — identical. Not from this PR, and untouched by it.

Known trade-offs, deliberately not fixed here: null-valued numeric fields crash the `index.ts` output formatters (pre-existing, unrelated to auth); `cli/` still has no coverage floor; `createAgent` is dead code in `client.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JSjib4fGRdhYF9AMUazdC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added browser-based OAuth login with secure authorization, automatic token refresh, and scope reporting.
  - Added read-only sessions and a `logout` command that revokes OAuth sessions when possible and clears local credentials.
  - Added headless and CI authentication using API keys.
  - Improved authentication errors, request retries, timeouts, and status reporting.

- **Security**
  - Credentials now use restricted permissions, atomic updates, and protection against concurrent access.

- **Documentation**
  - Updated CLI and OAuth guides with login methods, token behavior, scopes, and logout.
  - CLI now requires Node.js 20 or newer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->