### PR TITLE
Deploy the merged tree to Cloudflare or Vercel after a merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          for queue in stratum-events-staging stratum-imports-staging; do
+          for queue in stratum-events-staging stratum-imports-staging stratum-deploys-staging stratum-deploys-dlq-staging; do
             if out=$(npx wrangler queues create "$queue" 2>&1); then
               echo "✓ Created queue $queue"
             elif echo "$out" | grep -qiE "already (exists|taken)|11009"; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   public API reference. Without the optional `CLOUDFLARE_WORKERS_SUBDOMAIN`
   secret a Cloudflare deploy succeeds with no URL. And a project that only wants
   deploys must still write an `evaluators:` block, because a policy file without
-  one is malformed and blocks every merge. Limits (2,000 files, 25 MiB total,
-  10 MiB per file) are enforced before the first provider request, so a deploy
-  never publishes half a tree. Full reference:
+  one is malformed and blocks every merge. Limits (16 `deploys:` entries per
+  policy file, 2,000 files, 25 MiB total, 10 MiB per file) are enforced before
+  the first provider request, so a deploy never publishes half a tree. Full reference:
   [Deployments](docs/user-guide/deployments.md).
 - **`stratum login` signs you in through the browser.** The CLI had one way to
   authenticate — `--key`, with a token you first created by hand in the settings
@@ -238,6 +238,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   grants as well as scoped tokens.
 
 ### Fixed
+- **A post-merge deploy cannot be lost or run twice.** Four fixes to the new
+  deployment path, all invisible until they bite: the deploy queue ran two
+  messages per isolate, and two concurrent Vercel deploys exceeded the isolate's
+  memory before a terminal status could be written, stranding rows at `running`
+  (`max_concurrency` is now 1); the runner had no deadline, so its storage lease
+  could expire mid-upload and let a second consumer publish the same commit (it
+  now gives up strictly before the lease can); a queue send that failed silently
+  dropped the deploy — after a merge there was no row to recover at all, and
+  after approve or retry the row sat `queued` forever while the response advised
+  a retry that could not work (the request is now recorded durably and picked up
+  by the existing five-minute sweep); and several rejected `deploys:` entries
+  collapsed into one row, so only one of their reasons survived — a rejection
+  sharing a name with a valid entry could even take that entry's row and stop it
+  deploying. Every rejected entry now gets its own `failed` row.
 - **The header fits a phone.** Signed in, the nav's five links were laid out in
   one unwrappable row, so below about 460px the row ran past the viewport, the
   page scrolled sideways, and the wordmark and "logout" were clipped off either

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than folded into this change.
 
 ### Added
+- **Stratum can deploy a merged change.** A new `deploys:` block in
+  `.stratum/policy.yaml` names one or more deploys, each with a `target`
+  (`cloudflare-pages`, `cloudflare-workers`, or `vercel`), an optional `dir` to
+  publish, the `secrets` it needs, and an optional `requiresApproval` gate.
+  After a change merges *and* the post-merge check declines to revert it, the
+  merged tree is read at the pinned merge commit — configuration and code are
+  therefore provably the same commit — and published to the provider. Every
+  attempt is a row you can see: status, reason, provider URL, duration, and (for
+  project writers) a redacted log tail, on a new deployments page and at
+  `GET /api/projects/{namespace}/{slug}/deployments`. `deployment.requested`,
+  `deployment.succeeded` and `deployment.failed` are subscribable from a project
+  webhook.
+
+  Credentials live in a new **per-project secret store**, encrypted with AES-GCM
+  under a `DEPLOY_SECRET_KEY` the instance holds as a Wrangler secret, with the
+  project id and secret name bound as additional authenticated data. There is no
+  read path: no API, UI, or CLI surface returns a stored value, and only the
+  deploy runner decrypts one. Managing secrets requires a project admin who is
+  **not** an agent — an agent token is refused on every secret route even when
+  its owner owns the project, because a deploy credential is the one thing an
+  agent identity is never trusted with. Approving a gated deployment likewise
+  refuses agent identities; as with a human review verdict, that means "not an
+  agent", not "a human at a keyboard" — a user's scoped API token and MCP OAuth
+  grants are accepted. A finished deployment can be retried as a new attempt,
+  which carries the originating change id so a change reverted in the meantime
+  is still refused.
+
+  The honest boundaries, documented rather than buried: **there is no build
+  step** — v1 publishes the tree exactly as committed, so commit your built
+  output or use the `vercel` target, which builds the uploaded source remotely.
+  There are no preview deploys of unmerged changes, no rollback (retrying an
+  earlier successful deployment is the recovery path), and no Netlify support. A
+  `vercel` deployment recorded as `succeeded` means **accepted for build**:
+  Vercel builds asynchronously and Stratum deliberately does not poll it. The
+  `cloudflare-pages` target is implemented against Workers Static Assets rather
+  than Pages Direct Upload, whose asset endpoints are absent from Cloudflare's
+  public API reference. Without the optional `CLOUDFLARE_WORKERS_SUBDOMAIN`
+  secret a Cloudflare deploy succeeds with no URL. And a project that only wants
+  deploys must still write an `evaluators:` block, because a policy file without
+  one is malformed and blocks every merge. Limits (2,000 files, 25 MiB total,
+  10 MiB per file) are enforced before the first provider request, so a deploy
+  never publishes half a tree. Full reference:
+  [Deployments](docs/user-guide/deployments.md).
+- **`stratum login` signs you in through the browser.** The CLI had one way to
+  authenticate — `--key`, with a token you first created by hand in the settings
+  UI and pasted into a terminal. It now runs the OAuth 2.1 authorization-code
+  flow that native apps use (RFC 8252): it registers itself as a public client,
+  proves possession of the code with PKCE, and receives the redirect on a
+  loopback listener bound to an ephemeral port on `127.0.0.1`. There is no token
+  to create and none to paste, and the grant appears under **Settings →
+  Connected applications** alongside your editors, revocable like any other.
+  This uses the authorization server Stratum already ran for MCP clients; no
+  server-side change was needed. `--read-only` requests a read-only session, and
+  the **granted** scope (not the requested one) is printed at login and by
+  `stratum status`, so a narrowed grant is visible immediately rather than at the
+  first write. Sessions renew themselves silently.
+- **`stratum logout`.** Revokes the session with the host, then clears the local
+  credential — and still clears it locally when the host cannot be reached.
+  Revocation is reported as delivered, never as confirmed: RFC 7009 §2.2 has the
+  server answer `200` whether or not anything matched.
+
 - **Display name and username editing on Settings.** The Account section now
   has a display name (free-form, shown in the header instead of the username,
   changeable any time) and, while the account owns no projects, a username

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ curl -X POST .../api/projects/@you/my-project/changes -d '{"workspace": "fix-bug
 curl -X POST .../api/changes/<change-id>/merge
 ```
 
-The full surface — 86 paths, 107 operations — is specified in
+The full surface — 93 paths, 116 operations — is specified in
 [`docs/api/openapi.yml`](docs/api/openapi.yml), with per-resource guides under
 [`docs/api/endpoints/`](docs/api/endpoints/README.md).
 
@@ -286,6 +286,14 @@ diff analysis · webhook for external CI · LLM review via the Workers AI bindin
 test execution · per-evaluator evidence and estimated resource costs (LLM tokens, sandbox
 time, git ops) · branch protection · provenance recorded per merged commit.
 
+**Post-merge deployments**
+A `deploys:` block in `.stratum/policy.yaml` publishes the merged tree to Cloudflare
+(static assets or a Worker script) or Vercel · encrypted per-project deploy secrets that
+no API ever reads back and that agent identities cannot manage · an optional approval gate
+per deploy · retry as a new attempt · supersession when a newer merge lands first ·
+deployment events on the webhook stream. There is no build step — see
+[Known limitations](#known-limitations).
+
 **Import and sync**
 Import from GitHub, GitLab, and Bitbucket · bidirectional GitHub sync (inbound webhooks,
 outbound PR promotion) with conflict resolution · bulk import · queue-backed with
@@ -308,7 +316,7 @@ tested restore path · deletion jobs · admin metrics API · durable event outbo
 queue consumer and a stale-event sweep · workspace TTL sweep.
 
 **Interfaces**
-Server-rendered web UI · REST API (86 paths) · remote MCP server at `/mcp` with an
+Server-rendered web UI · REST API (93 paths) · remote MCP server at `/mcp` with an
 OAuth 2.1 authorization server (dynamic client registration, PKCE, rotating refresh
 tokens) · `@stratum/cli` at full API parity · `@stratum/agent` reference agent.
 
@@ -325,6 +333,11 @@ tokens) · `@stratum/cli` at full API parity · `@stratum/agent` reference agent
   viable. Keep LFS repos on GitHub and use layer mode.
 - **Git submodules are rejected**, not supported — a gitlink or `.gitmodules` fails import,
   gated push, and change creation rather than corrupting the tree silently.
+- **Deploys have no build step** — v1 publishes the tree **exactly as committed**. There's
+  no install, bundle, or framework build, so commit your built output (and point `dir:` at
+  it) or use the `vercel` target, which builds the uploaded source remotely. There's also
+  no preview deploy of an unmerged change and no rollback: retrying an earlier successful
+  deployment is the recovery path. Netlify isn't supported.
 - **Scale** — git operations run in-memory on the Worker; large repos will hit Worker limits.
 - **Synchronous evaluation** — the evaluator suite runs inline at change creation, so change
   creation latency includes it.
@@ -381,6 +394,7 @@ Published at [docs.usestratum.dev](https://docs.usestratum.dev), built from
 **Users** — [Getting started](docs/user-guide/getting-started.md) ·
 [Importing from GitHub](docs/user-guide/importing.md) ·
 [CI integration](docs/user-guide/ci-integration.md) ·
+[Deployments](docs/user-guide/deployments.md) ·
 [Troubleshooting](docs/user-guide/troubleshooting.md) ·
 [FAQ](docs/user-guide/faq.md)
 

--- a/docs/CURRENT_CAPABILITIES.md
+++ b/docs/CURRENT_CAPABILITIES.md
@@ -29,6 +29,19 @@ limitation recorded below.
   advanced since it was evaluated (409 STALE_WORKSPACE).
 - Post-merge smoke command in a sandbox with auto-revert (forward revert commit,
   change marked `reverted`, `change.reverted` event).
+- Post-merge deployments in `.stratum/policy.yaml` (`deploys:`): a named list of
+  deploys, each with a `target` (`cloudflare-pages`, `cloudflare-workers`,
+  `vercel`), an optional `dir`, declared `secrets`, and an optional
+  `requiresApproval` gate. Triggered only when the post-merge check did not
+  revert or fail, run from a queue consumer against the tree at the pinned merge
+  commit, with per-project AES-GCM-encrypted secrets (`DEPLOY_SECRET_KEY`
+  required; project admins only, agents refused), supersession of older deploys
+  of the same name, retry as a new attempt, and `deployment.requested` /
+  `deployment.succeeded` / `deployment.failed` events. **No build step, no
+  preview deploy, and no rollback** — see `user-guide/deployments.md`. A batch
+  merge (`changes/merge-batch`) triggers neither the post-merge check nor a
+  deploy. The deploy DLQ (`stratum-deploys-dlq`) has no consumer: dead-lettered
+  messages sit there for manual inspection.
 - Human reviews (approve / request changes) move the change state machine and are
   human-only; agents cannot approve work.
 
@@ -59,7 +72,9 @@ limitation recorded below.
 - Server-rendered (Hono JSX): dashboard, repo browser with collapsible file tree,
   syntax-highlighted file viewer (dependency-free lexer), commit log, changes with
   diff viewer + evaluator evidence + costs + reviews + comments, issues, activity,
-  webhooks management, settings. Open changes poll via meta refresh.
+  webhooks management, deployments (history, log tail for writers, Approve and
+  Retry buttons), deploy-secret management in project settings, settings. Open
+  changes poll via meta refresh.
 
 ## Tooling
 

--- a/docs/api/endpoints/README.md
+++ b/docs/api/endpoints/README.md
@@ -5,6 +5,8 @@
 - [Changes](changes.md) — the change lifecycle, merging, GitHub promotion
 - [Reviews and Comments](reviews.md) — comment threads and review verdicts
 - [Issues](issues.md) — the built-in issue tracker
+- [Deployments and Deploy Secrets](deployments.md) — post-merge deployments,
+  the approval gate, and the per-project secret store
 - [Agents](agents.md)
 - [Users](users.md) — profile, account deletion, API tokens
 - [Organizations](organizations.md)

--- a/docs/api/endpoints/deployments.md
+++ b/docs/api/endpoints/deployments.md
@@ -17,13 +17,32 @@ split:
 No route on either router returns a secret value. There is no read path for a
 stored secret anywhere in the API.
 
+## An agent token gets `403` from a secret route and `401` from approve
+
+Both routes refuse an agent identity, but with different status codes, and the
+difference is deliberate rather than an inconsistency to be normalized away:
+
+| Caller | Secret routes | `POST /api/deployments/{id}/approve` |
+|---|---|---|
+| Anonymous / no credential | `401` | `401` |
+| Agent token (`stratum_agent_…`) | `403 Agent credentials cannot manage deploy secrets` | `401 Only authenticated users can approve a deployment` |
+| User without the required access | `403` | `403 Project access denied` |
+
+A secret route checks `agentId` **first**, so an agent is a recognized principal
+being told what it may not do — "we know exactly who you are, and this is not
+yours": `403`. Approve checks only for a `userId`, which an agent token never
+sets, so an agent falls into the same branch as an unauthenticated caller —
+"we do not know who you are *as a user*": `401`. Neither code is retryable with
+the same credential; both mean "use a user identity".
+
 ## Deploy secrets
 
 ### List secret names
 `GET /api/projects/{namespace}/{slug}/secrets`
 
-Requires **project admin** and a non-agent identity. Returns names and
-metadata only:
+Requires **project admin** and a non-agent identity: `403` for an agent token
+(and for a user who is not an admin), `401` for a caller with no user identity
+at all. Returns names and metadata only:
 
 ```json
 { "secrets": [
@@ -97,10 +116,23 @@ token is refused. This is the same guarantee (and the same limitation) as a
 human review verdict: a user's scoped API token and MCP OAuth grants are
 accepted, so it means "not an agent", not "a human at a keyboard".
 
+- `401` — no `userId` on the request. This covers both an anonymous caller and
+  an agent token, because an agent token sets `agentId` and never `userId`;
+  unlike the secret routes, this check does not look at `agentId` at all. See
+  [the note above](#an-agent-token-gets-403-from-a-secret-route-and-401-from-approve).
+- `403` — a user identity that cannot write to the deployment's project.
 - `409 DEPLOYMENT_NOT_PENDING` — the row already left `pending_approval`
   (a second approver lands here rather than deploying the commit twice).
 - `503 DEPLOY_QUEUE_UNAVAILABLE` — the instance has no `DEPLOY_QUEUE` binding.
   Checked *before* the status flip, since approval is not repeatable.
+
+**A failed enqueue is not an error.** If the queue send is rejected after the
+row has moved to `queued`, the request is written to the event outbox and the
+call still succeeds — the five-minute sweep starts it. This is deliberate: the
+row is already `queued`, so `approve` would refuse a second attempt and
+`retry` only accepts terminal rows, which made the old "try again" advice
+impossible to act on. A `500` now means the outbox write failed too, i.e.
+nothing durable was recorded.
 
 Audited as `deployment.approved`. A form-encoded caller gets a `302` back to
 the deployment page.
@@ -117,6 +149,11 @@ identity is accepted. Answers `201` with the new row.
   row would start `queued` and route around the approval gate.
 - `409 DEPLOYMENT_RETRY_EXISTS` — someone else already created this attempt.
 - `503 DEPLOY_QUEUE_UNAVAILABLE` — as above.
+
+A failed enqueue is recorded to the outbox and still answers `201`, for the
+same reason as approve: the new attempt row already exists and is `queued`, so
+a repeat call would only collide with the unique index on
+`(project, name, commit, attempt)`.
 
 The originating change id is carried onto the retry, so the "was this change
 reverted?" check still applies to it. Audited as `deployment.retried`.

--- a/docs/api/endpoints/deployments.md
+++ b/docs/api/endpoints/deployments.md
@@ -1,0 +1,128 @@
+# Deployments and Deploy Secrets API
+
+Post-merge deployments and the per-project secret store that feeds them. See
+the [Deployments user guide](../../user-guide/deployments.md) for the concepts
+— the `deploys:` policy block, the three targets, limits, and what each status
+means — and the [OpenAPI specification](../openapi.yml) for exact schemas.
+
+Two authorization rules here are stricter than the usual project read/write
+split:
+
+- **Every secret route refuses agent identities**, even when the agent's owner
+  is a project admin. Deploy credentials are the one thing an agent token is
+  never trusted with.
+- **`logTail` is served to project writers only.** It carries a redacted
+  provider payload, and redaction is literal-substring matching.
+
+No route on either router returns a secret value. There is no read path for a
+stored secret anywhere in the API.
+
+## Deploy secrets
+
+### List secret names
+`GET /api/projects/{namespace}/{slug}/secrets`
+
+Requires **project admin** and a non-agent identity. Returns names and
+metadata only:
+
+```json
+{ "secrets": [
+  { "name": "CLOUDFLARE_API_TOKEN", "createdBy": "usr_abc", "updatedBy": "usr_abc",
+    "createdAt": "2026-09-01T10:00:00.000Z", "updatedAt": "2026-09-01T10:00:00.000Z" }
+] }
+```
+
+### Create or replace a secret
+`PUT /api/projects/{namespace}/{slug}/secrets/{name}`
+
+```json
+{ "value": "…" }
+```
+
+`name` must match `^[A-Z][A-Z0-9_]{0,63}$`; `value` is capped at 4096 bytes.
+Writing an existing name replaces it. Audited as `secret.written`.
+
+Answers `500 DEPLOY_SECRET_KEY_MISSING` when the instance has no
+`DEPLOY_SECRET_KEY` configured — secrets cannot be encrypted without it.
+
+### Create or replace a secret (form-friendly)
+`POST /api/projects/{namespace}/{slug}/secrets`
+
+The browser's way in to the PUT above, which an HTML form cannot issue. Takes
+`name` and `value` in the body and runs the same authorization gate. A
+form-encoded caller is redirected back to the project settings page with a
+fixed error code in the query string; a JSON caller gets JSON.
+
+### Delete a secret
+`DELETE /api/projects/{namespace}/{slug}/secrets/{name}`
+
+`404` if the project has no such name. Audited as `secret.deleted`.
+
+### Delete a secret (form-friendly)
+`POST /api/projects/{namespace}/{slug}/secrets/{name}/delete`
+
+Browsers cannot issue DELETE. Same gate; a form caller lands back on the
+settings page, including when the name was already gone.
+
+## Deployments
+
+### List deployments
+`GET /api/projects/{namespace}/{slug}/deployments`
+
+Readable by anyone who can read the project (anonymously, for a public
+project). Newest first.
+
+| Parameter | Meaning |
+|---|---|
+| `name` | Only deployments for this `deploys:` entry name |
+| `status` | One of `pending_approval`, `queued`, `running`, `succeeded`, `failed`, `superseded`, `skipped` |
+| `limit` | Default 50, max 200 |
+| `offset` | Rows to skip |
+
+`logTail` is present only when the caller can write to the project.
+
+### Get a deployment
+`GET /api/deployments/{id}`
+
+The URL carries no project; the row's own project is what gets authorized. A
+deployment in a project the caller cannot read answers `404`, not `403`, so an
+id cannot be confirmed by probing.
+
+### Approve a deployment
+`POST /api/deployments/{id}/approve`
+
+Releases a `pending_approval` deployment: the row moves to `queued` and is
+enqueued. Requires project **write** access and a **user** identity — an agent
+token is refused. This is the same guarantee (and the same limitation) as a
+human review verdict: a user's scoped API token and MCP OAuth grants are
+accepted, so it means "not an agent", not "a human at a keyboard".
+
+- `409 DEPLOYMENT_NOT_PENDING` — the row already left `pending_approval`
+  (a second approver lands here rather than deploying the commit twice).
+- `503 DEPLOY_QUEUE_UNAVAILABLE` — the instance has no `DEPLOY_QUEUE` binding.
+  Checked *before* the status flip, since approval is not repeatable.
+
+Audited as `deployment.approved`. A form-encoded caller gets a `302` back to
+the deployment page.
+
+### Retry a deployment
+`POST /api/deployments/{id}/retry`
+
+Creates a **new attempt row** for the same commit with `attempt` incremented,
+and enqueues it. Requires project write access; unlike approve, an agent
+identity is accepted. Answers `201` with the new row.
+
+- `409 DEPLOYMENT_NOT_RETRYABLE` — the deployment is not in a terminal status.
+  A `pending_approval` row in particular cannot be retried, because the retry
+  row would start `queued` and route around the approval gate.
+- `409 DEPLOYMENT_RETRY_EXISTS` — someone else already created this attempt.
+- `503 DEPLOY_QUEUE_UNAVAILABLE` — as above.
+
+The originating change id is carried onto the retry, so the "was this change
+reverted?" check still applies to it. Audited as `deployment.retried`.
+
+## Events
+
+Deployments emit `deployment.requested`, `deployment.succeeded` and
+`deployment.failed` onto the project's event stream; all three are subscribable
+from a project webhook.

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -1252,10 +1252,43 @@ paths:
         the secret's name travels in the body. Same authorization gate. A
         form-encoded caller is redirected back to the project settings page
         with a fixed error code rather than a caller-supplied message.
+
+        The content type is what selects the response shape, not just the
+        parser: `application/json` is answered with JSON, and anything else is
+        treated as a browser form and answered with a `302`.
       requestBody:
         required: true
         content:
           application/json:
+            schema:
+              type: object
+              required: [name, value]
+              properties:
+                name:
+                  type: string
+                  pattern: "^[A-Z][A-Z0-9_]{0,63}$"
+                value:
+                  type: string
+                  description: At most 4096 bytes. Never returned by any endpoint.
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [name, value]
+              properties:
+                name:
+                  type: string
+                  pattern: "^[A-Z][A-Z0-9_]{0,63}$"
+                  description: >
+                    Surrounding whitespace is trimmed before validation. A name
+                    that does not match the pattern redirects with
+                    `?secretError=name` instead of returning `400`.
+                value:
+                  type: string
+                  description: >
+                    At most 4096 bytes; must not be empty (an empty value
+                    redirects with `?secretError=value`). Never returned by any
+                    endpoint.
+          multipart/form-data:
             schema:
               type: object
               required: [name, value]

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -69,6 +69,8 @@ tags:
     description: Project issues
   - name: webhooks
     description: Outbound project webhooks
+  - name: deployments
+    description: Post-merge deployments and the per-project deploy secret store
   - name: orgs
     description: Organizations, members, and teams
   - name: users
@@ -1059,7 +1061,8 @@ paths:
                     change.rejected, change.reverted, change.commented,
                     change.reviewed, project.created, project.imported,
                     workspace.created, sync.completed, issue.opened,
-                    issue.commented, issue.closed
+                    issue.commented, issue.closed, deployment.requested,
+                    deployment.succeeded, deployment.failed
       responses:
         "201":
           description: Webhook created (includes the secret, shown once)
@@ -1207,6 +1210,375 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+
+  /api/projects/{namespace}/{slug}/secrets:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: listProjectSecrets
+      tags: [deployments]
+      summary: List deploy secret names (values never returned)
+      description: |
+        Requires **project admin**, and the caller must not be an agent: an
+        agent token is refused on every secret route even when its owner owns
+        the project. There is no read path for a stored secret value anywhere
+        in the API.
+      responses:
+        "200":
+          description: Secret names and metadata
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  secrets:
+                    type: array
+                    items: { $ref: "#/components/schemas/ProjectSecret" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      operationId: putProjectSecretForm
+      tags: [deployments]
+      summary: Create or replace a deploy secret (form-friendly alias)
+      description: |
+        The browser's way in to the PUT below, which an HTML form cannot issue;
+        the secret's name travels in the body. Same authorization gate. A
+        form-encoded caller is redirected back to the project settings page
+        with a fixed error code rather than a caller-supplied message.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, value]
+              properties:
+                name:
+                  type: string
+                  pattern: "^[A-Z][A-Z0-9_]{0,63}$"
+                value:
+                  type: string
+                  description: At most 4096 bytes. Never returned by any endpoint.
+      responses:
+        "200":
+          description: Secret stored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  secret: { $ref: "#/components/schemas/ProjectSecret" }
+        "302":
+          description: Form-encoded caller redirected back to project settings
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          description: >
+            Storage failed, or the instance has no DEPLOY_SECRET_KEY configured
+            (`DEPLOY_SECRET_KEY_MISSING`), without which secrets cannot be encrypted
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/projects/{namespace}/{slug}/secrets/{name}:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: "^[A-Z][A-Z0-9_]{0,63}$"
+    put:
+      operationId: putProjectSecret
+      tags: [deployments]
+      summary: Create or replace a deploy secret
+      description: |
+        Requires project admin and a non-agent identity. Encrypted at rest with
+        the project id and secret name bound as additional authenticated data;
+        only the deploy runner ever decrypts it. Audited as `secret.written`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [value]
+              properties:
+                value:
+                  type: string
+                  description: At most 4096 bytes. Never returned by any endpoint.
+      responses:
+        "200":
+          description: Secret stored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  secret: { $ref: "#/components/schemas/ProjectSecret" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          description: >
+            Storage failed, or the instance has no DEPLOY_SECRET_KEY configured
+            (`DEPLOY_SECRET_KEY_MISSING`)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    delete:
+      operationId: deleteProjectSecret
+      tags: [deployments]
+      summary: Delete a deploy secret
+      description: Requires project admin and a non-agent identity. Audited as `secret.deleted`.
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+                  name: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/secrets/{name}/delete:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+      - name: name
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      operationId: deleteProjectSecretForm
+      tags: [deployments]
+      summary: Delete a deploy secret (form-friendly alias)
+      description: |
+        Browsers cannot issue DELETE. Same gate as the DELETE above; a
+        form-encoded caller is redirected back to project settings even when the
+        name was already gone.
+      responses:
+        "200":
+          description: Deleted (JSON caller)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+                  name: { type: string }
+        "302":
+          description: Form-encoded caller redirected back to project settings
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/projects/{namespace}/{slug}/deployments:
+    parameters:
+      - $ref: "#/components/parameters/Namespace"
+      - $ref: "#/components/parameters/Slug"
+    get:
+      operationId: listDeployments
+      tags: [deployments]
+      summary: List post-merge deployments, newest first
+      description: |
+        Readable by anyone who can read the project (anonymously, on a public
+        project). `logTail` is included **only** for callers with project write
+        access — it holds a redacted provider payload.
+      parameters:
+        - name: name
+          in: query
+          schema: { type: string }
+          description: Only deployments for this `deploys:` entry name
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [pending_approval, queued, running, succeeded, failed, superseded, skipped]
+        - name: limit
+          in: query
+          schema: { type: integer, default: 50, maximum: 200 }
+        - name: offset
+          in: query
+          schema: { type: integer, default: 0 }
+      responses:
+        "200":
+          description: Deployments
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deployments:
+                    type: array
+                    items: { $ref: "#/components/schemas/Deployment" }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/deployments/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      operationId: getDeployment
+      tags: [deployments]
+      summary: Get one deployment
+      description: |
+        The URL carries no project, so the row's own project is authorized. A
+        deployment in a project the caller cannot read answers `404` rather than
+        `403`, so an id cannot be confirmed by probing. `logTail` is included
+        only for project writers.
+      responses:
+        "200":
+          description: The deployment
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deployment: { $ref: "#/components/schemas/Deployment" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/deployments/{id}/approve:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      operationId: approveDeployment
+      tags: [deployments]
+      summary: Approve a deployment awaiting approval
+      description: |
+        Moves a `pending_approval` deployment to `queued` and enqueues it.
+        Requires project **write** access and a **user** identity — an agent
+        token is refused. Like a human review verdict, the guarantee is "not an
+        agent identity": a user's scoped API token and MCP OAuth grants are
+        accepted, so this is not evidence of a human at a keyboard.
+
+        Audited as `deployment.approved`. A form-encoded caller receives a
+        `302` back to the deployment page instead of JSON.
+      responses:
+        "200":
+          description: Approved and enqueued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deployment: { $ref: "#/components/schemas/Deployment" }
+        "302":
+          description: Form-encoded caller redirected to the deployment page
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The deployment is not awaiting approval (`DEPLOYMENT_NOT_PENDING`)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          description: Deployments are not enabled on this instance (`DEPLOY_QUEUE_UNAVAILABLE`)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/deployments/{id}/retry:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      operationId: retryDeployment
+      tags: [deployments]
+      summary: Re-run a finished deployment as a new attempt
+      description: |
+        Creates a new row for the same commit with `attempt` incremented and
+        enqueues it; the original row is kept. Requires project write access,
+        and unlike approve an agent identity is accepted. The originating
+        change id is carried over, so the "was this change reverted?" check
+        still applies. Audited as `deployment.retried`.
+      responses:
+        "201":
+          description: Retry attempt created and enqueued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deployment: { $ref: "#/components/schemas/Deployment" }
+        "302":
+          description: Form-encoded caller redirected to the new deployment page
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: >
+            The deployment is not in a terminal status
+            (`DEPLOYMENT_NOT_RETRYABLE`) — a `pending_approval` row in
+            particular cannot be retried, since the retry would start `queued`
+            and route around the approval gate — or this attempt already exists
+            (`DEPLOYMENT_RETRY_EXISTS`)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          description: Deployments are not enabled on this instance (`DEPLOY_QUEUE_UNAVAILABLE`)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/projects/{namespace}/{slug}/issues:
     parameters:
@@ -4168,6 +4540,74 @@ components:
         active: { type: boolean }
         createdBy: { type: string }
         createdAt: { type: string, format: date-time }
+
+    ProjectSecret:
+      type: object
+      required: [name, createdBy, updatedBy, createdAt, updatedAt]
+      description: >
+        A deploy secret as anyone other than the deploy runner may ever see it.
+        The value is deliberately absent: no endpoint returns it.
+      properties:
+        name: { type: string, pattern: "^[A-Z][A-Z0-9_]{0,63}$" }
+        createdBy: { type: string }
+        updatedBy: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    Deployment:
+      type: object
+      required: [id, projectId, project, commitSha, name, target, attempt, status, requestedByType, createdAt]
+      properties:
+        id: { type: string }
+        projectId: { type: string }
+        project: { type: string }
+        changeId:
+          type: string
+          description: Absent for a deploy not traceable to a change
+        commitSha: { type: string }
+        name:
+          type: string
+          description: >
+            The `deploys:` entry name, or "(unresolved)" for a row that never
+            selected one — a rejected entry, an unreadable tree, or a merge with
+            nothing configured
+        target:
+          type: string
+          enum: [cloudflare-pages, cloudflare-workers, vercel, unresolved]
+        attempt:
+          type: integer
+          description: 1 for the original; incremented by each retry
+        status:
+          type: string
+          enum: [pending_approval, queued, running, succeeded, failed, superseded, skipped]
+          description: >
+            `skipped` means only that nothing was configured to deploy. Every
+            operator error (missing secret, unset DEPLOY_SECRET_KEY, limit
+            exceeded, provider error) is `failed` with a reason. For the
+            `vercel` target, `succeeded` means "accepted for build" — Vercel
+            builds asynchronously and Stratum does not poll it.
+        reason: { type: string }
+        url:
+          type: string
+          description: >
+            Absent when the provider returned none. The Cloudflare targets derive
+            it from the optional CLOUDFLARE_WORKERS_SUBDOMAIN secret, so without
+            that secret a deployment succeeds with no URL.
+        logTail:
+          type: string
+          description: >
+            Redacted, truncated provider payload (16 KiB). Returned **only** to
+            callers with project write access.
+        durationMs: { type: number }
+        leaseExpiresAt: { type: string, format: date-time }
+        requestedByType:
+          type: string
+          enum: [user, agent, system]
+        requestedById: { type: string }
+        approvedBy: { type: string }
+        createdAt: { type: string, format: date-time }
+        startedAt: { type: string, format: date-time }
+        completedAt: { type: string, format: date-time }
 
     WebhookDelivery:
       type: object

--- a/docs/developer/queues.md
+++ b/docs/developer/queues.md
@@ -8,6 +8,28 @@ Processes GitHub imports asynchronously.
 
 Handles notifications and webhooks.
 
+## Deploy Queue
+
+`stratum-deploys` (binding `DEPLOY_QUEUE`) carries post-merge deployments — one
+deployment per message, `max_batch_size = 1`, `max_concurrency = 2`,
+`max_retries = 2`, `visibility_timeout_ms = 900000`. The visibility timeout is
+tied to the bounds in `src/deploy/limits.ts`; raising those limits means raising
+it, or a run that outlives its lease is redelivered while still uploading.
+
+A message is retried only for an *indeterminate* failure (D1 or KV unavailable,
+the project unreadable). A failed deployment is a result, not a delivery
+failure: it is acked with a `failed` row. A malformed message is acked and
+logged.
+
+**`stratum-deploys-dlq` has no consumer.** Dead-lettered messages sit there for
+manual inspection; nothing alerts and no deployment row is written for them.
+Staging uses `stratum-deploys-staging` / `stratum-deploys-dlq-staging` so its
+messages can never reach the production consumer.
+
+Deploys also require the `DEPLOY_SECRET_KEY` Wrangler secret; without it every
+deployment fails, because project secrets cannot be decrypted. See
+[the deployments guide](../user-guide/deployments.md).
+
 ## Configuration
 
 ```toml

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -43,6 +43,26 @@ do not rotate it without re-encrypting or retaining the old value.
 Independently, lock the `BACKUPS` bucket down: no public access, least-privilege
 tokens, and a bucket lifecycle policy that matches your retention expectations.
 
+### The second key a restore depends on: `DEPLOY_SECRET_KEY`
+
+`BACKUP_ENCRYPTION_SECRET` is not the only key a restore needs. The
+`project_secrets` table is backed up as **ciphertext only** — the plaintext of a
+deploy secret is never stored and no route can read one back — and those rows are
+decryptable solely by the `DEPLOY_SECRET_KEY` that was in force when they were
+written. That key is a Wrangler secret and is **not in any backup**.
+
+Consequences to plan for *before* you need them:
+
+- Restoring `project_secrets` into an instance with a different or missing
+  `DEPLOY_SECRET_KEY` produces rows that look present on each project's settings
+  page but fail every deploy with `Could not decrypt project secret…` (or, with
+  no key at all, `DEPLOY_SECRET_KEY is not configured on this instance`).
+- There is no re-encryption path. The only recovery is the original key, or
+  having every project re-enter its secret values by hand.
+- So: store `DEPLOY_SECRET_KEY` wherever you store `BACKUP_ENCRYPTION_SECRET`,
+  retain the old value across a rotation, and treat a restore into a fresh
+  instance as needing *both* keys carried over.
+
 ## Configuration
 
 | Binding / var | Purpose | Default |
@@ -117,6 +137,14 @@ Restore tables in the file order `BACKUP_TABLES` lists — it is FK-dependency
 ordered (parents before children). `restoreTable` verifies the NDJSON header's
 table name matches and chunks inserts under D1's bind cap.
 
+`project_secrets` restores like any other table, but its rows are only *usable*
+if the target instance has the same `DEPLOY_SECRET_KEY` — see
+[the second key a restore depends on](#the-second-key-a-restore-depends-on-deploy_secret_key).
+If you cannot carry that key over, restore the table anyway (the names and
+metadata are still the record of what each project needs) and tell project
+admins to re-enter every value; a stale row is silently unusable, not visibly
+missing.
+
 ### KV identity
 
 Use `restoreKvIdentity` (in `src/storage/kv-backup.ts`) with `projects.json` then
@@ -161,5 +189,9 @@ Artifacts client, and before relying on backups in production.
   being skipped.
 - **Decrypt failure on restore** — `BACKUP_ENCRYPTION_SECRET` differs from the one
   used at backup time. Restore requires the original secret.
+- **Deploys fail with `Could not decrypt project secret…` after a restore** — the
+  restored `project_secrets` rows were encrypted under a different
+  `DEPLOY_SECRET_KEY`. Not a backup defect: that key is never backed up. Restore
+  the original key, or have each project re-enter its secrets.
 - **Repo restore `409`** — the target repo still exists; restore into a fresh
   instance, or pass `force` only when intentionally overwriting.

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -18,6 +18,7 @@ Welcome to Stratum! This guide helps you get started.
 - [Code Review](code-review.md) — comment threads, line anchors, and review verdicts
 - [Issues](issues.md) — the built-in tracker, and linking issues to changes
 - [CI Integration (Bring Your Own CI)](ci-integration.md) — the webhook evaluator
+- [Deployments](deployments.md) — publishing the merged tree after a change lands
 - [The CLI](cli.md) — the change flow from the terminal
 - [The MCP server](mcp.md) — the change flow for any MCP-capable agent or editor
 - [Troubleshooting](troubleshooting.md) — symptoms and fixes

--- a/docs/user-guide/ci-integration.md
+++ b/docs/user-guide/ci-integration.md
@@ -2,14 +2,16 @@
 
 Stratum has **no native CI runner** — there are no workflow files, no hosted
 build agents, and no GitHub Actions replacement. What Stratum *does* run for
-you is its evaluation and merge pipeline, and it gives you exactly three ways
-to execute code as part of that pipeline. This page inventories them honestly
-and shows how to wire an external CI system you host into the evaluation gate.
+you is its evaluation and merge pipeline, and it gives you a small, fixed set
+of ways to get code executed as part of that pipeline. This page inventories
+them honestly and shows how to wire an external CI system you host into the
+evaluation gate.
 
 ## The complete code-execution inventory
 
-Stratum can execute code in exactly three places, all driven by
-`.stratum/policy.yaml`:
+Stratum causes code to run in exactly four places, all driven by
+`.stratum/policy.yaml`. The first three run inside Stratum's own pipeline; the
+fourth hands your code to a hosting provider that runs it:
 
 ### 1. The sandbox evaluator
 
@@ -81,8 +83,24 @@ automatically reverted unless `merge.autoRevert: false`. Like the sandbox
 evaluator, this requires the `SANDBOX` binding; without it the check is
 skipped with a warning.
 
-That's it. Everything else — building artifacts, deploying, scheduled jobs —
-must live in a system you run outside Stratum.
+### 4. `deploys:` — publishing the merged tree to a provider
+
+After a merge survives the post-merge check, each entry in the policy's
+`deploys:` list uploads the merged tree to a hosting provider —
+Cloudflare (static assets or a Worker script) or Vercel — using credentials
+stored in the project's encrypted secret store. Stratum does not execute that
+code itself; the provider does, once it is published.
+
+There is **no build step**: the tree is deployed exactly as committed. Commit
+your built output, or use the `vercel` target, which builds the uploaded source
+remotely. A deploy can be gated behind an approval
+(`requiresApproval: true`), and a failed one can be retried, but there is no
+rollback and no preview environment. See
+[Deployments](deployments.md) for the full configuration reference, the
+per-target secrets, and the limits.
+
+That's it. Everything else — building artifacts, scheduled jobs, matrix runs,
+artifact retention — must live in a system you run outside Stratum.
 
 ## The webhook evaluator contract
 
@@ -267,8 +285,16 @@ To set expectations, Stratum has none of the following today:
 - Build artifacts (upload/download/retention)
 - Dependency/build caching
 - Scheduled jobs (cron workflows)
-- A secrets store for CI (the webhook `secret` lives in the policy file)
-- Deployment environments, approvals-per-environment, or deploy gates
+- A secrets store *for evaluators*. Stratum does have an encrypted per-project
+  secret store, but it is **deploy-only**: the deploy runner is the sole reader,
+  and nothing interpolates it into a policy file. The webhook evaluator's
+  `secret` still lives literally in `.stratum/policy.yaml`.
+- Deployment *environments* — no staging/production separation, no
+  per-environment variables, no environment protection rules. What exists is a
+  flat list of named deploys, each optionally gated by a single approval
+  (`requiresApproval: true`), plus a retry. There is no rollback, no preview
+  deploy of an unmerged change, and no build step. See
+  [Deployments](deployments.md).
 - Status-check aggregation — Stratum does not collect external CI check
   results the way a GitHub PR's checks tab does. An external system reports a
   verdict only by answering the webhook evaluator synchronously; a check that
@@ -279,5 +305,6 @@ evaluator (for gating) or via GitHub sync in layer mode (for everything else).
 
 ## See also
 
+- [Deployments](deployments.md) — the `deploys:` policy block, targets, secrets, and limits
 - [FAQ: Does Stratum replace GitHub Actions?](faq.md#does-stratum-replace-github-actions)
 - `docs/CURRENT_CAPABILITIES.md` — the authoritative current state

--- a/docs/user-guide/deployments.md
+++ b/docs/user-guide/deployments.md
@@ -112,6 +112,11 @@ deploys:
 | `secrets` | no | Up to 16 secret names, each `^[A-Z][A-Z0-9_]{0,63}$`. Naming a secret here makes it **required**: a declared name that is not stored fails the deploy. You do not have to list the target's own secrets — they are loaded either way. |
 | `requiresApproval` | no | Boolean (a quoted `"false"` is rejected, not coerced). `true` holds the deployment at `pending_approval` until someone approves it. |
 
+**A policy file may declare at most 16 `deploys:` entries.** Anything beyond
+the sixteenth is not run and is reported as a single `failed` deployment row
+naming how many were declared — siblings run sequentially inside one Worker
+invocation, so an unbounded list would be an unbounded merge.
+
 **Unknown fields are rejected, not ignored.** An entry containing
 `requireApproval` (missing the "s") is refused with a reason naming the field,
 rather than being silently rebuilt without it — which would turn a deploy you
@@ -126,8 +131,30 @@ cloudflare-pages, cloudflare-workers, vercel)`). A deploy that was written and
 never runs means production quietly stopped updating, so it is reported where
 you will see it — on the project's Deployments page.
 
-A policy file that fails to parse at all produces one `failed` row pointing at
-the file, in addition to blocking merges.
+### The malformed-policy row is a post-merge fallback, not the merge block
+
+A policy file that fails to parse at all produces one `failed` deployment row
+(named `(unresolved)`) pointing at the file. That row is **not** the merge gate
+reporting itself — it is a separate, later check, and the distinction matters
+because the two look at different commits:
+
+- **Before the merge**, the gate parses the project's *current* policy. A file
+  that does not parse blocks the merge outright, and no deployment row exists
+  because no merge happened.
+- **After a merge**, the deploy runner re-parses the policy out of the *pinned
+  merge commit's* tree, so configuration and code always come from the same
+  commit. If **that** commit's policy is the unparseable one, there is nothing
+  to deploy and nothing to name, so the failure is recorded as an
+  `(unresolved)` row reading `Policy file .stratum/policy.yaml is present but
+  invalid (…); no deploy configuration could be read from it.` rather than
+  being dropped in silence.
+
+The two reads happen at different times against different trees, so they can
+disagree — which is exactly when this row shows up. Treat it as "the commit
+that was deployed had a broken policy", not as a second copy of the merge
+error. Fixing the project's current policy unblocks merges; it does not
+retroactively change a row already recorded against an older commit, and it
+does not re-run that deploy. Retry it once the fix is merged.
 
 ## Targets and their secrets
 
@@ -236,7 +263,7 @@ runner decrypts them.
 - **Over the API:**
 
   ```bash
-  curl -X PUT https://your-instance.workers.dev/api/projects/acme/site/secrets/CLOUDFLARE_API_TOKEN \
+  curl -X PUT https://your-instance.workers.dev/api/projects/@acme/site/secrets/CLOUDFLARE_API_TOKEN \
     -H "Authorization: Bearer $STRATUM_TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"value":"…"}'
@@ -345,6 +372,7 @@ so they judge the bytes actually being uploaded.
 | Deployment lease / queue visibility timeout | 15 minutes |
 | Secret value | 4,096 bytes |
 | Secrets named per deploy entry | 16 |
+| `deploys:` entries per policy file | 16 |
 
 Exceeding one is a `failed` deployment naming the number, e.g. `too many files:
 2431 exceeds the 2000-file deploy limit`. An empty selection is also a failure
@@ -406,7 +434,7 @@ production consumer.
 | `POST /api/projects/{namespace}/{slug}/secrets` | Form-friendly create/replace (`name`, `value` in the body). |
 | `DELETE /api/projects/{namespace}/{slug}/secrets/{name}` | Project admin, agents refused. |
 | `POST /api/projects/{namespace}/{slug}/secrets/{name}/delete` | Form-friendly delete. |
-| `GET /api/projects/{namespace}/{slug}/deployments` | Anyone who can read the project. `log_tail` is included only for writers. Filters: `name`, `status`, `limit` (default 50, max 200), `offset`. |
+| `GET /api/projects/{namespace}/{slug}/deployments` | Anyone who can read the project. `logTail` is included only for writers. Filters: `name`, `status`, `limit` (default 50, max 200), `offset`. |
 | `GET /api/deployments/{id}` | Anyone who can read the deployment's project; unknown or unreadable ids answer 404 alike. |
 | `POST /api/deployments/{id}/approve` | Project writer, **user identity required**. |
 | `POST /api/deployments/{id}/retry` | Project writer; agents allowed. |

--- a/docs/user-guide/deployments.md
+++ b/docs/user-guide/deployments.md
@@ -1,0 +1,457 @@
+# Deployments
+
+Stratum can publish the merged tree to a hosting provider after a change lands.
+You declare deploys in the same `.stratum/policy.yaml` that gates your merges,
+store the provider credential once as a project secret, and every subsequent
+merge that survives the post-merge check publishes automatically.
+
+This is deliberately small. It is **not a CI system**: there is no build step,
+no preview environment, and no rollback. Read
+[Limitations](#limitations-read-this-before-you-rely-on-it) before you point
+production at it.
+
+## Contents
+
+- [Before you start: your policy still needs `evaluators:`](#before-you-start-your-policy-still-needs-evaluators)
+- [How a deploy is triggered](#how-a-deploy-is-triggered)
+- [The `deploys:` configuration reference](#the-deploys-configuration-reference)
+- [Targets and their secrets](#targets-and-their-secrets)
+- [Storing a secret](#storing-a-secret)
+- [The approval gate](#the-approval-gate)
+- [Retry](#retry)
+- [Deployment statuses](#deployment-statuses)
+- [Limits](#limits)
+- [Operating a Stratum instance with deploys enabled](#operating-a-stratum-instance-with-deploys-enabled)
+- [API](#api)
+- [Limitations](#limitations-read-this-before-you-rely-on-it)
+
+## Before you start: your policy still needs `evaluators:`
+
+**A `.stratum/policy.yaml` that has a `deploys:` block but no top-level
+`evaluators:` array is treated as malformed, and a malformed policy blocks
+every merge in the project.** The policy parser requires `evaluators` to be
+present and to be an array; anything else is a parse failure, and a parse
+failure fails the merge gate closed:
+
+> Policy file .stratum/policy.yaml is present but invalid (missing or non-array
+> 'evaluators'); merges are blocked until it is fixed.
+
+That is intended behaviour for the merge gate, but it means "I only want
+deploys" is not a configuration you can write. If you have no opinion about
+evaluation, declare the cheap default explicitly:
+
+```yaml
+# The minimum viable deploy-only policy. `evaluators:` is REQUIRED — a policy
+# file without it is malformed and blocks all merges.
+evaluators:
+  - type: diff
+
+deploys:
+  - name: site
+    target: cloudflare-pages
+    dir: public
+```
+
+The secret scanner runs on every change regardless of what this file says, so a
+lone `diff` evaluator is not "no gate at all".
+
+The same rule applies to the JSON form, `stratum.config.json`. Stratum reads
+`.stratum/policy.yaml` first and, only if it is absent, `stratum.config.json`.
+A file that is present but broken is an answer — Stratum does not fall through
+to the other one.
+
+## How a deploy is triggered
+
+1. A change merges.
+2. The post-merge smoke check runs (if the policy configures one). A failing
+   check auto-reverts the merge.
+3. **Only if the post-merge check did not revert or fail**, Stratum enqueues a
+   deploy of the merge commit. A deploy is never triggered from the
+   `change.merged` event, because that event fires before the check runs.
+4. The deploy consumer reads the tree **at the pinned merge commit** and parses
+   the policy out of *those* bytes. Configuration and code are therefore always
+   from the same commit: a policy change that lands after your merge cannot
+   retroactively change how your merge deploys.
+5. One `deployments` row is created per `deploys:` entry, and each entry is run
+   in turn.
+
+Things that do **not** trigger a deploy:
+
+- A merge that the post-merge check reverted.
+- `POST /api/projects/{name}/changes/merge-batch` — batch merges run neither the
+  post-merge check nor a deploy.
+- A push straight to the project's default branch (deploys hang off the change
+  merge path).
+- An instance with no `DEPLOY_QUEUE` binding configured.
+
+Before it runs, the deploy re-reads the change's status and the project's
+deletion state. A change that was reverted between the merge and the deploy is
+refused, and so is a project that is being deleted.
+
+## The `deploys:` configuration reference
+
+`deploys:` is a top-level list in `.stratum/policy.yaml`. Each entry is a
+mapping:
+
+```yaml
+deploys:
+  - name: marketing-site        # required
+    target: cloudflare-pages    # required
+    dir: dist                   # optional
+    secrets:                    # optional
+      - CLOUDFLARE_API_TOKEN
+      - CLOUDFLARE_ACCOUNT_ID
+    requiresApproval: false     # optional, default false
+```
+
+| Field | Required | Rules |
+|---|---|---|
+| `name` | yes | `^[a-z][a-z0-9-]{0,31}$` — lowercase letters, digits and dashes, max 32 characters. It is this deploy's stable identity across merges, and it is what supersession and the deployments list group by. Must be unique within the file. |
+| `target` | yes | One of `cloudflare-pages`, `cloudflare-workers`, `vercel`. |
+| `dir` | no | Repo-relative directory to publish. Must be relative (no leading `/`), contain no `..` segment and no null byte, max 255 characters. The prefix is stripped, so `dir: dist` publishes `dist/index.html` as `index.html`. Omit it to publish the whole tree. |
+| `secrets` | no | Up to 16 secret names, each `^[A-Z][A-Z0-9_]{0,63}$`. Naming a secret here makes it **required**: a declared name that is not stored fails the deploy. You do not have to list the target's own secrets — they are loaded either way. |
+| `requiresApproval` | no | Boolean (a quoted `"false"` is rejected, not coerced). `true` holds the deployment at `pending_approval` until someone approves it. |
+
+**Unknown fields are rejected, not ignored.** An entry containing
+`requireApproval` (missing the "s") is refused with a reason naming the field,
+rather than being silently rebuilt without it — which would turn a deploy you
+gated behind an approval into one that ships straight to production.
+
+### A rejected entry becomes a visible failed deployment
+
+Bad `deploys:` configuration does not block your merge, and it is not dropped
+in silence either: each rejected entry is recorded as a `failed` deployment row
+carrying the reason (`deploys[0]: unknown target "netlify" (expected one of
+cloudflare-pages, cloudflare-workers, vercel)`). A deploy that was written and
+never runs means production quietly stopped updating, so it is reported where
+you will see it — on the project's Deployments page.
+
+A policy file that fails to parse at all produces one `failed` row pointing at
+the file, in addition to blocking merges.
+
+## Targets and their secrets
+
+All three targets are first-class. Secrets are read from the project's secret
+store by these exact names.
+
+### `cloudflare-pages` — a static site on Cloudflare
+
+| Secret | | Meaning |
+|---|---|---|
+| `CLOUDFLARE_API_TOKEN` | **required** | API token with Workers Scripts edit permission on the account. |
+| `CLOUDFLARE_ACCOUNT_ID` | **required** | The account that owns the Worker. |
+| `CLOUDFLARE_WORKER_NAME` | optional | Script name to publish as. Defaults to the deploy's `name`. |
+| `CLOUDFLARE_WORKERS_SUBDOMAIN` | optional | Your account's `workers.dev` subdomain. Without it the deployment **succeeds with no URL** (see below). |
+
+**This target is implemented against Workers Static Assets, not Pages Direct
+Upload.** The `target:` name is the user-facing name for "publish my static
+site on Cloudflare" and is unchanged, but the implementation uploads an asset
+manifest and publishes a Worker with an `assets` binding and no `main_module`.
+Two reasons: Pages Direct Upload's asset endpoints (the upload-token,
+check-missing and asset-upload calls Wrangler drives) are not in Cloudflare's
+public API reference, so implementing it would mean guessing at a surface that
+carries a production credential; and Cloudflare itself steers new projects to
+Workers rather than Pages. The practical consequences are that the deployment
+appears in your Cloudflare account as a **Worker**, not as a Pages project, and
+that Pages-specific features (preview branches, the Pages dashboard) do not
+apply.
+
+Content types are set at upload time from the file extension, which is what
+visitors are served. An unrecognized extension is uploaded as
+`application/octet-stream`.
+
+### `cloudflare-workers` — a Worker script
+
+| Secret | | Meaning |
+|---|---|---|
+| `CLOUDFLARE_API_TOKEN` | **required** | As above. |
+| `CLOUDFLARE_ACCOUNT_ID` | **required** | As above. |
+| `CLOUDFLARE_WORKER_NAME` | optional | Script name. Defaults to the deploy's `name`. |
+| `CLOUDFLARE_WORKER_MAIN_MODULE` | optional | Entry-point path within the deployed tree. |
+| `CLOUDFLARE_WORKERS_SUBDOMAIN` | optional | Your `workers.dev` subdomain; without it the deployment succeeds with no URL. |
+
+Only `.js` and `.mjs` files are uploaded, as ES modules. Everything else in the
+selected tree (a README, a lockfile) is skipped, and the count of skipped files
+is reported on the deployment. If no module is found, the deploy fails.
+
+Without `CLOUDFLARE_WORKER_MAIN_MODULE`, the entry point is the first of
+`worker.js`, `worker.mjs`, `index.js`, `index.mjs`, `src/index.js`,
+`src/index.mjs` present in the tree; if none is, the deploy fails and names the
+candidates. When you do set it, it is validated against the tree — a typo fails
+with a reason instead of deploying some other file.
+
+The upload sends a pinned `compatibility_date` (currently `2026-08-20`) rather
+than the current date, so redeploying the same commit cannot silently change
+its runtime behaviour.
+
+### `vercel` — build and host on Vercel
+
+| Secret | | Meaning |
+|---|---|---|
+| `VERCEL_TOKEN` | **required** | Vercel API token. |
+| `VERCEL_PROJECT_ID` | **required** | The Vercel project to deploy into. |
+| `VERCEL_TEAM_ID` | optional | Required in practice for a team-scoped token — without it the API resolves the token against your personal account. |
+
+The whole tree is inlined (base64) into a single `POST /v13/deployments` with
+`target: production`, rather than uploaded file-by-file: one provider request
+instead of one per file, which is what the Worker's subrequest budget can
+afford. Base64 inflates the payload by about a third, so the 25 MB tree limit
+becomes roughly a 33 MB request body — that is this target's binding
+constraint.
+
+**A `vercel` deployment recorded as `succeeded` means "accepted for build".**
+Vercel answers as soon as it has queued the deployment (`readyState: QUEUED`)
+and builds asynchronously; Stratum does **not** poll for the result, because
+polling would hold a queue message open for the length of somebody else's
+build. The provider's state at hand-off and its deployment id are recorded in
+the row's reason, e.g. `provider state at hand-off: QUEUED (the provider
+finishes asynchronously; Stratum does not poll it); provider deployment
+dpl_…`. A build that fails **after** hand-off is visible in Vercel, not in
+Stratum. If the API returns `ERROR`, `CANCELED` or `BLOCKED` outright, the
+deployment is recorded as `failed`.
+
+### When a deployment has no URL
+
+The Cloudflare targets derive the deployment URL from
+`CLOUDFLARE_WORKERS_SUBDOMAIN`, because the account's `workers.dev` subdomain
+is not part of the API surface these targets were written against and inventing
+a lookup for it would be a guess. **If you do not store that secret, the deploy
+still succeeds — it just records no URL.** Store it if you want a clickable
+link on the deployments page.
+
+Note that `CLOUDFLARE_WORKERS_SUBDOMAIN` lives in the secrets table for
+uniformity, but it is not confidential: it is a public hostname component,
+written verbatim into the deployment's `url`. Treat it as configuration that
+happens to be stored beside your credentials, not as a credential.
+
+## Storing a secret
+
+Secrets are per project, encrypted at rest (AES-GCM, with the project id and
+secret name bound as additional authenticated data), and there is **no read
+path** — no API, UI or CLI surface returns a stored value. Only the deploy
+runner decrypts them.
+
+- **In the UI:** *Project → Settings → Deploy secrets*. Add by name and value;
+  delete by name. Values are never rendered back.
+- **Over the API:**
+
+  ```bash
+  curl -X PUT https://your-instance.workers.dev/api/projects/acme/site/secrets/CLOUDFLARE_API_TOKEN \
+    -H "Authorization: Bearer $STRATUM_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"value":"…"}'
+  ```
+
+Rules:
+
+- Names must match `^[A-Z][A-Z0-9_]{0,63}$`.
+- Values are capped at 4096 bytes. There is no minimum — some providers
+  legitimately accept an empty value.
+- Writing an existing name replaces it.
+- Every write and delete is recorded in the audit trail (`secret.written`,
+  `secret.deleted`).
+
+**Only a project admin who is not an agent may manage secrets.** An agent token
+is refused on every secret route, even when the agent's owner is the project
+owner: deploy credentials are the one thing an agent identity is never trusted
+with. Deleting the project deletes its secrets and its deployment history.
+
+## The approval gate
+
+With `requiresApproval: true`, the merge creates the deployment at
+`pending_approval` and nothing is uploaded. Someone then presses **Approve** on
+the deployment page, or calls `POST /api/deployments/{id}/approve`; the row
+moves to `queued`, is enqueued, and runs.
+
+Approving requires project **write** access and a **user** identity. An agent
+token (`stratum_agent_…`) sets no user id and is refused.
+
+**Be precise about what that buys you.** The guarantee is "not an agent
+identity" — exactly the same guarantee, and the same limitation, as a human
+review verdict. A user's scoped API token and an MCP OAuth grant both
+authenticate as the user and are both accepted. It is therefore **not**
+evidence that a human was at a keyboard: an automation running under your token
+can approve a deploy. If your threat model needs a real human, this gate does
+not provide one.
+
+Approval is single-use and safe to double-click: the status flip is a
+conditional update, so a second approver gets `409 DEPLOYMENT_NOT_PENDING`
+rather than a second deployment of the same commit.
+
+## Retry
+
+A finished deployment can be re-run from the **Retry** button or
+`POST /api/deployments/{id}/retry`. This creates a *new attempt row* for the
+same commit with `attempt` incremented, and enqueues it; the original row is
+kept, so the history shows both.
+
+- Only a terminal deployment (`succeeded`, `failed`, `superseded`, `skipped`)
+  can be retried. Retrying a `queued`, `running` or `pending_approval` row is
+  refused with `409 DEPLOYMENT_NOT_RETRYABLE` — for `pending_approval` in
+  particular, allowing it would route straight around the approval gate,
+  because a retry row starts `queued`.
+- Retry requires project write access, and unlike approve it **does** accept an
+  agent identity.
+- The originating change id is carried onto the retry, so the "was this change
+  reverted?" check still applies. Retrying a change that has since been
+  reverted is refused.
+- Two people retrying at once is safe: the second gets
+  `409 DEPLOYMENT_RETRY_EXISTS`.
+- A retry counts as the *newest* intent for that deploy name, even when the
+  commit it re-runs is old — an operator re-running an earlier commit is
+  asserting that they want it live.
+
+Retry is also the closest thing to a rollback — see
+[Limitations](#limitations-read-this-before-you-rely-on-it).
+
+## Deployment statuses
+
+| Status | Meaning |
+|---|---|
+| `pending_approval` | `requiresApproval: true` and nobody has approved it yet. Nothing has been uploaded. |
+| `queued` | Waiting for the deploy consumer to pick it up. |
+| `running` | A consumer holds a lease on the row and is uploading. |
+| `succeeded` | The provider accepted the deployment. For `vercel`, this means **accepted for build**, not "live" — see above. |
+| `failed` | Anything that went wrong, with a reason: a rejected `deploys:` entry, an unreadable tree, a missing or undecryptable secret, `DEPLOY_SECRET_KEY` unset, a limit exceeded, a provider 4xx/5xx, an unreachable provider. |
+| `superseded` | A newer merge of the same deploy `name` took over. Either this row had not started when the newer one ran, or the newer one had already succeeded by the time this one reached the front of the queue — in which case this deployment is refused rather than published, so an out-of-order delivery cannot put the older commit back into production. |
+| `skipped` | **Only one thing:** there was nothing configured to deploy — no policy file at that commit, or a policy with no `deploys:` entries. Every operator error is `failed`, never `skipped`. |
+
+`succeeded`, `failed`, `superseded` and `skipped` are terminal.
+
+A deploy that hits a provider error also stores a **log tail**: the provider's
+response, with every secret value substituted out, truncated to 16 KiB.
+Redaction always runs on the full text before truncation, so a secret cannot
+survive by straddling the cut. The log tail is served **only to project
+writers** — never on the public read path, and never in a list response for a
+reader who cannot write.
+
+Deployments also emit events you can subscribe to with a project webhook:
+`deployment.requested`, `deployment.succeeded`, `deployment.failed`.
+
+## Limits
+
+Every limit is checked **before the first provider request goes out** — a
+deploy that uploaded half a tree and then failed would leave the site in a
+state nobody asked for. Limits are applied to the tree *after* `dir` narrowing,
+so they judge the bytes actually being uploaded.
+
+| Limit | Value |
+|---|---|
+| Files per deployment | 2,000 |
+| Total bytes per deployment | 25 MiB |
+| Bytes per file | 10 MiB |
+| Provider HTTP requests per deployment | 2,048 |
+| Stored log tail | 16 KiB |
+| Deployment lease / queue visibility timeout | 15 minutes |
+| Secret value | 4,096 bytes |
+| Secrets named per deploy entry | 16 |
+
+Exceeding one is a `failed` deployment naming the number, e.g. `too many files:
+2431 exceeds the 2000-file deploy limit`. An empty selection is also a failure
+(`no files found under "dist" at this commit — check the deploy's "dir"`), not
+a silent no-op.
+
+Sibling deploys from one merge run **sequentially**, not concurrently: they
+share one Worker invocation's CPU, memory and subrequest budget.
+
+## Operating a Stratum instance with deploys enabled
+
+Self-hosters need three things beyond the default deployment:
+
+1. **`DEPLOY_SECRET_KEY` must be set as a Wrangler secret.** It is the master
+   key every project secret is derived from. Without it, storing a secret fails
+   and every deploy fails with `DEPLOY_SECRET_KEY is not configured on this
+   instance, so deploy secrets cannot be decrypted.`
+
+   ```bash
+   wrangler secret put DEPLOY_SECRET_KEY --env production
+   ```
+
+   **Rotating it makes every stored secret undecryptable.** There is no
+   re-encryption path: after a rotation, deploys fail with `Could not decrypt
+   project secret…` and every project must re-enter its values.
+
+2. **The queues must exist**, and the `DEPLOY_QUEUE` binding must be
+   configured. Without the binding, merges simply never enqueue a deploy, and
+   approve/retry answer `503 DEPLOY_QUEUE_UNAVAILABLE`.
+
+   ```bash
+   wrangler queues create stratum-deploys
+   wrangler queues create stratum-deploys-dlq
+   ```
+
+3. **The dead-letter queue has no consumer.** `stratum-deploys-dlq` is
+   configured as the DLQ for `stratum-deploys`, but nothing reads it: a message
+   that exhausts its retries lands there and **sits for manual inspection**.
+   Nothing alerts, and no deployment row is written by the DLQ itself. This is
+   a deliberate v1 choice, not an oversight — but it means "the queue is
+   healthy" is something an operator has to check, not something Stratum
+   reports.
+
+   In practice a message only reaches the DLQ for an *indeterminate* failure
+   (D1 or KV unavailable, the project unreadable). A failed deployment is a
+   result, not a delivery failure, and is acked with a `failed` row rather than
+   retried; a malformed message is acked and logged.
+
+The staging environment uses `stratum-deploys-staging` and
+`stratum-deploys-dlq-staging` so its messages can never be handed to the
+production consumer.
+
+## API
+
+| Route | Access |
+|---|---|
+| `GET /api/projects/{namespace}/{slug}/secrets` | Project admin, agents refused. Names and metadata only — never values. |
+| `PUT /api/projects/{namespace}/{slug}/secrets/{name}` | Project admin, agents refused. |
+| `POST /api/projects/{namespace}/{slug}/secrets` | Form-friendly create/replace (`name`, `value` in the body). |
+| `DELETE /api/projects/{namespace}/{slug}/secrets/{name}` | Project admin, agents refused. |
+| `POST /api/projects/{namespace}/{slug}/secrets/{name}/delete` | Form-friendly delete. |
+| `GET /api/projects/{namespace}/{slug}/deployments` | Anyone who can read the project. `log_tail` is included only for writers. Filters: `name`, `status`, `limit` (default 50, max 200), `offset`. |
+| `GET /api/deployments/{id}` | Anyone who can read the deployment's project; unknown or unreadable ids answer 404 alike. |
+| `POST /api/deployments/{id}/approve` | Project writer, **user identity required**. |
+| `POST /api/deployments/{id}/retry` | Project writer; agents allowed. |
+
+In the UI, deployments live at `/{namespace}/{slug}/deployments`, and secrets
+under *Settings*.
+
+Full request and response schemas are in the
+[OpenAPI specification](../api/openapi.yml); see also
+[the endpoint reference](../api/endpoints/deployments.md).
+
+## Limitations (read this before you rely on it)
+
+These are design boundaries of v1, not bugs:
+
+- **No build step.** Stratum deploys the tree **exactly as committed**. There
+  is no `npm install`, no bundler, no framework build. If your site needs a
+  build, commit the built output (and point `dir:` at it) or use a provider
+  that builds for you — `vercel` builds the uploaded source remotely, the two
+  Cloudflare targets do not.
+- **No preview deploys.** Only merged commits deploy. There is no way to
+  publish an unmerged change for review.
+- **No rollback.** There is no "revert to the previous deployment" button. The
+  recovery path is to **retry an earlier successful deployment** of the same
+  commit, or to merge a revert change and let that deploy. Neither is
+  instantaneous.
+- **Netlify is not supported.** The three targets above are the whole list.
+- **The approval gate refuses agent identities, not automation.** It accepts a
+  user's scoped API token and MCP OAuth grants. See
+  [The approval gate](#the-approval-gate).
+- **A deploy-only project still needs an `evaluators:` block**, or every merge
+  is blocked. See
+  [the top of this page](#before-you-start-your-policy-still-needs-evaluators).
+- **Secret redaction is literal-substring matching.** A provider that echoes a
+  credential back in some encoded or transformed form (URL-encoded, hashed,
+  split across a JSON boundary) would not be caught, which is part of why the
+  log tail is writers-only.
+- **No per-project deploy quota.** Nothing rate-limits how often a project
+  deploys beyond the limits table above.
+- **Deployment history has no retention policy.** Rows accumulate until the
+  project is deleted.
+
+## See also
+
+- [CI Integration (Bring Your Own CI)](ci-integration.md) — what Stratum does
+  and does not execute
+- [Getting Started](getting-started.md) — the policy file and the merge gate
+- [FAQ](faq.md)

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -35,16 +35,24 @@ invariants GitHub doesn't have:
 ## Does Stratum replace GitHub Actions?
 
 No. Stratum has no native CI runner — no workflows, hosted runners, matrix
-builds, artifacts, caching, scheduled jobs, CI secrets store, deployment
-environments, or status-check aggregation (it does not collect external CI
-check results the way a GitHub PR's checks tab does). Its code execution is
-limited to the evaluation pipeline: the
-sandbox evaluator (needs the optional `SANDBOX` binding; fails closed without
-it), the `webhook` evaluator (a synchronous call-out to CI *you* host, which
-must answer within the request timeout — default 10s), and the post-merge
-smoke command run in a sandbox. Bring your own CI and wire it in via the
-webhook evaluator, or use layer mode and keep running GitHub Actions on the
+builds, artifacts, caching, scheduled jobs, deployment environments, or
+status-check aggregation (it does not collect external CI check results the way
+a GitHub PR's checks tab does). Its code execution is limited to the evaluation
+pipeline: the sandbox evaluator (needs the optional `SANDBOX` binding; fails
+closed without it), the `webhook` evaluator (a synchronous call-out to CI *you*
+host, which must answer within the request timeout — default 10s), and the
+post-merge smoke command run in a sandbox. Bring your own CI and wire it in via
+the webhook evaluator, or use layer mode and keep running GitHub Actions on the
 promoted PRs. See [CI Integration](ci-integration.md).
+
+Two things on that list have since arrived in a narrow form. Stratum now has an
+**encrypted per-project secret store** — but it is deploy-only: the deploy
+runner is its sole reader, and the webhook evaluator's `secret` still lives
+literally in the policy file. And it can **deploy the merged tree** to
+Cloudflare or Vercel from a `deploys:` block, with an optional approval gate
+and a retry. That is not deployment environments: there is no
+staging/production separation, no per-environment variables, no build step, no
+preview deploy, and no rollback. See [Deployments](deployments.md).
 
 ## Do I have to leave GitHub to use it?
 

--- a/migrations/047_deployments_and_secrets.sql
+++ b/migrations/047_deployments_and_secrets.sql
@@ -1,0 +1,93 @@
+-- Migration 047: Post-merge deployments and the per-project secret store.
+--
+-- Timestamps are ISO 8601 strings written by the application, NOT
+-- `datetime('now')`, for the reason spelled out in 042: the two formats sort
+-- differently as TEXT (' ' 0x20 < 'T' 0x54), so a column mixing them silently
+-- breaks every range comparison. `lease_expires_at` in particular is compared
+-- against `now` to decide whether a running deployment is reclaimable — a
+-- mixed-format value there would either strand a deployment forever or let the
+-- consumer reclaim a live one and deploy the same commit twice.
+
+-- Encrypted provider credentials (Vercel / Cloudflare API tokens).
+--
+-- `ciphertext` is AES-GCM with `(project_id, name)` bound as additional
+-- authenticated data, so a row copied into another project or renamed fails to
+-- decrypt rather than silently authorising against the wrong account. There is
+-- deliberately no plaintext column and no read path: values leave D1 only
+-- through the deploy consumer.
+--
+-- Scoped on `project_id` alone — never on the bare project name. Names are not
+-- globally unique, and resolving a credential by name would cross tenants.
+CREATE TABLE IF NOT EXISTS project_secrets (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  ciphertext TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  -- Kept alongside created_by so a listing can name who last rotated a
+  -- credential; a listing is the only view anyone ever gets of a secret.
+  updated_by TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+-- Also the lookup index for resolving a deployment's declared secret names.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_project_secrets_name
+  ON project_secrets(project_id, name);
+
+-- One row per deployment attempt. The row is the lease: the unique index below
+-- is what makes a deploy run once, so the consumer inserts and lets a
+-- constraint violation mean "someone else has it" — there is no check-then-act
+-- window to lose.
+CREATE TABLE IF NOT EXISTS deployments (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  -- The bare project name, mirroring `changes`/`events`: the project deletion
+  -- cascade (src/storage/deletion.ts) matches project-scoped rows on either
+  -- form, and a row reachable by only one of them survives a deletion.
+  project TEXT NOT NULL,
+  -- NULL for a deploy not traceable to a change (a retry of an older commit).
+  -- It is deliberately NOT part of the unique key: SQLite unique indexes do not
+  -- constrain NULLs, so a nullable column there would stop excluding anything.
+  change_id TEXT,
+  commit_sha TEXT NOT NULL,
+  name TEXT NOT NULL,
+  target TEXT NOT NULL,
+  -- A manual retry inserts attempt + 1 for the same commit. NOT NULL with a
+  -- DEFAULT so it can carry the unique index (see above).
+  attempt INTEGER NOT NULL DEFAULT 1,
+  -- CHECK'd because a status outside this set is unreachable by the state
+  -- machine and would render as an unknown state in the UI forever. 'skipped'
+  -- means exactly one thing: no deploy was configured. Every other non-success
+  -- is 'failed' with a reason — reporting a missing credential as a calm grey
+  -- state is failing open on something that stops production updating.
+  status TEXT NOT NULL CHECK (status IN
+    ('pending_approval','queued','running','succeeded','failed','superseded','skipped')),
+  reason TEXT,
+  url TEXT,
+  -- The provider's error payload, redacted against this deployment's secret
+  -- values and truncated to MAX_LOG_TAIL (src/deploy/limits.ts). Served only to
+  -- project writers: a provider error can echo request context, and
+  -- canReadProject returns true unconditionally for public projects.
+  log_tail TEXT,
+  duration_ms INTEGER,
+  -- A 'running' row past its lease is reclaimable by the deploy consumer, and
+  -- by nothing else — read-time reclamation would let a page view flip a live
+  -- deployment to 'failed', after which a retry deploys the same commit twice.
+  lease_expires_at TEXT,
+  requested_by_type TEXT NOT NULL,
+  requested_by_id TEXT,
+  approved_by TEXT,
+  created_at TEXT NOT NULL,
+  started_at TEXT,
+  completed_at TEXT
+);
+
+-- The mutual exclusion for a deployment, not merely a data-integrity rule:
+-- two consumers racing the same merge both INSERT, and exactly one wins.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_deployments_attempt
+  ON deployments(project_id, name, commit_sha, attempt);
+
+-- Covers the history listing's `WHERE project_id = ? ORDER BY created_at DESC`.
+CREATE INDEX IF NOT EXISTS idx_deployments_project
+  ON deployments(project_id, created_at DESC);

--- a/src/deploy/config.ts
+++ b/src/deploy/config.ts
@@ -17,6 +17,16 @@ const DEPLOY_ENTRY_KEYS = new Set(["name", "target", "secrets", "dir", "requires
 const MAX_SECRETS_PER_DEPLOY = 16;
 const MAX_DIR_LENGTH = 255;
 
+/**
+ * Most `deploys:` entries one policy file may declare.
+ *
+ * Siblings from one merge run sequentially inside a single Worker invocation,
+ * sharing its CPU, memory and subrequest budget, and every entry — accepted or
+ * rejected — becomes a persisted `deployments` row. Without a cap a policy file
+ * could turn one merge into an unbounded number of rows and provider calls.
+ */
+const MAX_DEPLOY_ENTRIES = 16;
+
 /** Longest policy-supplied value echoed into a rejection reason (which is persisted and rendered). */
 const MAX_QUOTED_LENGTH = 64;
 
@@ -60,7 +70,19 @@ export function sanitizeDeploys(raw: unknown): SanitizedDeploys {
 
   const seenNames = new Set<string>();
 
-  raw.forEach((entry, index) => {
+  // The excess is reported as one rejection rather than one per entry: a file
+  // declaring thousands of deploys must not turn into thousands of failed rows.
+  // Rejected, not thrown — the caller persists this like any other rejection.
+  let entries = raw;
+  if (raw.length > MAX_DEPLOY_ENTRIES) {
+    entries = raw.slice(0, MAX_DEPLOY_ENTRIES);
+    rejected.push({
+      name: null,
+      reason: `deploys: at most ${MAX_DEPLOY_ENTRIES} entries are allowed, but ${raw.length} were declared; entries ${MAX_DEPLOY_ENTRIES + 1}-${raw.length} were not run`,
+    });
+  }
+
+  entries.forEach((entry, index) => {
     const at = `deploys[${index}]`;
 
     if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {

--- a/src/deploy/config.ts
+++ b/src/deploy/config.ts
@@ -1,0 +1,199 @@
+import type { DeployConfig, DeployRejection, DeployTargetName } from "../evaluation/types";
+
+/** Targets the deploy runner can drive, in the order they are listed to users. */
+export const DEPLOY_TARGETS = ["cloudflare-pages", "cloudflare-workers", "vercel"] as const;
+
+const DEPLOY_TARGET_SET = new Set<string>(DEPLOY_TARGETS);
+
+/** Deploy names are used as a stable identity across merges, so they are as narrow as a slug. */
+const DEPLOY_NAME_PATTERN = /^[a-z][a-z0-9-]{0,31}$/;
+
+/** Matches the env-var shape every supported provider expects. */
+const SECRET_NAME_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
+
+/** Fields a `deploys:` entry may carry. Anything else is rejected — see `sanitizeDeploys`. */
+const DEPLOY_ENTRY_KEYS = new Set(["name", "target", "secrets", "dir", "requiresApproval"]);
+
+const MAX_SECRETS_PER_DEPLOY = 16;
+const MAX_DIR_LENGTH = 255;
+
+/** Longest policy-supplied value echoed into a rejection reason (which is persisted and rendered). */
+const MAX_QUOTED_LENGTH = 64;
+
+export interface SanitizedDeploys {
+  /** Entries that passed every rule, as fresh objects. */
+  accepted: DeployConfig[];
+  /** Entries that did not, each with a reason to persist as a failed deployment. */
+  rejected: DeployRejection[];
+}
+
+/**
+ * Validate the `deploys:` list from a policy file.
+ *
+ * Returns **both** halves: accepted entries and rejected ones with reasons.
+ * Rejections are returned rather than logged because a deploy the author wrote
+ * and that never runs means production silently stopped updating; the caller
+ * persists each one as a `failed` deployment row so it is visible in the UI.
+ *
+ * Deliberately *unlike* `evaluators`, where a single unusable entry fails the
+ * whole file closed and blocks merges (see the comment at
+ * `policy-loader.ts`'s dropped-entry check). The asymmetry is intentional: an
+ * evaluator is a gate, so losing one has to stop the merge, whereas a deploy
+ * runs *after* the merge — blocking merges on a bad deploy entry would change
+ * the merge gate's behavior, which is out of this feature's scope. Reporting a
+ * named failed deployment delivers the same visibility without that blast
+ * radius. Do not "fix" this into a `configError`.
+ *
+ * Pure: no logger, no I/O, no mutation of `raw`. Every returned object is newly
+ * allocated, so a returned policy shares no identity with the parsed file.
+ */
+export function sanitizeDeploys(raw: unknown): SanitizedDeploys {
+  const accepted: DeployConfig[] = [];
+  const rejected: DeployRejection[] = [];
+
+  if (raw === undefined || raw === null) return { accepted, rejected };
+
+  if (!Array.isArray(raw)) {
+    rejected.push({ name: null, reason: "'deploys' must be a list of deploy entries" });
+    return { accepted, rejected };
+  }
+
+  const seenNames = new Set<string>();
+
+  raw.forEach((entry, index) => {
+    const at = `deploys[${index}]`;
+
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      rejected.push({ name: null, reason: `${at}: entry must be a mapping` });
+      return;
+    }
+
+    const source = entry as Record<string, unknown>;
+    const issues: string[] = [];
+
+    // An unrecognized key is a rejection, not a warning. The whitelist rebuild
+    // below would otherwise discard `requireApproval` (missing "s") in silence
+    // — turning a deploy the author gated behind an approval into one that
+    // ships straight to production. The cost is that an entry using a field a
+    // future release adds is rejected here rather than half-applied; for a
+    // credentialed production deploy that is the safer direction, and the
+    // reason names the field so the fix is obvious.
+    const unknownKeys = Object.keys(source).filter((key) => !DEPLOY_ENTRY_KEYS.has(key));
+    if (unknownKeys.length > 0) {
+      const plural = unknownKeys.length === 1 ? "" : "s";
+      issues.push(`unrecognized field${plural} ${unknownKeys.map(quoted).join(", ")}`);
+    }
+
+    let name: string | null = null;
+    if (typeof source.name !== "string") {
+      issues.push(`"name" is required and must be a string`);
+    } else if (!DEPLOY_NAME_PATTERN.test(source.name)) {
+      issues.push(
+        `"name" ${quoted(source.name)} must match ${DEPLOY_NAME_PATTERN.source} (lowercase letters, digits and dashes, max 32 chars)`,
+      );
+    } else {
+      name = source.name;
+      if (seenNames.has(name)) {
+        issues.push(`duplicate deploy name ${quoted(name)}`);
+      }
+      // Recorded even when this entry is rejected for another reason: two
+      // entries sharing a name is ambiguous whichever one is at fault.
+      seenNames.add(name);
+    }
+
+    let target: DeployTargetName | null = null;
+    if (typeof source.target !== "string") {
+      issues.push(`"target" is required and must be one of ${DEPLOY_TARGETS.join(", ")}`);
+    } else if (!DEPLOY_TARGET_SET.has(source.target)) {
+      issues.push(
+        `unknown target ${quoted(source.target)} (expected one of ${DEPLOY_TARGETS.join(", ")})`,
+      );
+    } else {
+      target = source.target as DeployTargetName;
+    }
+
+    let secrets: string[] | undefined;
+    if (source.secrets !== undefined) {
+      if (!Array.isArray(source.secrets)) {
+        issues.push(`"secrets" must be a list of secret names`);
+      } else if (source.secrets.length > MAX_SECRETS_PER_DEPLOY) {
+        issues.push(`"secrets" may name at most ${MAX_SECRETS_PER_DEPLOY} secrets`);
+      } else {
+        const invalid = source.secrets.filter(
+          (value) => typeof value !== "string" || !SECRET_NAME_PATTERN.test(value),
+        );
+        if (invalid.length > 0) {
+          issues.push(
+            `invalid secret name${invalid.length === 1 ? "" : "s"} ${invalid.map(quoted).join(", ")} (expected ${SECRET_NAME_PATTERN.source})`,
+          );
+        } else {
+          secrets = source.secrets.map((value) => value as string);
+        }
+      }
+    }
+
+    let dir: string | undefined;
+    if (source.dir !== undefined) {
+      if (typeof source.dir !== "string") {
+        issues.push(`"dir" must be a string`);
+      } else {
+        const trimmed = source.dir.trim();
+        const problem = dirProblem(trimmed);
+        if (problem) issues.push(problem);
+        else dir = trimmed;
+      }
+    }
+
+    let requiresApproval = false;
+    if (source.requiresApproval !== undefined) {
+      if (typeof source.requiresApproval !== "boolean") {
+        // A string "false" is truthy, and this field decides whether a deploy
+        // can reach production without a human — coercion is not acceptable here.
+        issues.push(`"requiresApproval" must be a boolean`);
+      } else {
+        requiresApproval = source.requiresApproval;
+      }
+    }
+
+    if (issues.length > 0 || target === null || name === null) {
+      rejected.push({ name, reason: `${at}: ${issues.join("; ")}` });
+      return;
+    }
+
+    const config: DeployConfig = { name, target, requiresApproval };
+    // Copied, never aliased: the accepted config must not share an array with
+    // the parsed policy file.
+    if (secrets) config.secrets = [...secrets];
+    if (dir !== undefined) config.dir = dir;
+    accepted.push(config);
+  });
+
+  return { accepted, rejected };
+}
+
+/**
+ * Why a `dir` is unusable, or null if it is fine.
+ *
+ * `dir` selects which part of the merged tree is uploaded, so traversal out of
+ * the repo root is the thing being prevented: `..` or an absolute path would
+ * let a policy file choose bytes the change never contained.
+ */
+function dirProblem(dir: string): string | null {
+  if (dir === "") return `"dir" must not be empty`;
+  if (dir.length > MAX_DIR_LENGTH) return `"dir" must be at most ${MAX_DIR_LENGTH} characters`;
+  // A NUL can truncate the path for a consumer that hands it to a C-backed API.
+  if (dir.includes("\0")) return `"dir" must not contain a null byte`;
+  if (dir.startsWith("/") || dir.startsWith("\\")) return `"dir" must be relative (no leading "/")`;
+  // Backslash is split on as well: a repo can legitimately contain a file whose
+  // name has one, and treating "a\\..\\b" as a single segment would let it past.
+  if (dir.split(/[/\\]/).includes("..")) return `"dir" must not contain ".."`;
+  return null;
+}
+
+/** Render a policy-supplied value into a reason string without letting it set the reason's size. */
+function quoted(value: unknown): string {
+  const rendered = typeof value === "string" ? value : String(value);
+  return rendered.length > MAX_QUOTED_LENGTH
+    ? `"${rendered.slice(0, MAX_QUOTED_LENGTH)}…"`
+    : `"${rendered}"`;
+}

--- a/src/deploy/limits.ts
+++ b/src/deploy/limits.ts
@@ -1,0 +1,61 @@
+/**
+ * Bounds on a single post-merge deployment.
+ *
+ * They live in their own module for the same reason `src/evaluation/limits.ts`
+ * does: the provider targets, the runner, and (eventually) the queue's
+ * `visibility_timeout_ms` all need the same numbers, and none of them should
+ * have to import a provider implementation to get them.
+ *
+ * Every one of these is enforced **before the first provider request is
+ * issued**. A deployment that uploads half a tree and then fails leaves the
+ * site in a state no one asked for; a clean up-front rejection with a named
+ * reason does not.
+ */
+
+/**
+ * Most files one deployment may publish.
+ *
+ * The Worker holds the whole tree in memory while it uploads, so this is a
+ * memory bound as much as a fairness one.
+ */
+export const MAX_FILES = 2_000;
+
+/** Most bytes one deployment may publish, summed across every file. */
+export const MAX_TOTAL_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Largest single file one deployment may publish.
+ *
+ * Below `MAX_TOTAL_BYTES` on purpose: one file must not be able to consume the
+ * entire budget and starve the rest of the tree.
+ */
+export const MAX_FILE_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Most provider HTTP requests one deployment may issue.
+ *
+ * Cloudflare's own ceiling is the real limit — 10,000 per invocation on paid
+ * plans since 2026-02-11, and only 50 external subrequests on the free plan.
+ * This budget sits far below the paid ceiling because a deployment shares its
+ * invocation with D1 reads, the git tree read, and the queue's own traffic,
+ * and because `wrangler.toml` sets no `[limits]` block to raise it.
+ *
+ * It is deliberately just above `MAX_FILES + 2`: the Cloudflare static-asset
+ * flow's worst case is one upload request per file plus a manifest
+ * registration and a script deploy, so a tree that passes `MAX_FILES` can
+ * never be rejected here for a reason the author cannot act on.
+ *
+ * A self-hoster on the Workers free plan will hit the platform's 50-subrequest
+ * ceiling long before this one. That is a platform failure, not a limit this
+ * module can enforce away.
+ */
+export const MAX_SUBREQUESTS = 2_048;
+
+/**
+ * Longest provider output persisted on a deployment row (`deployments.log_tail`).
+ *
+ * Redaction always runs on the full text *before* truncation to this length —
+ * see `src/deploy/redact.ts`. Truncating first would let a secret survive by
+ * straddling the cut.
+ */
+export const MAX_LOG_TAIL = 16_384;

--- a/src/deploy/limits.ts
+++ b/src/deploy/limits.ts
@@ -59,3 +59,63 @@ export const MAX_SUBREQUESTS = 2_048;
  * straddling the cut.
  */
 export const MAX_LOG_TAIL = 16_384;
+
+/**
+ * Memory one Worker isolate has, in bytes. Not configurable — it is the
+ * platform's per-isolate limit, and exceeding it kills the isolate outright
+ * rather than throwing something a `finally` could catch.
+ */
+export const ISOLATE_MEMORY_BYTES = 128 * 1024 * 1024;
+
+/**
+ * How many deploy messages one isolate may run at once — the
+ * `max_concurrency` every `stratum-deploys` consumer in `wrangler.toml` must
+ * be set to.
+ *
+ * **It is 1 because concurrent queue invocations share one isolate's
+ * {@link ISOLATE_MEMORY_BYTES}, and an OOM kill is not catchable.** The Vercel
+ * target inlines the whole tree in one JSON request body
+ * (`src/deploy/targets/vercel.ts`), so one accepted deployment peaks at
+ * `MAX_TOTAL_BYTES` of raw bytes plus a base64 copy plus the serialized body —
+ * roughly 92 MiB. Two of those at once is ~183 MiB: the isolate dies *before*
+ * `runOneDeployment` reaches the `finally` that writes a terminal status, and
+ * every row it was holding is stranded at `running` with no lease to recover.
+ *
+ * The price, stated so nobody "optimizes" it back: this also serializes
+ * Cloudflare Pages and Workers deploys, which are nowhere near that peak. That
+ * is the accepted cost of a bound that holds whatever mix of targets a merge
+ * fans out to — a Vercel-only byte limit would have to be re-derived every time
+ * a target changes how it buffers, and would reject trees that deploy fine
+ * today. Raising this requires cutting the per-deploy peak first (a streamed
+ * request body), not the other way round.
+ */
+export const MAX_DEPLOY_CONCURRENCY = 1;
+
+/**
+ * Wall-clock budget for one deployment attempt, after which the runner gives up
+ * and writes a terminal `failed` row.
+ *
+ * **Invariant, and the reason this constant exists:**
+ *
+ * ```
+ * DEPLOY_ATTEMPT_DEADLINE_MS < DEFAULT_DEPLOY_LEASE_MS
+ *                           <= visibility_timeout_ms (wrangler.toml)
+ *                           <= QUEUE_CONSUMER_WALL_MS
+ * ```
+ *
+ * Every `<` and `<=` is load bearing. Without the first one, the storage lease
+ * (`DEFAULT_DEPLOY_LEASE_MS` in `src/storage/deployments.ts`) can expire while
+ * the first runner is still uploading to the provider, and `claimDeployment`
+ * will then hand a *genuinely running* row to a second consumer — the double
+ * deploy the lease exists to prevent. Bounding the runner below the lease makes
+ * "the lease expired" mean "no runner is alive", which is what every reclaim
+ * decision already assumes.
+ */
+export const DEPLOY_ATTEMPT_DEADLINE_MS = 10 * 60 * 1000;
+
+/**
+ * Cloudflare's wall-clock ceiling on one queue-consumer invocation. Recorded
+ * here because it is the outermost term of the ordering above and nothing else
+ * in the codebase states it.
+ */
+export const QUEUE_CONSUMER_WALL_MS = 15 * 60 * 1000;

--- a/src/deploy/redact.ts
+++ b/src/deploy/redact.ts
@@ -1,0 +1,63 @@
+import { MAX_LOG_TAIL } from "./limits";
+
+/** What a redacted secret is replaced with. Fixed-width so it cannot leak a value's length. */
+export const REDACTION_PLACEHOLDER = "[redacted]";
+
+/** Appended when text was cut short, so a reader can tell truncation from a provider that said little. */
+export const TRUNCATION_MARKER = "\n…[truncated]";
+
+/**
+ * Replace every literal occurrence of each secret value with
+ * {@link REDACTION_PLACEHOLDER}.
+ *
+ * **Known limitation, stated rather than claimed away:** this is literal
+ * substring matching. A provider that echoes a credential base64-encoded,
+ * percent-encoded, or JSON-string-escaped defeats it. The mitigation is
+ * structural — no untrusted code runs in the deploy path and no request is
+ * ever logged — not this function.
+ *
+ * Values are matched longest-first so that when one secret contains another
+ * (a token and the account id embedded in it, say), the longer match wins and
+ * the shorter one cannot leave a recognisable fragment behind.
+ *
+ * Empty values are skipped: `String.replaceAll("")` inserts the placeholder
+ * between every character, which would destroy the text without protecting
+ * anything.
+ */
+export function redactSecrets(text: string, secretValues: Iterable<string>): string {
+  const values = [...new Set(secretValues)]
+    .filter((value) => value.length > 0)
+    .sort((a, b) => b.length - a.length);
+
+  let redacted = text;
+  for (const value of values) {
+    redacted = redacted.split(value).join(REDACTION_PLACEHOLDER);
+  }
+  return redacted;
+}
+
+/**
+ * Redact secret values from provider output, then cap it at `max` characters.
+ *
+ * **The order is the point.** Truncating first and redacting after would let a
+ * secret that straddles the cut survive as a prefix in the retained half, with
+ * nothing left for the matcher to find. Redacting first means the retained
+ * text provably contains no whole secret before a single character is dropped,
+ * so the cut cannot reveal one.
+ *
+ * The *head* is kept rather than the tail despite the `log_tail` column name:
+ * v1 stores provider error documents, not build logs, and a provider's
+ * `{"errors":[{"message":...}]}` puts the actionable part first. When the
+ * build tier lands and real logs are stored, that trade-off should be revisited.
+ */
+export function redactAndTruncate(
+  text: string,
+  secretValues: Iterable<string>,
+  max: number = MAX_LOG_TAIL,
+): string {
+  const redacted = redactSecrets(text, secretValues);
+  if (redacted.length <= max) return redacted;
+
+  const keep = Math.max(0, max - TRUNCATION_MARKER.length);
+  return redacted.slice(0, keep) + TRUNCATION_MARKER;
+}

--- a/src/deploy/runner.ts
+++ b/src/deploy/runner.ts
@@ -58,6 +58,7 @@ import { projectDefaultBranch } from "../types";
 import type { AppError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
 import { type Result, err, ok } from "../utils/result";
+import { DEPLOY_ATTEMPT_DEADLINE_MS } from "./limits";
 import { redactAndTruncate } from "./redact";
 import { type DeployFetch, getDeployTarget } from "./targets/index";
 
@@ -110,11 +111,17 @@ export type DeployFilesReader = (
   branch: string,
 ) => Promise<Result<Map<string, Uint8Array>, AppError>>;
 
-/** The seams a test replaces. All three default to the production implementation. */
+/** The seams a test replaces. Every one defaults to the production implementation. */
 export interface DeployRunnerDeps {
   readFiles?: DeployFilesReader;
   now?: () => number;
   fetch?: DeployFetch;
+  /**
+   * Wall-clock budget for one deployment attempt. Defaults to
+   * {@link DEPLOY_ATTEMPT_DEADLINE_MS}; a test shortens it rather than waiting
+   * ten minutes for a provider that never answers.
+   */
+  deadlineMs?: number;
 }
 
 /** One deployment row this run touched, for the queue consumer's log. */
@@ -163,6 +170,11 @@ const MAX_REASON_LENGTH = 1_000;
 /** Stamped only if something threw between the assignments in `runOneDeployment`. */
 const ABANDONED_REASON = "The deploy runner exited without recording an outcome";
 
+/** Stamped on a row whose attempt outlived the runner's wall-clock budget. */
+function deadlineReason(deadlineMs: number): string {
+  return `The deploy did not finish within ${Math.round(deadlineMs / 1000)}s and was abandoned before its lease could expire; retry it`;
+}
+
 const DELETING_REASON = "The project is being deleted; the deploy was not run";
 
 const NO_PROJECT_ID_REASON =
@@ -206,6 +218,7 @@ interface RunContext {
   iso: () => string;
   readFiles: DeployFilesReader;
   fetch: DeployFetch;
+  deadlineMs: number;
 }
 
 /**
@@ -250,6 +263,7 @@ export async function runDeployMessage(
     iso: () => new Date(now()).toISOString(),
     readFiles: deps.readFiles ?? readRepoFiles,
     fetch: deps.fetch ?? ((url, init) => fetch(url, init)),
+    deadlineMs: deps.deadlineMs ?? DEPLOY_ATTEMPT_DEADLINE_MS,
   };
 
   return message.kind === "merge"
@@ -344,9 +358,19 @@ async function runMergeMessage(
   // A rejected entry becomes a visible failed row, never a dropped one: a deploy
   // the author wrote and that never runs means production silently stopped
   // updating. See the note in `sanitizeDeploys`.
+  //
+  // *One row per rejection*, which is why the names are made distinct first.
+  // `insertDeployment` excludes on (project, name, commit, attempt), so two
+  // rejections sharing a name — two entries with no usable `name` at all, or a
+  // duplicate-name pair — would collapse into one row and silently lose a
+  // reason. A rejection can also collide with an *accepted* entry, because the
+  // duplicate-name rule rejects the second declaration of a name the first
+  // declaration is legitimately using; the accepted names are therefore claimed
+  // up front, so a rejection row can never take the key the real deploy needs.
+  const claimedNames = new Set(policy.deploys.map((entry) => entry.name));
   for (const rejection of policy.rejections) {
     const created = await createDeployment(ctx, {
-      name: rejection.name ?? UNRESOLVED_DEPLOY_NAME,
+      name: distinctName(rejection.name ?? UNRESOLVED_DEPLOY_NAME, claimedNames),
       target: UNRESOLVED_TARGET,
       commitSha: message.commitSha,
       changeId: message.changeId,
@@ -582,8 +606,29 @@ async function runOneDeployment(
   let terminal: TerminalWrite = { status: "failed", reason: ABANDONED_REASON };
   let writtenReason: string | null = null;
 
+  /**
+   * The runner's half of the lease invariant (`src/deploy/limits.ts`). The
+   * attempt is abandoned strictly before `DEFAULT_DEPLOY_LEASE_MS` can elapse,
+   * so "the lease expired" can only ever mean "no runner is alive" — otherwise
+   * `claimDeployment` would hand this still-uploading row to a second consumer
+   * and the same commit would deploy twice. The signal is threaded into the
+   * provider `fetch` so the timeout actually cuts the upload off rather than
+   * leaving it running behind a resolved race.
+   */
+  const controller = new AbortController();
+  let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+  const deadline = new Promise<TerminalWrite>((resolve) => {
+    deadlineTimer = setTimeout(() => {
+      controller.abort();
+      resolve({ status: "failed", reason: deadlineReason(ctx.deadlineMs) });
+    }, ctx.deadlineMs);
+  });
+
   try {
-    terminal = await deployOnce(ctx, claim.data.deployment, config, files, secretValues);
+    terminal = await Promise.race([
+      deployOnce(ctx, claim.data.deployment, config, files, secretValues, controller.signal),
+      deadline,
+    ]);
   } catch (error) {
     // A target that throws — a malformed provider response, an unexpected
     // runtime fault — must still leave a terminal row. This is why the write
@@ -597,6 +642,9 @@ async function runOneDeployment(
       reason: `Deploy failed unexpectedly: ${error instanceof Error ? error.message : String(error)}`,
     };
   } finally {
+    // Left armed, this keeps the invocation alive for the rest of the budget.
+    if (deadlineTimer !== null) clearTimeout(deadlineTimer);
+
     // The single point where anything from a provider reaches D1, so redaction
     // goes here rather than at each producer: a payload that echoed a credential
     // cannot get past it, whichever branch produced it.
@@ -655,6 +703,7 @@ async function deployOnce(
   config: DeployConfig,
   files: ReadonlyMap<string, Uint8Array>,
   secretValues: string[],
+  signal: AbortSignal,
 ): Promise<TerminalWrite> {
   const { env, logger, project } = ctx;
   const target = getDeployTarget(config.target);
@@ -718,7 +767,10 @@ async function deployOnce(
     config,
     commitSha: deployment.commitSha,
     logger,
-    fetch: ctx.fetch,
+    // Every target reaches its provider through this one `fetch`, so attaching
+    // the deadline's signal here covers all of them without a target ever
+    // having to know a deadline exists.
+    fetch: (url, init) => ctx.fetch(url, { ...init, signal }),
   });
 
   if (!result.success) {
@@ -1039,6 +1091,23 @@ function toRecord(deployment: Deployment): DeployRunRecord {
   if (deployment.reason !== undefined) record.reason = deployment.reason;
   if (deployment.url !== undefined) record.url = deployment.url;
   return record;
+}
+
+/**
+ * `base`, or the first of `base #2`, `base #3`, … not already spoken for.
+ * Records the answer in `claimed`, so successive calls keep diverging.
+ *
+ * Deterministic given the same policy, which is what keeps `insertDeployment`'s
+ * unique index doing its job: two consumers fanning out the same merge derive
+ * the same names in the same order, so exactly one of them wins each row. The
+ * suffixed form cannot collide with a declared deploy name either — those match
+ * `^[a-z][a-z0-9-]{0,31}$`, which admits neither a space nor a `#`.
+ */
+function distinctName(base: string, claimed: Set<string>): string {
+  let candidate = base;
+  for (let n = 2; claimed.has(candidate); n++) candidate = `${base} #${n}`;
+  claimed.add(candidate);
+  return candidate;
 }
 
 /** The commit prefix humans recognise, for reasons that name a commit. */

--- a/src/deploy/runner.ts
+++ b/src/deploy/runner.ts
@@ -1,0 +1,1047 @@
+/**
+ * Runs post-merge deployments: one queue message in, terminal `deployments`
+ * rows out.
+ *
+ * Four properties of this module are load bearing.
+ *
+ * **The tree is read once, at the pinned merge commit, and the policy is parsed
+ * out of those same bytes.** `loadPolicy` takes a branch, not a ref, so using it
+ * here would let a *newer* policy apply to an *older* tree: land a benign
+ * change, land a policy change, and the first change's still-queued deploy picks
+ * up the second policy. Reading at the commit makes config and code provably one
+ * commit, and costs nothing extra because the files are what gets uploaded.
+ *
+ * **`skipped` means exactly one thing: no deploy was configured.** A missing
+ * secret, an unset `DEPLOY_SECRET_KEY`, an undecryptable value, an unreadable
+ * tree, a rejected `deploys:` entry, a provider error — every one of those is
+ * `failed` with a reason naming the cause. Reporting an operator error as a calm
+ * grey state is failing open on something that stops production updating.
+ *
+ * **Everything is scoped on `projectId`, and a message without one is refused.**
+ * Project names are not globally unique, so resolving one by name would hand a
+ * deploy another tenant's credentials (see `webhookBelongsToProject`).
+ *
+ * **Every path that claims a row writes a terminal status in a `finally`.** A
+ * row left `running` with no lease is a deployment nobody finishes and nobody
+ * can retry.
+ *
+ * `readFiles`, `now` and `fetch` are injected for the reason `SandboxEvaluator`
+ * injects its own seams: without them, testing any of the above needs a real git
+ * remote, a real clock, and a real provider account.
+ */
+import { parsePolicyContent } from "../evaluation/policy-loader";
+import type { DeployConfig, DeployRejection } from "../evaluation/types";
+import { type StratumEvent, emitEvent } from "../queue/events";
+import { getChange } from "../storage/changes";
+import { recordCosts } from "../storage/costs";
+import { isTargetDeleting } from "../storage/deletion";
+import {
+  type Deployment,
+  type DeploymentStatus,
+  type DeploymentTarget,
+  SUPERSEDED_REASON,
+  type TerminalDeploymentStatus,
+  UNRESOLVED_TARGET,
+  claimDeployment,
+  completeDeployment,
+  findNewerSucceededDeployment,
+  getDeployment,
+  insertDeployment,
+  isIsoTimestamp,
+  supersedeOlder,
+} from "../storage/deployments";
+import { freshRepoToken, readRepoFiles } from "../storage/git-ops";
+import { DEPLOY_SECRET_KEY_MISSING, loadSecretValues } from "../storage/project-secrets";
+import { getProjectById } from "../storage/state";
+import type { Env, ProjectEntry } from "../types";
+import { projectDefaultBranch } from "../types";
+import type { AppError } from "../utils/errors";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+import { redactAndTruncate } from "./redact";
+import { type DeployFetch, getDeployTarget } from "./targets/index";
+
+/**
+ * What the `stratum-deploys` queue carries. Two shapes, discriminated on `kind`.
+ *
+ * - `merge` fans out: the runner reads the tree at `commitSha`, parses the
+ *   policy from it, creates one row per declared deploy, and runs the ones that
+ *   need no approval.
+ * - `deployment` runs one row that already exists. This is what the approve and
+ *   retry routes enqueue — they have already decided *which* deployment, and
+ *   re-deriving it from the policy could pick a different set.
+ *
+ * `projectId` is on both because it is the only tenant scope this runner
+ * accepts; see the fail-closed check in {@link runDeployMessage}.
+ */
+export type DeployQueueMessage =
+  | {
+      kind: "merge";
+      projectId: string;
+      changeId: string;
+      commitSha: string;
+      /**
+       * When the merge happened, ISO 8601 — **not** when this message is
+       * processed. It is carried on the message because the queue is the one
+       * place the two can diverge: Cloudflare Queues promise no ordering and a
+       * retry reorders outright, so deriving order from processing time let
+       * merge A, delivered after merge B, sort *newer* than B and publish the
+       * older commit over it. Stamped by `enqueueMergeDeploy` from the change's
+       * own `merged_at`.
+       *
+       * Optional only for compatibility: see {@link mergeTimeOf}.
+       */
+      mergedAt?: string;
+    }
+  | { kind: "deployment"; projectId: string; deploymentId: string };
+
+/**
+ * Reads a repo tree into path → raw bytes at a pinned commit. Injectable so a
+ * test never touches git; `readRepoFiles` is the production implementation.
+ *
+ * `ref` is the commit and is required here, unlike on `readRepoFiles` itself:
+ * the whole point of this runner is that it never reads a branch tip.
+ */
+export type DeployFilesReader = (
+  remote: string,
+  token: string,
+  logger: Logger,
+  ref: string,
+  branch: string,
+) => Promise<Result<Map<string, Uint8Array>, AppError>>;
+
+/** The seams a test replaces. All three default to the production implementation. */
+export interface DeployRunnerDeps {
+  readFiles?: DeployFilesReader;
+  now?: () => number;
+  fetch?: DeployFetch;
+}
+
+/** One deployment row this run touched, for the queue consumer's log. */
+export interface DeployRunRecord {
+  deploymentId: string;
+  name: string;
+  /** The status this run believes the row now holds. */
+  status: DeploymentStatus;
+  reason?: string;
+  url?: string;
+}
+
+/** Everything one queue message produced. */
+export interface DeployRunSummary {
+  /** Rows created or completed, in the order they were handled. */
+  deployments: DeployRunRecord[];
+  /**
+   * Why the message was abandoned before any deploy ran, when it was. Present
+   * on a reverted change, a deleting project, and a message with no
+   * `projectId` — none of which are retryable, so the consumer should ack.
+   */
+  aborted?: string;
+}
+
+/**
+ * Name for a row that is not tied to a declared deploy entry: a policy that
+ * could not be parsed, a tree that could not be read, or a merge with nothing
+ * configured. The parentheses put it outside `^[a-z][a-z0-9-]{0,31}$`, so it can
+ * never collide with a name a policy file is allowed to declare.
+ */
+const UNRESOLVED_DEPLOY_NAME = "(unresolved)";
+
+/** Repo-relative policy files, in the order `loadPolicy` tries them. */
+const POLICY_FILES = [
+  { path: ".stratum/policy.yaml", format: "yaml" },
+  { path: "stratum.config.json", format: "json" },
+] as const;
+
+/**
+ * Longest `reason` persisted on a row. The reason is rendered in a list view, so
+ * a provider that returns a wall of text must not decide how tall that row is;
+ * the full payload is on `log_tail`.
+ */
+const MAX_REASON_LENGTH = 1_000;
+
+/** Stamped only if something threw between the assignments in `runOneDeployment`. */
+const ABANDONED_REASON = "The deploy runner exited without recording an outcome";
+
+const DELETING_REASON = "The project is being deleted; the deploy was not run";
+
+const NO_PROJECT_ID_REASON =
+  "The deploy message carried no projectId; refusing to resolve a project by name";
+
+const NO_POLICY_REASON =
+  "No .stratum/policy.yaml or stratum.config.json at this commit, so no deploy is configured";
+
+const NO_DEPLOYS_REASON = "The policy at this commit declares no 'deploys:' entries";
+
+/** Stamped on a row refused because a newer merge of the same name already shipped. */
+function alreadyShippedReason(newer: Deployment): string {
+  return `${SUPERSEDED_REASON}: ${shortSha(newer.commitSha)} already succeeded`;
+}
+
+const GUARD_UNREADABLE_REASON =
+  "Could not check whether a newer deployment of this name already succeeded, so the deploy was not run; retry it";
+
+/** What one deployment attempt decided to write. */
+interface TerminalWrite {
+  status: TerminalDeploymentStatus;
+  reason?: string;
+  url?: string;
+  logTail?: string;
+}
+
+/** The `deploys:` half of a policy, read out of a pinned tree. */
+interface TreePolicy {
+  deploys: DeployConfig[];
+  rejections: DeployRejection[];
+  /** True when neither policy file exists at this commit. */
+  absent: boolean;
+}
+
+/** Resolved once per message so no helper has to re-derive it. */
+interface RunContext {
+  env: Env;
+  logger: Logger;
+  project: ProjectEntry;
+  now: () => number;
+  iso: () => string;
+  readFiles: DeployFilesReader;
+  fetch: DeployFetch;
+}
+
+/**
+ * Run one deploy queue message.
+ *
+ * Never throws: a deploy failure is a row, not an exception. The `err` channel
+ * is reserved for a fault that leaves the runner unable to say what happened —
+ * the project could not be resolved, or D1 refused a write — which is the only
+ * case where redelivering the message can help.
+ *
+ * @param deps - Test seams; every one defaults to the production implementation
+ */
+export async function runDeployMessage(
+  env: Env,
+  message: DeployQueueMessage,
+  logger: Logger,
+  deps: DeployRunnerDeps = {},
+): Promise<Result<DeployRunSummary, AppError>> {
+  const projectId = message.projectId;
+  // Fail closed. Legacy event rows can carry no project id at all
+  // (`src/queue/events.ts`), and the tempting fallback — resolve the project by
+  // its bare name — crosses tenants, because a same-named project in another
+  // account would hand this deploy someone else's credentials. Reported as an
+  // abort rather than an error: no redelivery of this message can fix it.
+  if (typeof projectId !== "string" || projectId.trim() === "") {
+    logger.error("Deploy message has no projectId", undefined, { kind: message.kind });
+    return ok({ deployments: [], aborted: NO_PROJECT_ID_REASON });
+  }
+
+  const projectResult = await getProjectById(env.STATE, projectId, logger);
+  if (!projectResult.success) {
+    logger.error("Could not resolve the deploy's project", projectResult.error, { projectId });
+    return err(projectResult.error);
+  }
+
+  const now = deps.now ?? Date.now;
+  const ctx: RunContext = {
+    env,
+    logger,
+    project: projectResult.data,
+    now,
+    iso: () => new Date(now()).toISOString(),
+    readFiles: deps.readFiles ?? readRepoFiles,
+    fetch: deps.fetch ?? ((url, init) => fetch(url, init)),
+  };
+
+  return message.kind === "merge"
+    ? runMergeMessage(ctx, message)
+    : runDeploymentMessage(ctx, message);
+}
+
+/**
+ * The timestamp every row this merge creates is stamped with.
+ *
+ * Falls back to processing time when the message carries no usable `mergedAt`.
+ * That fallback exists for exactly one reason: a `merge` message enqueued by the
+ * previous deployment of this Worker is still in flight when this one starts
+ * consuming, and it has no `mergedAt` field at all. Crashing or dropping it
+ * would lose a real deploy over a schema change; stamping processing time
+ * restores that single message to the pre-fix behaviour, and every message
+ * enqueued afterwards carries a real merge time. It also covers a `merged_at`
+ * that is not the ISO form the columns require (a legacy or imported change
+ * row) — a value the storage layer would reject outright, stranding the deploy.
+ *
+ * @returns The merge time, and whether it came from the message or the clock
+ */
+function mergeTimeOf(
+  ctx: RunContext,
+  message: Extract<DeployQueueMessage, { kind: "merge" }>,
+): string {
+  if (isIsoTimestamp(message.mergedAt)) return message.mergedAt;
+
+  ctx.logger.warn("Deploy message carries no usable merge time; ordering on processing time", {
+    changeId: message.changeId,
+    commitSha: message.commitSha,
+    mergedAt: message.mergedAt ?? null,
+  });
+  return ctx.iso();
+}
+
+/** Fan a merge out into one row per declared deploy, then run the queued ones. */
+async function runMergeMessage(
+  ctx: RunContext,
+  message: Extract<DeployQueueMessage, { kind: "merge" }>,
+): Promise<Result<DeployRunSummary, AppError>> {
+  const { env, logger, project } = ctx;
+
+  if (await isTargetDeleting(env, project, logger)) {
+    logger.info("Not deploying: the project is being deleted", {
+      projectId: project.id,
+      changeId: message.changeId,
+    });
+    return ok({ deployments: [], aborted: DELETING_REASON });
+  }
+
+  const guard = await changeStillDeployable(ctx, message.changeId);
+  if (guard !== null) {
+    logger.info("Not deploying", { changeId: message.changeId, reason: guard });
+    return ok({ deployments: [], aborted: guard });
+  }
+
+  // Every row this message creates is stamped with the *merge* time, so the
+  // history — and the two supersession checks that read `created_at` — order by
+  // when the code merged, not by when the queue got round to this message.
+  const createdAt = mergeTimeOf(ctx, message);
+
+  const records = new Map<string, DeployRunRecord>();
+
+  const treeResult = await readTree(ctx, message.commitSha, message.changeId);
+  if (!treeResult.success) {
+    // The config lives in the tree, so there is no deploy name to attach this
+    // to — but staying silent would make a merge that never deployed
+    // indistinguishable from one that had nothing to deploy.
+    const created = await createDeployment(ctx, {
+      name: UNRESOLVED_DEPLOY_NAME,
+      target: UNRESOLVED_TARGET,
+      commitSha: message.commitSha,
+      changeId: message.changeId,
+      createdAt,
+      status: "failed",
+      reason: `Could not read the tree at ${shortSha(message.commitSha)}: ${treeResult.error.message}`,
+    });
+    if (!created.success) return err(created.error);
+    if (created.data) {
+      records.set(created.data.id, toRecord(created.data));
+      await emitDeploymentEvent(ctx, created.data, "deployment.failed", {
+        reason: created.data.reason,
+      });
+    }
+    return ok({ deployments: [...records.values()] });
+  }
+
+  const files = treeResult.data;
+  const policy = policyFromTree(files, logger);
+
+  // A rejected entry becomes a visible failed row, never a dropped one: a deploy
+  // the author wrote and that never runs means production silently stopped
+  // updating. See the note in `sanitizeDeploys`.
+  for (const rejection of policy.rejections) {
+    const created = await createDeployment(ctx, {
+      name: rejection.name ?? UNRESOLVED_DEPLOY_NAME,
+      target: UNRESOLVED_TARGET,
+      commitSha: message.commitSha,
+      changeId: message.changeId,
+      createdAt,
+      status: "failed",
+      reason: rejection.reason,
+    });
+    if (!created.success) return err(created.error);
+    if (created.data) {
+      records.set(created.data.id, toRecord(created.data));
+      await emitDeploymentEvent(ctx, created.data, "deployment.failed", {
+        reason: created.data.reason,
+      });
+    }
+  }
+
+  if (policy.deploys.length === 0) {
+    // `skipped` only when there is genuinely nothing configured. If entries were
+    // rejected, those failures are the story and a calm grey row alongside them
+    // would misreport it.
+    if (policy.rejections.length === 0) {
+      const created = await createDeployment(ctx, {
+        name: UNRESOLVED_DEPLOY_NAME,
+        target: UNRESOLVED_TARGET,
+        commitSha: message.commitSha,
+        changeId: message.changeId,
+        createdAt,
+        status: "skipped",
+        reason: policy.absent ? NO_POLICY_REASON : NO_DEPLOYS_REASON,
+      });
+      if (!created.success) return err(created.error);
+      if (created.data) records.set(created.data.id, toRecord(created.data));
+    }
+    return ok({ deployments: [...records.values()] });
+  }
+
+  const runnable: Array<{ deployment: Deployment; config: DeployConfig }> = [];
+  for (const config of policy.deploys) {
+    const status: DeploymentStatus = config.requiresApproval ? "pending_approval" : "queued";
+    const created = await createDeployment(ctx, {
+      name: config.name,
+      target: config.target,
+      commitSha: message.commitSha,
+      changeId: message.changeId,
+      createdAt,
+      status,
+    });
+    if (!created.success) return err(created.error);
+    // `null` means another consumer won the unique index for this exact
+    // (project, name, commit, attempt) — a normal outcome, and its owner runs it.
+    if (!created.data) continue;
+    records.set(created.data.id, toRecord(created.data));
+    await emitDeploymentEvent(ctx, created.data, "deployment.requested");
+    if (status === "queued") runnable.push({ deployment: created.data, config });
+  }
+
+  // Sequential, not concurrent: these deploys share one invocation's CPU and
+  // subrequest budget, and two targets uploading the same tree at once would
+  // double the peak memory the Worker holds.
+  for (const { deployment, config } of runnable) {
+    records.set(deployment.id, await runOneDeployment(ctx, deployment, config, files));
+  }
+
+  return ok({ deployments: [...records.values()] });
+}
+
+/** Run one row that already exists — what the approve and retry routes enqueue. */
+async function runDeploymentMessage(
+  ctx: RunContext,
+  message: Extract<DeployQueueMessage, { kind: "deployment" }>,
+): Promise<Result<DeployRunSummary, AppError>> {
+  const { env, logger, project } = ctx;
+
+  const existing = await getDeployment(env.DB, logger, {
+    projectId: project.id,
+    deploymentId: message.deploymentId,
+  });
+  if (!existing.success) return err(existing.error);
+  if (!existing.data) {
+    // Scoped lookup: "not in this project" and "does not exist" are the same
+    // answer on purpose, so a probe cannot confirm an id in another tenant.
+    const aborted = `Deployment ${message.deploymentId} is not in this project`;
+    logger.warn("Deploy message names an unknown deployment", {
+      deploymentId: message.deploymentId,
+      projectId: project.id,
+    });
+    return ok({ deployments: [], aborted });
+  }
+  const deployment = existing.data;
+
+  if (await isTargetDeleting(env, project, logger)) {
+    return ok({
+      deployments: [await failWithoutRunning(ctx, deployment, DELETING_REASON)],
+      aborted: DELETING_REASON,
+    });
+  }
+
+  // A retry of an older commit carries no change id and there is nothing to
+  // re-read; the operator picked that commit deliberately.
+  if (deployment.changeId !== undefined) {
+    const guard = await changeStillDeployable(ctx, deployment.changeId);
+    if (guard !== null) {
+      return ok({
+        deployments: [await failWithoutRunning(ctx, deployment, guard)],
+        aborted: guard,
+      });
+    }
+  }
+
+  const treeResult = await readTree(ctx, deployment.commitSha, deployment.changeId);
+  if (!treeResult.success) {
+    const reason = `Could not read the tree at ${shortSha(deployment.commitSha)}: ${treeResult.error.message}`;
+    return ok({ deployments: [await failWithoutRunning(ctx, deployment, reason)] });
+  }
+
+  // Config comes from the pinned commit here too, so an approval granted days
+  // later still deploys with the configuration the commit was reviewed under.
+  const policy = policyFromTree(treeResult.data, logger);
+  const config = policy.deploys.find((entry) => entry.name === deployment.name);
+  if (!config) {
+    const rejection = policy.rejections.find((entry) => entry.name === deployment.name);
+    const reason =
+      rejection?.reason ??
+      `Deploy "${deployment.name}" is not declared in the policy at ${shortSha(deployment.commitSha)}`;
+    return ok({ deployments: [await failWithoutRunning(ctx, deployment, reason)] });
+  }
+
+  return ok({
+    deployments: [await runOneDeployment(ctx, deployment, config, treeResult.data)],
+  });
+}
+
+/**
+ * Claim a row and publish it, always leaving it terminal.
+ *
+ * Both ordering checks run *before* the claim, because two merges in quick
+ * succession arrive in whatever order the queue chooses and without them the
+ * older commit can be the one left in production. They are two halves of one
+ * rule and neither covers the other's case:
+ *
+ * - {@link findNewerSucceededDeployment} refuses *this* deploy when a newer
+ *   merge of the same name has already shipped. This is the half that closes
+ *   the race, because by then there is nothing left for `supersedeOlder` to
+ *   retire — the newer row is terminal.
+ * - {@link supersedeOlder} retires the older rows that have not started yet, so
+ *   a message for one of them cannot come back and publish it later.
+ */
+async function runOneDeployment(
+  ctx: RunContext,
+  deployment: Deployment,
+  config: DeployConfig,
+  files: ReadonlyMap<string, Uint8Array>,
+): Promise<DeployRunRecord> {
+  const { env, logger, project } = ctx;
+
+  const newer = await findNewerSucceededDeployment(env.DB, logger, {
+    projectId: project.id,
+    name: deployment.name,
+    createdAt: deployment.createdAt,
+    excludeDeploymentId: deployment.id,
+  });
+  if (!newer.success) {
+    // Fatal, unlike the `supersedeOlder` failure below, and the asymmetry is
+    // deliberate: that one only tidies stale history, while this one is the only
+    // thing standing between a reordered message and an older commit going live.
+    // A visible `failed` row an operator can retry is the cheaper mistake.
+    logger.error("Could not check for a newer succeeded deployment", newer.error, {
+      deploymentId: deployment.id,
+      projectId: project.id,
+    });
+    return await failWithoutRunning(ctx, deployment, GUARD_UNREADABLE_REASON);
+  }
+  if (newer.data !== null) {
+    logger.info("Not deploying: a newer commit of this deploy already succeeded", {
+      deploymentId: deployment.id,
+      projectId: project.id,
+      name: deployment.name,
+      commitSha: deployment.commitSha,
+      newerDeploymentId: newer.data.id,
+      newerCommitSha: newer.data.commitSha,
+    });
+    return await supersedeWithoutRunning(ctx, deployment, alreadyShippedReason(newer.data));
+  }
+
+  const superseded = await supersedeOlder(env.DB, logger, {
+    projectId: project.id,
+    name: deployment.name,
+    keepDeploymentId: deployment.id,
+    createdAt: deployment.createdAt,
+    now: ctx.iso(),
+  });
+  if (!superseded.success) {
+    // Not fatal. Superseding is about ordering older *queued* rows; refusing to
+    // deploy because that bookkeeping failed would turn a stale history entry
+    // into a production outage.
+    logger.error("Could not supersede older deployments", superseded.error, {
+      deploymentId: deployment.id,
+      projectId: project.id,
+    });
+  }
+
+  const claim = await claimDeployment(env.DB, logger, {
+    projectId: project.id,
+    deploymentId: deployment.id,
+    now: ctx.iso(),
+  });
+  if (!claim.success) {
+    logger.error("Could not claim the deployment", claim.error, {
+      deploymentId: deployment.id,
+      projectId: project.id,
+    });
+    return { deploymentId: deployment.id, name: deployment.name, status: deployment.status };
+  }
+  if (!claim.data.claimed) {
+    // Someone else holds the lease, or the row is not claimable at all
+    // (`pending_approval` deliberately is not). Writing a status here would
+    // clobber whatever its real owner is about to write.
+    logger.warn("Deployment not claimed; leaving it to its owner", {
+      deploymentId: deployment.id,
+      projectId: project.id,
+      why: claim.data.reason,
+    });
+    return { deploymentId: deployment.id, name: deployment.name, status: deployment.status };
+  }
+
+  const startedAt = ctx.now();
+  /**
+   * Filled in by `deployOnce` the moment secrets resolve — before anything that
+   * could throw with a value in hand — so the redaction in the `finally` covers
+   * a thrown provider error as well as a returned one.
+   */
+  const secretValues: string[] = [];
+  let terminal: TerminalWrite = { status: "failed", reason: ABANDONED_REASON };
+  let writtenReason: string | null = null;
+
+  try {
+    terminal = await deployOnce(ctx, claim.data.deployment, config, files, secretValues);
+  } catch (error) {
+    // A target that throws — a malformed provider response, an unexpected
+    // runtime fault — must still leave a terminal row. This is why the write
+    // below is in a `finally` and not on the happy path.
+    logger.error("Deploy threw", error instanceof Error ? error : undefined, {
+      deploymentId: deployment.id,
+      projectId: project.id,
+    });
+    terminal = {
+      status: "failed",
+      reason: `Deploy failed unexpectedly: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  } finally {
+    // The single point where anything from a provider reaches D1, so redaction
+    // goes here rather than at each producer: a payload that echoed a credential
+    // cannot get past it, whichever branch produced it.
+    writtenReason =
+      terminal.reason === undefined
+        ? null
+        : redactAndTruncate(terminal.reason, secretValues, MAX_REASON_LENGTH);
+    const logTail =
+      terminal.logTail === undefined ? null : redactAndTruncate(terminal.logTail, secretValues);
+
+    const completed = await completeDeployment(env.DB, logger, {
+      projectId: project.id,
+      deploymentId: deployment.id,
+      status: terminal.status,
+      reason: writtenReason,
+      url: terminal.url ?? null,
+      logTail,
+      durationMs: Math.max(0, ctx.now() - startedAt),
+      completedAt: ctx.iso(),
+    });
+    if (!completed.success) {
+      logger.error("Could not write the deployment's terminal status", completed.error, {
+        deploymentId: deployment.id,
+        projectId: project.id,
+      });
+    }
+
+    await emitDeploymentEvent(
+      ctx,
+      deployment,
+      terminal.status === "succeeded" ? "deployment.succeeded" : "deployment.failed",
+      {
+        ...(terminal.url !== undefined ? { url: terminal.url } : {}),
+        ...(writtenReason !== null ? { reason: writtenReason } : {}),
+      },
+    );
+  }
+
+  const record: DeployRunRecord = {
+    deploymentId: deployment.id,
+    name: deployment.name,
+    status: terminal.status,
+  };
+  if (writtenReason !== null) record.reason = writtenReason;
+  if (terminal.url !== undefined) record.url = terminal.url;
+  return record;
+}
+
+/**
+ * Resolve secrets and hand the tree to the provider. Returns what should be
+ * written; never writes anything itself, so its caller's `finally` owns the row.
+ */
+async function deployOnce(
+  ctx: RunContext,
+  deployment: Deployment,
+  config: DeployConfig,
+  files: ReadonlyMap<string, Uint8Array>,
+  secretValues: string[],
+): Promise<TerminalWrite> {
+  const { env, logger, project } = ctx;
+  const target = getDeployTarget(config.target);
+
+  // The policy's `secrets:` list is what the author declared; the target's own
+  // names are what it actually reads. Loading the union means a policy that
+  // omits `VERCEL_TOKEN` still works, while a name the author *did* declare and
+  // never stored is still an error they are told about.
+  const declared = config.secrets ?? [];
+  const wanted = [...new Set([...declared, ...target.requiredSecrets, ...target.optionalSecrets])];
+
+  const loaded = await loadSecretValues(env.DB, logger, env, {
+    projectId: project.id,
+    names: wanted,
+  });
+  if (!loaded.success) {
+    return {
+      status: "failed",
+      reason:
+        loaded.error.code === DEPLOY_SECRET_KEY_MISSING
+          ? "DEPLOY_SECRET_KEY is not configured on this instance, so deploy secrets cannot be decrypted. Set it as a Wrangler secret and retry."
+          : `Could not load deploy secrets: ${loaded.error.message}`,
+    };
+  }
+  secretValues.push(...loaded.data.values.values());
+
+  // Reported apart from `missing`, and before it, because the remedy is
+  // different and more alarming: the ciphertext is there but will not
+  // authenticate, which means DEPLOY_SECRET_KEY was rotated or the row was
+  // moved. An *optional* secret counts here too — deploying without a
+  // `VERCEL_TEAM_ID` that exists but cannot be read would publish to the wrong
+  // account rather than fail.
+  if (loaded.data.undecryptable.length > 0) {
+    const names = loaded.data.undecryptable.join(", ");
+    const plural = loaded.data.undecryptable.length === 1 ? "" : "s";
+    return {
+      status: "failed",
+      reason: `Could not decrypt project secret${plural}: ${names} — DEPLOY_SECRET_KEY may have been rotated; re-enter the value${plural} in project settings`,
+    };
+  }
+
+  const required = new Set([...declared, ...target.requiredSecrets]);
+  const missing = loaded.data.missing.filter((name) => required.has(name));
+  if (missing.length > 0) {
+    const plural = missing.length === 1 ? "" : "s";
+    return {
+      status: "failed",
+      reason: `Missing project secret${plural}: ${missing.join(", ")} — add ${missing.length === 1 ? "it" : "them"} in project settings`,
+    };
+  }
+
+  const secrets: Record<string, string> = {};
+  for (const [name, value] of loaded.data.values) secrets[name] = value;
+
+  // Limits are deliberately *not* enforced here. Each target narrows the tree to
+  // its own `dir` first, so `enforceLimits` has to run there or it would judge
+  // bytes that are never uploaded.
+  const result = await target.deploy({
+    files,
+    secrets,
+    config,
+    commitSha: deployment.commitSha,
+    logger,
+    fetch: ctx.fetch,
+  });
+
+  if (!result.success) {
+    const failure: TerminalWrite = { status: "failed", reason: result.error.reason };
+    if (result.error.logTail !== undefined) failure.logTail = result.error.logTail;
+    return failure;
+  }
+
+  const success: TerminalWrite = { status: "succeeded" };
+  if (result.data.url !== undefined) success.url = result.data.url;
+  if (result.data.logTail !== undefined) success.logTail = result.data.logTail;
+
+  // Honesty about asynchronous providers. Vercel answers as soon as it has
+  // *accepted* the deployment (`readyState: "QUEUED"`) and builds afterwards,
+  // and this runner deliberately does not poll — polling would hold a queue
+  // message open for the length of someone else's build, and the visibility
+  // timeout is sized for an upload, not a build. Recording that as a bare
+  // `succeeded` would claim the commit is live when it may still be building,
+  // so the provider's own state is carried into the reason and the row says
+  // "accepted for build" rather than implying more than the provider promised.
+  const detail: string[] = [];
+  if (result.data.state !== undefined) {
+    detail.push(
+      `provider state at hand-off: ${result.data.state} (the provider finishes asynchronously; Stratum does not poll it)`,
+    );
+  }
+  if (result.data.providerId !== undefined) {
+    detail.push(`provider deployment ${result.data.providerId}`);
+  }
+  if (detail.length > 0) success.reason = detail.join("; ");
+
+  return success;
+}
+
+/**
+ * Why this change must not be deployed, or `null` when it may be.
+ *
+ * A merge can be reverted between the enqueue and this run —
+ * `runPostMergeCheck` auto-reverts, and the queue promises nothing about when a
+ * message is delivered — so the change's status is re-read here rather than
+ * trusted from the message. Anything other than `merged` fails closed.
+ */
+async function changeStillDeployable(ctx: RunContext, changeId: string): Promise<string | null> {
+  const result = await getChange(ctx.env.DB, ctx.logger, changeId);
+  if (!result.success) {
+    return `Change ${changeId} could not be read (${result.error.message}); refusing to deploy`;
+  }
+
+  const change = result.data;
+  // Legacy rows carry no project id, so this can only be checked when present —
+  // but when it is present and disagrees, the message is pointing across tenants.
+  if (change.projectId !== undefined && change.projectId !== ctx.project.id) {
+    return `Change ${changeId} belongs to a different project; refusing to deploy`;
+  }
+  if (change.status !== "merged") {
+    return `Change ${changeId} is ${change.status}, not merged; refusing to deploy`;
+  }
+  return null;
+}
+
+/** Mint a read token and read the tree at the pinned commit, recording the git cost either way. */
+async function readTree(
+  ctx: RunContext,
+  commitSha: string,
+  changeId?: string,
+): Promise<Result<Map<string, Uint8Array>, AppError>> {
+  const { env, logger, project } = ctx;
+
+  // Read scope: this path never pushes. Minted fresh because no token is
+  // persisted and an Artifacts token is only good for about an hour.
+  const token = await freshRepoToken(env.ARTIFACTS, project.remote, "read", logger);
+  if (!token.success) return err(token.error);
+
+  const files = await ctx.readFiles(
+    project.remote,
+    token.data,
+    logger,
+    commitSha,
+    projectDefaultBranch(project),
+  );
+
+  // Recorded whether or not the read succeeded: a clone that failed still cost
+  // the round trip.
+  await recordCosts(
+    env.DB,
+    logger,
+    {
+      project: project.name,
+      projectId: project.id,
+      ...(changeId !== undefined ? { changeId } : {}),
+    },
+    [{ kind: "git_ops", quantity: 1 }],
+  );
+
+  return files;
+}
+
+/**
+ * Read the `deploys:` half of the policy out of tree bytes.
+ *
+ * Mirrors `loadPolicy`'s file order and its refusal to fall through after a
+ * *present but malformed* file: a broken policy is an answer, and reading the
+ * other file instead would apply configuration the author did not think was in
+ * effect. A malformed file yields one named rejection rather than silence,
+ * because a single YAML typo must not quietly stop production updating.
+ */
+function policyFromTree(files: ReadonlyMap<string, Uint8Array>, logger: Logger): TreePolicy {
+  const decoder = new TextDecoder();
+
+  for (const { path, format } of POLICY_FILES) {
+    const bytes = files.get(path);
+    if (bytes === undefined) continue;
+
+    const parsed = parsePolicyContent(decoder.decode(bytes), format, logger);
+    if (parsed.status === "malformed") {
+      return {
+        deploys: [],
+        rejections: [
+          {
+            name: null,
+            reason: `Policy file ${path} is present but invalid (${parsed.reason}); no deploy configuration could be read from it.`,
+          },
+        ],
+        absent: false,
+      };
+    }
+
+    return {
+      deploys: parsed.policy.deploys ?? [],
+      rejections: parsed.policy.deployRejections ?? [],
+      absent: false,
+    };
+  }
+
+  return { deploys: [], rejections: [], absent: true };
+}
+
+/**
+ * Insert one deployment row.
+ *
+ * @returns The row, or `null` when another consumer already owns this
+ *   `(project, name, commit, attempt)` — a normal outcome of the unique index
+ *   being the mutual exclusion, not a failure.
+ */
+async function createDeployment(
+  ctx: RunContext,
+  opts: {
+    name: string;
+    target: DeploymentTarget;
+    commitSha: string;
+    changeId?: string;
+    /**
+     * The merge time this row is ordered by. Omitted only by callers that have
+     * no merge behind them, which then get the clock — see
+     * `Deployment.createdAt`.
+     */
+    createdAt?: string;
+    status: DeploymentStatus;
+    reason?: string;
+  },
+): Promise<Result<Deployment | null, AppError>> {
+  const result = await insertDeployment(ctx.env.DB, ctx.logger, {
+    projectId: ctx.project.id,
+    project: ctx.project.name,
+    changeId: opts.changeId ?? null,
+    commitSha: opts.commitSha,
+    name: opts.name,
+    target: opts.target,
+    status: opts.status,
+    // Truncated, not redacted: nothing here has seen a secret value yet — these
+    // reasons come from the policy file and from git.
+    reason:
+      opts.reason === undefined ? null : redactAndTruncate(opts.reason, [], MAX_REASON_LENGTH),
+    // A merge-triggered deploy has no human behind it.
+    requestedByType: "system",
+    ...(opts.createdAt !== undefined ? { createdAt: opts.createdAt } : {}),
+    now: ctx.iso(),
+  });
+  if (!result.success) return err(result.error);
+
+  if (!result.data.inserted) {
+    ctx.logger.info("Deployment already owned by another consumer", {
+      projectId: ctx.project.id,
+      name: opts.name,
+      commitSha: opts.commitSha,
+    });
+    return ok(null);
+  }
+  return ok(result.data.deployment);
+}
+
+/**
+ * Write a terminal `failed` on a row that was never claimed — the change was
+ * reverted, the project is being deleted, the tree would not read, or the deploy
+ * is no longer declared. Leaving it `queued` would strand it forever.
+ */
+async function failWithoutRunning(
+  ctx: RunContext,
+  deployment: Deployment,
+  reason: string,
+): Promise<DeployRunRecord> {
+  const truncated = redactAndTruncate(reason, [], MAX_REASON_LENGTH);
+
+  const completed = await completeDeployment(ctx.env.DB, ctx.logger, {
+    projectId: ctx.project.id,
+    deploymentId: deployment.id,
+    status: "failed",
+    reason: truncated,
+    completedAt: ctx.iso(),
+  });
+  if (!completed.success) {
+    ctx.logger.error("Could not fail the deployment", completed.error, {
+      deploymentId: deployment.id,
+      projectId: ctx.project.id,
+    });
+  }
+
+  await emitDeploymentEvent(ctx, deployment, "deployment.failed", { reason: truncated });
+  return {
+    deploymentId: deployment.id,
+    name: deployment.name,
+    status: "failed",
+    reason: truncated,
+  };
+}
+
+/**
+ * Retire a row that lost to a newer commit, without ever claiming it.
+ *
+ * Writes `superseded` rather than `failed` because nothing went wrong: the
+ * commit this row would have published was simply overtaken. No event is
+ * emitted, matching `supersedeOlder` — the events registry has `requested`,
+ * `succeeded` and `failed`, and reporting a retired row as a failure would page
+ * someone about a healthy outcome.
+ *
+ * `completeDeployment` refuses a row that is already terminal, so replaying the
+ * message for an already-superseded deployment leaves it exactly where it is.
+ */
+async function supersedeWithoutRunning(
+  ctx: RunContext,
+  deployment: Deployment,
+  reason: string,
+): Promise<DeployRunRecord> {
+  const truncated = redactAndTruncate(reason, [], MAX_REASON_LENGTH);
+
+  const completed = await completeDeployment(ctx.env.DB, ctx.logger, {
+    projectId: ctx.project.id,
+    deploymentId: deployment.id,
+    status: "superseded",
+    reason: truncated,
+    completedAt: ctx.iso(),
+  });
+  if (!completed.success) {
+    ctx.logger.error("Could not supersede the deployment", completed.error, {
+      deploymentId: deployment.id,
+      projectId: ctx.project.id,
+    });
+  }
+
+  return {
+    deploymentId: deployment.id,
+    name: deployment.name,
+    status: "superseded",
+    reason: truncated,
+  };
+}
+
+/**
+ * Emit a `deployment.*` notification.
+ *
+ * The events registry carries notifications *about* deploys and never the work
+ * itself — that is why `stratum-deploys` exists — so a failure here is logged by
+ * `emitEvent` and never allowed to affect the deployment's outcome.
+ */
+async function emitDeploymentEvent(
+  ctx: RunContext,
+  deployment: Deployment,
+  type: "deployment.requested" | "deployment.succeeded" | "deployment.failed",
+  extra: { url?: string; reason?: string } = {},
+): Promise<void> {
+  const base = {
+    project: ctx.project.name,
+    deploymentId: deployment.id,
+    name: deployment.name,
+    target: deployment.target,
+    commit: deployment.commitSha,
+  };
+
+  let event: StratumEvent;
+  if (type === "deployment.succeeded") {
+    event = { type, ...base, ...(extra.url !== undefined ? { url: extra.url } : {}) };
+  } else if (type === "deployment.failed") {
+    event = { type, ...base, reason: extra.reason ?? deployment.reason ?? "Deployment failed" };
+  } else {
+    event = {
+      type,
+      ...base,
+      ...(deployment.changeId !== undefined ? { changeId: deployment.changeId } : {}),
+    };
+  }
+
+  await emitEvent(
+    ctx.env.DB,
+    ctx.env.EVENTS_QUEUE ?? null,
+    event,
+    { type: "system" },
+    ctx.logger,
+    ctx.project.id,
+  );
+}
+
+function toRecord(deployment: Deployment): DeployRunRecord {
+  const record: DeployRunRecord = {
+    deploymentId: deployment.id,
+    name: deployment.name,
+    status: deployment.status,
+  };
+  if (deployment.reason !== undefined) record.reason = deployment.reason;
+  if (deployment.url !== undefined) record.url = deployment.url;
+  return record;
+}
+
+/** The commit prefix humans recognise, for reasons that name a commit. */
+function shortSha(sha: string): string {
+  return sha.slice(0, 7);
+}

--- a/src/deploy/targets/cloudflare-pages.ts
+++ b/src/deploy/targets/cloudflare-pages.ts
@@ -1,0 +1,393 @@
+import type { Result } from "../../utils/result";
+import { err, ok } from "../../utils/result";
+import { redactAndTruncate } from "../redact";
+import type { DeployFailure, DeployOutcome, DeployTarget, DeployTargetInput } from "./index";
+import {
+  enforceLimits,
+  providerFailure,
+  readJson,
+  requireSecrets,
+  secretValuesOf,
+  selectFiles,
+  toBase64,
+  toHex,
+  transportFailure,
+} from "./shared";
+
+/**
+ * Publish a static tree to Cloudflare.
+ *
+ * ## Why this is Workers Static Assets and not Pages Direct Upload
+ *
+ * The `target:` name stayed `cloudflare-pages` because it is the user-facing
+ * name for "publish my static site on Cloudflare" and it is fixed by
+ * `DEPLOY_TARGETS` in `src/deploy/config.ts`. The *implementation* is Workers
+ * Static Assets, for two reasons:
+ *
+ * 1. **Pages Direct Upload cannot be implemented without guessing.** Its
+ *    public API reference documents only the create-deployment call; the
+ *    asset endpoints Wrangler actually drives (an upload-token call, a
+ *    check-missing call, an asset upload call) are not in the API reference at
+ *    all. Writing a credentialed production deploy against a reverse-engineered
+ *    surface is exactly what this feature's research rule forbids.
+ * 2. **Cloudflare steers new work to Workers.** Its own Workers best-practices
+ *    page says "If you are starting a new project, use Workers instead of
+ *    Pages… new features and optimizations are focused on Workers", and the
+ *    Pages migration index leads with "Start new projects with Workers."
+ *
+ * Workers Static Assets is fully documented, and a Worker with an `assets`
+ * directory and no `main` is the documented shape for a static site — which is
+ * why the metadata below carries no `main_module`. A repo that has a Worker
+ * script belongs on the `cloudflare-workers` target.
+ *
+ * ## The three-phase flow
+ *
+ * 1. `POST /accounts/{id}/workers/scripts/{name}/assets-upload-session` with a
+ *    manifest → an upload JWT (valid one hour) and `buckets`, the batches the
+ *    API wants the files uploaded in. Files it already has are absent from
+ *    `buckets`; when `buckets` is empty there is nothing to upload and the
+ *    upload JWT doubles as the completion token.
+ * 2. `POST /accounts/{id}/workers/assets/upload?base64=true` per bucket,
+ *    authenticated with that JWT. The 201 that completes the manifest carries
+ *    the completion JWT (also valid one hour).
+ * 3. `PUT /accounts/{id}/workers/scripts/{name}` with `assets: { jwt }`.
+ *
+ * The one-hour JWT lifetime is why the limits in `src/deploy/limits.ts` matter
+ * here beyond memory: a deploy that took longer than an hour between phase 1
+ * and phase 3 would fail with an expired token.
+ */
+
+const API_BASE = "https://api.cloudflare.com/client/v4";
+
+const SERVICE = "Cloudflare";
+
+/**
+ * Requests that are not per-file: the manifest registration and the final
+ * script `PUT`. The worst case adds one upload request per file, which is what
+ * `enforceLimits` budgets against.
+ */
+const FIXED_SUBREQUESTS = 2;
+
+/**
+ * Length of a manifest hash, in hex characters.
+ *
+ * The API rejects anything else. It is a *truncated* SHA-256, not a full one.
+ */
+const MANIFEST_HASH_LENGTH = 32;
+
+/** Sent as an asset's content type when the extension is unrecognised. */
+const DEFAULT_CONTENT_TYPE = "application/octet-stream";
+
+/**
+ * The `compatibility_date` sent with every upload from this target. Pinned for
+ * the same reason as in `cloudflare-workers.ts`: a date computed at deploy
+ * time makes the same commit behave differently on a redeploy.
+ */
+const COMPATIBILITY_DATE = "2026-08-20";
+
+const REQUIRED_SECRETS = ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"] as const;
+
+const OPTIONAL_SECRETS = ["CLOUDFLARE_WORKER_NAME", "CLOUDFLARE_WORKERS_SUBDOMAIN"] as const;
+
+/** Extension → served `Content-Type`. Whatever is sent at upload time is what visitors get. */
+const CONTENT_TYPES: Readonly<Record<string, string>> = {
+  html: "text/html",
+  htm: "text/html",
+  css: "text/css",
+  js: "text/javascript",
+  mjs: "text/javascript",
+  json: "application/json",
+  map: "application/json",
+  xml: "application/xml",
+  txt: "text/plain",
+  md: "text/markdown",
+  csv: "text/csv",
+  svg: "image/svg+xml",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  ico: "image/x-icon",
+  woff: "font/woff",
+  woff2: "font/woff2",
+  ttf: "font/ttf",
+  otf: "font/otf",
+  wasm: "application/wasm",
+  pdf: "application/pdf",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mp3: "audio/mpeg",
+  zip: "application/zip",
+};
+
+interface ManifestEntry {
+  hash: string;
+  size: number;
+}
+
+/** One file, prepared once so phase 2 never re-encodes or re-hashes it. */
+interface PreparedAsset {
+  base64: string;
+  contentType: string;
+}
+
+async function deploy(input: DeployTargetInput): Promise<Result<DeployOutcome, DeployFailure>> {
+  const secretValues = secretValuesOf(input.secrets);
+
+  const required = requireSecrets(input.secrets, REQUIRED_SECRETS);
+  if (!required.success) return required;
+  const apiToken = required.data.CLOUDFLARE_API_TOKEN;
+  const accountId = required.data.CLOUDFLARE_ACCOUNT_ID;
+
+  const selected = selectFiles(input.files, input.config.dir);
+  if (!selected.success) return selected;
+
+  const limits = enforceLimits(selected.data, (fileCount) => fileCount + FIXED_SUBREQUESTS);
+  if (!limits.success) return limits;
+
+  const scriptName = input.secrets.CLOUDFLARE_WORKER_NAME || input.config.name;
+  const account = encodeURIComponent(accountId);
+  const authorization = `Bearer ${apiToken}`;
+
+  const manifest: Record<string, ManifestEntry> = {};
+  const assetsByHash = new Map<string, PreparedAsset>();
+  for (const [path, bytes] of selected.data) {
+    const base64 = toBase64(bytes);
+    const hash = await manifestHash(base64, extensionOf(path));
+    manifest[`/${path}`] = { hash, size: bytes.byteLength };
+    assetsByHash.set(hash, { base64, contentType: contentTypeOf(path) });
+  }
+
+  const session = await postJson(
+    input,
+    `${API_BASE}/accounts/${account}/workers/scripts/${encodeURIComponent(scriptName)}/assets-upload-session`,
+    { manifest },
+    authorization,
+    secretValues,
+  );
+  if (!session.success) return session;
+
+  const uploadJwt = stringField(session.data, "jwt");
+  if (!uploadJwt) {
+    return err({
+      reason: `${SERVICE} did not return an upload token for the asset manifest`,
+      retryable: true,
+    });
+  }
+
+  const buckets = bucketsField(session.data);
+
+  // An empty `buckets` means every file is already stored; the upload token is
+  // then the completion token and phase 2 is skipped entirely.
+  let completionJwt = uploadJwt;
+  if (buckets.length > 0) {
+    const uploaded = await uploadBuckets(input, {
+      account,
+      buckets,
+      assetsByHash,
+      uploadJwt,
+      secretValues,
+    });
+    if (!uploaded.success) return uploaded;
+    completionJwt = uploaded.data;
+  }
+
+  const form = new FormData();
+  form.append(
+    "metadata",
+    new Blob(
+      [
+        JSON.stringify({
+          compatibility_date: COMPATIBILITY_DATE,
+          assets: { jwt: completionJwt },
+        }),
+      ],
+      { type: "application/json" },
+    ),
+  );
+
+  let response: Response;
+  try {
+    response = await input.fetch(
+      `${API_BASE}/accounts/${account}/workers/scripts/${encodeURIComponent(scriptName)}`,
+      { method: "PUT", headers: { Authorization: authorization }, body: form },
+    );
+  } catch (error) {
+    return err(transportFailure(SERVICE, error));
+  }
+
+  if (!response.ok) return err(await providerFailure(SERVICE, response, secretValues));
+
+  const document = await readJson(SERVICE, response, secretValues);
+  if (!document.success) return document;
+  if (document.data.success !== true) {
+    return err({
+      reason: `${SERVICE} rejected the static-asset deployment`,
+      logTail: redactAndTruncate(JSON.stringify(document.data), secretValues),
+      retryable: false,
+    });
+  }
+
+  const outcome: DeployOutcome = {};
+  const result = document.data.result;
+  if (typeof result === "object" && result !== null) {
+    const id = (result as Record<string, unknown>).id;
+    if (typeof id === "string") outcome.providerId = id;
+  }
+
+  // Only from a value the user supplied — see the same note in
+  // `cloudflare-workers.ts`.
+  const subdomain = input.secrets.CLOUDFLARE_WORKERS_SUBDOMAIN;
+  if (subdomain) outcome.url = `https://${scriptName}.${subdomain}.workers.dev`;
+
+  return ok(outcome);
+}
+
+/** Phase 2: upload each bucket the manifest registration asked for, returning the completion token. */
+async function uploadBuckets(
+  input: DeployTargetInput,
+  args: {
+    account: string;
+    buckets: readonly string[][];
+    assetsByHash: ReadonlyMap<string, PreparedAsset>;
+    uploadJwt: string;
+    secretValues: readonly string[];
+  },
+): Promise<Result<string, DeployFailure>> {
+  let completionJwt: string | undefined;
+
+  for (const bucket of args.buckets) {
+    const form = new FormData();
+    for (const hash of bucket) {
+      const asset = args.assetsByHash.get(hash);
+      if (!asset) {
+        // The API asked for a hash this deploy never produced. Continuing
+        // would upload an incomplete manifest and leave the site half-updated.
+        return err({
+          reason: `${SERVICE} asked for an asset this deployment did not produce`,
+          retryable: true,
+        });
+      }
+      // The *part* is the base64 text; the part's content type is what the
+      // asset is later served as. `base64=true` on the URL is what tells the
+      // API to decode it.
+      form.append(hash, new Blob([asset.base64], { type: asset.contentType }), hash);
+    }
+
+    let response: Response;
+    try {
+      response = await input.fetch(
+        `${API_BASE}/accounts/${args.account}/workers/assets/upload?base64=true`,
+        {
+          method: "POST",
+          // Authenticated with the manifest JWT, never with the API token.
+          headers: { Authorization: `Bearer ${args.uploadJwt}` },
+          body: form,
+        },
+      );
+    } catch (error) {
+      return err(transportFailure(SERVICE, error));
+    }
+
+    if (!response.ok) return err(await providerFailure(SERVICE, response, args.secretValues));
+
+    const document = await readJson(SERVICE, response, args.secretValues);
+    if (!document.success) return document;
+
+    // Only the response that completes the manifest carries the completion
+    // token; earlier buckets answer without one.
+    const jwt = stringField(document.data, "jwt");
+    if (jwt) completionJwt = jwt;
+  }
+
+  if (!completionJwt) {
+    return err({
+      reason: `${SERVICE} did not return a completion token after every asset was uploaded`,
+      retryable: true,
+    });
+  }
+
+  return ok(completionJwt);
+}
+
+/**
+ * The manifest hash Cloudflare expects.
+ *
+ * **The recipe is not what it looks like.** It is not a hash of the file: it is
+ * SHA-256 over the *base64 text* of the contents concatenated with the file
+ * extension (no dot), hex-encoded, truncated to 32 characters. Hashing the raw
+ * bytes instead produces a manifest the session call happily accepts and whose
+ * uploads are then rejected in phase 2, so this must match exactly. Covered by
+ * a known-fixture test.
+ */
+export async function manifestHash(base64Content: string, extension: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(base64Content + extension),
+  );
+  return toHex(digest).slice(0, MANIFEST_HASH_LENGTH);
+}
+
+/** The extension without its dot, or "" for a file with none (including a dotfile like `.gitignore`). */
+export function extensionOf(path: string): string {
+  const base = path.slice(path.lastIndexOf("/") + 1);
+  const dot = base.lastIndexOf(".");
+  return dot > 0 ? base.slice(dot + 1) : "";
+}
+
+function contentTypeOf(path: string): string {
+  return CONTENT_TYPES[extensionOf(path).toLowerCase()] ?? DEFAULT_CONTENT_TYPE;
+}
+
+/** POST a JSON body and return the Cloudflare envelope, as a value. */
+async function postJson(
+  input: DeployTargetInput,
+  url: string,
+  body: unknown,
+  authorization: string,
+  secretValues: readonly string[],
+): Promise<Result<Record<string, unknown>, DeployFailure>> {
+  let response: Response;
+  try {
+    response = await input.fetch(url, {
+      method: "POST",
+      headers: { Authorization: authorization, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    return err(transportFailure(SERVICE, error));
+  }
+
+  if (!response.ok) return err(await providerFailure(SERVICE, response, secretValues));
+  return readJson(SERVICE, response, secretValues);
+}
+
+/** Read a string off the Cloudflare envelope's `result` object. */
+function stringField(document: Record<string, unknown>, field: string): string | undefined {
+  const result = document.result;
+  if (typeof result !== "object" || result === null) return undefined;
+  const value = (result as Record<string, unknown>)[field];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/** Read `result.buckets`, tolerating its absence — an absent `buckets` means nothing to upload. */
+function bucketsField(document: Record<string, unknown>): string[][] {
+  const result = document.result;
+  if (typeof result !== "object" || result === null) return [];
+  const buckets = (result as Record<string, unknown>).buckets;
+  if (!Array.isArray(buckets)) return [];
+
+  return buckets
+    .filter((bucket): bucket is unknown[] => Array.isArray(bucket))
+    .map((bucket) => bucket.filter((hash): hash is string => typeof hash === "string"))
+    .filter((bucket) => bucket.length > 0);
+}
+
+export const cloudflarePagesTarget: DeployTarget = {
+  name: "cloudflare-pages",
+  requiredSecrets: REQUIRED_SECRETS,
+  optionalSecrets: OPTIONAL_SECRETS,
+  deploy,
+};

--- a/src/deploy/targets/cloudflare-workers.ts
+++ b/src/deploy/targets/cloudflare-workers.ts
@@ -1,0 +1,215 @@
+import type { Result } from "../../utils/result";
+import { err, ok } from "../../utils/result";
+import { redactAndTruncate } from "../redact";
+import type { DeployFailure, DeployOutcome, DeployTarget, DeployTargetInput } from "./index";
+import {
+  enforceLimits,
+  providerFailure,
+  readJson,
+  requireSecrets,
+  secretValuesOf,
+  selectFiles,
+  transportFailure,
+} from "./shared";
+
+/**
+ * Publish a Worker script with Cloudflare's single-shot script-upload API:
+ *
+ *   `PUT /accounts/{account_id}/workers/scripts/{script_name}` (multipart/form-data)
+ *
+ * **Why this endpoint and not the versions/deployments pair.** Cloudflare now
+ * offers `workers/beta/workers/versions` followed by
+ * `workers/scripts/{name}/deployments` with a percentage strategy, which is
+ * what the TypeScript SDK wraps. That is two subrequests and a gradual-rollout
+ * model this feature has no way to express — v1 publishes one commit, all
+ * traffic. The multipart `PUT` is still documented as supported, implicitly
+ * creates the version and the deployment, and costs one request. When
+ * per-version control (rollback, a canary percentage) becomes a goal, this is
+ * the call site to change.
+ *
+ * Only ECMAScript modules are uploaded. A Worker's tree may contain a README
+ * or a lockfile; those are not modules and failing the deploy over them would
+ * be absurd, so they are skipped and the count is reported on the outcome
+ * rather than dropped in silence. A tree of static files belongs on the
+ * `cloudflare-pages` target, which publishes assets.
+ */
+
+const API_BASE = "https://api.cloudflare.com/client/v4";
+
+const SERVICE = "Cloudflare";
+
+/** One `PUT`. The multipart body carries every module, so file count does not drive request count. */
+const SUBREQUESTS_PER_DEPLOY = 1;
+
+/** File extensions uploaded as ES modules. Everything else in the tree is skipped. */
+const MODULE_EXTENSIONS = [".js", ".mjs"] as const;
+
+/** The content type the script-upload API expects for an ES module part. */
+const MODULE_CONTENT_TYPE = "application/javascript+module";
+
+/**
+ * Entry points tried, in order, when `CLOUDFLARE_WORKER_MAIN_MODULE` is unset.
+ *
+ * Deliberately short and predictable: guessing widely would let a rename
+ * silently change which file is deployed.
+ */
+const ENTRYPOINT_CANDIDATES = [
+  "worker.js",
+  "worker.mjs",
+  "index.js",
+  "index.mjs",
+  "src/index.js",
+  "src/index.mjs",
+] as const;
+
+/**
+ * The `compatibility_date` sent with every upload from this target.
+ *
+ * Pinned, not `new Date()`: a date computed at deploy time means the same
+ * commit deployed twice can get two different runtime behaviours, and a
+ * Cloudflare runtime change would then break a redeploy of code nobody
+ * touched. Bump this deliberately, with a changelog entry.
+ */
+const COMPATIBILITY_DATE = "2026-08-20";
+
+const REQUIRED_SECRETS = ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"] as const;
+
+const OPTIONAL_SECRETS = [
+  "CLOUDFLARE_WORKER_NAME",
+  "CLOUDFLARE_WORKER_MAIN_MODULE",
+  "CLOUDFLARE_WORKERS_SUBDOMAIN",
+] as const;
+
+async function deploy(input: DeployTargetInput): Promise<Result<DeployOutcome, DeployFailure>> {
+  const secretValues = secretValuesOf(input.secrets);
+
+  const required = requireSecrets(input.secrets, REQUIRED_SECRETS);
+  if (!required.success) return required;
+  const apiToken = required.data.CLOUDFLARE_API_TOKEN;
+  const accountId = required.data.CLOUDFLARE_ACCOUNT_ID;
+
+  const selected = selectFiles(input.files, input.config.dir);
+  if (!selected.success) return selected;
+
+  const modules = new Map<string, Uint8Array>();
+  for (const [path, bytes] of selected.data) {
+    if (MODULE_EXTENSIONS.some((extension) => path.endsWith(extension))) modules.set(path, bytes);
+  }
+
+  if (modules.size === 0) {
+    return err({
+      reason: `no ${MODULE_EXTENSIONS.join(" or ")} module found to deploy as a Worker script`,
+      retryable: false,
+    });
+  }
+
+  const mainModule = resolveMainModule(modules, input.secrets.CLOUDFLARE_WORKER_MAIN_MODULE);
+  if (!mainModule.success) return mainModule;
+
+  const limits = enforceLimits(modules, () => SUBREQUESTS_PER_DEPLOY);
+  if (!limits.success) return limits;
+
+  const scriptName = input.secrets.CLOUDFLARE_WORKER_NAME || input.config.name;
+
+  const form = new FormData();
+  form.append(
+    "metadata",
+    new Blob(
+      [JSON.stringify({ main_module: mainModule.data, compatibility_date: COMPATIBILITY_DATE })],
+      { type: "application/json" },
+    ),
+  );
+  for (const [path, bytes] of modules) {
+    form.append(path, new Blob([bytes], { type: MODULE_CONTENT_TYPE }), path);
+  }
+
+  const url = `${API_BASE}/accounts/${encodeURIComponent(accountId)}/workers/scripts/${encodeURIComponent(scriptName)}`;
+
+  let response: Response;
+  try {
+    // No Content-Type header: `fetch` must set it so the multipart boundary
+    // matches the body it generated.
+    response = await input.fetch(url, {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${apiToken}` },
+      body: form,
+    });
+  } catch (error) {
+    return err(transportFailure(SERVICE, error));
+  }
+
+  if (!response.ok) return err(await providerFailure(SERVICE, response, secretValues));
+
+  const document = await readJson(SERVICE, response, secretValues);
+  if (!document.success) return document;
+
+  // Cloudflare can answer 200 with `success: false`; the status alone is not
+  // proof the script was accepted.
+  if (document.data.success !== true) {
+    const body = JSON.stringify(document.data);
+    return err({
+      reason: `${SERVICE} rejected the script upload`,
+      logTail: redactAndTruncate(body, secretValues),
+      retryable: false,
+    });
+  }
+
+  const skipped = selected.data.size - modules.size;
+  const outcome: DeployOutcome = {};
+
+  const result = document.data.result;
+  if (typeof result === "object" && result !== null) {
+    const id = (result as Record<string, unknown>).id;
+    if (typeof id === "string") outcome.providerId = id;
+  }
+
+  // Derived only from a value the user supplied. The account's workers.dev
+  // subdomain is not in the API surface this target was written against, and
+  // inventing an endpoint to look it up would be a guess.
+  const subdomain = input.secrets.CLOUDFLARE_WORKERS_SUBDOMAIN;
+  if (subdomain) outcome.url = `https://${scriptName}.${subdomain}.workers.dev`;
+
+  if (skipped > 0) {
+    outcome.logTail = `Uploaded ${modules.size} module(s); skipped ${skipped} non-module file(s).`;
+  }
+
+  return ok(outcome);
+}
+
+/**
+ * Decide which module is the Worker's entry point.
+ *
+ * An explicit `CLOUDFLARE_WORKER_MAIN_MODULE` wins and is validated against
+ * the tree, so a typo fails with a reason instead of deploying whichever file
+ * the candidate list happened to match.
+ */
+function resolveMainModule(
+  modules: ReadonlyMap<string, Uint8Array>,
+  configured: string | undefined,
+): Result<string, DeployFailure> {
+  if (configured) {
+    if (!modules.has(configured)) {
+      return err({
+        reason: `CLOUDFLARE_WORKER_MAIN_MODULE names "${configured}", which is not in the deployed tree`,
+        retryable: false,
+      });
+    }
+    return ok(configured);
+  }
+
+  for (const candidate of ENTRYPOINT_CANDIDATES) {
+    if (modules.has(candidate)) return ok(candidate);
+  }
+
+  return err({
+    reason: `no Worker entry point found — expected one of ${ENTRYPOINT_CANDIDATES.join(", ")}, or set the CLOUDFLARE_WORKER_MAIN_MODULE secret`,
+    retryable: false,
+  });
+}
+
+export const cloudflareWorkersTarget: DeployTarget = {
+  name: "cloudflare-workers",
+  requiredSecrets: REQUIRED_SECRETS,
+  optionalSecrets: OPTIONAL_SECRETS,
+  deploy,
+};

--- a/src/deploy/targets/index.ts
+++ b/src/deploy/targets/index.ts
@@ -1,0 +1,112 @@
+import type { DeployConfig, DeployTargetName } from "../../evaluation/types";
+import type { Logger } from "../../utils/logger";
+import type { Result } from "../../utils/result";
+import { cloudflarePagesTarget } from "./cloudflare-pages";
+import { cloudflareWorkersTarget } from "./cloudflare-workers";
+import { vercelTarget } from "./vercel";
+
+/**
+ * The `fetch` a target uses to reach its provider.
+ *
+ * Injected rather than taken from the global scope for the same reason
+ * `SandboxEvaluator` injects `readFiles` and `now`: it is the only seam that
+ * keeps the test suite off the network. Nothing in `src/deploy/targets/`
+ * references `globalThis.fetch`.
+ *
+ * `init` is required — every provider call here sets at least a method and an
+ * `Authorization` header — which keeps the real `fetch` assignable to this
+ * type while making an accidental bare GET a type error.
+ */
+export type DeployFetch = (url: string, init: RequestInit) => Promise<Response>;
+
+/** Everything a target needs to publish one commit. Assembled by the deploy runner. */
+export interface DeployTargetInput {
+  /**
+   * The merged tree as repo-relative path → raw bytes, exactly as
+   * `readRepoFiles` returns it.
+   *
+   * Passed whole: each target narrows it to `config.dir` itself, so the limit
+   * checks in `enforceLimits` run against the bytes that are actually uploaded
+   * rather than against the whole repository.
+   */
+  files: ReadonlyMap<string, Uint8Array>;
+  /** Decrypted project secrets by name. Never logged, never echoed into a reason or a log tail. */
+  secrets: Readonly<Record<string, string>>;
+  /** The sanitized `deploys:` entry being run. */
+  config: DeployConfig;
+  /** The pinned merge commit being published, for provider-side deployment metadata. */
+  commitSha: string;
+  logger: Logger;
+  fetch: DeployFetch;
+}
+
+/** What a successful provider call produced. */
+export interface DeployOutcome {
+  /**
+   * Where the commit is published, when the provider returns one or it can be
+   * derived from configuration the user supplied. Absent is an honest answer,
+   * not a failure: deriving a URL from an API shape we have not verified would
+   * be worse than returning none.
+   */
+  url?: string;
+  /** The provider's own identifier for the deployment, so a support ticket can name it. */
+  providerId?: string;
+  /**
+   * The provider's state at the instant the API returned. Some providers build
+   * asynchronously, so this is not the same as "the commit is live".
+   */
+  state?: string;
+  /** Redacted, truncated provider detail worth persisting even on success. */
+  logTail?: string;
+}
+
+/**
+ * Why a deployment did not happen.
+ *
+ * A dedicated type rather than `AppError` because a deploy failure is
+ * *persisted and rendered*, not mapped to an HTTP status: the row needs a
+ * reason a human can act on, a redacted payload, and a retryable flag that
+ * decides whether the Retry button is worth pressing. Returning it as a value
+ * also keeps provider 4xx/5xx from crossing the module boundary as a throw.
+ */
+export interface DeployFailure {
+  /** Actionable and safe to persist and render. Never contains a secret value. */
+  reason: string;
+  /** The provider's payload, redacted then truncated to `MAX_LOG_TAIL`. */
+  logTail?: string;
+  /** True when the same inputs could plausibly succeed later (5xx, 429, network). */
+  retryable: boolean;
+}
+
+/** One provider's implementation of "publish this tree". */
+export interface DeployTarget {
+  /** The `target:` value in `.stratum/policy.yaml` that selects this implementation. */
+  readonly name: DeployTargetName;
+  /**
+   * Secret names that must be present before anything is attempted. The runner
+   * may check these to fail early; every target also checks them itself so it
+   * is safe to call directly.
+   */
+  readonly requiredSecrets: readonly string[];
+  /** Secret names the target uses when present. Absence changes behaviour, never fails the deploy. */
+  readonly optionalSecrets: readonly string[];
+  deploy(input: DeployTargetInput): Promise<Result<DeployOutcome, DeployFailure>>;
+}
+
+/**
+ * Every target, keyed by the name a policy file uses.
+ *
+ * Typed as a total `Record<DeployTargetName, …>` so adding a member to
+ * `DeployTargetName` fails the build here rather than at runtime on the first
+ * merge that uses it.
+ */
+export const DEPLOY_TARGET_REGISTRY: Readonly<Record<DeployTargetName, DeployTarget>> = {
+  "cloudflare-pages": cloudflarePagesTarget,
+  "cloudflare-workers": cloudflareWorkersTarget,
+  vercel: vercelTarget,
+};
+
+/** Look up a target. Total over `DeployTargetName`, so it cannot fail. */
+export function getDeployTarget(name: DeployTargetName): DeployTarget {
+  return DEPLOY_TARGET_REGISTRY[name];
+}

--- a/src/deploy/targets/shared.ts
+++ b/src/deploy/targets/shared.ts
@@ -1,0 +1,289 @@
+import type { Result } from "../../utils/result";
+import { err, ok } from "../../utils/result";
+import { MAX_FILES, MAX_FILE_BYTES, MAX_SUBREQUESTS, MAX_TOTAL_BYTES } from "../limits";
+import { redactAndTruncate } from "../redact";
+import type { DeployFailure } from "./index";
+
+/**
+ * Machinery every provider target needs, kept out of `./index.ts` so the
+ * targets can import it without forming a module cycle with the registry that
+ * imports them.
+ */
+
+/**
+ * Longest provider-supplied detail spliced into a `reason`.
+ *
+ * The reason is rendered in a list view; a provider that returns a wall of
+ * text must not be able to decide how tall that row is. The full payload is
+ * still available on the deployment's `log_tail`.
+ */
+const MAX_REASON_DETAIL = 200;
+
+/** Chunk size for base64 encoding. Bounded so `String.fromCharCode` cannot overflow the arg stack. */
+const BASE64_CHUNK_BYTES = 8_192;
+
+/** HTTP status meaning "slow down", which a later attempt can clear. */
+const STATUS_TOO_MANY_REQUESTS = 429;
+
+/** First 5xx status. At or above it the provider, not the request, is at fault. */
+const STATUS_SERVER_ERROR = 500;
+
+/** The values that must never appear in a reason, a log tail, or a log line. */
+export function secretValuesOf(secrets: Readonly<Record<string, string>>): string[] {
+  return Object.values(secrets);
+}
+
+/**
+ * Narrow a repo tree to the deploy's `dir`, stripping the prefix so the
+ * provider sees `index.html` rather than `dist/index.html`.
+ *
+ * `sanitizeDeploys` has already rejected absolute paths and `..` segments, so
+ * this only has to handle the shape, not the traversal.
+ */
+export function selectFiles(
+  files: ReadonlyMap<string, Uint8Array>,
+  dir: string | undefined,
+): Result<Map<string, Uint8Array>, DeployFailure> {
+  if (dir === undefined || dir === "") return ok(new Map(files));
+
+  const prefix = `${dir.replace(/\/+$/, "")}/`;
+  const selected = new Map<string, Uint8Array>();
+  for (const [path, bytes] of files) {
+    if (path.startsWith(prefix)) selected.set(path.slice(prefix.length), bytes);
+  }
+
+  if (selected.size === 0) {
+    return err({
+      reason: `no files found under "${dir}" at this commit — check the deploy's "dir"`,
+      retryable: false,
+    });
+  }
+  return ok(selected);
+}
+
+/**
+ * Reject anything over the `src/deploy/limits.ts` bounds **before the first
+ * request goes out**.
+ *
+ * `estimateSubrequests` is the target's own worst case for the file count, not
+ * its typical case: a multi-phase upload that discovers it is out of budget
+ * halfway through has already published a partial tree, which is strictly
+ * worse than never having started.
+ */
+export function enforceLimits(
+  files: ReadonlyMap<string, Uint8Array>,
+  estimateSubrequests: (fileCount: number) => number,
+): Result<void, DeployFailure> {
+  if (files.size === 0) {
+    return err({ reason: "nothing to deploy: the selected tree is empty", retryable: false });
+  }
+
+  if (files.size > MAX_FILES) {
+    return err({
+      reason: `too many files: ${files.size} exceeds the ${MAX_FILES}-file deploy limit`,
+      retryable: false,
+    });
+  }
+
+  let totalBytes = 0;
+  for (const [path, bytes] of files) {
+    if (bytes.byteLength > MAX_FILE_BYTES) {
+      return err({
+        reason: `"${path}" is ${bytes.byteLength} bytes, over the ${MAX_FILE_BYTES}-byte per-file deploy limit`,
+        retryable: false,
+      });
+    }
+    totalBytes += bytes.byteLength;
+  }
+
+  if (totalBytes > MAX_TOTAL_BYTES) {
+    return err({
+      reason: `deploy is ${totalBytes} bytes, over the ${MAX_TOTAL_BYTES}-byte total limit`,
+      retryable: false,
+    });
+  }
+
+  const subrequests = estimateSubrequests(files.size);
+  if (subrequests > MAX_SUBREQUESTS) {
+    return err({
+      reason: `publishing ${files.size} files needs up to ${subrequests} provider requests, over the ${MAX_SUBREQUESTS}-request budget`,
+      retryable: false,
+    });
+  }
+
+  return ok(undefined);
+}
+
+/**
+ * Check that every required secret is present and non-empty.
+ *
+ * Names are safe to put in the reason — they come from the policy file, which
+ * is public to anyone who can read the repo. Values never are.
+ */
+export function requireSecrets<Names extends readonly string[]>(
+  secrets: Readonly<Record<string, string>>,
+  names: Names,
+): Result<Record<Names[number], string>, DeployFailure> {
+  const missing = names.filter((name) => {
+    const value = secrets[name];
+    return typeof value !== "string" || value.length === 0;
+  });
+
+  if (missing.length > 0) {
+    return err({
+      reason: `missing project secret${missing.length === 1 ? "" : "s"}: ${missing.join(", ")} — add ${missing.length === 1 ? "it" : "them"} in project settings`,
+      retryable: false,
+    });
+  }
+
+  // Keyed by the literal names the caller asked for, so a target reads
+  // `resolved.CLOUDFLARE_API_TOKEN` as a `string` rather than re-checking for
+  // undefined that the loop above has already ruled out.
+  const resolved = {} as Record<Names[number], string>;
+  for (const name of names) {
+    resolved[name as Names[number]] = secrets[name] as string;
+  }
+  return ok(resolved);
+}
+
+/** A provider status that a later attempt could plausibly clear. */
+export function isRetryableStatus(status: number): boolean {
+  return status >= STATUS_SERVER_ERROR || status === STATUS_TOO_MANY_REQUESTS;
+}
+
+/**
+ * Turn a non-OK provider response into a persistable failure.
+ *
+ * The body is read in full and redacted *before* it is truncated, so no secret
+ * can survive in either the reason or the log tail. The response itself is
+ * never logged: it was produced by a request carrying an `Authorization`
+ * header, and providers do echo request context back.
+ */
+export async function providerFailure(
+  service: string,
+  response: Response,
+  secretValues: readonly string[],
+): Promise<DeployFailure> {
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {
+    // A body that cannot be read is not worth failing differently over — the
+    // status alone is already an actionable reason. Swallowing is safe here
+    // precisely because the status is preserved below.
+    body = "";
+  }
+
+  const detail = providerMessage(body);
+  const safeDetail = detail
+    ? redactAndTruncate(detail, secretValues, MAX_REASON_DETAIL)
+    : undefined;
+
+  return {
+    reason: `${service} returned HTTP ${response.status}${safeDetail ? `: ${safeDetail}` : ""}`,
+    logTail: body.length > 0 ? redactAndTruncate(body, secretValues) : undefined,
+    retryable: isRetryableStatus(response.status),
+  };
+}
+
+/**
+ * Pull the human-readable message out of a provider error body.
+ *
+ * Handles both shapes this feature talks to: Cloudflare's
+ * `{"success":false,"errors":[{"code":…,"message":…}]}` and Vercel's
+ * `{"error":{"code":…,"message":…}}`. Anything else falls back to `undefined`
+ * and the caller reports the status alone rather than pasting an unparsed
+ * document into a list row.
+ */
+export function providerMessage(body: string): string | undefined {
+  if (body.trim() === "") return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const document = parsed as Record<string, unknown>;
+
+  const cloudflareErrors = document.errors;
+  if (Array.isArray(cloudflareErrors)) {
+    const messages = cloudflareErrors
+      .map((entry) =>
+        typeof entry === "object" && entry !== null
+          ? (entry as Record<string, unknown>).message
+          : undefined,
+      )
+      .filter((message): message is string => typeof message === "string");
+    if (messages.length > 0) return messages.join("; ");
+  }
+
+  const vercelError = document.error;
+  if (typeof vercelError === "object" && vercelError !== null) {
+    const message = (vercelError as Record<string, unknown>).message;
+    if (typeof message === "string") return message;
+  }
+
+  if (typeof document.message === "string") return document.message;
+
+  return undefined;
+}
+
+/** Failure for a `fetch` that never produced a response (DNS, TLS, connection reset). */
+export function transportFailure(service: string, error: unknown): DeployFailure {
+  // The message is ours, not the provider's: a thrown fetch error can carry a
+  // rendered request, and a rendered request carries the Authorization header.
+  return {
+    reason: `${service} could not be reached: ${error instanceof Error ? error.name : "network error"}`,
+    retryable: true,
+  };
+}
+
+/** Parse a JSON response body, as a value: a provider that returns HTML on success is a failure, not a throw. */
+export async function readJson(
+  service: string,
+  response: Response,
+  secretValues: readonly string[],
+): Promise<Result<Record<string, unknown>, DeployFailure>> {
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {
+    return err({ reason: `${service} returned an unreadable response body`, retryable: true });
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return err({
+        reason: `${service} returned an unexpected response shape`,
+        logTail: redactAndTruncate(body, secretValues),
+        retryable: false,
+      });
+    }
+    return ok(parsed as Record<string, unknown>);
+  } catch {
+    return err({
+      reason: `${service} returned a response that is not JSON`,
+      logTail: redactAndTruncate(body, secretValues),
+      retryable: false,
+    });
+  }
+}
+
+/** Base64-encode raw bytes without Node's `Buffer`, which the Workers runtime does not provide. */
+export function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += BASE64_CHUNK_BYTES) {
+    const chunk = bytes.subarray(offset, offset + BASE64_CHUNK_BYTES);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+/** Lowercase hex of a `crypto.subtle.digest` result. */
+export function toHex(digest: ArrayBuffer): string {
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/src/deploy/targets/vercel.ts
+++ b/src/deploy/targets/vercel.ts
@@ -159,6 +159,32 @@ export function inlineBodyBytes(bytes: number): number {
 /** The largest request body this target can produce, given the shared byte limit. */
 export const MAX_INLINE_BODY_BYTES = inlineBodyBytes(MAX_TOTAL_BYTES);
 
+/**
+ * Peak heap one accepted deployment of this target holds, in bytes.
+ *
+ * Three live copies of the tree exist at the instant `fetch` is called: the raw
+ * bytes the runner read (`MAX_TOTAL_BYTES`), the base64 strings in `files`, and
+ * the string `JSON.stringify` produced from them. Nothing can be released
+ * earlier — the runner still owns the raw map (it may have another deploy to
+ * run from the same tree), and `JSON.stringify` cannot see the array lazily.
+ *
+ * **This number is why `MAX_DEPLOY_CONCURRENCY` is 1.** It is exported so that
+ * relationship is asserted in the test suite rather than remembered: two of
+ * these in one isolate exceed `ISOLATE_MEMORY_BYTES` (both in `../limits`), and
+ * the isolate is killed before any `finally` can write a terminal deployment
+ * status.
+ *
+ * The only way to cut it meaningfully is to stop materializing the body at all
+ * — generate each file's base64 inside a `ReadableStream` and hand *that* to
+ * `fetch`, which would hold one file at a time. That is deliberately not done
+ * here: a streamed body is sent with `Transfer-Encoding: chunked`, whether
+ * Vercel's create-deployment endpoint accepts a chunked body is not something
+ * this repo's tests can establish (every target test injects `fetch`), and the
+ * failure mode of guessing wrong is that every Vercel deploy 400s. The
+ * concurrency bound removes the OOM without betting on that.
+ */
+export const MAX_PEAK_DEPLOY_BYTES = MAX_TOTAL_BYTES + 2 * MAX_INLINE_BODY_BYTES;
+
 export const vercelTarget: DeployTarget = {
   name: "vercel",
   requiredSecrets: REQUIRED_SECRETS,

--- a/src/deploy/targets/vercel.ts
+++ b/src/deploy/targets/vercel.ts
@@ -1,0 +1,167 @@
+import type { Result } from "../../utils/result";
+import { err, ok } from "../../utils/result";
+import { MAX_TOTAL_BYTES } from "../limits";
+import { redactAndTruncate } from "../redact";
+import type { DeployFailure, DeployOutcome, DeployTarget, DeployTargetInput } from "./index";
+import {
+  enforceLimits,
+  providerFailure,
+  readJson,
+  requireSecrets,
+  secretValuesOf,
+  selectFiles,
+  toBase64,
+  transportFailure,
+} from "./shared";
+
+/**
+ * Publish a tree to Vercel with `POST /v13/deployments`, which builds the
+ * uploaded source remotely.
+ *
+ * ## PRD Q1, resolved: files are inlined in the create-deployment body
+ *
+ * Vercel's current create-deployment reference documents both routes — "upload
+ * files first via the file upload API, then reference them here by SHA — or
+ * inline small files directly in the request body" — and the `files` array
+ * accepts either `{ file, data, encoding }` (inline) or `{ file, sha, size }`
+ * (by reference). Inlining wins here for a reason specific to running inside a
+ * Worker: `POST /v2/files` is **one request per file**, so a 2,000-file tree
+ * (`MAX_FILES`) would need 2,001 provider requests, while inlining needs
+ * exactly one no matter how many files there are. The subrequest budget is the
+ * scarce resource, not the request body.
+ *
+ * The cost of that choice, stated so the next person does not have to
+ * rediscover it: base64 inflates the payload by about a third, so
+ * `MAX_TOTAL_BYTES` (25 MB) becomes roughly a 33 MB request body. That is the
+ * binding constraint on this target. **If `MAX_TOTAL_BYTES` is ever raised,
+ * revisit this decision** — past some size the two-step upload-by-sha flow
+ * becomes the only workable one, and it will need `MAX_FILES` lowered to fit
+ * inside `MAX_SUBREQUESTS`.
+ *
+ * ## Asynchronous by design
+ *
+ * The API answers as soon as the deployment is *queued*: the response carries
+ * `readyState` (`QUEUED` → `INITIALIZING` → `BUILDING` → `READY`/`ERROR`), not
+ * a finished build. This target reports what the provider said and does not
+ * poll — polling would hold a queue message open for the length of someone
+ * else's build. `state` is on the outcome so the runner can decide.
+ */
+
+const API_BASE = "https://api.vercel.com";
+
+const SERVICE = "Vercel";
+
+/** One `POST`. The whole tree rides in its body — see the Q1 note above. */
+const SUBREQUESTS_PER_DEPLOY = 1;
+
+/** Roughly how much base64 inflates a payload, used only to explain the body size in a reason. */
+const BASE64_INFLATION = 4 / 3;
+
+/** `readyState` values that mean the deployment failed before it ever built. */
+const FAILED_STATES = new Set(["ERROR", "CANCELED", "BLOCKED"]);
+
+const REQUIRED_SECRETS = ["VERCEL_TOKEN", "VERCEL_PROJECT_ID"] as const;
+
+/** A token scoped to a team must say which team, or the API resolves it against the personal account. */
+const OPTIONAL_SECRETS = ["VERCEL_TEAM_ID"] as const;
+
+async function deploy(input: DeployTargetInput): Promise<Result<DeployOutcome, DeployFailure>> {
+  const secretValues = secretValuesOf(input.secrets);
+
+  const required = requireSecrets(input.secrets, REQUIRED_SECRETS);
+  if (!required.success) return required;
+  const token = required.data.VERCEL_TOKEN;
+  const projectId = required.data.VERCEL_PROJECT_ID;
+
+  const selected = selectFiles(input.files, input.config.dir);
+  if (!selected.success) return selected;
+
+  const limits = enforceLimits(selected.data, () => SUBREQUESTS_PER_DEPLOY);
+  if (!limits.success) return limits;
+
+  const files = [...selected.data].map(([path, bytes]) => ({
+    file: path,
+    data: toBase64(bytes),
+    encoding: "base64" as const,
+  }));
+
+  const query = new URLSearchParams({
+    // Without this, an identical tree deduplicates to the previous deployment
+    // and a manual retry would silently do nothing.
+    forceNew: "1",
+    // Vercel answers 400 and asks for confirmation when its framework
+    // detection disagrees with the project's setting. There is no one here to
+    // confirm, and the project's own setting is the one the owner chose.
+    skipAutoDetectionConfirmation: "1",
+  });
+  const teamId = input.secrets.VERCEL_TEAM_ID;
+  if (teamId) query.set("teamId", teamId);
+
+  const body = {
+    // Required by the API. `project` overrides it as the deployment's project,
+    // so this is the display name only.
+    name: input.config.name,
+    project: projectId,
+    // A post-merge deploy of the default branch is a production deploy; the
+    // API defaults to `preview`, which would publish nowhere useful.
+    target: "production",
+    files,
+    gitMetadata: { commitSha: input.commitSha },
+  };
+
+  let response: Response;
+  try {
+    response = await input.fetch(`${API_BASE}/v13/deployments?${query.toString()}`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    return err(transportFailure(SERVICE, error));
+  }
+
+  if (!response.ok) return err(await providerFailure(SERVICE, response, secretValues));
+
+  const document = await readJson(SERVICE, response, secretValues);
+  if (!document.success) return document;
+
+  const readyState =
+    typeof document.data.readyState === "string" ? document.data.readyState : undefined;
+
+  if (readyState && FAILED_STATES.has(readyState)) {
+    const message =
+      typeof document.data.errorMessage === "string" ? document.data.errorMessage : undefined;
+    return err({
+      reason: `${SERVICE} deployment entered ${readyState}${message ? `: ${redactAndTruncate(message, secretValues)}` : ""}`,
+      logTail: redactAndTruncate(JSON.stringify(document.data), secretValues),
+      // BLOCKED and CANCELED are account- or request-level decisions; only an
+      // ERROR is worth pressing Retry on.
+      retryable: readyState === "ERROR",
+    });
+  }
+
+  const outcome: DeployOutcome = {};
+  if (typeof document.data.id === "string") outcome.providerId = document.data.id;
+  if (readyState) outcome.state = readyState;
+  // `url` is a bare host, e.g. "my-site-abc123.vercel.app".
+  if (typeof document.data.url === "string" && document.data.url.length > 0) {
+    outcome.url = `https://${document.data.url}`;
+  }
+
+  return ok(outcome);
+}
+
+/** The approximate request-body size an inlined deploy of `bytes` produces. Exported for tests and docs. */
+export function inlineBodyBytes(bytes: number): number {
+  return Math.ceil(bytes * BASE64_INFLATION);
+}
+
+/** The largest request body this target can produce, given the shared byte limit. */
+export const MAX_INLINE_BODY_BYTES = inlineBodyBytes(MAX_TOTAL_BYTES);
+
+export const vercelTarget: DeployTarget = {
+  name: "vercel",
+  requiredSecrets: REQUIRED_SECRETS,
+  optionalSecrets: OPTIONAL_SECRETS,
+  deploy,
+};

--- a/src/evaluation/policy-loader.ts
+++ b/src/evaluation/policy-loader.ts
@@ -1,6 +1,7 @@
 import YAML from "yaml";
+import { sanitizeDeploys } from "../deploy/config";
 import { readFileFromRepo } from "../storage/git-ops";
-import type { Logger } from "../utils/logger";
+import { type Logger, defaultLogger } from "../utils/logger";
 import {
   MAX_COMMAND_LENGTH,
   MAX_PHASE_TIMEOUT_MS,
@@ -30,10 +31,13 @@ export function diffTouchesProtectedConfig(diff: string): boolean {
   return PROTECTED_CONFIG_FILES.some((path) => diff.includes(`diff --git a/${path} b/${path}`));
 }
 
-type PolicyLoad =
+/** Outcome of parsing policy-file bytes: the file either yields a policy or it does not. */
+export type PolicyParse =
   | { status: "ok"; policy: EvalPolicy }
-  | { status: "absent" }
   | { status: "malformed"; reason: string };
+
+/** `PolicyParse` plus the one outcome only a *fetch* can produce. */
+type PolicyLoad = PolicyParse | { status: "absent" };
 
 export async function loadPolicy(
   remote: string,
@@ -77,7 +81,139 @@ export async function loadPolicy(
 function malformedPolicy(path: string, reason: string, logger: Logger): EvalPolicy {
   const configError = `Policy file ${path} is present but invalid (${reason}); merges are blocked until it is fixed.`;
   logger.error("Malformed policy file — failing merge gate closed", undefined, { path, reason });
-  return { ...DEFAULT_POLICY, configError };
+  return {
+    ...DEFAULT_POLICY,
+    configError,
+    // A malformed file has no usable `deploys`, and leaving that as an absent
+    // field would mean a single YAML typo silently stops production updating —
+    // the quietest possible failure. Deliberately *not* salvaged: the parse
+    // failed, so there is no way to tell which half of the file the typo
+    // corrupted, and a truncated document can yield a structurally valid
+    // `deploys` list that says something the author never wrote. Instead the
+    // policy carries one rejection, which the deploy runner persists as a named
+    // failed deployment pointing at the file.
+    deployRejections: [
+      {
+        name: null,
+        reason: `Policy file ${path} is present but invalid (${reason}); no deploy configuration could be read from it.`,
+      },
+    ],
+  };
+}
+
+/**
+ * Parse and sanitize the bytes of a policy file.
+ *
+ * Split out of `readAndParsePolicy` so parsing is separable from fetching: the
+ * deploy runner reads the tree *pinned at a merge commit* and must parse the
+ * policy out of those bytes. Re-reading via `loadPolicy` would take the branch
+ * tip instead, letting a newer policy apply to an older tree.
+ *
+ * Never throws: a sanitization failure is returned as `malformed`.
+ */
+export function parsePolicyContent(
+  content: string,
+  format: "json" | "yaml",
+  logger: Logger = defaultLogger,
+): PolicyParse {
+  let parsed: unknown;
+  try {
+    parsed = format === "json" ? JSON.parse(content) : YAML.parse(content);
+  } catch (e) {
+    return { status: "malformed", reason: e instanceof Error ? e.message : "parse error" };
+  }
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("evaluators" in parsed) ||
+    !Array.isArray((parsed as Record<string, unknown>).evaluators)
+  ) {
+    return { status: "malformed", reason: "missing or non-array 'evaluators'" };
+  }
+
+  const raw = parsed as Record<string, unknown>;
+
+  // Sanitization gets its own catch. A throw in here is a statement about
+  // *this file* — a YAML alias cycle, say — not a transient read blip, and
+  // the caller's "treat as absent" would fall back to the permissive
+  // default with no `configError`, silently discarding the file's merge
+  // protection. Fail closed instead.
+  try {
+    const merge = sanitizeMergePolicy(raw.merge);
+    const {
+      merge: _unsanitized,
+      configError: _ce,
+      // Destructured out for the same reason `merge` is: the spread below
+      // copies whatever the file said into these fields, so leaving them in
+      // would hand downstream code the *unsanitized* parsed value, by
+      // reference. Both are rebuilt further down.
+      deploys: _rawDeploys,
+      deployRejections: _rawRejections,
+      ...policy
+    } = {
+      ...DEFAULT_POLICY,
+      ...(parsed as Partial<EvalPolicy>),
+    };
+
+    // Rebuilt rather than taken from the spread: every entry must be a fresh
+    // object owned by this policy, so nothing downstream can reach back into
+    // the parsed input (or, via `DEFAULT_POLICY`'s own array, into the module
+    // default) by mutating what it was handed.
+    const declared = raw.evaluators as unknown[];
+    const evaluators = declared
+      .map((entry) => sanitizeEvaluator(entry, logger))
+      .filter((entry): entry is EvaluatorConfig => entry !== null);
+
+    // Any dropped entry fails the gate closed — not just the case where every
+    // entry was dropped. An entry the author wrote is a gate they meant to
+    // have; silently discarding one while its siblings survive removes that
+    // gate and lets the change through on the remaining ones, which is the
+    // permissive fallback `malformedPolicy` exists to prevent. A `webhook`
+    // whose `url` was typo'd is the concrete case: it used to reach
+    // `WebhookEvaluator` and block on an unusable URL.
+    //
+    // Note this only counts entries that are structurally unusable. An
+    // unrecognised `type` is copied through and rejected downstream by
+    // `buildEvaluators`, so a policy naming a future evaluator type does not
+    // trip this.
+    if (evaluators.length < declared.length) {
+      return {
+        status: "malformed",
+        reason: `${declared.length - evaluators.length} unusable entr${
+          declared.length - evaluators.length === 1 ? "y" : "ies"
+        } in 'evaluators'`,
+      };
+    }
+    policy.evaluators = evaluators;
+
+    // Assigned unconditionally: the spread above already put the *raw* value
+    // in `policy.minScore`, so skipping the assignment on rejection would
+    // leave it there — and `-Infinity` or the string "-5" both make
+    // `score >= minScore` true for every score, disabling the gate.
+    policy.minScore = clampScore(raw.minScore, logger) ?? DEFAULT_POLICY.minScore;
+
+    // Rebuilt for the same reason `evaluators` is, and assigned only from the
+    // sanitizer's output — never from the spread. A rejected entry does *not*
+    // fail the file closed the way a dropped evaluator does; it is carried on
+    // the policy so the deploy runner can persist it as a named failed
+    // deployment. `sanitizeDeploys` explains why the two differ.
+    const { accepted, rejected } = sanitizeDeploys(raw.deploys);
+
+    const sanitized: EvalPolicy = { ...policy };
+    if (merge) sanitized.merge = merge;
+    if (accepted.length > 0) sanitized.deploys = accepted;
+    if (rejected.length > 0) sanitized.deployRejections = rejected;
+
+    return { status: "ok", policy: sanitized };
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    logger.error("Policy sanitization threw — failing merge gate closed", undefined, {
+      format,
+      reason,
+    });
+    return { status: "malformed", reason };
+  }
 }
 
 async function readAndParsePolicy(
@@ -95,90 +231,11 @@ async function readAndParsePolicy(
     const content = contentResult.data;
     if (content === null || content === undefined) return { status: "absent" };
 
-    let parsed: unknown;
-    try {
-      parsed = format === "json" ? JSON.parse(content) : YAML.parse(content);
-    } catch (e) {
-      return { status: "malformed", reason: e instanceof Error ? e.message : "parse error" };
-    }
-
-    if (
-      typeof parsed !== "object" ||
-      parsed === null ||
-      !("evaluators" in parsed) ||
-      !Array.isArray((parsed as Record<string, unknown>).evaluators)
-    ) {
-      return { status: "malformed", reason: "missing or non-array 'evaluators'" };
-    }
-
-    const raw = parsed as Record<string, unknown>;
-
-    // Sanitization gets its own catch. A throw in here is a statement about
-    // *this file* — a YAML alias cycle, say — not a transient read blip, and
-    // the outer handler's "treat as absent" would fall back to the permissive
-    // default with no `configError`, silently discarding the file's merge
-    // protection. Fail closed instead.
-    try {
-      const merge = sanitizeMergePolicy(raw.merge);
-      const {
-        merge: _unsanitized,
-        configError: _ce,
-        ...policy
-      } = {
-        ...DEFAULT_POLICY,
-        ...(parsed as Partial<EvalPolicy>),
-      };
-
-      // Rebuilt rather than taken from the spread: every entry must be a fresh
-      // object owned by this policy, so nothing downstream can reach back into
-      // the parsed input (or, via `DEFAULT_POLICY`'s own array, into the module
-      // default) by mutating what it was handed.
-      const declared = raw.evaluators as unknown[];
-      const evaluators = declared
-        .map((entry) => sanitizeEvaluator(entry, logger))
-        .filter((entry): entry is EvaluatorConfig => entry !== null);
-
-      // Any dropped entry fails the gate closed — not just the case where every
-      // entry was dropped. An entry the author wrote is a gate they meant to
-      // have; silently discarding one while its siblings survive removes that
-      // gate and lets the change through on the remaining ones, which is the
-      // permissive fallback `malformedPolicy` exists to prevent. A `webhook`
-      // whose `url` was typo'd is the concrete case: it used to reach
-      // `WebhookEvaluator` and block on an unusable URL.
-      //
-      // Note this only counts entries that are structurally unusable. An
-      // unrecognised `type` is copied through and rejected downstream by
-      // `buildEvaluators`, so a policy naming a future evaluator type does not
-      // trip this.
-      if (evaluators.length < declared.length) {
-        return {
-          status: "malformed",
-          reason: `${declared.length - evaluators.length} unusable entr${
-            declared.length - evaluators.length === 1 ? "y" : "ies"
-          } in 'evaluators'`,
-        };
-      }
-      policy.evaluators = evaluators;
-
-      // Assigned unconditionally: the spread above already put the *raw* value
-      // in `policy.minScore`, so skipping the assignment on rejection would
-      // leave it there — and `-Infinity` or the string "-5" both make
-      // `score >= minScore` true for every score, disabling the gate.
-      policy.minScore = clampScore(raw.minScore, logger) ?? DEFAULT_POLICY.minScore;
-
-      return { status: "ok", policy: merge ? { ...policy, merge } : policy };
-    } catch (e) {
-      const reason = e instanceof Error ? e.message : String(e);
-      logger.error("Policy sanitization threw — failing merge gate closed", undefined, {
-        path,
-        reason,
-      });
-      return { status: "malformed", reason };
-    }
+    return parsePolicyContent(content, format, logger);
   } catch (e) {
     // A transient repo-read blip — treat as absent so it doesn't block every
-    // merge. Sanitization failures no longer reach here; they are handled above
-    // and fail closed.
+    // merge. Sanitization failures cannot reach here; `parsePolicyContent`
+    // handles them itself and fails closed.
     logger.warn("Policy load failed; treating as absent", {
       path,
       error: e instanceof Error ? e.message : String(e),

--- a/src/evaluation/types.ts
+++ b/src/evaluation/types.ts
@@ -48,6 +48,49 @@ export interface EvalPolicy {
    * as fail-closed (blocks) rather than silently running on the default, so a
    * typo in a stricter policy can't quietly downgrade governance. */
   configError?: string;
+  /**
+   * Post-merge deploys declared under `deploys:`, after sanitization. Only
+   * entries that passed every rule in `sanitizeDeploys` appear here; anything
+   * rejected is in `deployRejections` instead, never silently absent.
+   */
+  deploys?: DeployConfig[];
+  /**
+   * Deploy entries the policy declared but that could not be used, with the
+   * reason. Carried on the policy rather than logged and dropped because each
+   * one becomes a persisted *failed* deployment: a deploy the author wrote and
+   * that never runs must be visible, not a `logger.warn` nobody reads.
+   */
+  deployRejections?: DeployRejection[];
+}
+
+/** Deploy targets the runner can drive. Each is a provider HTTP API. */
+export type DeployTargetName = "cloudflare-pages" | "cloudflare-workers" | "vercel";
+
+/**
+ * One entry of the `deploys:` list in `.stratum/policy.yaml`.
+ *
+ * Produced only by `sanitizeDeploys` (`src/deploy/config.ts`) — a value of this
+ * type is always a freshly built object, never a slice of the parsed policy
+ * file, so nothing downstream can reach back into user-supplied input.
+ */
+export interface DeployConfig {
+  /** `^[a-z][a-z0-9-]{0,31}$`, unique within the list. Identifies the deploy target across merges. */
+  name: string;
+  target: DeployTargetName;
+  /** Names of project secrets the target needs. Values live in D1, never in the policy file. */
+  secrets?: string[];
+  /** Output directory to publish, relative to the repo root. Consumed by `cloudflare-pages`. */
+  dir?: string;
+  /** Always set by the sanitizer, so an approval gate is never `undefined` downstream. */
+  requiresApproval?: boolean;
+}
+
+/** A `deploys:` entry that was rejected, and why. Becomes a failed deployment row. */
+export interface DeployRejection {
+  /** The entry's declared `name`, or null when it had no usable one. */
+  name: string | null;
+  /** Human-readable, safe to persist and render: derived from the policy file, never from a secret. */
+  reason: string;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { configGuardMiddleware } from "./middleware/config-guard";
 import { csrfMiddleware } from "./middleware/csrf";
 import { rateLimitMiddleware } from "./middleware/rate-limit";
 import { securityHeadersMiddleware, setHtmlSecurityHeaders } from "./middleware/security-headers";
+import { handleDeployQueue } from "./queue/deploy-queue";
 import { handleEventQueue } from "./queue/event-consumer";
 import type { EventQueueMessage } from "./queue/events";
 import { handleImportQueue } from "./queue/import-queue";
@@ -19,6 +20,7 @@ import { bulkImportRouter } from "./routes/bulk-import";
 import { changesRouter } from "./routes/changes";
 import { cspReportRouter } from "./routes/csp-report";
 import { deletionJobsRouter } from "./routes/deletion-jobs";
+import { deploymentsRouter, projectDeploymentsRouter } from "./routes/deployments";
 import { emailAuthRouter } from "./routes/email-auth";
 import { gitHttpRouter } from "./routes/git-http";
 import { healthRouter } from "./routes/health";
@@ -176,7 +178,12 @@ app.route("/auth/signup/complete", oauthSignupRouter);
 app.route("/auth/sessions", sessionRouter);
 app.route("/api/projects", webhooksRouter);
 app.route("/api/projects", issuesRouter);
+// Ahead of projectsRouter: both claim /api/projects, and Hono matches in mount
+// order, so the narrower :namespace/:slug/{secrets,deployments} paths have to be
+// offered first or the broader project routes shadow them.
+app.route("/api/projects", projectDeploymentsRouter);
 app.route("/api/projects", projectsRouter);
+app.route("/api/deployments", deploymentsRouter);
 app.route("/api/workspaces", workspacesRouter);
 app.route("/api/users", usersRouter);
 app.route("/api/agents", agentsRouter);
@@ -243,6 +250,8 @@ export default {
       await handleImportQueue(batch as MessageBatch<ImportJobMessage | SyncJobMessage>, env);
     } else if (queueName.startsWith("stratum-events")) {
       await handleEventQueue(batch as MessageBatch<EventQueueMessage>, env);
+    } else if (queueName.startsWith("stratum-deploys")) {
+      await handleDeployQueue(batch, env);
     } else {
       // Unknown queue - ack all messages to prevent retries
       logger.warn("Unknown queue", { queue: queueName });

--- a/src/queue/deploy-queue.ts
+++ b/src/queue/deploy-queue.ts
@@ -1,0 +1,225 @@
+/**
+ * Consumer for the `stratum-deploys` queue.
+ *
+ * The interesting decisions here are all about *when a message comes back*.
+ * `runDeployMessage` never throws and splits its outcomes into three:
+ *
+ * - `ok` with `aborted` — the message can never succeed (no `projectId`, a
+ *   reverted change, a deleting project, an unknown deployment row). Redelivery
+ *   would replay the same refusal until the retry budget ran out, so it is
+ *   acked.
+ * - `ok` otherwise — every deployment the message named reached a terminal
+ *   status. A `failed` row is a *result*, not a delivery failure: retrying it
+ *   would re-run a deploy the operator has to fix and re-trigger by hand.
+ * - `err` — the run could not determine what happened (D1 or KV unavailable,
+ *   the project unreadable). This is the only case redelivery helps, and it is
+ *   safe: the `ux_deployments_attempt` unique index and `claimDeployment`'s
+ *   lease give mutual exclusion, so a redelivered message cannot double-deploy.
+ *
+ * A malformed body is acked with a logged error rather than retried. Nothing
+ * about redelivering a message the runner cannot parse changes its shape, and
+ * the retry budget would only delay the DLQ.
+ */
+import { type DeployQueueMessage, runDeployMessage } from "../deploy/runner";
+import type { PostMergeStatus } from "../merge/post-merge";
+import { getChange } from "../storage/changes";
+import { isIsoTimestamp } from "../storage/deployments";
+import type { Env, Message, MessageBatch } from "../types";
+import { type Logger, createLogger } from "../utils/logger";
+
+/** Narrows an untrusted queue body to a message the runner will accept. */
+function parseDeployMessage(body: unknown): DeployQueueMessage | null {
+  if (typeof body !== "object" || body === null) return null;
+  const msg = body as Record<string, unknown>;
+
+  const nonEmpty = (value: unknown): value is string =>
+    typeof value === "string" && value.trim() !== "";
+
+  if (!nonEmpty(msg.projectId)) return null;
+
+  if (msg.kind === "merge") {
+    if (!nonEmpty(msg.changeId) || !nonEmpty(msg.commitSha)) return null;
+    return {
+      kind: "merge",
+      projectId: msg.projectId,
+      changeId: msg.changeId,
+      commitSha: msg.commitSha,
+      // Absent on a message enqueued before this field existed, and on one whose
+      // change carried a `merged_at` the deployments columns will not take. The
+      // runner falls back to processing time for both rather than dropping a
+      // real deploy; see `mergeTimeOf`.
+      ...(isIsoTimestamp(msg.mergedAt) ? { mergedAt: msg.mergedAt } : {}),
+    };
+  }
+
+  if (msg.kind === "deployment") {
+    if (!nonEmpty(msg.deploymentId)) return null;
+    return { kind: "deployment", projectId: msg.projectId, deploymentId: msg.deploymentId };
+  }
+
+  return null;
+}
+
+async function consumeOne(env: Env, msg: Message<unknown>, logger: Logger): Promise<void> {
+  const message = parseDeployMessage(msg.body);
+  if (message === null) {
+    logger.error("Deploy queue message is malformed; dropping", undefined, {
+      messageId: msg.id,
+    });
+    msg.ack();
+    return;
+  }
+
+  let result: Awaited<ReturnType<typeof runDeployMessage>>;
+  try {
+    result = await runDeployMessage(env, message, logger);
+  } catch (error) {
+    // runDeployMessage is documented never to throw, so reaching here means an
+    // unknown failure — the same class as `err`, and treated the same way.
+    logger.error("Deploy run threw", error instanceof Error ? error : new Error(String(error)), {
+      kind: message.kind,
+      projectId: message.projectId,
+    });
+    msg.retry();
+    return;
+  }
+
+  if (!result.success) {
+    logger.error("Deploy run could not complete; retrying", result.error, {
+      kind: message.kind,
+      projectId: message.projectId,
+    });
+    msg.retry();
+    return;
+  }
+
+  const summary = result.data;
+  if (summary.aborted !== undefined) {
+    logger.info("Deploy message abandoned", {
+      kind: message.kind,
+      projectId: message.projectId,
+      reason: summary.aborted,
+    });
+  } else {
+    logger.info("Deploy message handled", {
+      kind: message.kind,
+      projectId: message.projectId,
+      deployments: summary.deployments.map((record) => ({
+        deploymentId: record.deploymentId,
+        name: record.name,
+        status: record.status,
+      })),
+    });
+  }
+  msg.ack();
+}
+
+/**
+ * Queue entry point. One message is one deployment (or one merge fan-out), so
+ * the batch is walked serially — `max_batch_size = 1` in `wrangler.toml` makes
+ * that a formality, but a raised batch size must not turn into N concurrent
+ * provider uploads sharing one invocation's subrequest budget.
+ */
+export async function handleDeployQueue(batch: MessageBatch<unknown>, env: Env): Promise<void> {
+  const logger = createLogger({ component: "DeployConsumer" });
+  for (const msg of batch.messages) {
+    await consumeOne(env, msg, logger);
+  }
+}
+
+/**
+ * Enqueue a merged change for deployment — best effort, and deliberately gated
+ * on the post-merge outcome.
+ *
+ * **Why this is not driven by the `change.merged` event.** `change.merged` is
+ * emitted *before* `runPostMergeCheck` runs, and a post-merge failure
+ * auto-reverts the merge. Subscribing the deploy trigger to that event would
+ * therefore publish the exact commit Stratum had just decided to revert. The
+ * only safe trigger is the post-merge result, which is why callers pass it in
+ * and why `reverted` and `failed` are refused here rather than at the call
+ * site: both merge paths must make the same decision.
+ *
+ * `skipped` and `passed` both deploy. `skipped` means no post-merge command is
+ * configured — the overwhelmingly common case — and treating "the operator
+ * declared no smoke check" as "do not deploy" would make deployments
+ * unreachable for almost every project.
+ *
+ * A queue-send failure is logged and swallowed: the merge has already happened
+ * and the response describes it truthfully. Failing the request over an
+ * undeliverable deploy would report a completed merge as an error.
+ *
+ * **The message carries the merge time.** Every deployment row is ordered by it
+ * rather than by when its message is processed, because the queue promises no
+ * ordering and a retry reorders outright — see `DeployQueueMessage.mergedAt`.
+ */
+/**
+ * When the change actually merged, for the message to carry.
+ *
+ * Read back off the change row rather than stamped here, because this function
+ * runs *after* `runPostMergeCheck`, and that check can spend minutes in a
+ * sandbox. Stamping the clock here would put a merge whose smoke test ran long
+ * behind a later merge whose check was skipped — reintroducing the reordering
+ * this field exists to remove, just one layer up from the queue.
+ *
+ * Falls back to the clock when the row cannot be read or carries a `merged_at`
+ * the deployments columns would reject. That is strictly better than sending
+ * nothing: an approximate merge time still orders correctly against every other
+ * merge whose time is known, and the runner's own fallback then never has to
+ * fire. A caller-supplied `mergedAt` wins over both, for a path that already
+ * knows it.
+ */
+async function resolveMergeTime(
+  env: Env,
+  logger: Logger,
+  input: { changeId: string; mergedAt?: string },
+): Promise<string> {
+  if (isIsoTimestamp(input.mergedAt)) return input.mergedAt;
+
+  const change = await getChange(env.DB, logger, input.changeId);
+  if (change.success && isIsoTimestamp(change.data.mergedAt)) return change.data.mergedAt;
+
+  logger.warn("Merged change has no usable merged_at; ordering the deploy on enqueue time", {
+    changeId: input.changeId,
+  });
+  return new Date().toISOString();
+}
+
+export async function enqueueMergeDeploy(
+  env: Env,
+  logger: Logger,
+  input: {
+    projectId: string;
+    changeId: string;
+    commitSha: string;
+    postMergeStatus: PostMergeStatus;
+    /** The change's `merged_at`, when the caller already has it. */
+    mergedAt?: string;
+  },
+): Promise<void> {
+  if (input.postMergeStatus === "reverted" || input.postMergeStatus === "failed") {
+    logger.info("Not enqueuing a deploy: the post-merge check did not pass", {
+      changeId: input.changeId,
+      postMerge: input.postMergeStatus,
+    });
+    return;
+  }
+  if (!env.DEPLOY_QUEUE) return;
+  if (input.commitSha.trim() === "" || input.projectId.trim() === "") return;
+
+  const message: DeployQueueMessage = {
+    kind: "merge",
+    projectId: input.projectId,
+    changeId: input.changeId,
+    commitSha: input.commitSha,
+    mergedAt: await resolveMergeTime(env, logger, input),
+  };
+  try {
+    await env.DEPLOY_QUEUE.send(message);
+  } catch (error) {
+    logger.error(
+      "Failed to enqueue post-merge deploy",
+      error instanceof Error ? error : new Error(String(error)),
+      { changeId: input.changeId, commitSha: input.commitSha },
+    );
+  }
+}

--- a/src/queue/deploy-queue.ts
+++ b/src/queue/deploy-queue.ts
@@ -19,13 +19,175 @@
  * A malformed body is acked with a logged error rather than retried. Nothing
  * about redelivering a message the runner cannot parse changes its shape, and
  * the retry budget would only delay the DLQ.
+ *
+ * ## The send itself can fail, and losing it loses the deploy
+ *
+ * Everything above is about a message that *arrived*. `queue.send` can also
+ * reject, and every producer of this queue is in a position where it cannot
+ * usefully report that: the merge has already happened, or the deployment row
+ * has already been moved to `queued`, where nothing but a queue message can
+ * ever pick it up again. {@link recordDeployRequest} is the durable fallback —
+ * an outbox row in D1, swept by the five-minute cron and forwarded to this
+ * queue by {@link forwardDeployRequest}. See the note on that function for why
+ * the deploy work itself never rides the events queue.
  */
 import { type DeployQueueMessage, runDeployMessage } from "../deploy/runner";
 import type { PostMergeStatus } from "../merge/post-merge";
 import { getChange } from "../storage/changes";
 import { isIsoTimestamp } from "../storage/deployments";
+import { type EventRecord, insertEvent } from "../storage/events";
+import { getProjectById } from "../storage/state";
 import type { Env, Message, MessageBatch } from "../types";
 import { type Logger, createLogger } from "../utils/logger";
+import type { EventQueueMessage } from "./events";
+
+/**
+ * Outbox `events.type` for a deploy request that could not be handed to
+ * `DEPLOY_QUEUE` directly.
+ *
+ * Deliberately outside `StratumEvent`. A row of this type is *work*, not a
+ * notification: it carries no meaning for a subscriber, and the union is what
+ * webhook receivers and analytics see. Keeping it out of the union is what lets
+ * {@link forwardDeployRequest} be its only handler.
+ */
+export const DEPLOY_ENQUEUE_EVENT_TYPE = "deploy.enqueue";
+
+/**
+ * Is this outbox row internal work rather than a domain notification?
+ *
+ * The event consumer asks before choosing a handler set, so an internal row is
+ * never delivered to a `*`-subscribed webhook or counted as a product event.
+ */
+export function isInternalEventType(type: string): boolean {
+  return type === DEPLOY_ENQUEUE_EVENT_TYPE;
+}
+
+/**
+ * Record a deploy request that `DEPLOY_QUEUE.send` refused, so it can be
+ * delivered later instead of being lost.
+ *
+ * The row goes in the **existing event outbox** rather than a new table: that
+ * outbox already has the two halves this needs — a durable D1 row written
+ * before anything is sent, and a five-minute sweep that re-enqueues rows still
+ * `pending`. A `deployments`-only sweep could not cover the merge path at all,
+ * because a merge whose send fails has produced no deployment row to find (the
+ * runner creates rows only after it consumes the message).
+ *
+ * Never throws: every caller is on a path that has already succeeded at
+ * something the user was told about, and none of them can undo it.
+ *
+ * @param input.project - The project's name, for the outbox row's own column.
+ *   Callers that only know the id may omit it; it is resolved, best effort.
+ * @returns Whether the request is now durable. `false` means the outbox write
+ *   itself failed, and the request is genuinely lost.
+ */
+export async function recordDeployRequest(
+  env: Env,
+  logger: Logger,
+  input: { message: DeployQueueMessage; project?: string },
+): Promise<boolean> {
+  if (!env.DB) {
+    logger.error("Cannot record a deploy request: no database is bound", undefined, {
+      projectId: input.message.projectId,
+    });
+    return false;
+  }
+
+  let project = input.project;
+  if (project === undefined) {
+    // Only reached on a send failure, so the extra read costs nothing in the
+    // normal case. The id is a usable stand-in if the lookup fails: the column
+    // is descriptive here, and every consumer of this row scopes on project_id.
+    try {
+      const resolved = await getProjectById(env.STATE, input.message.projectId, logger);
+      project = resolved.success ? resolved.data.name : input.message.projectId;
+    } catch {
+      project = input.message.projectId;
+    }
+  }
+
+  const inserted = await insertEvent(env.DB, logger, {
+    type: DEPLOY_ENQUEUE_EVENT_TYPE,
+    project,
+    projectId: input.message.projectId,
+    actorType: "system",
+    payload: { ...input.message },
+  });
+  if (!inserted.success) {
+    logger.error("Could not record a deploy request for recovery", inserted.error, {
+      projectId: input.message.projectId,
+      kind: input.message.kind,
+    });
+    return false;
+  }
+
+  logger.warn("Deploy request recorded for recovery after a failed queue send", {
+    eventId: inserted.data.id,
+    projectId: input.message.projectId,
+    kind: input.message.kind,
+  });
+
+  // Best effort nudge so recovery does not always wait for the cron. The sweep
+  // is the guarantee; this is only latency.
+  if (env.EVENTS_QUEUE) {
+    try {
+      const nudge: EventQueueMessage = { eventId: inserted.data.id };
+      await env.EVENTS_QUEUE.send(nudge);
+    } catch (error) {
+      logger.warn("Could not nudge the events queue; the sweep will pick the request up", {
+        eventId: inserted.data.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return true;
+}
+
+/**
+ * Deliver one {@link DEPLOY_ENQUEUE_EVENT_TYPE} outbox row to `DEPLOY_QUEUE`.
+ *
+ * **Forwarding is all it does.** The deploy itself never runs on the events
+ * queue: that queue's consumer has no deploy lease, no visibility timeout sized
+ * for a provider upload, and a batch size that would put several deploys in one
+ * isolate — every property `stratum-deploys` exists to provide. This handler's
+ * whole job is to put the message back where it belongs.
+ *
+ * Throws when the forward fails, which is the contract `processEvent` expects:
+ * the event stays `pending`, the queue retries it, and the sweep re-enqueues it
+ * until the attempt budget runs out. A payload that cannot be parsed and an
+ * instance with no `DEPLOY_QUEUE` both return normally instead — no redelivery
+ * changes either answer.
+ */
+export async function forwardDeployRequest(
+  env: Env,
+  event: EventRecord,
+  logger: Logger,
+): Promise<void> {
+  if (event.type !== DEPLOY_ENQUEUE_EVENT_TYPE) return;
+
+  const message = parseDeployMessage(event.payload);
+  if (message === null) {
+    logger.error("Deploy enqueue outbox row is unusable; dropping it", undefined, {
+      eventId: event.id,
+    });
+    return;
+  }
+
+  if (!env.DEPLOY_QUEUE) {
+    logger.warn("Deployments are not enabled on this instance; dropping a recovered request", {
+      eventId: event.id,
+      projectId: message.projectId,
+    });
+    return;
+  }
+
+  await env.DEPLOY_QUEUE.send(message);
+  logger.info("Recovered deploy request forwarded to the deploy queue", {
+    eventId: event.id,
+    projectId: message.projectId,
+    kind: message.kind,
+  });
+}
 
 /** Narrows an untrusted queue body to a message the runner will accept. */
 function parseDeployMessage(body: unknown): DeployQueueMessage | null {
@@ -221,5 +383,18 @@ export async function enqueueMergeDeploy(
       error instanceof Error ? error : new Error(String(error)),
       { changeId: input.changeId, commitSha: input.commitSha },
     );
+    // Swallowing the failure is right — the merge happened and the response
+    // describes it truthfully. Losing the request is not: the runner creates
+    // deployment rows only *after* it consumes this message, so a dropped send
+    // leaves no row at all, and there is nothing for an operator to see, retry
+    // or sweep. The outbox row is the thing that can still be recovered.
+    const recorded = await recordDeployRequest(env, logger, { message });
+    if (!recorded) {
+      logger.error("Post-merge deploy request could not be made durable and is lost", undefined, {
+        changeId: input.changeId,
+        commitSha: input.commitSha,
+        projectId: input.projectId,
+      });
+    }
   }
 }

--- a/src/queue/event-consumer.ts
+++ b/src/queue/event-consumer.ts
@@ -13,6 +13,7 @@ import { getUser } from "../storage/users";
 import type { Env, Message, MessageBatch } from "../types";
 import type { Logger } from "../utils/logger";
 import { createLogger } from "../utils/logger";
+import { forwardDeployRequest, isInternalEventType } from "./deploy-queue";
 import type { EventQueueMessage } from "./events";
 import { autoCloseLinkedIssues } from "./issue-autoclose";
 import { deliverEventToWebhooks } from "./webhook-delivery";
@@ -134,6 +135,13 @@ const issueAutoCloseHandler: EventHandler = {
   },
 };
 
+const deployForwardHandler: EventHandler = {
+  name: "deploy-forward",
+  async handle(env, event, logger) {
+    await forwardDeployRequest(env, event, logger);
+  },
+};
+
 /**
  * Ordered handler registry. Every handler runs for every event and decides
  * internally whether the event type concerns it. Issue auto-close runs
@@ -141,15 +149,26 @@ const issueAutoCloseHandler: EventHandler = {
  */
 const handlers: EventHandler[] = [analyticsHandler, issueAutoCloseHandler, webhookHandler];
 
+/**
+ * Handlers for an *internal* outbox row — one that carries work rather than a
+ * domain notification, and whose only job is to reach the queue that owns that
+ * work. The registry above is deliberately not consulted for these: a webhook
+ * subscribed to `*` would otherwise receive a recovery record as though it were
+ * something that happened to the project, and analytics would count it as a
+ * product event.
+ */
+const internalHandlers: EventHandler[] = [deployForwardHandler];
+
 /** Exported for tests. Runs the ordered handlers, resuming past completed ones. */
 export async function processEvent(env: Env, event: EventRecord, logger: Logger): Promise<void> {
+  const active = isInternalEventType(event.type) ? internalHandlers : handlers;
   // Resume from where a prior attempt left off: skip handlers already recorded as
   // completed, and persist progress after each success so a later failure doesn't
   // re-run (and re-emit) the ones that already ran. On failure, stop — running a
   // later handler on an inconsistent earlier state would defeat the ordering.
   const completed = [...(event.completedHandlers ?? [])];
   const completedSet = new Set(completed);
-  for (const handler of handlers) {
+  for (const handler of active) {
     if (completedSet.has(handler.name)) continue;
     await handler.handle(env, event, logger);
     completed.push(handler.name);

--- a/src/queue/events.ts
+++ b/src/queue/events.ts
@@ -31,6 +31,37 @@ export type StratumEvent =
       issueNumber: number;
       title: string;
       changeId?: string;
+    }
+  // Deploy work never travels on this registry — `stratum-deploys` carries it.
+  // These are notifications *about* a deploy, for webhooks and analytics, and a
+  // subscriber that never sees one has lost a notification, not a deployment.
+  | {
+      type: "deployment.requested";
+      project: string;
+      deploymentId: string;
+      name: string;
+      target: string;
+      commit: string;
+      changeId?: string;
+    }
+  | {
+      type: "deployment.succeeded";
+      project: string;
+      deploymentId: string;
+      name: string;
+      target: string;
+      commit: string;
+      url?: string;
+    }
+  | {
+      type: "deployment.failed";
+      project: string;
+      deploymentId: string;
+      name: string;
+      target: string;
+      commit: string;
+      /** Already redacted against the deployment's secret values by the runner. */
+      reason: string;
     };
 
 export interface EventActor {

--- a/src/routes/changes.ts
+++ b/src/routes/changes.ts
@@ -5,6 +5,7 @@ import { GitHubClient } from "../github/client";
 import { buildEvaluationReport, reportEvaluationToGitHub } from "../github/sync";
 import { runPostMergeCheck } from "../merge/post-merge";
 import { checkMergeProtection } from "../merge/protection";
+import { enqueueMergeDeploy } from "../queue/deploy-queue";
 import { emitEvent } from "../queue/events";
 import type { MergeOutcome } from "../queue/merge-queue";
 import {
@@ -672,6 +673,17 @@ app.post("/changes/:id/merge", async (c) => {
         )
       : { status: "skipped" as const };
 
+    // Deploys are triggered HERE, from the post-merge result — never from the
+    // `change.merged` event emitted above. That event fires before the check
+    // runs, and a post-merge failure auto-reverts the merge, so an
+    // event-triggered deploy would publish the commit Stratum just reverted.
+    await enqueueMergeDeploy(c.env, logger, {
+      projectId: change.projectId ?? project.id,
+      changeId: id,
+      commitSha: result.commit ?? "",
+      postMergeStatus: postMergeViaQueue.status,
+    });
+
     return okOrFormRedirect(c, id, {
       merged: true,
       changeId: id,
@@ -852,6 +864,21 @@ app.post("/changes/:id/merge", async (c) => {
     { changeId: id, mergeCommit: commit, policy: mergePolicy },
     logger,
   );
+
+  // Same ordering constraint as the queue path above: the deploy trigger hangs
+  // off the post-merge result, not the `change.merged` event, because a failed
+  // post-merge check reverts the merge.
+  await enqueueMergeDeploy(c.env, logger, {
+    projectId: change.projectId ?? project.id,
+    changeId: id,
+    commitSha: commit,
+    postMergeStatus: postMerge.status,
+    // The merge time this route already stamped on the change. Deployment rows
+    // are ordered by it rather than by when the queue delivers their message,
+    // and the post-merge check above can take minutes — long enough for a later
+    // merge to overtake this one on enqueue order alone.
+    mergedAt,
+  });
 
   return okOrFormRedirect(c, id, {
     merged: true,

--- a/src/routes/deployments.ts
+++ b/src/routes/deployments.ts
@@ -26,6 +26,7 @@
  */
 import { Hono } from "hono";
 import type { DeployQueueMessage } from "../deploy/runner";
+import { recordDeployRequest } from "../queue/deploy-queue";
 import { recordAudit } from "../storage/audit";
 import {
   DEPLOYMENT_STATUSES,
@@ -590,7 +591,20 @@ deploymentApp.post("/:id/approve", async (c) => {
       error instanceof Error ? error : undefined,
       { deploymentId: approved.id, projectId: project.id },
     );
-    return internalError("Deployment was approved but could not be queued; retry it");
+    // The row has already left `pending_approval`, and only a queue message can
+    // move it any further — `claimDeployment` runs from the consumer, and a
+    // second approval of a `queued` row is refused. "Retry it" was therefore
+    // advice that could not succeed. Recording the request durably instead
+    // hands it to the outbox sweep, so the approval the user granted still runs.
+    const recorded = await recordDeployRequest(c.env, logger, {
+      message,
+      project: project.name,
+    });
+    if (!recorded) {
+      return internalError(
+        "Deployment was approved but could not be started, and the request could not be recorded for recovery",
+      );
+    }
   }
 
   await recordAudit(c.env.DB, logger, {
@@ -701,7 +715,19 @@ deploymentApp.post("/:id/retry", async (c) => {
       error instanceof Error ? error : undefined,
       { deploymentId: retry.id, projectId: project.id },
     );
-    return internalError("Retry was recorded but could not be queued; try again");
+    // Same dead end as approve, one step further along: the new attempt row
+    // exists and is `queued`, so "try again" would only be refused by the
+    // unique index on (project, name, commit, attempt). The outbox sweep is
+    // what can still start it.
+    const recorded = await recordDeployRequest(c.env, logger, {
+      message,
+      project: project.name,
+    });
+    if (!recorded) {
+      return internalError(
+        "Retry was recorded but could not be started, and the request could not be saved for recovery",
+      );
+    }
   }
 
   await recordAudit(c.env.DB, logger, {

--- a/src/routes/deployments.ts
+++ b/src/routes/deployments.ts
@@ -1,0 +1,727 @@
+/**
+ * Deploy secrets and deployment history.
+ *
+ * Two authorization rules here are stricter than the project's usual read/write
+ * split, and both are load bearing:
+ *
+ * 1. The secret routes refuse agent identities outright. `isProjectAdmin`
+ *    accepts an `agentOwnerId`, so an agent owned by the project owner would
+ *    otherwise be an admin — and could swap or delete the production deploy
+ *    credential. See {@link requireSecretsAdmin}.
+ * 2. `log_tail` is served to project *writers* only, never on the plain read
+ *    path. `canReadProject` returns true unconditionally for a public project,
+ *    and a provider error payload can echo request context back at us.
+ *
+ * No route on either router returns a secret value; there is no read path for
+ * one anywhere in the codebase (`loadSecretValues` is the deploy runner's, and
+ * is not reachable from here).
+ *
+ * The browser talks to these same routes. An HTML form can only issue GET or
+ * POST and cannot read a JSON body, so the secret writes have form-friendly
+ * POST aliases beside them and the approve/retry routes answer a form caller
+ * with a redirect — all sharing the one copy of each authorization gate above,
+ * because a second copy is a gate that can be fixed in one place and not the
+ * other. Which shape a caller gets is decided by its `content-type`, the same
+ * way `routes/webhooks.ts` and `routes/projects.ts` decide it.
+ */
+import { Hono } from "hono";
+import type { DeployQueueMessage } from "../deploy/runner";
+import { recordAudit } from "../storage/audit";
+import {
+  DEPLOYMENT_STATUSES,
+  type Deployment,
+  type DeploymentStatus,
+  TERMINAL_DEPLOYMENT_STATUSES,
+  approveDeployment,
+  findDeploymentById,
+  insertDeployment,
+  listDeployments,
+} from "../storage/deployments";
+import {
+  DEPLOY_SECRET_KEY_MISSING,
+  MAX_SECRET_VALUE_BYTES,
+  type ProjectSecretSummary,
+  SECRET_NAME_PATTERN,
+  deleteSecret,
+  listSecretNames,
+  putSecret,
+} from "../storage/project-secrets";
+import { getProjectById, getProjectByPath } from "../storage/state";
+import type { Env, ProjectEntry } from "../types";
+import { canReadProject, canWriteProject, isProjectAdmin } from "../utils/authz";
+import { AppError } from "../utils/errors";
+import { type Logger, createLogger } from "../utils/logger";
+import { readJsonWithLimit } from "../utils/request-body";
+import {
+  appError,
+  badRequest,
+  forbidden,
+  internalError,
+  notFound,
+  ok,
+  unauthorized,
+} from "../utils/response";
+import type { Result } from "../utils/result";
+
+/**
+ * A secret write body is one value plus its JSON envelope. Four times the value
+ * cap leaves room for whitespace and escaping while still rejecting a payload
+ * that could never contain a storable value.
+ */
+const MAX_SECRET_BODY_BYTES = MAX_SECRET_VALUE_BYTES * 4;
+
+/** The failures a secret form can report back to the settings page. */
+type SecretErrorCode = "name" | "value" | "key" | "failed";
+
+/**
+ * Secret-form failures as a closed set of codes, not free text: the reason has
+ * to survive a redirect through the query string, and echoing an attacker's
+ * string back into the page — escaped or not — invites it to be read as ours.
+ * The route emits the code; {@link secretErrorMessage} is what the settings
+ * page resolves it back to.
+ */
+const SECRET_ERRORS: Record<SecretErrorCode, string> = {
+  name: "Secret names must be uppercase letters, digits and underscores, starting with a letter.",
+  value: "A secret value is required.",
+  key: "This instance has no DEPLOY_SECRET_KEY configured, so secrets cannot be stored.",
+  failed: "Could not save that secret. Please try again.",
+};
+
+/**
+ * The message for a `?secretError=` code, or `undefined` for anything else —
+ * which is the whole point: an unrecognized code renders nothing rather than
+ * putting a caller-supplied string on the page.
+ */
+export function secretErrorMessage(code: string | undefined): string | undefined {
+  // `Object.hasOwn`, not `in`: `in` answers true for inherited keys such as
+  // "toString" and would hand the page a function instead of a message.
+  if (code === undefined || !Object.hasOwn(SECRET_ERRORS, code)) return undefined;
+  return SECRET_ERRORS[code as SecretErrorCode];
+}
+
+type AccessFailure = { response: Response };
+
+/** The subset of a Hono context these helpers read, so they stay unit-testable. */
+interface RouteContext {
+  env: Env;
+  get: (key: "userId" | "agentId" | "agentOwnerId") => string | undefined;
+  req: { param: (key: string) => string };
+}
+
+function routeLogger(c: {
+  get: (key: "userId") => string | undefined;
+  req: { path: string; method: string };
+}): Logger {
+  return createLogger({
+    requestId: crypto.randomUUID(),
+    userId: c.get("userId"),
+    path: c.req.path,
+    method: c.req.method,
+  });
+}
+
+async function loadProject(
+  c: RouteContext,
+  logger: Logger,
+): Promise<{ project: ProjectEntry } | AccessFailure> {
+  const namespace = c.req.param("namespace");
+  const slug = c.req.param("slug");
+  const projectResult = await getProjectByPath(c.env.STATE, namespace, slug, logger);
+  if (!projectResult.success) {
+    if (projectResult.error.code === "NOT_FOUND") {
+      return { response: notFound("Project", `${namespace}/${slug}`) };
+    }
+    logger.error("Failed to get project", projectResult.error);
+    return { response: internalError(projectResult.error.message) };
+  }
+  return { project: projectResult.data };
+}
+
+/**
+ * The one definition of who may manage a project's deploy secrets: a project
+ * admin that is not an agent.
+ *
+ * The agent check is not redundant with the admin check and must not be folded
+ * into it: `isProjectAdmin(db, project, userId, agentOwnerId)` grants admin to
+ * an agent whose *owner* owns the project, so a `stratum_agent_` token issued
+ * for routine work would be able to overwrite or delete the production deploy
+ * credential. Deploy credentials are the one thing an agent is never trusted
+ * with (PRD G3), so `agentOwnerId` is deliberately not passed below.
+ *
+ * Exported because the settings page decides whether to render the Deploy
+ * secrets section at all, and that decision has to be this rule rather than a
+ * second copy of it that can be fixed in one place and not the other.
+ */
+export async function canManageSecrets(
+  db: D1Database,
+  project: ProjectEntry,
+  identity: { userId: string | undefined; agentId: string | undefined },
+): Promise<boolean> {
+  if (identity.agentId !== undefined || identity.userId === undefined) return false;
+  return await isProjectAdmin(db, project, identity.userId);
+}
+
+/**
+ * {@link canManageSecrets} as a route guard, for the secret routes and their
+ * form-friendly aliases. The identity is refused before the project is even
+ * loaded, so a caller who may not manage secrets cannot use these routes to
+ * probe which projects exist.
+ */
+async function requireSecretsAdmin(
+  c: RouteContext,
+  logger: Logger,
+): Promise<{ project: ProjectEntry; userId: string } | AccessFailure> {
+  if (c.get("agentId")) {
+    return { response: forbidden("Agent credentials cannot manage deploy secrets") };
+  }
+  const userId = c.get("userId");
+  if (!userId) {
+    return { response: unauthorized("Only authenticated users can manage deploy secrets") };
+  }
+
+  const loaded = await loadProject(c, logger);
+  if ("response" in loaded) return loaded;
+
+  if (!(await canManageSecrets(c.env.DB, loaded.project, { userId, agentId: c.get("agentId") }))) {
+    return { response: forbidden("Project access denied") };
+  }
+  return { project: loaded.project, userId };
+}
+
+/**
+ * Whether the caller speaks JSON. A browser form posts
+ * `application/x-www-form-urlencoded` (or `multipart/form-data`) and cannot
+ * read a JSON body, so anything that is not JSON is answered with a redirect.
+ */
+function wantsJson(c: { req: { header: (name: string) => string | undefined } }): boolean {
+  return c.req.header("content-type")?.includes("application/json") ?? false;
+}
+
+/** The settings page a secret form came from, anchored at its own section. */
+function secretsSettingsUrl(project: ProjectEntry, error?: SecretErrorCode): string {
+  const base = `/${project.namespace}/${project.slug}/settings`;
+  return error === undefined ? `${base}#secrets` : `${base}?secretError=${error}#secrets`;
+}
+
+/**
+ * Stores one secret and audits the write. Shared by the PUT route and its
+ * form-friendly POST alias so the two cannot drift on what gets recorded — the
+ * audit trail is the only durable evidence that a deploy credential changed.
+ */
+async function writeSecret(
+  env: Env,
+  logger: Logger,
+  access: { project: ProjectEntry; userId: string },
+  name: string,
+  value: string,
+): Promise<Result<ProjectSecretSummary, AppError>> {
+  const result = await putSecret(env.DB, logger, env, {
+    projectId: access.project.id,
+    name,
+    value,
+    actorId: access.userId,
+  });
+  if (!result.success) {
+    logger.error("Failed to store project secret", result.error);
+    return result;
+  }
+
+  await recordAudit(env.DB, logger, {
+    action: "secret.written",
+    actorType: "user",
+    actorId: access.userId,
+    subject: `${access.project.id}:${name}`,
+    detail: { project: access.project.name, name },
+  });
+  return result;
+}
+
+/**
+ * Deletes one secret and audits it when a row was actually removed. Shared by
+ * the DELETE route and its form-friendly POST alias.
+ *
+ * Resolves to `false` when the project had no such name — nothing was removed,
+ * so nothing is audited.
+ */
+async function removeSecret(
+  env: Env,
+  logger: Logger,
+  access: { project: ProjectEntry; userId: string },
+  name: string,
+): Promise<Result<boolean, AppError>> {
+  const result = await deleteSecret(env.DB, logger, { projectId: access.project.id, name });
+  if (!result.success) {
+    logger.error("Failed to delete project secret", result.error);
+    return result;
+  }
+  if (!result.data) return result;
+
+  await recordAudit(env.DB, logger, {
+    action: "secret.deleted",
+    actorType: "user",
+    actorId: access.userId,
+    subject: `${access.project.id}:${name}`,
+    detail: { project: access.project.name, name },
+  });
+  return result;
+}
+
+/**
+ * The deployment as an API response. `logTail` is dropped unless the caller may
+ * write to the project — it holds a redacted provider payload, and redaction is
+ * literal-substring matching that a public-project reader should not be given
+ * the chance to test.
+ */
+function toResponse(deployment: Deployment, includeLogTail: boolean): Record<string, unknown> {
+  const { logTail, ...rest } = deployment;
+  if (includeLogTail && logTail !== undefined) return { ...rest, logTail };
+  return rest;
+}
+
+function isTerminal(status: DeploymentStatus): boolean {
+  return (TERMINAL_DEPLOYMENT_STATUSES as readonly string[]).includes(status);
+}
+
+function parseCount(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Project-scoped routes. Mounted at /api/projects.
+// ---------------------------------------------------------------------------
+
+const projectApp = new Hono<{ Bindings: Env }>();
+
+// GET /api/projects/:namespace/:slug/secrets — Names and metadata only
+projectApp.get("/:namespace/:slug/secrets", async (c) => {
+  const logger = routeLogger(c);
+  const access = await requireSecretsAdmin(c, logger);
+  if ("response" in access) return access.response;
+
+  const result = await listSecretNames(c.env.DB, logger, access.project.id);
+  if (!result.success) return appError(result.error);
+  return ok({ secrets: result.data });
+});
+
+// PUT /api/projects/:namespace/:slug/secrets/:name — Create or replace a value
+projectApp.put("/:namespace/:slug/secrets/:name", async (c) => {
+  const logger = routeLogger(c);
+  const access = await requireSecretsAdmin(c, logger);
+  if ("response" in access) return access.response;
+  const name = c.req.param("name");
+
+  let value: unknown;
+  const contentType = c.req.header("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    const parsed = await readJsonWithLimit<{ value?: unknown }>(
+      c,
+      MAX_SECRET_BODY_BYTES,
+      logger,
+    ).catch(() => ({}) as { value?: unknown });
+    if (parsed instanceof Response) return parsed;
+    value = parsed.value;
+  } else {
+    const form = await c.req.parseBody();
+    value = form.value;
+  }
+  if (typeof value !== "string") return badRequest("value must be a string");
+
+  const result = await writeSecret(c.env, logger, access, name, value);
+  if (!result.success) return appError(result.error);
+  return ok({ secret: result.data });
+});
+
+/**
+ * POST /api/projects/:namespace/:slug/secrets — Form-friendly create or replace
+ *
+ * The browser's way in to the PUT above, which an HTML form cannot issue. It
+ * runs the *same* {@link requireSecretsAdmin} guard rather than restating the
+ * agent refusal, and the secret's name arrives in the body because a form has
+ * no way to put it in the path.
+ *
+ * A form caller is redirected back to the settings page with the failure as one
+ * of a fixed set of codes ({@link SECRET_ERRORS}) — never as text the caller
+ * supplied, which the page would then render as ours.
+ */
+projectApp.post("/:namespace/:slug/secrets", async (c) => {
+  const logger = routeLogger(c);
+  const access = await requireSecretsAdmin(c, logger);
+  if ("response" in access) return access.response;
+  const json = wantsJson(c);
+
+  let body: { name?: unknown; value?: unknown };
+  if (json) {
+    const parsed = await readJsonWithLimit<{ name?: unknown; value?: unknown }>(
+      c,
+      MAX_SECRET_BODY_BYTES,
+      logger,
+    ).catch(() => ({}) as { name?: unknown; value?: unknown });
+    if (parsed instanceof Response) return parsed;
+    body = parsed;
+  } else {
+    body = await c.req.parseBody();
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  const value = typeof body.value === "string" ? body.value : "";
+  if (!SECRET_NAME_PATTERN.test(name)) {
+    return json
+      ? badRequest(SECRET_ERRORS.name)
+      : c.redirect(secretsSettingsUrl(access.project, "name"), 302);
+  }
+  if (value.length === 0) {
+    return json
+      ? badRequest(SECRET_ERRORS.value)
+      : c.redirect(secretsSettingsUrl(access.project, "value"), 302);
+  }
+
+  const result = await writeSecret(c.env, logger, access, name, value);
+  if (!result.success) {
+    if (json) return appError(result.error);
+    const code = result.error.code === DEPLOY_SECRET_KEY_MISSING ? "key" : "failed";
+    return c.redirect(secretsSettingsUrl(access.project, code), 302);
+  }
+
+  return json ? ok({ secret: result.data }) : c.redirect(secretsSettingsUrl(access.project), 302);
+});
+
+// DELETE /api/projects/:namespace/:slug/secrets/:name
+projectApp.delete("/:namespace/:slug/secrets/:name", async (c) => {
+  const logger = routeLogger(c);
+  const access = await requireSecretsAdmin(c, logger);
+  if ("response" in access) return access.response;
+  const name = c.req.param("name");
+
+  const result = await removeSecret(c.env, logger, access, name);
+  if (!result.success) return appError(result.error);
+  if (!result.data) return notFound("Secret", name);
+  return ok({ deleted: true, name });
+});
+
+/**
+ * POST /api/projects/:namespace/:slug/secrets/:name/delete — Form-friendly delete
+ *
+ * Browsers cannot issue DELETE. Behind the same {@link requireSecretsAdmin}
+ * guard as the route above; a form caller lands back on the settings page,
+ * including when the name was already gone — the row it was clicked from no
+ * longer exists either, so there is nothing to report.
+ */
+projectApp.post("/:namespace/:slug/secrets/:name/delete", async (c) => {
+  const logger = routeLogger(c);
+  const access = await requireSecretsAdmin(c, logger);
+  if ("response" in access) return access.response;
+  const name = c.req.param("name");
+  const json = wantsJson(c);
+
+  const result = await removeSecret(c.env, logger, access, name);
+  if (!result.success) {
+    return json
+      ? appError(result.error)
+      : c.redirect(secretsSettingsUrl(access.project, "failed"), 302);
+  }
+  if (!json) return c.redirect(secretsSettingsUrl(access.project), 302);
+  if (!result.data) return notFound("Secret", name);
+  return ok({ deleted: true, name });
+});
+
+// GET /api/projects/:namespace/:slug/deployments — History, newest first
+projectApp.get("/:namespace/:slug/deployments", async (c) => {
+  const logger = routeLogger(c);
+  const loaded = await loadProject(c, logger);
+  if ("response" in loaded) return loaded.response;
+  const { project } = loaded;
+
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
+    return notFound("Project", `${project.namespace}/${project.slug}`);
+  }
+
+  const status = c.req.query("status");
+  if (status !== undefined && !(DEPLOYMENT_STATUSES as readonly string[]).includes(status)) {
+    return badRequest(`status must be one of: ${DEPLOYMENT_STATUSES.join(", ")}`);
+  }
+
+  const name = c.req.query("name");
+  const limit = parseCount(c.req.query("limit"));
+  const offset = parseCount(c.req.query("offset"));
+
+  const result = await listDeployments(c.env.DB, logger, {
+    projectId: project.id,
+    ...(name !== undefined ? { name } : {}),
+    ...(status !== undefined ? { status: status as DeploymentStatus } : {}),
+    ...(limit !== undefined ? { limit } : {}),
+    ...(offset !== undefined ? { offset } : {}),
+  });
+  if (!result.success) return appError(result.error);
+
+  const includeLogTail = await canWriteProject(c.env.DB, project, userId, agentOwnerId);
+  return ok({ deployments: result.data.map((entry) => toResponse(entry, includeLogTail)) });
+});
+
+// ---------------------------------------------------------------------------
+// Deployment-scoped routes. Mounted at /api/deployments.
+// ---------------------------------------------------------------------------
+
+const deploymentApp = new Hono<{ Bindings: Env }>();
+
+/**
+ * Resolves `:id` to a deployment the caller may see.
+ *
+ * The URL carries no project, so the row's own `project_id` is what gets
+ * authorized. A deployment in a project the caller cannot read answers 404
+ * rather than 403: a 403 would confirm that the id exists, which is exactly
+ * what a cross-tenant probe is looking for.
+ */
+async function loadDeployment(
+  c: RouteContext & { req: { param: (key: string) => string } },
+  logger: Logger,
+): Promise<{ deployment: Deployment; project: ProjectEntry } | AccessFailure> {
+  const id = c.req.param("id");
+
+  const found = await findDeploymentById(c.env.DB, logger, id);
+  if (!found.success) return { response: appError(found.error) };
+  if (!found.data) return { response: notFound("Deployment", id) };
+  const deployment = found.data;
+
+  const projectResult = await getProjectById(c.env.STATE, deployment.projectId, logger);
+  if (!projectResult.success) {
+    // A row whose project is gone is not reportable as a deployment either.
+    if (projectResult.error.code === "NOT_FOUND") return { response: notFound("Deployment", id) };
+    return { response: appError(projectResult.error) };
+  }
+  const project = projectResult.data;
+
+  if (!(await canReadProject(c.env.DB, project, c.get("userId"), c.get("agentOwnerId")))) {
+    return { response: notFound("Deployment", id) };
+  }
+  return { deployment, project };
+}
+
+// GET /api/deployments/:id — Detail
+deploymentApp.get("/:id", async (c) => {
+  const logger = routeLogger(c);
+  const loaded = await loadDeployment(c, logger);
+  if ("response" in loaded) return loaded.response;
+  const { deployment, project } = loaded;
+
+  const includeLogTail = await canWriteProject(
+    c.env.DB,
+    project,
+    c.get("userId"),
+    c.get("agentOwnerId"),
+  );
+  return ok({ deployment: toResponse(deployment, includeLogTail) });
+});
+
+// POST /api/deployments/:id/approve — Release a pending_approval deployment
+//
+// Also the target of the Approve button on the deployments page: a form caller
+// (anything not sending JSON) is redirected back to the deployment instead of
+// being shown a JSON blob, since every page here must work with JavaScript
+// disabled. The user-only gate below is the same one either way.
+deploymentApp.post("/:id/approve", async (c) => {
+  const logger = routeLogger(c);
+
+  // Approval is a gate agent identities cannot pass: a `stratum_agent_` token
+  // sets `agentId` and never `userId`. The guarantee this buys is exactly "not
+  // an agent identity" — a user's scoped API token and an MCP OAuth grant both
+  // set `userId` and are accepted, so it is NOT evidence of a human at a
+  // keyboard. Same gate, and same stated limitation, as `reviews.ts`.
+  const userId = c.get("userId");
+  if (!userId) return unauthorized("Only authenticated users can approve a deployment");
+
+  const loaded = await loadDeployment(c, logger);
+  if ("response" in loaded) return loaded.response;
+  const { deployment, project } = loaded;
+
+  if (!(await canWriteProject(c.env.DB, project, userId))) {
+    return forbidden("Project access denied");
+  }
+
+  const queue = c.env.DEPLOY_QUEUE;
+  if (!queue) {
+    // Checked before the status flip: a row moved to `queued` with nothing to
+    // pick it up is unreachable — `claimDeployment` only ever runs from a queue
+    // message — and approval is not repeatable once the row has left
+    // `pending_approval`.
+    return appError(
+      new AppError(
+        "Deployments are not enabled on this instance (DEPLOY_QUEUE is not configured)",
+        "DEPLOY_QUEUE_UNAVAILABLE",
+        503,
+      ),
+    );
+  }
+
+  const result = await approveDeployment(c.env.DB, logger, {
+    projectId: project.id,
+    deploymentId: deployment.id,
+    approvedBy: userId,
+  });
+  if (!result.success) return appError(result.error);
+
+  if (!result.data.approved) {
+    if (result.data.reason === "not_found") return notFound("Deployment", deployment.id);
+    // The conditional UPDATE is what makes a double-approve safe: the second
+    // caller lands here instead of enqueueing the same commit twice.
+    return appError(
+      new AppError(
+        `Deployment is ${deployment.status}, not awaiting approval`,
+        "DEPLOYMENT_NOT_PENDING",
+        409,
+      ),
+    );
+  }
+  const approved = result.data.deployment;
+
+  const message: DeployQueueMessage = {
+    kind: "deployment",
+    projectId: project.id,
+    deploymentId: approved.id,
+  };
+  try {
+    await queue.send(message);
+  } catch (error) {
+    logger.error(
+      "Deployment was approved but could not be enqueued",
+      error instanceof Error ? error : undefined,
+      { deploymentId: approved.id, projectId: project.id },
+    );
+    return internalError("Deployment was approved but could not be queued; retry it");
+  }
+
+  await recordAudit(c.env.DB, logger, {
+    action: "deployment.approved",
+    actorType: "user",
+    actorId: userId,
+    subject: approved.id,
+    detail: {
+      project: project.name,
+      name: approved.name,
+      commitSha: approved.commitSha,
+      attempt: approved.attempt,
+    },
+  });
+
+  if (!wantsJson(c)) {
+    return c.redirect(`/${project.namespace}/${project.slug}/deployments/${approved.id}`, 302);
+  }
+  return ok({ deployment: toResponse(approved, true) });
+});
+
+// POST /api/deployments/:id/retry — Re-run the same commit as a new attempt
+//
+// Also the target of the Retry button. As with approve, a form caller gets a
+// redirect and a JSON caller gets the row; the terminal-status check below is
+// what keeps a retry from routing around the approval gate, and there is one
+// copy of it.
+deploymentApp.post("/:id/retry", async (c) => {
+  const logger = routeLogger(c);
+  const userId = c.get("userId");
+  const agentId = c.get("agentId");
+  const agentOwnerId = c.get("agentOwnerId");
+
+  const loaded = await loadDeployment(c, logger);
+  if ("response" in loaded) return loaded.response;
+  const { deployment, project } = loaded;
+
+  if (!(await canWriteProject(c.env.DB, project, userId, agentOwnerId))) {
+    return forbidden("Project access denied");
+  }
+
+  if (!isTerminal(deployment.status)) {
+    // A `queued`, `running` or `pending_approval` row still has a future. A new
+    // attempt alongside it would publish the same commit twice — and, for
+    // `pending_approval`, would route around the approval gate entirely, since
+    // the new row starts `queued`.
+    return appError(
+      new AppError(
+        `Deployment is ${deployment.status}; only a finished deployment can be retried`,
+        "DEPLOYMENT_NOT_RETRYABLE",
+        409,
+      ),
+    );
+  }
+
+  const queue = c.env.DEPLOY_QUEUE;
+  if (!queue) {
+    return appError(
+      new AppError(
+        "Deployments are not enabled on this instance (DEPLOY_QUEUE is not configured)",
+        "DEPLOY_QUEUE_UNAVAILABLE",
+        503,
+      ),
+    );
+  }
+
+  const inserted = await insertDeployment(c.env.DB, logger, {
+    projectId: project.id,
+    project: project.name,
+    // The change id is carried over deliberately: it is what lets the runner
+    // re-check that the change was not reverted between the original deploy and
+    // this retry. Dropping it would turn a retry into the one path that can
+    // publish reverted code.
+    changeId: deployment.changeId ?? null,
+    commitSha: deployment.commitSha,
+    name: deployment.name,
+    target: deployment.target,
+    attempt: deployment.attempt + 1,
+    status: "queued",
+    requestedByType: agentId ? "agent" : "user",
+    requestedById: agentId ?? userId ?? null,
+  });
+  if (!inserted.success) return appError(inserted.error);
+
+  if (!inserted.data.inserted) {
+    // The unique index on (project, name, commit, attempt) already holds this
+    // attempt — someone retried first, and their row is the live one.
+    return appError(
+      new AppError(
+        `Attempt ${deployment.attempt + 1} of this deployment already exists`,
+        "DEPLOYMENT_RETRY_EXISTS",
+        409,
+      ),
+    );
+  }
+  const retry = inserted.data.deployment;
+
+  const message: DeployQueueMessage = {
+    kind: "deployment",
+    projectId: project.id,
+    deploymentId: retry.id,
+  };
+  try {
+    await queue.send(message);
+  } catch (error) {
+    logger.error(
+      "Retry row was created but could not be enqueued",
+      error instanceof Error ? error : undefined,
+      { deploymentId: retry.id, projectId: project.id },
+    );
+    return internalError("Retry was recorded but could not be queued; try again");
+  }
+
+  await recordAudit(c.env.DB, logger, {
+    action: "deployment.retried",
+    actorType: agentId ? "agent" : "user",
+    actorId: agentId ?? userId,
+    subject: retry.id,
+    detail: {
+      project: project.name,
+      name: retry.name,
+      commitSha: retry.commitSha,
+      attempt: retry.attempt,
+      retryOf: deployment.id,
+    },
+  });
+
+  if (!wantsJson(c)) {
+    return c.redirect(`/${project.namespace}/${project.slug}/deployments/${retry.id}`, 302);
+  }
+  return ok({ deployment: toResponse(retry, true) }, 201);
+});
+
+export { projectApp as projectDeploymentsRouter, deploymentApp as deploymentsRouter };

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -15,6 +15,7 @@ import { recordAudit } from "../storage/audit";
 import { listComments, listReviews } from "../storage/change-reviews";
 import { getChange, listChanges } from "../storage/changes";
 import { getChangeCostSummary } from "../storage/costs";
+import { type Deployment, getDeployment, listDeployments } from "../storage/deployments";
 import { listEvalRuns } from "../storage/eval-runs";
 import { listProjectEvents } from "../storage/events";
 import type { RefResolutionFailure } from "../storage/git-ops";
@@ -34,6 +35,7 @@ import { getLabelsForIssues, listIssueLabels } from "../storage/issue-labels";
 import { getIssueByNumber, listIssues } from "../storage/issues";
 import { type OAuthGrantSummary, listGrantsForUser, revokeGrantForUser } from "../storage/oauth";
 import { ownerHasClaims } from "../storage/project-namespace";
+import { listSecretNames } from "../storage/project-secrets";
 import { getProvenance } from "../storage/provenance";
 import { readRepoSnapshot } from "../storage/repo-snapshot";
 import {
@@ -62,6 +64,7 @@ import { ActivityPage } from "../ui/pages/activity";
 import { BranchesPage } from "../ui/pages/branches";
 import { ChangeDetailPage } from "../ui/pages/change-detail";
 import { ChangesPage } from "../ui/pages/changes";
+import { DeploymentDetailPage, DeploymentsPage } from "../ui/pages/deployments";
 import { ErrorPage } from "../ui/pages/error";
 import { FileViewerPage } from "../ui/pages/file-viewer";
 import { HomePage } from "../ui/pages/home";
@@ -85,6 +88,7 @@ import type { AppError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
 import { createLogger } from "../utils/logger";
 import { isValidNamespace, isValidSlug } from "../utils/validation";
+import { canManageSecrets, secretErrorMessage } from "./deployments";
 import { DEFAULT_COMMENTS_PAGE, DEFAULT_ISSUES_PAGE } from "./issues";
 import { SUBSCRIBABLE_EVENTS } from "./webhooks";
 
@@ -103,6 +107,20 @@ const projectRef = (project: ProjectEntry) => ({
   slug: project.slug,
   ...(project.visibility !== undefined ? { visibility: project.visibility } : {}),
 });
+
+/**
+ * Drops `logTail` for anyone who cannot write to the project.
+ *
+ * It holds a redacted provider payload, and redaction is literal-substring
+ * matching a public-project reader should not get to probe. The JSON API strips
+ * the same field on the same rule (`toResponse` in routes/deployments.ts); the
+ * page never assumes the field is present either way.
+ */
+function stripLogTail(deployment: Deployment, canWrite: boolean): Deployment {
+  if (canWrite) return deployment;
+  const { logTail: _logTail, ...rest } = deployment;
+  return rest;
+}
 
 // Helper to get current user info
 async function getCurrentUser(
@@ -2038,6 +2056,107 @@ app.get("/:namespace/:slug/sync", async (c) => {
   );
 });
 
+/**
+ * Loads a project for a page that has already validated `:namespace`/`:slug`,
+ * answering the shared 404 page on any failure so a caller can `return` it
+ * directly.
+ */
+async function loadProjectPage(
+  c: Context<{ Bindings: Env }>,
+  logger: Logger,
+): Promise<{ project: ProjectEntry; user: PageUser } | { response: Response }> {
+  const namespace = c.req.param("namespace") ?? "";
+  const slug = c.req.param("slug") ?? "";
+  const [user, projectResult] = await Promise.all([
+    getCurrentUser(c, logger),
+    getProjectByPath(c.env.STATE, namespace, slug, logger),
+  ]);
+  if (!projectResult.success) {
+    return {
+      response: await c.html(
+        errorPage(404, `Project '${namespace}/${slug}' not found.`, user),
+        404,
+      ),
+    };
+  }
+  return { project: projectResult.data, user };
+}
+
+// GET /:namespace/:slug/deployments — Post-merge deploy history
+//
+// Readable by anyone who can read the project, like Activity. `logTail` is the
+// one field that is not: it carries a redacted provider payload, so it is
+// stripped for non-writers here exactly as `GET /api/.../deployments` strips it.
+app.get("/:namespace/:slug/deployments", async (c) => {
+  const { namespace, slug } = c.req.param();
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const logger = createLogger({ path: c.req.path, userId });
+
+  if (!isValidNamespace(namespace) || !isValidSlug(slug)) return c.notFound();
+
+  const loaded = await loadProjectPage(c, logger);
+  if ("response" in loaded) return loaded.response;
+  const { project, user } = loaded;
+
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
+    return c.html(errorPage(404, `Project '${namespace}/${slug}' not found.`, user), 404);
+  }
+  const canWrite = await canWriteProject(c.env.DB, project, userId, agentOwnerId);
+
+  const result = await listDeployments(c.env.DB, logger, { projectId: project.id });
+  if (!result.success) {
+    logger.error("Failed to list deployments", result.error);
+    return c.html(errorPage(500, "Error loading deployments. Please try again.", user), 500);
+  }
+
+  return c.html(
+    <DeploymentsPage
+      project={projectRef(project)}
+      deployments={result.data.map((deployment) => stripLogTail(deployment, canWrite))}
+      canWrite={canWrite}
+      user={user}
+    />,
+  );
+});
+
+// GET /:namespace/:slug/deployments/:id — One attempt, with its log tail
+app.get("/:namespace/:slug/deployments/:id", async (c) => {
+  const { namespace, slug, id } = c.req.param();
+  const userId = c.get("userId");
+  const agentOwnerId = c.get("agentOwnerId");
+  const logger = createLogger({ path: c.req.path, userId });
+
+  if (!isValidNamespace(namespace) || !isValidSlug(slug)) return c.notFound();
+
+  const loaded = await loadProjectPage(c, logger);
+  if ("response" in loaded) return loaded.response;
+  const { project, user } = loaded;
+
+  if (!(await canReadProject(c.env.DB, project, userId, agentOwnerId))) {
+    return c.html(errorPage(404, `Project '${namespace}/${slug}' not found.`, user), 404);
+  }
+  const canWrite = await canWriteProject(c.env.DB, project, userId, agentOwnerId);
+
+  const result = await getDeployment(c.env.DB, logger, { projectId: project.id, deploymentId: id });
+  if (!result.success) {
+    logger.error("Failed to get deployment", result.error);
+    return c.html(errorPage(500, "Error loading deployment. Please try again.", user), 500);
+  }
+  if (!result.data) {
+    return c.html(errorPage(404, `Deployment '${id}' not found.`, user), 404);
+  }
+
+  return c.html(
+    <DeploymentDetailPage
+      project={projectRef(project)}
+      deployment={stripLogTail(result.data, canWrite)}
+      canWrite={canWrite}
+      user={user}
+    />,
+  );
+});
+
 // GET /:namespace/:slug/settings — Project settings (writers only; danger zone owner-only)
 app.get("/:namespace/:slug/settings", async (c) => {
   const { namespace, slug } = c.req.param();
@@ -2065,6 +2184,22 @@ app.get("/:namespace/:slug/settings", async (c) => {
   const isOwner = project.ownerType === "user" && project.ownerId === userId;
   const sourceUrl = getProjectSourceUrl(project);
 
+  // Deploy credentials are admin-only *and* refused to agent identities, which
+  // is stricter than the write access the rest of this page needs. The rule
+  // itself lives with the routes that enforce it, so what this page renders and
+  // what those routes allow cannot drift apart.
+  const showSecrets = await canManageSecrets(c.env.DB, project, {
+    userId,
+    agentId: c.get("agentId"),
+  });
+  const secretsResult = showSecrets ? await listSecretNames(c.env.DB, logger, project.id) : null;
+  if (secretsResult && !secretsResult.success) {
+    logger.error("Failed to list project secrets", secretsResult.error);
+  }
+  // The secret forms post to the API router and come back here with the reason
+  // as a fixed code; anything not in that closed set resolves to no message.
+  const secretError = secretErrorMessage(c.req.query("secretError"));
+
   return c.html(
     <ProjectSettingsPage
       project={{
@@ -2073,6 +2208,9 @@ app.get("/:namespace/:slug/settings", async (c) => {
         ...(sourceUrl !== undefined ? { sourceUrl } : {}),
       }}
       isOwner={isOwner}
+      canManageSecrets={showSecrets}
+      secrets={secretsResult?.success ? secretsResult.data : []}
+      {...(secretError !== undefined ? { secretError } : {})}
       user={userResult}
     />,
   );

--- a/src/routes/ui.tsx
+++ b/src/routes/ui.tsx
@@ -2210,6 +2210,7 @@ app.get("/:namespace/:slug/settings", async (c) => {
       isOwner={isOwner}
       canManageSecrets={showSecrets}
       secrets={secretsResult?.success ? secretsResult.data : []}
+      secretsUnavailable={secretsResult !== null && !secretsResult.success}
       {...(secretError !== undefined ? { secretError } : {})}
       user={userResult}
     />,

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { StratumEvent } from "../queue/events";
 import { recordAudit } from "../storage/audit";
 import { getProjectByPath } from "../storage/state";
 import {
@@ -24,26 +25,38 @@ const MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
 
 const app = new Hono<{ Bindings: Env }>();
 
-/** Event types a webhook may subscribe to. */
-const SUBSCRIBABLE_EVENTS = [
-  "change.created",
-  "change.evaluated",
-  "change.merged",
-  "change.rejected",
-  "change.reverted",
-  "change.commented",
-  "change.reviewed",
-  "project.created",
-  "project.imported",
-  "workspace.created",
-  "sync.completed",
-  "issue.opened",
-  "issue.commented",
-  "issue.closed",
-  "deployment.requested",
-  "deployment.succeeded",
-  "deployment.failed",
-];
+/**
+ * Event types a webhook may subscribe to.
+ *
+ * Keyed by `StratumEvent["type"]` rather than written as a bare string array so
+ * the two cannot drift: adding a variant to the event union without listing it
+ * here is a missing-property error, and listing a type the union does not have
+ * is an excess-property error. Both fail the build instead of silently making
+ * an event unsubscribable (or advertising one that can never fire).
+ *
+ * Object key order is the order the list is rendered and reported in.
+ */
+const SUBSCRIBABLE_EVENT_TYPES: Record<StratumEvent["type"], true> = {
+  "change.created": true,
+  "change.evaluated": true,
+  "change.merged": true,
+  "change.rejected": true,
+  "change.reverted": true,
+  "change.commented": true,
+  "change.reviewed": true,
+  "project.created": true,
+  "project.imported": true,
+  "workspace.created": true,
+  "sync.completed": true,
+  "issue.opened": true,
+  "issue.commented": true,
+  "issue.closed": true,
+  "deployment.requested": true,
+  "deployment.succeeded": true,
+  "deployment.failed": true,
+};
+
+const SUBSCRIBABLE_EVENTS: string[] = Object.keys(SUBSCRIBABLE_EVENT_TYPES);
 
 interface ProjectAccess {
   project: ProjectEntry;

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -40,6 +40,9 @@ const SUBSCRIBABLE_EVENTS = [
   "issue.opened",
   "issue.commented",
   "issue.closed",
+  "deployment.requested",
+  "deployment.succeeded",
+  "deployment.failed",
 ];
 
 interface ProjectAccess {

--- a/src/storage/audit.ts
+++ b/src/storage/audit.ts
@@ -34,7 +34,13 @@ export type AuditAction =
   // so "which editor did I connect, and when did I disconnect it" is answerable
   // from the trail rather than only from the live grant list.
   | "oauth.authorized"
-  | "oauth.revoked";
+  | "oauth.revoked"
+  // Post-merge deployments. The secret entries record only the name — the value
+  // is never read back anywhere, and an audit row is not the place to start.
+  | "secret.written"
+  | "secret.deleted"
+  | "deployment.approved"
+  | "deployment.retried";
 
 export interface AuditEntry {
   id: string;

--- a/src/storage/d1-backup.ts
+++ b/src/storage/d1-backup.ts
@@ -53,6 +53,13 @@ export const BACKUP_TABLES: readonly string[] = [
   "audit_log",
   "deletion_jobs",
   "commit_metrics",
+  // Post-merge deployments (migration 047). `project_secrets` holds the
+  // encrypted provider credentials and is the only copy that exists — the
+  // plaintext was never stored and no route can read one back, so a restore
+  // without it means every deploying project is silently broken until each
+  // token is re-pasted by hand. Both declare no foreign keys, so order is free.
+  "project_secrets",
+  "deployments",
 ];
 
 /**

--- a/src/storage/d1-backup.ts
+++ b/src/storage/d1-backup.ts
@@ -58,6 +58,15 @@ export const BACKUP_TABLES: readonly string[] = [
   // plaintext was never stored and no route can read one back, so a restore
   // without it means every deploying project is silently broken until each
   // token is re-pasted by hand. Both declare no foreign keys, so order is free.
+  //
+  // RESTORE DEPENDENCY: these rows are ciphertext only. They are decryptable
+  // *solely* by the `DEPLOY_SECRET_KEY` in force when they were written — that
+  // key is a Wrangler secret and is NOT in any backup. Restoring these rows
+  // into an instance with a different (or missing) key yields rows that look
+  // present in the UI but fail every deploy with "Could not decrypt project
+  // secret…". Preserve `DEPLOY_SECRET_KEY` alongside the backups, or plan on
+  // every project re-entering its secrets after the restore. See
+  // `docs/runbooks/backup-restore.md`.
   "project_secrets",
   "deployments",
 ];

--- a/src/storage/deletion.ts
+++ b/src/storage/deletion.ts
@@ -60,7 +60,21 @@ const PROJECT_SCOPED_TABLES = [
   "cost_records",
   "commit_metrics",
   "issues",
+  "deployments",
 ] as const;
+
+/**
+ * Project-scoped tables that postdate migration 025 and therefore have NO bare
+ * `project` name column — they were never written by the pre-025 code paths, so
+ * `project_id` is the only identifier a row can carry. They need their own list
+ * because the name-form fallback above would be a `no such column: project`
+ * error here, which the cascade would report as a failed deletion.
+ *
+ * `project_secrets` holds encrypted production credentials. Omitting it would
+ * leave a deleted project's provider tokens in D1 permanently, reachable by no
+ * UI and cleaned up by nothing.
+ */
+const PROJECT_ID_ONLY_TABLES = ["project_secrets"] as const;
 
 /** Tables keyed by the globally-unique (namespace, slug) tuple. */
 const NS_SLUG_TABLES = ["sync_history", "import_jobs", "import_metrics", "failed_imports"] as const;
@@ -438,6 +452,13 @@ export async function deleteProjectCascade(
     for (const table of PROJECT_SCOPED_TABLES) {
       await deleteProjectScopedTable(env.DB, table, target, residuals);
     }
+    // Unaffected by nameCollision: with no `project` column there is no way for
+    // a row of another tenant's to be selected by name in the first place.
+    for (const table of PROJECT_ID_ONLY_TABLES) {
+      await env.DB.prepare(`DELETE FROM ${table} WHERE project_id = ?`)
+        .bind(target.projectId)
+        .run();
+    }
 
     // 2) Tables keyed by the globally-unique (namespace, slug) tuple.
     for (const table of NS_SLUG_TABLES) {
@@ -585,6 +606,13 @@ export async function verifyProjectDeleted(
       if (n > 0) residuals.push(`d1:${table}:${n}-rows`);
     }
 
+    for (const table of PROJECT_ID_ONLY_TABLES) {
+      const n = await countRows(env.DB, `SELECT COUNT(*) AS n FROM ${table} WHERE project_id = ?`, [
+        target.projectId,
+      ]);
+      if (n > 0) residuals.push(`d1:${table}:${n}-rows`);
+    }
+
     for (const table of NS_SLUG_TABLES) {
       const n = await countRows(
         env.DB,
@@ -634,6 +662,17 @@ const IDENTITY_COLUMNS: readonly [table: string, column: string][] = [
   ["change_reviews", "reviewer_id"],
   ["webhooks", "created_by"],
   ["changes", "agent_id"],
+  // Deploy rows survive an erasure whenever the project is org-owned, so the
+  // "who rotated this credential" and "who approved this production deploy"
+  // trails would otherwise keep naming a deleted account indefinitely. The
+  // secret VALUES are not touched here — those go with the project cascade,
+  // which is the only thing that may destroy another tenant's deploy config.
+  ["project_secrets", "created_by"],
+  ["project_secrets", "updated_by"],
+  // Only matches a user id; a deployment requested by an agent carries that
+  // agent's id under requested_by_type = 'agent' and is left alone.
+  ["deployments", "requested_by_id"],
+  ["deployments", "approved_by"],
 ];
 
 /**

--- a/src/storage/deployments.ts
+++ b/src/storage/deployments.ts
@@ -78,9 +78,25 @@ export type DeploymentTarget = DeployTargetName | typeof UNRESOLVED_TARGET;
 /**
  * How long a claim holds the row before another consumer may reclaim it.
  *
- * Must not exceed the deploy queue's `visibility_timeout_ms`: a redelivery that
- * arrived while the lease was still valid could not claim the row and the
- * deployment would stall until the message was exhausted.
+ * This sits in the middle of an ordering that must not be disturbed:
+ *
+ * ```
+ * DEPLOY_ATTEMPT_DEADLINE_MS < DEFAULT_DEPLOY_LEASE_MS
+ *                           <= visibility_timeout_ms (wrangler.toml)
+ *                           <= QUEUE_CONSUMER_WALL_MS
+ * ```
+ *
+ * The upper bounds keep a redelivery from arriving while the lease is still
+ * valid, which would leave the deployment unclaimable until the message was
+ * exhausted. The lower bound is what makes the lease *safe*: the runner
+ * (`src/deploy/limits.ts`) gives up strictly before the lease can expire, so an
+ * expired lease means no runner is alive rather than "the first runner is still
+ * uploading". Without it {@link claimDeployment} can hand a genuinely running
+ * row to a second consumer and the same commit deploys twice.
+ *
+ * The three companion constants live in `src/deploy/limits.ts` and are not
+ * imported here on purpose — storage does not depend on the deploy package —
+ * so the ordering is asserted in the test suite instead.
  */
 export const DEFAULT_DEPLOY_LEASE_MS = 15 * 60 * 1000;
 

--- a/src/storage/deployments.ts
+++ b/src/storage/deployments.ts
@@ -11,12 +11,16 @@
  *    racing the same row cannot both win. It is the *only* place a stale
  *    `running` row is reclaimed, and only the deploy consumer may call it.
  *
- * Every timestamp is an application-written ISO 8601 string. `datetime('now')`
- * produces `YYYY-MM-DD HH:MM:SS`, which sorts before the ISO form as TEXT
- * (' ' 0x20 < 'T' 0x54); a column mixing the two silently breaks every range
- * comparison, and `lease_expires_at` is range-compared on the claim path.
- * Mixing formats there would either strand a deployment forever or let a
- * consumer reclaim a live one and deploy the same commit twice. See
+ * Every timestamp is an application-written ISO 8601 string, canonicalised to
+ * UTC with a millisecond fraction by {@link resolveTimestamp} before it is
+ * bound. These columns are compared as TEXT, so a column holding more than one
+ * spelling of an instant sorts by bytes rather than by time: `datetime('now')`
+ * produces `YYYY-MM-DD HH:MM:SS`, which sorts before the ISO form (' ' 0x20 <
+ * 'T' 0x54) and is rejected outright, while an offset or fraction-less ISO form
+ * is accepted and rewritten. Either would break `lease_expires_at`, which is
+ * range-compared on the claim path — stranding a deployment forever or letting a
+ * consumer reclaim a live one and deploy the same commit twice — and
+ * `created_at`, which decides which of two merges publishes over the other. See
  * `migrations/042_api_tokens.sql`.
  *
  * Every query is scoped on `project_id` and never on the bare `project` name:
@@ -111,6 +115,12 @@ const DEFAULT_LIST_LIMIT = 50;
  * format that would silently corrupt `lease_expires_at` comparisons —
  * SQLite's `YYYY-MM-DD HH:MM:SS` — is also the one a caller is most likely to
  * reach for.
+ *
+ * This admits more than one spelling of the same instant on purpose (`Z` or a
+ * `±HH:MM` offset, with or without a fraction). Accepting them is safe *only*
+ * because {@link resolveTimestamp} rewrites every one to the canonical UTC form
+ * before it reaches a column; widening this pattern without that step would put
+ * text back into the columns whose byte order is not chronological.
  */
 const ISO_8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 
@@ -123,6 +133,14 @@ const ISO_8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\
  * one definition of the format: a value that passes here is one
  * {@link insertDeployment} cannot reject, so no queue message can strand a
  * deploy on a timestamp that only fails at the last step.
+ *
+ * It deliberately only *validates*. Canonicalisation belongs at the storage
+ * boundary ({@link resolveTimestamp}) and nowhere else: a message in transit is
+ * never compared against a column, so normalising it early would add a second
+ * place that has to agree on the canonical form while fixing nothing. A guard
+ * also cannot return a rewritten value without ceasing to be a guard, and
+ * callers here (`resolveMergeTime`, `mergeTimeOf`) want to pass the operator's
+ * own timestamp through untouched.
  */
 export function isIsoTimestamp(value: unknown): value is string {
   return typeof value === "string" && ISO_8601.test(value) && !Number.isNaN(Date.parse(value));
@@ -264,13 +282,36 @@ function isUniqueViolation(error: unknown): boolean {
   return error instanceof Error && /UNIQUE constraint failed/i.test(error.message);
 }
 
-/** Validates a caller-supplied timestamp, or mints one, so no non-ISO value can reach a column. */
+/**
+ * Validates a caller-supplied timestamp and rewrites it to the one canonical
+ * form, or mints one, so no value whose byte order disagrees with its
+ * chronological order can reach a column.
+ *
+ * Validating alone is not enough. {@link ISO_8601} admits several spellings of a
+ * single instant, and SQLite compares these columns as TEXT, so storing the
+ * caller's spelling verbatim makes lexical order diverge from time order:
+ * `...T17:20:43-04:00` sorts *before* the identical instant written
+ * `...T21:20:43.000Z` (`1` < `2`), and `...T21:20:43Z` sorts *after*
+ * `...T21:20:43.000Z` (`.` 0x2E < `Z` 0x5A). Both comparisons that guard a
+ * deploy read this order: `created_at` in {@link supersedeOlder} and
+ * {@link findNewerSucceededDeployment} — which decide whether an older commit
+ * may publish over a newer one — and `lease_expires_at <= now` in
+ * {@link claimDeployment}, which decides whether a lease is dead. `created_at`
+ * in particular now carries the merge time, which arrives over the queue from a
+ * different code path than the one that wrote the rows it is compared against,
+ * so the two spellings genuinely do meet in one column.
+ *
+ * `Date#toISOString` gives UTC with a fixed-width millisecond fraction, so every
+ * accepted input collapses to a single fixed-width representation and byte order
+ * *is* chronological order.
+ */
 function resolveTimestamp(
   value: string | undefined,
   field: string,
 ): Result<string, ValidationError> {
   if (value === undefined) return ok(new Date().toISOString());
-  if (!ISO_8601.test(value) || Number.isNaN(Date.parse(value))) {
+  const parsed = Date.parse(value);
+  if (!ISO_8601.test(value) || Number.isNaN(parsed)) {
     return err(
       new ValidationError(
         `${field} must be an ISO 8601 timestamp (e.g. 2026-09-04T00:00:00.000Z); SQLite's 'YYYY-MM-DD HH:MM:SS' form sorts differently and breaks lease comparisons`,
@@ -278,7 +319,7 @@ function resolveTimestamp(
       ),
     );
   }
-  return ok(value);
+  return ok(new Date(parsed).toISOString());
 }
 
 function isTerminal(status: DeploymentStatus): status is TerminalDeploymentStatus {

--- a/src/storage/deployments.ts
+++ b/src/storage/deployments.ts
@@ -1,0 +1,981 @@
+/**
+ * Storage for post-merge deployments.
+ *
+ * The `deployments` row *is* the lease. Two properties of this module are load
+ * bearing and neither is visible from a casual read of the SQL:
+ *
+ * 1. {@link insertDeployment} never checks before it inserts. The unique index
+ *    `ux_deployments_attempt` is the mutual exclusion — see the comment on that
+ *    function before "simplifying" it into a SELECT-then-INSERT.
+ * 2. {@link claimDeployment} is a single conditional UPDATE, so two consumers
+ *    racing the same row cannot both win. It is the *only* place a stale
+ *    `running` row is reclaimed, and only the deploy consumer may call it.
+ *
+ * Every timestamp is an application-written ISO 8601 string. `datetime('now')`
+ * produces `YYYY-MM-DD HH:MM:SS`, which sorts before the ISO form as TEXT
+ * (' ' 0x20 < 'T' 0x54); a column mixing the two silently breaks every range
+ * comparison, and `lease_expires_at` is range-compared on the claim path.
+ * Mixing formats there would either strand a deployment forever or let a
+ * consumer reclaim a live one and deploy the same commit twice. See
+ * `migrations/042_api_tokens.sql`.
+ *
+ * Every query is scoped on `project_id` and never on the bare `project` name:
+ * names are not globally unique, so matching on one crosses tenants (see
+ * `webhookBelongsToProject` in `./webhooks.ts`).
+ */
+import type { DeployTargetName } from "../evaluation/types";
+import { AppError, ValidationError } from "../utils/errors";
+import { newId } from "../utils/ids";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+
+/** Every status the `status` CHECK in migration 047 admits. */
+export const DEPLOYMENT_STATUSES = [
+  "pending_approval",
+  "queued",
+  "running",
+  "succeeded",
+  "failed",
+  "superseded",
+  "skipped",
+] as const;
+
+export type DeploymentStatus = (typeof DEPLOYMENT_STATUSES)[number];
+
+/**
+ * Statuses from which no further transition happens. A deployment that reaches
+ * one holds no lease, and {@link completeDeployment} refuses to overwrite it —
+ * a runner that lost its lease must not clobber the result written by the
+ * consumer that reclaimed the row.
+ */
+export const TERMINAL_DEPLOYMENT_STATUSES = [
+  "succeeded",
+  "failed",
+  "superseded",
+  "skipped",
+] as const;
+
+export type TerminalDeploymentStatus = (typeof TERMINAL_DEPLOYMENT_STATUSES)[number];
+
+/** Which kind of identity asked for this deployment. */
+export type DeploymentRequesterType = "user" | "agent" | "system";
+
+/**
+ * `target` for a row that never selected a provider: a rejected `deploys:`
+ * entry, a tree that could not be read at the merge commit, or a merge with no
+ * deploy configured at all. Those rows exist to make the failure visible, and
+ * the column is NOT NULL.
+ *
+ * Deliberately *not* a member of `DeployTargetName`: that type keys the target
+ * registry as a total `Record`, so adding a sentinel there would force every
+ * dispatch site to handle a case that never dispatches.
+ */
+export const UNRESOLVED_TARGET = "unresolved";
+
+/** What `deployments.target` can hold: a real provider, or {@link UNRESOLVED_TARGET}. */
+export type DeploymentTarget = DeployTargetName | typeof UNRESOLVED_TARGET;
+
+/**
+ * How long a claim holds the row before another consumer may reclaim it.
+ *
+ * Must not exceed the deploy queue's `visibility_timeout_ms`: a redelivery that
+ * arrived while the lease was still valid could not claim the row and the
+ * deployment would stall until the message was exhausted.
+ */
+export const DEFAULT_DEPLOY_LEASE_MS = 15 * 60 * 1000;
+
+/** Default `reason` stamped on a row superseded by a newer merge. */
+export const SUPERSEDED_REASON = "Superseded by a newer deployment of the same name";
+
+const MAX_LIST_LIMIT = 200;
+const DEFAULT_LIST_LIMIT = 50;
+
+/**
+ * ISO 8601 with the `T` separator. Enforced rather than assumed because the one
+ * format that would silently corrupt `lease_expires_at` comparisons —
+ * SQLite's `YYYY-MM-DD HH:MM:SS` — is also the one a caller is most likely to
+ * reach for.
+ */
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * Is this a timestamp every column in this module will accept?
+ *
+ * Exported because the merge time now travels through the queue
+ * (`DeployQueueMessage`) before it reaches a column, and the producer and the
+ * runner both have to decide whether to trust it. Sharing this predicate keeps
+ * one definition of the format: a value that passes here is one
+ * {@link insertDeployment} cannot reject, so no queue message can strand a
+ * deploy on a timestamp that only fails at the last step.
+ */
+export function isIsoTimestamp(value: unknown): value is string {
+  return typeof value === "string" && ISO_8601.test(value) && !Number.isNaN(Date.parse(value));
+}
+
+/** One deployment attempt, as every reader outside this module sees it. */
+export interface Deployment {
+  id: string;
+  /** Canonical project id. The only thing project scoping ever consults. */
+  projectId: string;
+  /** Bare project name, mirrored so the project-deletion cascade matches on either form. */
+  project: string;
+  /** Absent for a deploy not traceable to a change, such as a retry of an older commit. */
+  changeId?: string;
+  commitSha: string;
+  name: string;
+  target: DeploymentTarget;
+  attempt: number;
+  status: DeploymentStatus;
+  reason?: string;
+  url?: string;
+  /** Redacted, truncated provider error payload. Serve only to project writers. */
+  logTail?: string;
+  durationMs?: number;
+  leaseExpiresAt?: string;
+  requestedByType: DeploymentRequesterType;
+  requestedById?: string;
+  approvedBy?: string;
+  /**
+   * **The merge this deployment publishes, not the moment the row was written.**
+   *
+   * Cloudflare Queues promise no ordering and a retry reorders outright, so
+   * stamping this when the message was *processed* let a late-delivered older
+   * merge sort after a newer one — and publish over it. Every consumer of
+   * deployment order (`listDeployments`, {@link supersedeOlder},
+   * {@link findNewerSucceededDeployment}) reads this column, so it has to carry
+   * merge order or none of them mean anything.
+   *
+   * A retry is the deliberate exception: it stamps the current time, because an
+   * operator re-running an old commit is asserting it is the newest intent.
+   */
+  createdAt: string;
+  startedAt?: string;
+  completedAt?: string;
+}
+
+/**
+ * Outcome of racing the unique index. `inserted: false` is a *success* — the
+ * caller lost a legitimate race — and is deliberately not an error, so a
+ * genuine database failure stays distinguishable from a duplicate.
+ */
+export type InsertDeploymentOutcome =
+  | { inserted: true; deployment: Deployment }
+  | {
+      inserted: false;
+      /** The row that already holds this `(project_id, name, commit_sha, attempt)`, if still readable. */
+      existing: Deployment | null;
+    };
+
+/** Outcome of a claim attempt. Only `claimed: true` grants the right to deploy. */
+export type ClaimDeploymentOutcome =
+  | { claimed: true; deployment: Deployment }
+  | { claimed: false; reason: "not_found" | "not_claimable" };
+
+interface DeploymentRow {
+  id: string;
+  project_id: string;
+  project: string;
+  change_id: string | null;
+  commit_sha: string;
+  name: string;
+  target: string;
+  attempt: number;
+  status: string;
+  reason: string | null;
+  url: string | null;
+  log_tail: string | null;
+  duration_ms: number | null;
+  lease_expires_at: string | null;
+  requested_by_type: string;
+  requested_by_id: string | null;
+  approved_by: string | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+const DEPLOYMENT_SELECT =
+  "SELECT id, project_id, project, change_id, commit_sha, name, target, attempt, status, " +
+  "reason, url, log_tail, duration_ms, lease_expires_at, requested_by_type, requested_by_id, " +
+  "approved_by, created_at, started_at, completed_at FROM deployments";
+
+function rowToDeployment(row: DeploymentRow): Deployment {
+  const deployment: Deployment = {
+    id: row.id,
+    projectId: row.project_id,
+    project: row.project,
+    commitSha: row.commit_sha,
+    name: row.name,
+    target: row.target as DeploymentTarget,
+    attempt: row.attempt,
+    status: row.status as DeploymentStatus,
+    requestedByType: row.requested_by_type as DeploymentRequesterType,
+    createdAt: row.created_at,
+  };
+  if (row.change_id !== null) deployment.changeId = row.change_id;
+  if (row.reason !== null) deployment.reason = row.reason;
+  if (row.url !== null) deployment.url = row.url;
+  if (row.log_tail !== null) deployment.logTail = row.log_tail;
+  if (row.duration_ms !== null) deployment.durationMs = row.duration_ms;
+  if (row.lease_expires_at !== null) deployment.leaseExpiresAt = row.lease_expires_at;
+  if (row.requested_by_id !== null) deployment.requestedById = row.requested_by_id;
+  if (row.approved_by !== null) deployment.approvedBy = row.approved_by;
+  if (row.started_at !== null) deployment.startedAt = row.started_at;
+  if (row.completed_at !== null) deployment.completedAt = row.completed_at;
+  return deployment;
+}
+
+function toAppError(error: unknown, operation: string, context: Record<string, unknown>): AppError {
+  return error instanceof AppError
+    ? error
+    : new AppError(
+        error instanceof Error ? error.message : `Failed in ${operation}`,
+        "DATABASE_ERROR",
+        500,
+        { operation, ...context },
+      );
+}
+
+/**
+ * Is this the unique index rejecting a duplicate attempt, or a real failure?
+ *
+ * Matched on the message because neither D1 nor `node:sqlite` exposes a
+ * structured constraint code; D1 prefixes its message with `D1_ERROR:`, hence
+ * the substring match rather than an equality check. Same approach as
+ * `isUniqueViolation` in `./deletion-jobs.ts`.
+ */
+function isUniqueViolation(error: unknown): boolean {
+  return error instanceof Error && /UNIQUE constraint failed/i.test(error.message);
+}
+
+/** Validates a caller-supplied timestamp, or mints one, so no non-ISO value can reach a column. */
+function resolveTimestamp(
+  value: string | undefined,
+  field: string,
+): Result<string, ValidationError> {
+  if (value === undefined) return ok(new Date().toISOString());
+  if (!ISO_8601.test(value) || Number.isNaN(Date.parse(value))) {
+    return err(
+      new ValidationError(
+        `${field} must be an ISO 8601 timestamp (e.g. 2026-09-04T00:00:00.000Z); SQLite's 'YYYY-MM-DD HH:MM:SS' form sorts differently and breaks lease comparisons`,
+        { field, value },
+      ),
+    );
+  }
+  return ok(value);
+}
+
+function isTerminal(status: DeploymentStatus): status is TerminalDeploymentStatus {
+  return (TERMINAL_DEPLOYMENT_STATUSES as readonly string[]).includes(status);
+}
+
+async function readDeployment(
+  db: D1Database,
+  projectId: string,
+  deploymentId: string,
+): Promise<Deployment | null> {
+  const row = await db
+    .prepare(`${DEPLOYMENT_SELECT} WHERE id = ? AND project_id = ?`)
+    .bind(deploymentId, projectId)
+    .first<DeploymentRow>();
+  return row ? rowToDeployment(row) : null;
+}
+
+/**
+ * Inserts a deployment attempt, letting the database decide who owns it.
+ *
+ * **This is the mutual exclusion for a deploy.** It does not look for an
+ * existing row first: two consumers handling the same merge would both pass
+ * such a check and both insert, because there is no transaction spanning the
+ * read and the write across isolates. Instead both INSERT against
+ * `ux_deployments_attempt` on `(project_id, name, commit_sha, attempt)` and
+ * exactly one wins; the loser gets `inserted: false`, which means "someone else
+ * already owns this deployment" and is a normal outcome, not a failure. Only a
+ * genuine database fault comes back through the `err` channel.
+ *
+ * A retry inserts the same commit with `attempt + 1`, which is a different key
+ * and is therefore admitted.
+ *
+ * @param opts.projectId - Canonical project id; never a project name
+ * @param opts.project - Bare project name, mirrored for the deletion cascade
+ * @param opts.status - Starting status; defaults to `queued`. A terminal status
+ *   (a rejected `deploys:` entry lands as `failed`) also stamps `completed_at`.
+ * @param opts.createdAt - What `created_at` should hold: the **merge time** for
+ *   a merge-triggered deploy, so the row sorts by merge order rather than by
+ *   whenever the queue happened to deliver its message. Defaults to `now`,
+ *   which is what a retry wants — see {@link Deployment.createdAt}.
+ * @param opts.now - Injected clock, ISO 8601. Defaults to the current time.
+ */
+export async function insertDeployment(
+  db: D1Database,
+  logger: Logger,
+  opts: {
+    projectId: string;
+    project: string;
+    changeId?: string | null;
+    commitSha: string;
+    name: string;
+    target: DeploymentTarget;
+    attempt?: number;
+    status?: DeploymentStatus;
+    reason?: string | null;
+    url?: string | null;
+    logTail?: string | null;
+    durationMs?: number | null;
+    requestedByType: DeploymentRequesterType;
+    requestedById?: string | null;
+    approvedBy?: string | null;
+    createdAt?: string;
+    now?: string;
+  },
+): Promise<Result<InsertDeploymentOutcome, AppError>> {
+  const nowResult = resolveTimestamp(opts.now, "now");
+  if (!nowResult.success) return err(nowResult.error);
+  const now = nowResult.data;
+  const createdAtResult = resolveTimestamp(opts.createdAt ?? now, "createdAt");
+  if (!createdAtResult.success) return err(createdAtResult.error);
+  const createdAt = createdAtResult.data;
+
+  const id = newId("dep");
+  const attempt = opts.attempt ?? 1;
+  const status: DeploymentStatus = opts.status ?? "queued";
+  const completedAt = isTerminal(status) ? now : null;
+
+  try {
+    await db
+      .prepare(
+        "INSERT INTO deployments (id, project_id, project, change_id, commit_sha, name, target, " +
+          "attempt, status, reason, url, log_tail, duration_ms, requested_by_type, " +
+          "requested_by_id, approved_by, created_at, completed_at) " +
+          "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      )
+      .bind(
+        id,
+        opts.projectId,
+        opts.project,
+        opts.changeId ?? null,
+        opts.commitSha,
+        opts.name,
+        opts.target,
+        attempt,
+        status,
+        opts.reason ?? null,
+        opts.url ?? null,
+        opts.logTail ?? null,
+        opts.durationMs ?? null,
+        opts.requestedByType,
+        opts.requestedById ?? null,
+        opts.approvedBy ?? null,
+        createdAt,
+        completedAt,
+      )
+      .run();
+
+    const deployment: Deployment = {
+      id,
+      projectId: opts.projectId,
+      project: opts.project,
+      commitSha: opts.commitSha,
+      name: opts.name,
+      target: opts.target,
+      attempt,
+      status,
+      requestedByType: opts.requestedByType,
+      createdAt,
+    };
+    if (opts.changeId) deployment.changeId = opts.changeId;
+    if (opts.reason) deployment.reason = opts.reason;
+    if (opts.url) deployment.url = opts.url;
+    if (opts.logTail) deployment.logTail = opts.logTail;
+    if (opts.durationMs !== undefined && opts.durationMs !== null) {
+      deployment.durationMs = opts.durationMs;
+    }
+    if (opts.requestedById) deployment.requestedById = opts.requestedById;
+    if (opts.approvedBy) deployment.approvedBy = opts.approvedBy;
+    if (completedAt) deployment.completedAt = completedAt;
+
+    logger.info("Deployment row created", {
+      deploymentId: id,
+      projectId: opts.projectId,
+      name: opts.name,
+      commitSha: opts.commitSha,
+      attempt,
+      status,
+      createdAt,
+    });
+    return ok({ inserted: true, deployment });
+  } catch (error) {
+    if (!isUniqueViolation(error)) {
+      const appError = toAppError(error, "insertDeployment", { projectId: opts.projectId });
+      logger.error("Failed to create deployment row", appError, {
+        projectId: opts.projectId,
+        name: opts.name,
+        commitSha: opts.commitSha,
+        attempt,
+      });
+      return err(appError);
+    }
+
+    logger.info("Deployment already owned by another consumer", {
+      projectId: opts.projectId,
+      name: opts.name,
+      commitSha: opts.commitSha,
+      attempt,
+    });
+
+    try {
+      const row = await db
+        .prepare(
+          `${DEPLOYMENT_SELECT} WHERE project_id = ? AND name = ? AND commit_sha = ? AND attempt = ?`,
+        )
+        .bind(opts.projectId, opts.name, opts.commitSha, attempt)
+        .first<DeploymentRow>();
+      return ok({ inserted: false, existing: row ? rowToDeployment(row) : null });
+    } catch (readError) {
+      // The insert result is already known — losing the read-back only costs the
+      // caller the winner's id, so report the duplicate rather than an error.
+      logger.warn("Could not read back the winning deployment row", {
+        projectId: opts.projectId,
+        name: opts.name,
+        error: readError instanceof Error ? readError.message : String(readError),
+      });
+      return ok({ inserted: false, existing: null });
+    }
+  }
+}
+
+/**
+ * Claims a deployment for execution, taking a lease on it. **Deploy consumer
+ * only.**
+ *
+ * The single conditional UPDATE is the whole point: the `WHERE` clause and the
+ * write happen atomically, so of two consumers holding the same message exactly
+ * one sees `meta.changes > 0`. Splitting this into a read followed by a write
+ * reintroduces the race it exists to close, after which the same commit deploys
+ * twice.
+ *
+ * A row is claimable when it is `queued`, or when it is `running` with a lease
+ * that has already expired — a consumer that died mid-deploy must not strand
+ * the deployment forever. Reclamation lives here and nowhere else: doing it on
+ * a read path would let a page view flip a live deployment to `failed`, and a
+ * retry would then deploy the same commit a second time.
+ *
+ * `pending_approval` is deliberately not claimable. Approval moves the row to
+ * `queued` and enqueues it; a consumer must never run an unapproved deploy.
+ *
+ * @param opts.leaseMs - Lease duration; defaults to {@link DEFAULT_DEPLOY_LEASE_MS}
+ * @param opts.now - Injected clock, ISO 8601. Defaults to the current time.
+ */
+export async function claimDeployment(
+  db: D1Database,
+  logger: Logger,
+  opts: {
+    projectId: string;
+    deploymentId: string;
+    leaseMs?: number;
+    now?: string;
+  },
+): Promise<Result<ClaimDeploymentOutcome, AppError>> {
+  const nowResult = resolveTimestamp(opts.now, "now");
+  if (!nowResult.success) return err(nowResult.error);
+  const now = nowResult.data;
+
+  const leaseMs = opts.leaseMs ?? DEFAULT_DEPLOY_LEASE_MS;
+  if (!Number.isFinite(leaseMs) || leaseMs <= 0) {
+    return err(
+      new ValidationError("leaseMs must be a positive number of milliseconds", { leaseMs }),
+    );
+  }
+  const leaseExpiresAt = new Date(Date.parse(now) + leaseMs).toISOString();
+
+  try {
+    const updated = await db
+      .prepare(
+        "UPDATE deployments SET status = 'running', started_at = COALESCE(started_at, ?), " +
+          "lease_expires_at = ? WHERE id = ? AND project_id = ? AND (" +
+          "status = 'queued' OR " +
+          "(status = 'running' AND lease_expires_at IS NOT NULL AND lease_expires_at <= ?))",
+      )
+      .bind(now, leaseExpiresAt, opts.deploymentId, opts.projectId, now)
+      .run();
+
+    if (updated.meta.changes === 0) {
+      const existing = await readDeployment(db, opts.projectId, opts.deploymentId);
+      if (!existing) {
+        logger.warn("Deployment not found for claim", {
+          deploymentId: opts.deploymentId,
+          projectId: opts.projectId,
+        });
+        return ok({ claimed: false, reason: "not_found" });
+      }
+      logger.info("Deployment not claimable", {
+        deploymentId: opts.deploymentId,
+        projectId: opts.projectId,
+        status: existing.status,
+        leaseExpiresAt: existing.leaseExpiresAt,
+      });
+      return ok({ claimed: false, reason: "not_claimable" });
+    }
+
+    const claimed = await readDeployment(db, opts.projectId, opts.deploymentId);
+    if (!claimed) {
+      const appError = new AppError(
+        "Deployment disappeared immediately after being claimed",
+        "DATABASE_ERROR",
+        500,
+        { operation: "claimDeployment", deploymentId: opts.deploymentId },
+      );
+      logger.error("Failed to read back claimed deployment", appError, {
+        deploymentId: opts.deploymentId,
+      });
+      return err(appError);
+    }
+
+    logger.info("Deployment claimed", {
+      deploymentId: opts.deploymentId,
+      projectId: opts.projectId,
+      leaseExpiresAt,
+    });
+    return ok({ claimed: true, deployment: claimed });
+  } catch (error) {
+    const appError = toAppError(error, "claimDeployment", {
+      deploymentId: opts.deploymentId,
+      projectId: opts.projectId,
+    });
+    logger.error("Failed to claim deployment", appError, {
+      deploymentId: opts.deploymentId,
+      projectId: opts.projectId,
+    });
+    return err(appError);
+  }
+}
+
+/**
+ * Writes a deployment's terminal status and releases its lease.
+ *
+ * Refuses to overwrite a row that is already terminal, so a runner whose lease
+ * expired mid-deploy cannot clobber the result written by the consumer that
+ * reclaimed the row. `false` therefore means "this row is no longer yours" —
+ * the caller should log it rather than retry.
+ *
+ * `lease_expires_at` is always cleared: a finished deployment holding a lease
+ * would look reclaimable to the next consumer that read it.
+ *
+ * @returns `true` when a row was written, `false` when the row was missing,
+ *   in another project, or already terminal.
+ */
+export async function completeDeployment(
+  db: D1Database,
+  logger: Logger,
+  opts: {
+    projectId: string;
+    deploymentId: string;
+    status: TerminalDeploymentStatus;
+    reason?: string | null;
+    url?: string | null;
+    logTail?: string | null;
+    durationMs?: number | null;
+    completedAt?: string;
+  },
+): Promise<Result<boolean, AppError>> {
+  const completedAtResult = resolveTimestamp(opts.completedAt, "completedAt");
+  if (!completedAtResult.success) return err(completedAtResult.error);
+  const completedAt = completedAtResult.data;
+
+  const terminalList = TERMINAL_DEPLOYMENT_STATUSES.map(() => "?").join(", ");
+
+  try {
+    const result = await db
+      .prepare(
+        `UPDATE deployments SET status = ?, reason = ?, url = ?, log_tail = ?, duration_ms = ?, completed_at = ?, lease_expires_at = NULL WHERE id = ? AND project_id = ? AND status NOT IN (${terminalList})`,
+      )
+      .bind(
+        opts.status,
+        opts.reason ?? null,
+        opts.url ?? null,
+        opts.logTail ?? null,
+        opts.durationMs ?? null,
+        completedAt,
+        opts.deploymentId,
+        opts.projectId,
+        ...TERMINAL_DEPLOYMENT_STATUSES,
+      )
+      .run();
+
+    const written = result.meta.changes > 0;
+    if (written) {
+      logger.info("Deployment completed", {
+        deploymentId: opts.deploymentId,
+        projectId: opts.projectId,
+        status: opts.status,
+      });
+    } else {
+      logger.warn("Deployment was already terminal or not in this project", {
+        deploymentId: opts.deploymentId,
+        projectId: opts.projectId,
+        status: opts.status,
+      });
+    }
+    return ok(written);
+  } catch (error) {
+    const appError = toAppError(error, "completeDeployment", {
+      deploymentId: opts.deploymentId,
+      projectId: opts.projectId,
+    });
+    logger.error("Failed to complete deployment", appError, {
+      deploymentId: opts.deploymentId,
+      projectId: opts.projectId,
+    });
+    return err(appError);
+  }
+}
+
+/**
+ * Marks every older not-yet-started deployment of the same `(projectId, name)`
+ * as `superseded`.
+ *
+ * Called by the consumer immediately before it runs. Without it, two merges in
+ * quick succession can land in either order and the *older* commit can be the
+ * one left in production — the queue makes no ordering promise.
+ *
+ * The comparison is on `created_at`, which carries **merge order** and not
+ * delivery order (see {@link Deployment.createdAt}); comparing delivery order
+ * here would retire the newer commit whenever the queue reordered two messages.
+ * This only reaches rows that have not started, so it cannot help once the
+ * newer deploy is already `succeeded` — {@link findNewerSucceededDeployment} is
+ * the half that covers that.
+ *
+ * Only `queued` and `pending_approval` rows are touched. A `running` row is
+ * left alone: it is either live, or expired and reclaimable by
+ * {@link claimDeployment}, and superseding it here would abandon a deploy that
+ * is still uploading.
+ *
+ * @param opts.createdAt - The keeper's `created_at`; rows at or before it are
+ *   superseded. A row sharing the exact timestamp is a genuine race, and the
+ *   keeper is the one that reached the consumer.
+ * @returns How many rows were superseded.
+ */
+export async function supersedeOlder(
+  db: D1Database,
+  logger: Logger,
+  opts: {
+    projectId: string;
+    name: string;
+    keepDeploymentId: string;
+    createdAt: string;
+    reason?: string;
+    now?: string;
+  },
+): Promise<Result<number, AppError>> {
+  const createdAtResult = resolveTimestamp(opts.createdAt, "createdAt");
+  if (!createdAtResult.success) return err(createdAtResult.error);
+  const nowResult = resolveTimestamp(opts.now, "now");
+  if (!nowResult.success) return err(nowResult.error);
+
+  try {
+    const result = await db
+      .prepare(
+        "UPDATE deployments SET status = 'superseded', reason = ?, completed_at = ?, " +
+          "lease_expires_at = NULL WHERE project_id = ? AND name = ? AND id != ? " +
+          "AND created_at <= ? AND status IN ('queued', 'pending_approval')",
+      )
+      .bind(
+        opts.reason ?? SUPERSEDED_REASON,
+        nowResult.data,
+        opts.projectId,
+        opts.name,
+        opts.keepDeploymentId,
+        createdAtResult.data,
+      )
+      .run();
+
+    const superseded = result.meta.changes;
+    if (superseded > 0) {
+      logger.info("Superseded older deployments", {
+        projectId: opts.projectId,
+        name: opts.name,
+        keepDeploymentId: opts.keepDeploymentId,
+        superseded,
+      });
+    }
+    return ok(superseded);
+  } catch (error) {
+    const appError = toAppError(error, "supersedeOlder", {
+      projectId: opts.projectId,
+      name: opts.name,
+    });
+    logger.error("Failed to supersede older deployments", appError, {
+      projectId: opts.projectId,
+      name: opts.name,
+    });
+    return err(appError);
+  }
+}
+
+/**
+ * The newest already-`succeeded` deployment of the same name that this one would
+ * publish *over*, or `null` when there is none.
+ *
+ * This is the half of ordering that {@link supersedeOlder} cannot cover. That
+ * function only touches rows which have not started, so once the newer merge has
+ * already reached `succeeded` it retires nothing — and a late-delivered older
+ * merge would then deploy straight over the newer commit. Cloudflare Queues
+ * promise no ordering and a retry reorders outright, so "the older message
+ * arrives second" is a routine delivery, not a rare race.
+ *
+ * The comparison is strictly greater-than on purpose. Equal timestamps are
+ * either siblings of one merge (different `name`, so they never match here) or a
+ * retry stamped in the same millisecond as the row it retries; refusing on
+ * equality would make that retry unrunnable for no gain.
+ *
+ * @param opts.createdAt - The candidate's merge time; anything succeeded strictly
+ *   after it wins
+ * @param opts.excludeDeploymentId - The candidate itself, which must never count
+ *   as its own superseder
+ */
+export async function findNewerSucceededDeployment(
+  db: D1Database,
+  logger: Logger,
+  opts: {
+    projectId: string;
+    name: string;
+    createdAt: string;
+    excludeDeploymentId: string;
+  },
+): Promise<Result<Deployment | null, AppError>> {
+  const createdAtResult = resolveTimestamp(opts.createdAt, "createdAt");
+  if (!createdAtResult.success) return err(createdAtResult.error);
+
+  try {
+    const row = await db
+      .prepare(
+        `${DEPLOYMENT_SELECT} WHERE project_id = ? AND name = ? AND id != ? AND status = 'succeeded' AND created_at > ? ORDER BY created_at DESC, id DESC LIMIT 1`,
+      )
+      .bind(opts.projectId, opts.name, opts.excludeDeploymentId, createdAtResult.data)
+      .first<DeploymentRow>();
+    return ok(row ? rowToDeployment(row) : null);
+  } catch (error) {
+    const appError = toAppError(error, "findNewerSucceededDeployment", {
+      projectId: opts.projectId,
+      name: opts.name,
+    });
+    logger.error("Failed to look for a newer succeeded deployment", appError, {
+      projectId: opts.projectId,
+      name: opts.name,
+    });
+    return err(appError);
+  }
+}
+
+/**
+ * Lists a project's deployments, newest first.
+ *
+ * Newest first by **merge time** (see {@link Deployment.createdAt}), so the
+ * commit that is actually live sorts to the top even when the queue delivered
+ * its message second.
+ *
+ * `name` then `id` break ties on `created_at`. `name` is the one that matters to
+ * a reader: the deploys fanned out from a single merge are stamped from that
+ * merge's timestamp, so they *always* tie, and with only `id` behind them a
+ * random hex string decided the order of every row on the page — the same
+ * deployments rendered in a different order on each request. `id` stays as the
+ * final tiebreaker to keep paging stable, since two rows can share both a
+ * timestamp and a name across attempts.
+ *
+ * @param opts.projectId - Canonical project id; a bare project name would cross tenants
+ * @param opts.name - Optional deploy name filter (`production`, `staging`, ...)
+ */
+export async function listDeployments(
+  db: D1Database,
+  logger: Logger,
+  opts: {
+    projectId: string;
+    name?: string;
+    status?: DeploymentStatus;
+    limit?: number;
+    offset?: number;
+  },
+): Promise<Result<Deployment[], AppError>> {
+  const limit = Math.min(Math.max(Math.trunc(opts.limit ?? DEFAULT_LIST_LIMIT), 1), MAX_LIST_LIMIT);
+  const offset = Math.max(Math.trunc(opts.offset ?? 0), 0);
+
+  const conditions = ["project_id = ?"];
+  const binds: unknown[] = [opts.projectId];
+  if (opts.name !== undefined) {
+    conditions.push("name = ?");
+    binds.push(opts.name);
+  }
+  if (opts.status !== undefined) {
+    conditions.push("status = ?");
+    binds.push(opts.status);
+  }
+
+  try {
+    const result = await db
+      .prepare(
+        `${DEPLOYMENT_SELECT} WHERE ${conditions.join(" AND ")} ORDER BY created_at DESC, name ASC, id DESC LIMIT ? OFFSET ?`,
+      )
+      .bind(...binds, limit, offset)
+      .all<DeploymentRow>();
+    return ok(result.results.map(rowToDeployment));
+  } catch (error) {
+    const appError = toAppError(error, "listDeployments", { projectId: opts.projectId });
+    logger.error("Failed to list deployments", appError, { projectId: opts.projectId });
+    return err(appError);
+  }
+}
+
+/**
+ * Reads one deployment, scoped to its project.
+ *
+ * @returns The deployment, or `null` when it does not exist *or* belongs to
+ *   another project — the two are indistinguishable on purpose, so a probe
+ *   cannot confirm an id in a project the caller cannot read.
+ */
+export async function getDeployment(
+  db: D1Database,
+  logger: Logger,
+  opts: { projectId: string; deploymentId: string },
+): Promise<Result<Deployment | null, AppError>> {
+  try {
+    return ok(await readDeployment(db, opts.projectId, opts.deploymentId));
+  } catch (error) {
+    const appError = toAppError(error, "getDeployment", {
+      deploymentId: opts.deploymentId,
+      projectId: opts.projectId,
+    });
+    logger.error("Failed to get deployment", appError, {
+      deploymentId: opts.deploymentId,
+      projectId: opts.projectId,
+    });
+    return err(appError);
+  }
+}
+
+/**
+ * Outcome of an approval attempt. Only `approved: true` enqueues — see
+ * {@link approveDeployment} for why that distinction is the whole safety
+ * property.
+ */
+export type ApproveDeploymentOutcome =
+  | { approved: true; deployment: Deployment }
+  | { approved: false; reason: "not_found" | "not_pending" };
+
+/**
+ * Moves an approved deployment from `pending_approval` to `queued`, stamping
+ * who approved it.
+ *
+ * Without this the approval gate is a dead end: {@link claimDeployment}
+ * deliberately refuses `pending_approval`, so a row that is never moved out of
+ * it can never be claimed and the deployment hangs forever.
+ *
+ * The conditional UPDATE is what makes a double-approve safe. Two concurrent
+ * approvals of the same row both target `status = 'pending_approval'`, so
+ * exactly one sees `meta.changes > 0`; only that caller may enqueue, and the
+ * commit therefore cannot deploy twice. A read-then-write would let both
+ * callers observe `pending_approval` and both enqueue.
+ *
+ * @param opts.approvedBy - The approving user id, recorded on the row
+ * @param opts.now - Injected clock, ISO 8601. Defaults to the current time.
+ */
+export async function approveDeployment(
+  db: D1Database,
+  logger: Logger,
+  opts: {
+    projectId: string;
+    deploymentId: string;
+    approvedBy: string;
+    now?: string;
+  },
+): Promise<Result<ApproveDeploymentOutcome, AppError>> {
+  const nowResult = resolveTimestamp(opts.now, "now");
+  if (!nowResult.success) return err(nowResult.error);
+
+  try {
+    const updated = await db
+      .prepare(
+        "UPDATE deployments SET status = 'queued', approved_by = ? " +
+          "WHERE id = ? AND project_id = ? AND status = 'pending_approval'",
+      )
+      .bind(opts.approvedBy, opts.deploymentId, opts.projectId)
+      .run();
+
+    if (updated.meta.changes === 0) {
+      const existing = await readDeployment(db, opts.projectId, opts.deploymentId);
+      if (!existing) {
+        logger.warn("Deployment not found for approval", {
+          deploymentId: opts.deploymentId,
+          projectId: opts.projectId,
+        });
+        return ok({ approved: false, reason: "not_found" });
+      }
+      logger.info("Deployment is not awaiting approval", {
+        deploymentId: opts.deploymentId,
+        projectId: opts.projectId,
+        status: existing.status,
+      });
+      return ok({ approved: false, reason: "not_pending" });
+    }
+
+    const approved = await readDeployment(db, opts.projectId, opts.deploymentId);
+    if (!approved) {
+      const appError = new AppError(
+        "Deployment disappeared immediately after being approved",
+        "DATABASE_ERROR",
+        500,
+        { operation: "approveDeployment", deploymentId: opts.deploymentId },
+      );
+      logger.error("Failed to read back approved deployment", appError, {
+        deploymentId: opts.deploymentId,
+      });
+      return err(appError);
+    }
+
+    logger.info("Deployment approved", {
+      deploymentId: opts.deploymentId,
+      projectId: opts.projectId,
+      approvedBy: opts.approvedBy,
+    });
+    return ok({ approved: true, deployment: approved });
+  } catch (error) {
+    const appError = toAppError(error, "approveDeployment", {
+      deploymentId: opts.deploymentId,
+      projectId: opts.projectId,
+    });
+    logger.error("Failed to approve deployment", appError, {
+      deploymentId: opts.deploymentId,
+      projectId: opts.projectId,
+    });
+    return err(appError);
+  }
+}
+
+/**
+ * Reads one deployment without knowing its project.
+ *
+ * Exists only for `GET|POST /api/deployments/:id`, whose URL carries no
+ * project: the row's own `project_id` is what the route then authorizes
+ * against. **It performs no access control** — every caller must check the
+ * returned `projectId` before revealing anything, including whether the id
+ * exists.
+ *
+ * Every other read stays project-scoped ({@link getDeployment}), so this is the
+ * one query that could cross tenants if a caller forgot that check.
+ */
+export async function findDeploymentById(
+  db: D1Database,
+  logger: Logger,
+  deploymentId: string,
+): Promise<Result<Deployment | null, AppError>> {
+  try {
+    const row = await db
+      .prepare(`${DEPLOYMENT_SELECT} WHERE id = ?`)
+      .bind(deploymentId)
+      .first<DeploymentRow>();
+    return ok(row ? rowToDeployment(row) : null);
+  } catch (error) {
+    const appError = toAppError(error, "findDeploymentById", { deploymentId });
+    logger.error("Failed to find deployment", appError, { deploymentId });
+    return err(appError);
+  }
+}

--- a/src/storage/project-secrets.ts
+++ b/src/storage/project-secrets.ts
@@ -1,0 +1,345 @@
+/**
+ * Per-project encrypted secret store, backing deploy provider credentials.
+ *
+ * Write-only by construction: the only function that yields a plaintext value is
+ * {@link loadSecretValues}, which exists for the deploy runner and is deliberately
+ * not reachable from any route. Everything else returns names and metadata.
+ */
+import type { Env } from "../types";
+import { type SecretScope, decryptSecret, deriveSecretKey, encryptSecret } from "../utils/crypto";
+import { AppError, ValidationError } from "../utils/errors";
+import { newId } from "../utils/ids";
+import type { Logger } from "../utils/logger";
+import { type Result, err, ok } from "../utils/result";
+
+/**
+ * Environment-shaped uppercase name, so a secret maps cleanly onto the provider
+ * environment variables the deploy targets expect. The 64-character bound keeps
+ * a name inside the AAD and the log-redaction paths without truncation.
+ */
+export const SECRET_NAME_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
+
+/**
+ * Cap on a secret's UTF-8 length. Generous for every credential the three deploy
+ * targets accept (API tokens, account ids), while keeping a project's whole
+ * secret set well inside one D1 row-size budget.
+ *
+ * There is deliberately no *minimum*: some providers legitimately accept an
+ * empty value, and rejecting one would only push operators to store a
+ * placeholder that reads like a real credential.
+ */
+export const MAX_SECRET_VALUE_BYTES = 4096;
+
+/**
+ * Error code raised when `DEPLOY_SECRET_KEY` is unset. Distinct from a generic
+ * database failure because it is an operator misconfiguration with a specific
+ * remedy, and the deploy runner reports it verbatim on the failed deployment.
+ */
+export const DEPLOY_SECRET_KEY_MISSING = "DEPLOY_SECRET_KEY_MISSING";
+
+/** A secret as anyone other than the deploy runner may ever see it. */
+export interface ProjectSecretSummary {
+  name: string;
+  createdBy: string;
+  updatedBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Outcome of resolving a deploy's declared secret names. */
+export interface LoadedSecrets {
+  /** Name to plaintext, for the names that resolved. */
+  values: Map<string, string>;
+  /** Requested names with no row in this project. */
+  missing: string[];
+  /**
+   * Rows that exist but failed AES-GCM authentication — `DEPLOY_SECRET_KEY` was
+   * rotated, or the ciphertext was moved between projects or names. Reported
+   * apart from `missing` because the remedy differs: re-enter the value versus
+   * restore the key.
+   */
+  undecryptable: string[];
+}
+
+type SecretKeyEnv = Pick<Env, "DEPLOY_SECRET_KEY">;
+
+interface SecretRow {
+  name: string;
+  ciphertext: string;
+  created_by: string;
+  updated_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToSummary(row: Omit<SecretRow, "ciphertext">): ProjectSecretSummary {
+  return {
+    name: row.name,
+    createdBy: row.created_by,
+    updatedBy: row.updated_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function toAppError(error: unknown, operation: string, context: Record<string, unknown>): AppError {
+  return error instanceof AppError
+    ? error
+    : new AppError(
+        error instanceof Error ? error.message : `Failed in ${operation}`,
+        "DATABASE_ERROR",
+        500,
+        { operation, ...context },
+      );
+}
+
+function validateName(name: string): ValidationError | null {
+  if (SECRET_NAME_PATTERN.test(name)) return null;
+  return new ValidationError(
+    "Secret name must match ^[A-Z][A-Z0-9_]{0,63}$ (uppercase letter first, then letters, digits, or underscores)",
+    { name },
+  );
+}
+
+function validateValue(value: string): ValidationError | null {
+  const bytes = new TextEncoder().encode(value).length;
+  if (bytes <= MAX_SECRET_VALUE_BYTES) return null;
+  return new ValidationError(`Secret value exceeds ${MAX_SECRET_VALUE_BYTES} bytes`, {
+    bytes,
+    limit: MAX_SECRET_VALUE_BYTES,
+  });
+}
+
+/**
+ * Resolves the derived AES key, or a typed error when the instance is not
+ * configured for deploys. Returned as a value rather than thrown so a route can
+ * render an actionable 500 and the deploy runner can write a named failure.
+ */
+async function resolveKey(env: SecretKeyEnv): Promise<Result<CryptoKey, AppError>> {
+  const secret = env.DEPLOY_SECRET_KEY;
+  if (!secret) {
+    return err(
+      new AppError(
+        "DEPLOY_SECRET_KEY is not configured; deploy secrets cannot be encrypted or decrypted",
+        DEPLOY_SECRET_KEY_MISSING,
+        500,
+      ),
+    );
+  }
+  try {
+    return ok(await deriveSecretKey(secret));
+  } catch (error) {
+    return err(toAppError(error, "deriveSecretKey", {}));
+  }
+}
+
+/**
+ * Creates or replaces a project's secret, returning only its metadata.
+ *
+ * An overwrite keeps `created_by`/`created_at` and stamps `updated_by`, so a
+ * second admin rotating another admin's credential stays attributable.
+ *
+ * @param env - Needs `DEPLOY_SECRET_KEY`
+ * @param opts.projectId - Canonical project id; never a project name
+ * @param opts.actorId - The user performing the write
+ */
+export async function putSecret(
+  db: D1Database,
+  logger: Logger,
+  env: SecretKeyEnv,
+  opts: { projectId: string; name: string; value: string; actorId: string },
+): Promise<Result<ProjectSecretSummary, AppError>> {
+  const nameError = validateName(opts.name);
+  if (nameError) return err(nameError);
+  const valueError = validateValue(opts.value);
+  if (valueError) return err(valueError);
+
+  const keyResult = await resolveKey(env);
+  if (!keyResult.success) {
+    logger.error("Cannot store project secret", keyResult.error, {
+      projectId: opts.projectId,
+      name: opts.name,
+    });
+    return err(keyResult.error);
+  }
+
+  const scope: SecretScope = { projectId: opts.projectId, name: opts.name };
+  const now = new Date().toISOString();
+
+  try {
+    const ciphertext = await encryptSecret(opts.value, keyResult.data, scope);
+
+    await db
+      .prepare(
+        "INSERT INTO project_secrets (id, project_id, name, ciphertext, created_by, updated_by, created_at, updated_at) " +
+          "VALUES (?, ?, ?, ?, ?, ?, ?, ?) " +
+          "ON CONFLICT(project_id, name) DO UPDATE SET ciphertext = excluded.ciphertext, updated_by = excluded.updated_by, updated_at = excluded.updated_at",
+      )
+      .bind(
+        newId("psec"),
+        opts.projectId,
+        opts.name,
+        ciphertext,
+        opts.actorId,
+        opts.actorId,
+        now,
+        now,
+      )
+      .run();
+
+    const row = await db
+      .prepare(
+        "SELECT name, created_by, updated_by, created_at, updated_at FROM project_secrets WHERE project_id = ? AND name = ?",
+      )
+      .bind(opts.projectId, opts.name)
+      .first<Omit<SecretRow, "ciphertext">>();
+
+    if (!row) {
+      const appError = new AppError(
+        "Secret disappeared immediately after being written",
+        "DATABASE_ERROR",
+        500,
+        { operation: "putSecret", projectId: opts.projectId },
+      );
+      logger.error("Failed to read back project secret", appError, { projectId: opts.projectId });
+      return err(appError);
+    }
+
+    logger.info("Project secret stored", { projectId: opts.projectId, name: opts.name });
+    return ok(rowToSummary(row));
+  } catch (error) {
+    const appError = toAppError(error, "putSecret", { projectId: opts.projectId });
+    logger.error("Failed to store project secret", appError, {
+      projectId: opts.projectId,
+      name: opts.name,
+    });
+    return err(appError);
+  }
+}
+
+/**
+ * Lists a project's secret names and metadata. Never returns a value.
+ *
+ * Scoped on `project_id` alone — a bare project name collides across
+ * namespaces, so matching on it would let a same-named project in another
+ * tenant enumerate these credentials (see `webhookBelongsToProject`).
+ */
+export async function listSecretNames(
+  db: D1Database,
+  logger: Logger,
+  projectId: string,
+): Promise<Result<ProjectSecretSummary[], AppError>> {
+  try {
+    const result = await db
+      .prepare(
+        "SELECT name, created_by, updated_by, created_at, updated_at FROM project_secrets WHERE project_id = ? ORDER BY name ASC",
+      )
+      .bind(projectId)
+      .all<Omit<SecretRow, "ciphertext">>();
+    return ok(result.results.map(rowToSummary));
+  } catch (error) {
+    const appError = toAppError(error, "listSecretNames", { projectId });
+    logger.error("Failed to list project secrets", appError, { projectId });
+    return err(appError);
+  }
+}
+
+/**
+ * Deletes one secret.
+ *
+ * @returns `true` when a row was removed, `false` when the project had no such
+ *   secret — so a route can answer 404 without a preceding read.
+ */
+export async function deleteSecret(
+  db: D1Database,
+  logger: Logger,
+  opts: { projectId: string; name: string },
+): Promise<Result<boolean, AppError>> {
+  const nameError = validateName(opts.name);
+  if (nameError) return err(nameError);
+
+  try {
+    const result = await db
+      .prepare("DELETE FROM project_secrets WHERE project_id = ? AND name = ?")
+      .bind(opts.projectId, opts.name)
+      .run();
+    const deleted = result.meta.changes > 0;
+    if (deleted)
+      logger.info("Project secret deleted", { projectId: opts.projectId, name: opts.name });
+    return ok(deleted);
+  } catch (error) {
+    const appError = toAppError(error, "deleteSecret", { projectId: opts.projectId });
+    logger.error("Failed to delete project secret", appError, {
+      projectId: opts.projectId,
+      name: opts.name,
+    });
+    return err(appError);
+  }
+}
+
+/**
+ * Resolves plaintext secret values for the deploy runner. **The only read path
+ * for a value anywhere in the codebase** — do not call it from a route.
+ *
+ * Derives the AES key once for the whole batch: PBKDF2 at 100k iterations is CPU
+ * work and the deploy consumer runs under a CPU limit, so per-secret derivation
+ * would put a multi-secret deploy at risk of being cut off mid-run.
+ *
+ * Unresolvable names are reported rather than thrown, so the runner can name the
+ * offender on the failed deployment row.
+ */
+export async function loadSecretValues(
+  db: D1Database,
+  logger: Logger,
+  env: SecretKeyEnv,
+  opts: { projectId: string; names: readonly string[] },
+): Promise<Result<LoadedSecrets, AppError>> {
+  const wanted = [...new Set(opts.names)];
+  if (wanted.length === 0) {
+    return ok({ values: new Map(), missing: [], undecryptable: [] });
+  }
+
+  const keyResult = await resolveKey(env);
+  if (!keyResult.success) {
+    logger.error("Cannot load project secrets", keyResult.error, { projectId: opts.projectId });
+    return err(keyResult.error);
+  }
+
+  try {
+    const placeholders = wanted.map(() => "?").join(", ");
+    const result = await db
+      .prepare(
+        `SELECT name, ciphertext FROM project_secrets WHERE project_id = ? AND name IN (${placeholders})`,
+      )
+      .bind(opts.projectId, ...wanted)
+      .all<Pick<SecretRow, "name" | "ciphertext">>();
+
+    const values = new Map<string, string>();
+    const undecryptable: string[] = [];
+    for (const row of result.results) {
+      const plaintext = await decryptSecret(row.ciphertext, keyResult.data, {
+        projectId: opts.projectId,
+        name: row.name,
+      });
+      if (plaintext === null) undecryptable.push(row.name);
+      else values.set(row.name, plaintext);
+    }
+
+    const found = new Set(result.results.map((row) => row.name));
+    const missing = wanted.filter((name) => !found.has(name));
+
+    if (missing.length > 0 || undecryptable.length > 0) {
+      logger.warn("Some project secrets could not be resolved", {
+        projectId: opts.projectId,
+        missing,
+        undecryptable,
+      });
+    }
+
+    return ok({ values, missing, undecryptable });
+  } catch (error) {
+    const appError = toAppError(error, "loadSecretValues", { projectId: opts.projectId });
+    logger.error("Failed to load project secrets", appError, { projectId: opts.projectId });
+    return err(appError);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+// Type-only: erased at compile time, so parameterizing DEPLOY_QUEUE with the
+// runner's message union cannot create a runtime import cycle.
+import type { DeployQueueMessage } from "./deploy/runner";
 import type { MagicLinkRateLimiter } from "./queue/magic-link-limiter";
 import type { LoggerContext } from "./utils/logger";
 export type { LoggerContext };
@@ -179,7 +182,7 @@ export interface Env {
   /** Post-merge deployments. Deliberately NOT the events queue: a deploy is a
    * minutes-long job, and the shared `stratum-events` consumer awaits each
    * message in turn, so a slow deploy there would stall webhook delivery. */
-  DEPLOY_QUEUE?: Queue;
+  DEPLOY_QUEUE?: Queue<DeployQueueMessage>;
   EVENTS_QUEUE?: Queue;
   IMPORT_QUEUE?: Queue<ImportJobMessage | SyncJobMessage>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,6 +169,17 @@ export interface Env {
   ENVIRONMENT?: string;
   /** Comma-separated extra CORS origin allowlist (beyond same-origin). Optional. */
   ALLOWED_ORIGINS?: string;
+  /** Master key for the per-project deploy secret store: provider credentials
+   * are AES-GCM encrypted under a key derived from it. Optional because a
+   * self-hoster who never deploys never needs one — but a project that HAS
+   * configured a deploy fails loudly (a `failed` deployment naming the missing
+   * key) rather than silently not deploying. Rotating it makes every existing
+   * ciphertext undecryptable, so secrets must be re-entered after a rotation. */
+  DEPLOY_SECRET_KEY?: string;
+  /** Post-merge deployments. Deliberately NOT the events queue: a deploy is a
+   * minutes-long job, and the shared `stratum-events` consumer awaits each
+   * message in turn, so a slow deploy there would stall webhook delivery. */
+  DEPLOY_QUEUE?: Queue;
   EVENTS_QUEUE?: Queue;
   IMPORT_QUEUE?: Queue<ImportJobMessage | SyncJobMessage>;
 }

--- a/src/ui/components/project-header.tsx
+++ b/src/ui/components/project-header.tsx
@@ -7,6 +7,7 @@ export type ProjectTab =
   | "activity"
   | "branches"
   | "tags"
+  | "deployments"
   | "settings";
 
 export interface ProjectRef {
@@ -42,6 +43,10 @@ export const ProjectHeader: FC<ProjectHeaderProps> = ({ project, active, canWrit
     // sections together rather than burying branches under Code.
     { key: "branches", label: "Branches", href: `${base}/branches` },
     { key: "tags", label: "Tags", href: `${base}/tags` },
+    // Deploy history follows the same read rules as Activity, so it is a tab
+    // rather than a Settings sub-page — only the credentials it uses are
+    // admin-only, and those live under Settings.
+    { key: "deployments", label: "Deploys", href: `${base}/deployments` },
     ...(canWrite
       ? [{ key: "settings" as const, label: "Settings", href: `${base}/settings` }]
       : []),

--- a/src/ui/pages/deployments.tsx
+++ b/src/ui/pages/deployments.tsx
@@ -1,0 +1,306 @@
+import type { FC } from "hono/jsx";
+import {
+  type Deployment,
+  type DeploymentStatus,
+  TERMINAL_DEPLOYMENT_STATUSES,
+  UNRESOLVED_TARGET,
+} from "../../storage/deployments";
+import { ProjectHeader } from "../components/project-header";
+import { Layout } from "../layout";
+
+interface DeploymentsProject {
+  name: string;
+  namespace: string;
+  slug: string;
+  visibility?: string;
+}
+
+type PageUser = { id: string; email: string; username: string } | null;
+
+interface DeploymentsPageProps {
+  project: DeploymentsProject;
+  deployments: Deployment[];
+  /**
+   * Writers get the action buttons *and* the log tail. The route strips
+   * `logTail` for everyone else, so the page never assumes it is present.
+   */
+  canWrite: boolean;
+  user?: PageUser;
+}
+
+interface DeploymentDetailPageProps {
+  project: DeploymentsProject;
+  deployment: Deployment;
+  canWrite: boolean;
+  user?: PageUser;
+}
+
+/**
+ * Badge class per status, reusing the palette the rest of the UI already uses.
+ *
+ * `skipped` deliberately reads as neutral, not as a failure: it means the merge
+ * had nothing configured to deploy, which is the normal state of most projects.
+ * `superseded` is neutral for the same reason — a newer merge won the race.
+ */
+export function deploymentStatusClass(status: DeploymentStatus): string {
+  switch (status) {
+    case "pending_approval":
+      return "badge-pending-approval";
+    case "queued":
+      return "badge-queued";
+    case "running":
+      return "badge-running";
+    case "succeeded":
+      return "badge-succeeded";
+    case "failed":
+      return "badge-failed";
+    case "superseded":
+      return "badge-superseded";
+    case "skipped":
+      return "badge-skipped";
+  }
+}
+
+/** "pending approval" reads better than the wire value in a badge. */
+export function deploymentStatusLabel(status: DeploymentStatus): string {
+  return status.replace(/_/g, " ");
+}
+
+export function isTerminalStatus(status: DeploymentStatus): boolean {
+  return (TERMINAL_DEPLOYMENT_STATUSES as readonly string[]).includes(status);
+}
+
+/** Elapsed provider time. Absent until the row reaches a terminal status. */
+export function formatDuration(ms: number | undefined): string {
+  if (ms === undefined || !Number.isFinite(ms) || ms < 0) return "—";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${Math.round(seconds - minutes * 60)}s`;
+}
+
+function shortSha(sha: string): string {
+  return sha.slice(0, 7);
+}
+
+const EXAMPLE_POLICY = `deploys:
+  - name: production
+    target: vercel
+    secrets: [VERCEL_TOKEN, VERCEL_PROJECT_ID]
+    requiresApproval: false`;
+
+/**
+ * Shown instead of an empty table. A project with no deployments has almost
+ * always never configured one, so the state that needs explaining is the
+ * configuration, not the absence of rows.
+ */
+const EmptyState: FC = () => (
+  <div class="empty-state">
+    <p>No deployments yet.</p>
+    <p class="empty-state-hint">
+      Deployments run after a change merges. Add a <code>deploys:</code> block to{" "}
+      <code>.stratum/policy.yaml</code> on the default branch:
+    </p>
+    <pre class="cli-hint">{EXAMPLE_POLICY}</pre>
+    <p class="empty-state-hint">
+      Provider credentials are stored per project under Settings → Deploy secrets, and referenced by
+      name from <code>secrets:</code>.
+    </p>
+  </div>
+);
+
+/**
+ * Approve and Retry as plain forms — no page in this UI depends on client JS.
+ * Both post to `/api/deployments/:id/*`, the same routes a programmatic caller
+ * uses: they answer a form submission with a redirect back here and a JSON
+ * caller with the deployment, so there is one authorization gate per action
+ * rather than a browser copy and an API copy.
+ */
+const RowActions: FC<{ deployment: Deployment }> = ({ deployment }) => {
+  const api = `/api/deployments/${encodeURIComponent(deployment.id)}`;
+  if (deployment.status === "pending_approval") {
+    return (
+      <form method="post" action={`${api}/approve`}>
+        <button type="submit" class="btn btn-small btn-primary">
+          Approve
+        </button>
+      </form>
+    );
+  }
+  // Only a finished attempt can be retried: a queued or running row still has a
+  // future, and retrying a `pending_approval` one would route around approval.
+  if (isTerminalStatus(deployment.status)) {
+    return (
+      <form method="post" action={`${api}/retry`}>
+        <button type="submit" class="btn btn-small">
+          Retry
+        </button>
+      </form>
+    );
+  }
+  return null;
+};
+
+export const DeploymentsPage: FC<DeploymentsPageProps> = ({
+  project,
+  deployments,
+  canWrite,
+  user,
+}) => {
+  const base = `/${project.namespace}/${project.slug}/deployments`;
+  return (
+    <Layout title={`Deployments — ${project.name}`} user={user}>
+      <ProjectHeader project={project} active="deployments" canWrite={canWrite} />
+      <div class="page-header">
+        <h1>Deployments</h1>
+      </div>
+
+      {deployments.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div class="card">
+          <div class="table-scroll">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Status</th>
+                  <th>Name</th>
+                  <th>Target</th>
+                  <th>Commit</th>
+                  <th>Duration</th>
+                  <th>Created</th>
+                  {canWrite && <th>Actions</th>}
+                </tr>
+              </thead>
+              <tbody>
+                {deployments.map((deployment) => (
+                  <tr key={deployment.id}>
+                    <td>
+                      <a href={`${base}/${deployment.id}`}>
+                        <span class={`badge ${deploymentStatusClass(deployment.status)}`}>
+                          {deploymentStatusLabel(deployment.status)}
+                        </span>
+                      </a>
+                    </td>
+                    <td>
+                      {deployment.name}
+                      {deployment.attempt > 1 && (
+                        <span class="deploy-attempt"> · attempt {deployment.attempt}</span>
+                      )}
+                    </td>
+                    <td class={deployment.target === UNRESOLVED_TARGET ? "deploy-target-none" : ""}>
+                      {deployment.target}
+                    </td>
+                    <td class="mono" title={deployment.commitSha}>
+                      {shortSha(deployment.commitSha)}
+                    </td>
+                    <td>{formatDuration(deployment.durationMs)}</td>
+                    <td>{deployment.createdAt}</td>
+                    {canWrite && (
+                      <td>
+                        <RowActions deployment={deployment} />
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </Layout>
+  );
+};
+
+export const DeploymentDetailPage: FC<DeploymentDetailPageProps> = ({
+  project,
+  deployment,
+  canWrite,
+  user,
+}) => {
+  const base = `/${project.namespace}/${project.slug}/deployments`;
+  return (
+    <Layout title={`${deployment.name} deployment — ${project.name}`} user={user}>
+      <ProjectHeader project={project} active="deployments" canWrite={canWrite} />
+      <div class="page-header">
+        <h1>
+          {deployment.name}{" "}
+          <span class={`badge ${deploymentStatusClass(deployment.status)}`}>
+            {deploymentStatusLabel(deployment.status)}
+          </span>
+        </h1>
+        <a class="btn btn-small" href={base}>
+          All deployments
+        </a>
+      </div>
+
+      <div class="card">
+        <dl class="detail-list">
+          <dt>Target</dt>
+          <dd>{deployment.target}</dd>
+          <dt>Commit</dt>
+          <dd class="mono">{deployment.commitSha}</dd>
+          <dt>Attempt</dt>
+          <dd>{deployment.attempt}</dd>
+          <dt>Requested by</dt>
+          <dd>{deployment.requestedById ?? deployment.requestedByType}</dd>
+          {deployment.approvedBy !== undefined && (
+            <>
+              <dt>Approved by</dt>
+              <dd>{deployment.approvedBy}</dd>
+            </>
+          )}
+          <dt>Created</dt>
+          <dd>{deployment.createdAt}</dd>
+          {deployment.completedAt !== undefined && (
+            <>
+              <dt>Completed</dt>
+              <dd>{deployment.completedAt}</dd>
+            </>
+          )}
+          <dt>Duration</dt>
+          <dd>{formatDuration(deployment.durationMs)}</dd>
+          {deployment.url !== undefined && (
+            <>
+              <dt>URL</dt>
+              <dd>
+                <a href={deployment.url} rel="noopener noreferrer">
+                  {deployment.url}
+                </a>
+              </dd>
+            </>
+          )}
+          {deployment.changeId !== undefined && (
+            <>
+              <dt>Change</dt>
+              <dd>
+                <a href={`/changes/${deployment.changeId}`}>{deployment.changeId}</a>
+              </dd>
+            </>
+          )}
+        </dl>
+
+        {deployment.reason !== undefined && <p class="deploy-reason">{deployment.reason}</p>}
+
+        {canWrite && (
+          <div class="action-row">
+            <RowActions deployment={deployment} />
+          </div>
+        )}
+      </div>
+
+      {/* Only writers are served a log tail at all — it holds a redacted
+          provider payload — so its absence is the normal case, not an error. */}
+      {deployment.logTail !== undefined && (
+        <div class="card">
+          <h3 style={{ marginTop: 0 }}>Log tail</h3>
+          <p class="settings-help">
+            The last output from the provider, truncated and with known secret values redacted.
+          </p>
+          <pre class="deploy-log">{deployment.logTail}</pre>
+        </div>
+      )}
+    </Layout>
+  );
+};

--- a/src/ui/pages/project-settings.tsx
+++ b/src/ui/pages/project-settings.tsx
@@ -22,6 +22,13 @@ interface ProjectSettingsProps {
    */
   secrets?: ProjectSecretSummary[];
   /**
+   * The secret listing failed. Rendered as its own state because an empty list
+   * and a failed lookup are different facts: "you have none" versus "we could
+   * not tell", and showing the former after a storage error invites an admin to
+   * re-paste credentials that are already stored.
+   */
+  secretsUnavailable?: boolean;
+  /**
    * Deploy credentials are admin-only and refused to agent identities, which is
    * stricter than the write access this page otherwise requires.
    */
@@ -35,6 +42,7 @@ export const ProjectSettingsPage: FC<ProjectSettingsProps> = ({
   project,
   isOwner,
   secrets,
+  secretsUnavailable,
   canManageSecrets,
   secretError,
   user,
@@ -142,7 +150,13 @@ export const ProjectSettingsPage: FC<ProjectSettingsProps> = ({
             </button>
           </form>
 
-          {secrets === undefined || secrets.length === 0 ? (
+          {secretsUnavailable ? (
+            <p class="settings-help settings-help-error" style="margin-top: 1rem;">
+              Could not load this project's secrets. They are still stored — this is a read failure,
+              not an empty list. Reload the page; adding a secret under an existing name would
+              replace it.
+            </p>
+          ) : secrets === undefined || secrets.length === 0 ? (
             <p class="settings-help" style="margin-top: 1rem;">
               No deploy secrets stored for this project.
             </p>

--- a/src/ui/pages/project-settings.tsx
+++ b/src/ui/pages/project-settings.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "hono/jsx";
+import type { ProjectSecretSummary } from "../../storage/project-secrets";
 import { ProjectHeader } from "../components/project-header";
 import { Layout } from "../layout";
 
@@ -14,11 +15,35 @@ interface ProjectSettingsProps {
     autoSyncEnabled?: boolean;
   };
   isOwner: boolean;
+  /**
+   * Names and metadata only. There is no read path for a secret value anywhere
+   * in the codebase, so the page could not render one even if it wanted to —
+   * see `src/storage/project-secrets.ts`.
+   */
+  secrets?: ProjectSecretSummary[];
+  /**
+   * Deploy credentials are admin-only and refused to agent identities, which is
+   * stricter than the write access this page otherwise requires.
+   */
+  canManageSecrets?: boolean;
+  /** Set after a failed add, so the reason survives the redirect back here. */
+  secretError?: string;
   user?: { id: string; email: string; username: string } | null;
 }
 
-export const ProjectSettingsPage: FC<ProjectSettingsProps> = ({ project, isOwner, user }) => {
+export const ProjectSettingsPage: FC<ProjectSettingsProps> = ({
+  project,
+  isOwner,
+  secrets,
+  canManageSecrets,
+  secretError,
+  user,
+}) => {
   const base = `/${project.namespace}/${project.slug}`;
+  // The secret forms post to the API router: it holds the one copy of the
+  // admin-and-not-an-agent gate, and answers a form submission with a redirect
+  // back to this page rather than JSON.
+  const secretsApi = `/api/projects/${project.namespace}/${project.slug}/secrets`;
   return (
     <Layout title={`Settings — ${project.name}`} user={user}>
       <ProjectHeader project={project} active="settings" canWrite={true} />
@@ -68,6 +93,94 @@ export const ProjectSettingsPage: FC<ProjectSettingsProps> = ({ project, isOwner
           </a>
         </div>
       </div>
+
+      <div class="card">
+        <h3 style={{ marginTop: 0 }}>Deployments</h3>
+        <p class="settings-help">
+          Post-merge deploys declared under <code>deploys:</code> in{" "}
+          <code>.stratum/policy.yaml</code>, with their history and log tails.
+        </p>
+        <div class="action-row">
+          <a class="btn" href={`${base}/deployments`}>
+            View deployments
+          </a>
+        </div>
+      </div>
+
+      {canManageSecrets && (
+        <div class="card" id="secrets">
+          <h3 style={{ marginTop: 0 }}>Deploy secrets</h3>
+          <p class="settings-help">
+            Provider credentials the deploy runner resolves by name from a deploy's{" "}
+            <code>secrets:</code> list. Values are encrypted at rest and are never shown again — not
+            here, not through the API. Replace one by adding it under the same name.
+          </p>
+          {secretError !== undefined && (
+            <p class="settings-help settings-help-error">{secretError}</p>
+          )}
+          <form method="post" action={secretsApi} class="secret-form">
+            <label>
+              Name
+              <input
+                type="text"
+                name="name"
+                placeholder="VERCEL_TOKEN"
+                pattern="[A-Z][A-Z0-9_]{0,63}"
+                title="Uppercase letters, digits and underscores; must start with a letter"
+                required
+                autocomplete="off"
+              />
+            </label>
+            <label>
+              Value
+              {/* type=password so the value is not shoulder-surfed while typing;
+                  it is never re-rendered, so nothing is ever masked back. */}
+              <input type="password" name="value" required autocomplete="off" />
+            </label>
+            <button type="submit" class="btn btn-primary">
+              Save secret
+            </button>
+          </form>
+
+          {secrets === undefined || secrets.length === 0 ? (
+            <p class="settings-help" style="margin-top: 1rem;">
+              No deploy secrets stored for this project.
+            </p>
+          ) : (
+            <div class="table-scroll" style="margin-top: 1rem;">
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Added</th>
+                    <th>Last updated</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {secrets.map((secret) => (
+                    <tr key={secret.name}>
+                      <td class="mono">{secret.name}</td>
+                      <td>{secret.createdAt}</td>
+                      <td>{secret.updatedAt}</td>
+                      <td>
+                        <form
+                          method="post"
+                          action={`${secretsApi}/${encodeURIComponent(secret.name)}/delete`}
+                        >
+                          <button type="submit" class="btn btn-small btn-danger">
+                            Delete
+                          </button>
+                        </form>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
 
       {isOwner && (
         <div class="card danger-zone">

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -546,6 +546,30 @@ ${NAV_CSS}
 .webhook-delivery-meta { color: var(--text-muted); }
 .webhook-delivery-time { color: var(--text-muted); margin-left: auto; }
 .btn-small, .btn-sm { font-size: 0.75rem; padding: 0.25rem 0.6rem; min-height: 2rem; }
+
+/* Deployments.
+   skipped and superseded share the muted treatment on purpose: neither is a
+   failure, and colouring them like one would make "nothing was configured to
+   deploy" look like a broken build. */
+.badge-pending-approval { background: var(--warning-surface); color: var(--warning-text); }
+.badge-running { background: var(--accent); color: var(--accent-text); }
+.badge-succeeded { background: var(--success-surface); color: var(--success-text); }
+.badge-superseded { background: var(--bg-raised); color: var(--text-muted); }
+.badge-skipped { background: var(--bg-raised); color: var(--text-muted); }
+.deploy-attempt { color: var(--text-muted); font-size: 0.8rem; }
+.deploy-target-none { color: var(--text-muted); font-style: italic; }
+.deploy-reason { margin: 1rem 0 0; color: var(--text-body); overflow-wrap: anywhere; }
+.deploy-log {
+  background: var(--bg-raised); border: 1px solid var(--border); border-radius: 4px;
+  padding: 0.75rem; overflow-x: auto; white-space: pre-wrap; overflow-wrap: anywhere;
+  font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; color: var(--text-body); margin: 0;
+}
+.secret-form { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: flex-end; }
+.secret-form label { display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.85rem; color: var(--text-body); }
+.secret-form input {
+  background: var(--bg-card); border: 1px solid var(--border-strong); color: #eee;
+  padding: 0.5rem; border-radius: 4px; font-family: inherit;
+}
 .btn-link { background: none; border-color: transparent; color: var(--accent-text); }
 
 /* Issues */

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -4,6 +4,7 @@
 
 const ALGORITHM = "AES-GCM";
 const KEY_LENGTH = 256;
+const IV_LENGTH = 12;
 
 /**
  * Hash a token using SHA-256
@@ -54,6 +55,18 @@ export async function generateApiKey(prefix: string): Promise<string> {
   return `${prefix}_${hex}`;
 }
 
+function toBase64(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+function fromBase64(encoded: string): Uint8Array {
+  return new Uint8Array(
+    atob(encoded)
+      .split("")
+      .map((c) => c.charCodeAt(0)),
+  );
+}
+
 /**
  * Derive encryption key from environment secret using PBKDF2
  */
@@ -86,7 +99,7 @@ async function getEncryptionKey(secret: string): Promise<CryptoKey> {
 export async function encryptToken(plaintext: string, secret: string): Promise<string> {
   const key = await getEncryptionKey(secret);
   const encoder = new TextEncoder();
-  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
 
   const encrypted = await crypto.subtle.encrypt(
     { name: ALGORITHM, iv },
@@ -98,7 +111,7 @@ export async function encryptToken(plaintext: string, secret: string): Promise<s
   combined.set(iv);
   combined.set(new Uint8Array(encrypted), iv.length);
 
-  return btoa(String.fromCharCode(...combined));
+  return toBase64(combined);
 }
 
 /**
@@ -108,16 +121,143 @@ export async function decryptToken(ciphertext: string, secret: string): Promise<
   try {
     const key = await getEncryptionKey(secret);
 
-    const combined = new Uint8Array(
-      atob(ciphertext)
-        .split("")
-        .map((c) => c.charCodeAt(0)),
-    );
+    const combined = fromBase64(ciphertext);
 
-    const iv = combined.slice(0, 12);
-    const encrypted = combined.slice(12);
+    const iv = combined.slice(0, IV_LENGTH);
+    const encrypted = combined.slice(IV_LENGTH);
 
     const decrypted = await crypto.subtle.decrypt({ name: ALGORITHM, iv }, key, encrypted);
+
+    return new TextDecoder().decode(decrypted);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The `(project_id, name)` pair a deploy secret's ciphertext is cryptographically
+ * bound to. Both fields are authenticated but not encrypted — they are already
+ * public in the row that stores the ciphertext.
+ */
+export interface SecretScope {
+  projectId: string;
+  name: string;
+}
+
+/**
+ * Salt for deploy-secret key derivation.
+ *
+ * Deliberately distinct from the GitHub-token salt above: an operator who sets
+ * `DEPLOY_SECRET_KEY` and the GitHub token key to the same string must still end
+ * up with two unrelated AES keys, so compromise of one derived key cannot unlock
+ * the other store.
+ */
+const DEPLOY_SECRET_SALT = "stratum-deploy-secret-salt";
+
+/**
+ * NUL-separated so the AAD is an injective encoding of the pair: with a plain
+ * concatenation, ("proj_1A", "B") and ("proj_1", "AB") would authenticate
+ * identically and a ciphertext could be transplanted between them. Neither field
+ * can contain a NUL — ids are `prefix_<hex>` and names match
+ * `^[A-Z][A-Z0-9_]{0,63}$` — so the separator is unambiguous.
+ */
+function secretAad(scope: SecretScope): Uint8Array {
+  return new TextEncoder().encode(`${scope.projectId}\u0000${scope.name}`);
+}
+
+/**
+ * Derives the AES-GCM key used for deploy secrets from `DEPLOY_SECRET_KEY`.
+ *
+ * Call this **once** per deployment and pass the result to every
+ * {@link encryptSecret} / {@link decryptSecret} call. PBKDF2 at 100k iterations
+ * is real CPU work and the deploy queue consumer runs under a CPU limit, so
+ * deriving per secret is not viable for a deploy that resolves several.
+ *
+ * @param secret - The raw `DEPLOY_SECRET_KEY` value
+ * @returns A non-extractable AES-GCM key
+ */
+export async function deriveSecretKey(secret: string): Promise<CryptoKey> {
+  const encoder = new TextEncoder();
+  const baseKey = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "PBKDF2" },
+    false,
+    ["deriveBits", "deriveKey"],
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: encoder.encode(DEPLOY_SECRET_SALT),
+      iterations: 100000,
+      hash: "SHA-256",
+    },
+    baseKey,
+    { name: ALGORITHM, length: KEY_LENGTH },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+/**
+ * Encrypts a deploy secret, binding it to one project and one secret name.
+ *
+ * The scope travels as AES-GCM additional authenticated data, so a ciphertext
+ * copied into another project's row — or renamed within the same project — fails
+ * authentication instead of silently authenticating against the wrong provider
+ * account.
+ *
+ * @param plaintext - The secret value
+ * @param key - A key from {@link deriveSecretKey}
+ * @param scope - The `(project_id, name)` pair to bind the ciphertext to
+ * @returns Base64 of `iv || ciphertext || tag`
+ */
+export async function encryptSecret(
+  plaintext: string,
+  key: CryptoKey,
+  scope: SecretScope,
+): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+
+  const encrypted = await crypto.subtle.encrypt(
+    { name: ALGORITHM, iv, additionalData: secretAad(scope) },
+    key,
+    new TextEncoder().encode(plaintext),
+  );
+
+  const combined = new Uint8Array(iv.length + encrypted.byteLength);
+  combined.set(iv);
+  combined.set(new Uint8Array(encrypted), iv.length);
+
+  return toBase64(combined);
+}
+
+/**
+ * Decrypts a deploy secret produced by {@link encryptSecret}.
+ *
+ * @param ciphertext - Base64 of `iv || ciphertext || tag`
+ * @param key - A key from {@link deriveSecretKey}
+ * @param scope - The `(project_id, name)` pair the ciphertext must be bound to
+ * @returns The plaintext, or `null` when the key, the scope, or the bytes fail to
+ *   authenticate. `null` never means "empty secret": the empty string is a legal
+ *   value and round-trips as `""`.
+ */
+export async function decryptSecret(
+  ciphertext: string,
+  key: CryptoKey,
+  scope: SecretScope,
+): Promise<string | null> {
+  try {
+    const combined = fromBase64(ciphertext);
+    const iv = combined.slice(0, IV_LENGTH);
+    const encrypted = combined.slice(IV_LENGTH);
+
+    const decrypted = await crypto.subtle.decrypt(
+      { name: ALGORITHM, iv, additionalData: secretAad(scope) },
+      key,
+      encrypted,
+    );
 
     return new TextDecoder().decode(decrypted);
   } catch {

--- a/tests/changes.test.ts
+++ b/tests/changes.test.ts
@@ -146,6 +146,13 @@ vi.mock("../src/queue/events", () => ({
   emitEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
+// The default matches what the real module does for the policies these tests
+// use — no postMergeCommand, so nothing runs. Tests of the deploy trigger
+// override it, because that trigger keys off this result.
+vi.mock("../src/merge/post-merge", () => ({
+  runPostMergeCheck: vi.fn(async () => ({ status: "skipped" })),
+}));
+
 vi.mock("../src/storage/users", () => ({
   getUserByToken: vi.fn(),
   // Agent auth resolves the agent's owner via getUser (fail-closed on the
@@ -177,6 +184,7 @@ import {
   loadPolicy,
 } from "../src/evaluation";
 import { resetCircuitBreakersForTests } from "../src/github/client";
+import { runPostMergeCheck } from "../src/merge/post-merge";
 import { emitEvent } from "../src/queue/events";
 import { getAgent, getAgentByToken } from "../src/storage/agents";
 import { recordAudit } from "../src/storage/audit";
@@ -1658,6 +1666,107 @@ describe("POST /api/changes/:id/merge", () => {
       env,
     );
     expect(res.status).toBe(200);
+  });
+
+  /**
+   * The deploy trigger hangs off the post-merge RESULT, not the change.merged
+   * event, because a failed post-merge check auto-reverts the merge. Anyone who
+   * "simplifies" this onto the event reintroduces deploying reverted code.
+   */
+  describe("post-merge deploy trigger", () => {
+    let send: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      send = vi.fn(async () => {});
+      env.DEPLOY_QUEUE = { send } as unknown as Env["DEPLOY_QUEUE"];
+      vi.mocked(getChange).mockResolvedValue({
+        success: true,
+        data: { ...mockChange, status: "accepted" },
+      });
+      vi.mocked(runPostMergeCheck).mockResolvedValue({ status: "skipped" });
+    });
+
+    afterEach(() => {
+      // Restore the module default for the rest of the file.
+      vi.mocked(runPostMergeCheck).mockResolvedValue({ status: "skipped" });
+    });
+
+    it("enqueues the merged commit after a clean post-merge check", async () => {
+      vi.mocked(runPostMergeCheck).mockResolvedValue({ status: "passed" });
+
+      const res = await app.fetch(
+        request("POST", "/api/changes/chg_abc123/merge", undefined, USER_AUTH),
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      // `mergedAt` is the merge time the route just stamped on the change. The
+      // deployment row is ordered by it rather than by when the queue delivers
+      // the message, because the queue promises no ordering.
+      expect(send).toHaveBeenCalledWith({
+        kind: "merge",
+        projectId: mockProject.id,
+        changeId: "chg_abc123",
+        commitSha: "sha_merged",
+        mergedAt: expect.any(String),
+      });
+    });
+
+    it("does not enqueue when the post-merge check reverted the merge", async () => {
+      vi.mocked(runPostMergeCheck).mockResolvedValue({
+        status: "reverted",
+        reason: "smoke test failed",
+        revertCommit: "sha_revert",
+      });
+
+      const res = await app.fetch(
+        request("POST", "/api/changes/chg_abc123/merge", undefined, USER_AUTH),
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it("does not enqueue when the post-merge check failed", async () => {
+      vi.mocked(runPostMergeCheck).mockResolvedValue({
+        status: "failed",
+        reason: "smoke test failed",
+      });
+
+      await app.fetch(request("POST", "/api/changes/chg_abc123/merge", undefined, USER_AUTH), env);
+
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it("enqueues only after the post-merge check has run", async () => {
+      const order: string[] = [];
+      vi.mocked(runPostMergeCheck).mockImplementation(async () => {
+        order.push("post-merge");
+        return { status: "passed" };
+      });
+      send.mockImplementation(async () => {
+        order.push("enqueue");
+      });
+
+      await app.fetch(request("POST", "/api/changes/chg_abc123/merge", undefined, USER_AUTH), env);
+
+      expect(order).toEqual(["post-merge", "enqueue"]);
+    });
+
+    it("still reports the merge when the queue send fails", async () => {
+      send.mockRejectedValue(new Error("queue unavailable"));
+
+      const res = await app.fetch(
+        request("POST", "/api/changes/chg_abc123/merge", undefined, USER_AUTH),
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { merged: boolean; commit: string };
+      expect(body.merged).toBe(true);
+      expect(body.commit).toBe("sha_merged");
+    });
   });
 });
 

--- a/tests/deletion-account.test.ts
+++ b/tests/deletion-account.test.ts
@@ -80,7 +80,7 @@ describe("anonymizeUserContributions", () => {
     expect(result.success).toBe(true);
 
     const updates = executed.filter((s) => s.sql.startsWith("UPDATE"));
-    expect(updates.length).toBe(7);
+    expect(updates.length).toBe(11);
     for (const stmt of updates) {
       expect(stmt.sql).toMatch(/^UPDATE \w+ SET \w+ = \? WHERE \w+ = \?$/);
       expect(stmt.bindings).toEqual([DELETED_USER_SENTINEL, "usr_1"]);
@@ -91,6 +91,8 @@ describe("anonymizeUserContributions", () => {
     expect(cols).toContain("UPDATE audit_log SET actor_id = ? WHERE actor_id = ?");
     expect(cols).toContain("UPDATE change_reviews SET reviewer_id = ? WHERE reviewer_id = ?");
     expect(cols).toContain("UPDATE webhooks SET created_by = ? WHERE created_by = ?");
+    expect(cols).toContain("UPDATE project_secrets SET updated_by = ? WHERE updated_by = ?");
+    expect(cols).toContain("UPDATE deployments SET approved_by = ? WHERE approved_by = ?");
   });
 });
 

--- a/tests/deploy-bounds.test.ts
+++ b/tests/deploy-bounds.test.ts
@@ -1,0 +1,125 @@
+/// <reference types="vite/client" />
+/**
+ * The two numeric bounds a post-merge deployment runs inside, asserted against
+ * the config that actually ships.
+ *
+ * Both were wrong in a way no unit test could see, because each is a
+ * relationship between a constant in `src/` and a knob in `wrangler.toml`:
+ *
+ * 1. **Isolate memory.** Concurrent queue invocations share one isolate's
+ *    128 MiB. A Vercel deploy inlines the whole tree in its request body, so
+ *    one peaks near 92 MiB — and `max_concurrency = 2` let two of them run at
+ *    once. The isolate is killed on OOM *before* the runner's `finally` can
+ *    write a terminal status, which strands rows at `running` with no lease.
+ * 2. **Lease ordering.** The runner's own deadline has to be shorter than the
+ *    storage lease, which has to fit inside the queue's visibility timeout,
+ *    which has to fit inside the consumer's wall-clock limit. Break the first
+ *    `<` and a lease can expire while its runner is still uploading, so
+ *    `claimDeployment` hands a genuinely-running row to a second consumer and
+ *    the same commit deploys twice.
+ *
+ * These assertions are the reason those relationships cannot be re-broken by
+ * editing one side of them.
+ */
+import { describe, expect, it } from "vitest";
+// Loaded via Vite's raw import (not node:fs) so this type-checks under the
+// Workers tsconfig, matching tests/wrangler-telemetry-config.test.ts.
+import wranglerToml from "../wrangler.toml?raw";
+
+import {
+  DEPLOY_ATTEMPT_DEADLINE_MS,
+  ISOLATE_MEMORY_BYTES,
+  MAX_DEPLOY_CONCURRENCY,
+  QUEUE_CONSUMER_WALL_MS,
+} from "../src/deploy/limits";
+import { MAX_PEAK_DEPLOY_BYTES } from "../src/deploy/targets/vercel";
+import { DEFAULT_DEPLOY_LEASE_MS } from "../src/storage/deployments";
+
+interface TomlSection {
+  name: string;
+  body: string;
+}
+
+/** Split a TOML file into `[section]` / `[[array]]` blocks. Not a general parser. */
+function splitSections(toml: string): TomlSection[] {
+  const sections: TomlSection[] = [];
+  let current: TomlSection = { name: "", body: "" };
+
+  for (const line of toml.split("\n")) {
+    const header = /^\s*\[{1,2}([^\]]+)\]{1,2}\s*$/.exec(line);
+    if (header?.[1]) {
+      sections.push(current);
+      current = { name: header[1], body: "" };
+      continue;
+    }
+    current.body += `${line}\n`;
+  }
+  sections.push(current);
+  return sections;
+}
+
+/** The value of an uncommented `key = <number>` line, or undefined. */
+function numberSetting(section: TomlSection, key: string): number | undefined {
+  for (const line of section.body.split("\n")) {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith("#")) continue;
+    const match = new RegExp(`^${key}\\s*=\\s*(\\d+)`).exec(trimmed);
+    if (match?.[1]) return Number(match[1]);
+  }
+  return undefined;
+}
+
+/** Every `stratum-deploys` consumer block: top level, production, and staging. */
+function deployConsumers(): TomlSection[] {
+  return splitSections(wranglerToml).filter(
+    (section) =>
+      section.name.endsWith("queues.consumers") &&
+      /^queue\s*=\s*"stratum-deploys(-staging)?"/m.test(section.body),
+  );
+}
+
+describe("the isolate-memory bound on concurrent deploys", () => {
+  it("declares a concurrency every environment's consumer actually uses", () => {
+    const consumers = deployConsumers();
+    // Top level (self-hosting template), production, and staging. A new
+    // environment that forgets the knob has to fail here.
+    expect(consumers).toHaveLength(3);
+
+    for (const consumer of consumers) {
+      expect(numberSetting(consumer, "max_concurrency")).toBe(MAX_DEPLOY_CONCURRENCY);
+    }
+  });
+
+  it("fits the declared concurrency inside one isolate", () => {
+    expect(MAX_DEPLOY_CONCURRENCY * MAX_PEAK_DEPLOY_BYTES).toBeLessThanOrEqual(
+      ISOLATE_MEMORY_BYTES,
+    );
+  });
+
+  // The regression itself: `max_concurrency = 2` put ~183 MiB of peak into a
+  // 128 MiB isolate. An OOM kill is not catchable, so the deployment rows those
+  // two runs were holding never reached a terminal status.
+  it("would not fit one more concurrent deploy, which is why the knob is 1", () => {
+    expect((MAX_DEPLOY_CONCURRENCY + 1) * MAX_PEAK_DEPLOY_BYTES).toBeGreaterThan(
+      ISOLATE_MEMORY_BYTES,
+    );
+  });
+});
+
+describe("the lease ordering", () => {
+  // The `<` that stops a lease expiring under a live runner. Everything else in
+  // this ordering is about redelivery timing; only this one is about two
+  // consumers publishing the same commit.
+  it("gives up on an attempt strictly before its lease can expire", () => {
+    expect(DEPLOY_ATTEMPT_DEADLINE_MS).toBeLessThan(DEFAULT_DEPLOY_LEASE_MS);
+  });
+
+  it("keeps the lease inside every consumer's visibility timeout", () => {
+    for (const consumer of deployConsumers()) {
+      const visibility = numberSetting(consumer, "visibility_timeout_ms");
+      expect(visibility).toBeDefined();
+      expect(visibility as number).toBeGreaterThanOrEqual(DEFAULT_DEPLOY_LEASE_MS);
+      expect(visibility as number).toBeLessThanOrEqual(QUEUE_CONSUMER_WALL_MS);
+    }
+  });
+});

--- a/tests/deploy-config.test.ts
+++ b/tests/deploy-config.test.ts
@@ -276,6 +276,55 @@ describe("sanitizeDeploys — rejected entries", () => {
   });
 });
 
+describe("sanitizeDeploys — entry-count cap", () => {
+  const entry = (index: number) => ({ name: `deploy-${index}`, target: "vercel" });
+
+  it("accepts a file declaring exactly the cap", () => {
+    const { accepted, rejected } = sanitizeDeploys(
+      Array.from({ length: 16 }, (_, index) => entry(index)),
+    );
+
+    expect(accepted).toHaveLength(16);
+    expect(rejected).toEqual([]);
+  });
+
+  it("runs only the first 16 entries and rejects the excess", () => {
+    const { accepted, rejected } = sanitizeDeploys(
+      Array.from({ length: 20 }, (_, index) => entry(index)),
+    );
+
+    expect(accepted.map((d) => d.name)).toEqual(
+      Array.from({ length: 16 }, (_, index) => `deploy-${index}`),
+    );
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.name).toBeNull();
+    expect(rejected[0]?.reason).toContain("at most 16 entries");
+    expect(rejected[0]?.reason).toContain("20 were declared");
+    expect(rejected[0]?.reason).toContain("entries 17-20");
+  });
+
+  it("reports the excess once, not once per entry — a huge file cannot flood the history", () => {
+    // Every rejection becomes a persisted `deployments` row, so the cap must not
+    // itself be the thing that writes thousands of them.
+    const { accepted, rejected } = sanitizeDeploys(
+      Array.from({ length: 500 }, (_, index) => entry(index)),
+    );
+
+    expect(accepted).toHaveLength(16);
+    expect(rejected).toHaveLength(1);
+  });
+
+  it("still validates the entries it does keep", () => {
+    const raw: unknown[] = Array.from({ length: 20 }, (_, index) => entry(index));
+    raw[0] = { name: "bad", target: "netlify" };
+
+    const { accepted, rejected } = sanitizeDeploys(raw);
+
+    expect(accepted).toHaveLength(15);
+    expect(rejected.map((r) => r.name)).toEqual([null, "bad"]);
+  });
+});
+
 describe("parsePolicyContent", () => {
   it("parses YAML and JSON to the same policy without any fetch", () => {
     const yaml = parsePolicyContent(

--- a/tests/deploy-config.test.ts
+++ b/tests/deploy-config.test.ts
@@ -1,0 +1,450 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEPLOY_TARGETS, sanitizeDeploys } from "../src/deploy/config";
+import { loadPolicy, parsePolicyContent } from "../src/evaluation/policy-loader";
+import type { DeployConfig, EvalPolicy } from "../src/evaluation/types";
+import { AppError } from "../src/utils/errors";
+import type { Logger } from "../src/utils/logger";
+
+const mockLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => mockLogger),
+};
+
+vi.mock("../src/storage/git-ops", () => ({
+  readFileFromRepo: vi.fn(),
+}));
+
+import { readFileFromRepo } from "../src/storage/git-ops";
+const mockReadFileFromRepo = vi.mocked(readFileFromRepo);
+
+/** The one reason string for a single rejected entry. */
+function onlyReason(result: ReturnType<typeof sanitizeDeploys>): string {
+  expect(result.rejected).toHaveLength(1);
+  return result.rejected[0]?.reason ?? "";
+}
+
+describe("sanitizeDeploys — accepted entries", () => {
+  it("accepts a fully specified entry", () => {
+    const { accepted, rejected } = sanitizeDeploys([
+      {
+        name: "production",
+        target: "cloudflare-pages",
+        secrets: ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"],
+        dir: "dist/site",
+        requiresApproval: true,
+      },
+    ]);
+
+    expect(rejected).toEqual([]);
+    expect(accepted).toEqual([
+      {
+        name: "production",
+        target: "cloudflare-pages",
+        secrets: ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"],
+        dir: "dist/site",
+        requiresApproval: true,
+      },
+    ]);
+  });
+
+  it("accepts a minimal entry and defaults requiresApproval to false", () => {
+    // Set explicitly rather than left undefined: the approval gate decides
+    // whether a deploy can reach production unattended, so downstream code must
+    // never have to guess what an absent field meant.
+    const { accepted } = sanitizeDeploys([{ name: "prod", target: "vercel" }]);
+
+    expect(accepted).toEqual([{ name: "prod", target: "vercel", requiresApproval: false }]);
+  });
+
+  it("accepts every declared target", () => {
+    const { accepted, rejected } = sanitizeDeploys(
+      DEPLOY_TARGETS.map((target, i) => ({ name: `d${i}`, target })),
+    );
+
+    expect(rejected).toEqual([]);
+    expect(accepted.map((d) => d.target)).toEqual([...DEPLOY_TARGETS]);
+  });
+
+  it("treats an absent or empty deploys list as no deploys and no rejections", () => {
+    expect(sanitizeDeploys(undefined)).toEqual({ accepted: [], rejected: [] });
+    expect(sanitizeDeploys(null)).toEqual({ accepted: [], rejected: [] });
+    expect(sanitizeDeploys([])).toEqual({ accepted: [], rejected: [] });
+  });
+
+  it("returns fresh objects that share no identity with the input", () => {
+    // The whole point of rebuilding rather than passing the parsed value
+    // through: nothing downstream may reach back into user-supplied input.
+    const secrets = ["VERCEL_TOKEN"];
+    const entry = { name: "prod", target: "vercel", secrets };
+    const input = [entry];
+
+    const { accepted } = sanitizeDeploys(input);
+
+    expect(accepted).not.toBe(input);
+    expect(accepted[0]).not.toBe(entry);
+    expect(accepted[0]?.secrets).not.toBe(secrets);
+
+    secrets.push("SNEAKED_IN");
+    expect(accepted[0]?.secrets).toEqual(["VERCEL_TOKEN"]);
+  });
+});
+
+describe("sanitizeDeploys — rejected entries", () => {
+  it("rejects a non-list deploys value", () => {
+    const result = sanitizeDeploys({ name: "prod", target: "vercel" });
+
+    expect(result.accepted).toEqual([]);
+    expect(result.rejected).toEqual([
+      { name: null, reason: expect.stringMatching(/must be a list/) },
+    ]);
+  });
+
+  it("rejects entries that are not mappings", () => {
+    const { accepted, rejected } = sanitizeDeploys([null, "vercel", 42, []]);
+
+    expect(accepted).toEqual([]);
+    expect(rejected).toHaveLength(4);
+    for (const entry of rejected) {
+      expect(entry.name).toBeNull();
+      expect(entry.reason).toMatch(/must be a mapping/);
+    }
+  });
+
+  it("rejects a missing or non-string name", () => {
+    expect(onlyReason(sanitizeDeploys([{ target: "vercel" }]))).toMatch(/"name" is required/);
+    expect(onlyReason(sanitizeDeploys([{ name: 7, target: "vercel" }]))).toMatch(
+      /"name" is required/,
+    );
+  });
+
+  it("rejects names that do not match the slug pattern", () => {
+    const bad = ["Production", "1prod", "-prod", "pro_duction", "prod!", "p".repeat(33), ""];
+
+    for (const name of bad) {
+      const result = sanitizeDeploys([{ name, target: "vercel" }]);
+      expect(result.accepted, `expected ${JSON.stringify(name)} to be rejected`).toEqual([]);
+      expect(onlyReason(result)).toMatch(/"name"/);
+    }
+
+    // The boundary on the other side of the length rule still passes.
+    expect(
+      sanitizeDeploys([{ name: `p${"o".repeat(31)}`, target: "vercel" }]).accepted,
+    ).toHaveLength(1);
+  });
+
+  it("rejects a duplicate name and keeps the first", () => {
+    const { accepted, rejected } = sanitizeDeploys([
+      { name: "prod", target: "vercel" },
+      { name: "prod", target: "cloudflare-pages" },
+    ]);
+
+    expect(accepted).toHaveLength(1);
+    expect(accepted[0]?.target).toBe("vercel");
+    expect(rejected).toEqual([{ name: "prod", reason: expect.stringMatching(/duplicate/i) }]);
+  });
+
+  it("rejects an unknown or missing target", () => {
+    const unknown = sanitizeDeploys([{ name: "prod", target: "netlify" }]);
+    expect(unknown.accepted).toEqual([]);
+    expect(unknown.rejected[0]).toEqual({
+      name: "prod",
+      reason: expect.stringMatching(/unknown target "netlify"/),
+    });
+
+    expect(onlyReason(sanitizeDeploys([{ name: "prod" }]))).toMatch(/"target" is required/);
+  });
+
+  it("rejects malformed secret names", () => {
+    expect(
+      onlyReason(sanitizeDeploys([{ name: "p", target: "vercel", secrets: "TOKEN" }])),
+    ).toMatch(/"secrets" must be a list/);
+
+    for (const secret of ["vercel_token", "1TOKEN", "TOKEN-1", `A${"B".repeat(64)}`]) {
+      const result = sanitizeDeploys([{ name: "p", target: "vercel", secrets: [secret] }]);
+      expect(result.accepted, `expected ${secret} to be rejected`).toEqual([]);
+      expect(onlyReason(result)).toMatch(/invalid secret name/);
+    }
+
+    expect(onlyReason(sanitizeDeploys([{ name: "p", target: "vercel", secrets: [1] }]))).toMatch(
+      /invalid secret name/,
+    );
+
+    const tooMany = sanitizeDeploys([
+      { name: "p", target: "vercel", secrets: Array.from({ length: 17 }, (_, i) => `S${i}`) },
+    ]);
+    expect(onlyReason(tooMany)).toMatch(/at most/);
+  });
+
+  it("rejects a dir that escapes the repo root", () => {
+    const traversals = [
+      "..",
+      "../secrets",
+      "dist/../../etc",
+      "/etc/passwd",
+      "\\windows",
+      "dist\\..\\..\\etc",
+      "dist/\0",
+      "",
+      "   ",
+      "d".repeat(256),
+    ];
+
+    for (const dir of traversals) {
+      const result = sanitizeDeploys([{ name: "p", target: "cloudflare-pages", dir }]);
+      expect(result.accepted, `expected ${JSON.stringify(dir)} to be rejected`).toEqual([]);
+      expect(onlyReason(result)).toMatch(/"dir"/);
+    }
+
+    expect(
+      onlyReason(sanitizeDeploys([{ name: "p", target: "cloudflare-pages", dir: 1 }])),
+    ).toMatch(/"dir" must be a string/);
+  });
+
+  it("keeps a relative dir, trimmed", () => {
+    const { accepted } = sanitizeDeploys([
+      { name: "p", target: "cloudflare-pages", dir: "  dist/site  " },
+    ]);
+
+    expect(accepted[0]?.dir).toBe("dist/site");
+  });
+
+  it("rejects a non-boolean requiresApproval instead of coercing it", () => {
+    // "false" is a truthy string; coercion here would arm or disarm the gate
+    // that keeps an agent from shipping to production.
+    for (const value of ["true", "false", 1, 0, null]) {
+      const result = sanitizeDeploys([{ name: "p", target: "vercel", requiresApproval: value }]);
+      expect(result.accepted, `expected ${JSON.stringify(value)} to be rejected`).toEqual([]);
+      expect(onlyReason(result)).toMatch(/"requiresApproval" must be a boolean/);
+    }
+  });
+
+  it("rejects an entry carrying an unrecognized field", () => {
+    // `requireApproval` (no "s") is the typo that matters: a whitelist rebuild
+    // that dropped it silently would ship an approval-gated deploy unattended.
+    const result = sanitizeDeploys([
+      { name: "prod", target: "vercel", requireApproval: true, token: "hunter2" },
+    ]);
+
+    expect(result.accepted).toEqual([]);
+    expect(onlyReason(result)).toMatch(/unrecognized fields "requireApproval", "token"/);
+  });
+
+  it("reports every problem with an entry, not just the first", () => {
+    const reason = onlyReason(
+      sanitizeDeploys([{ name: "Prod", target: "netlify", secrets: ["nope"] }]),
+    );
+
+    expect(reason).toMatch(/"name"/);
+    expect(reason).toMatch(/unknown target/);
+    expect(reason).toMatch(/invalid secret name/);
+  });
+
+  it("locates the offending entry by index and names it when it has a usable name", () => {
+    const { rejected } = sanitizeDeploys([
+      { name: "ok", target: "vercel" },
+      { name: "staging", target: "netlify" },
+    ]);
+
+    expect(rejected).toEqual([
+      { name: "staging", reason: expect.stringMatching(/^deploys\[1\]: /) },
+    ]);
+  });
+
+  it("truncates a huge policy-supplied value out of the reason string", () => {
+    // The reason is persisted and rendered; a megabyte of YAML must not become
+    // a megabyte of deployment row.
+    const reason = onlyReason(sanitizeDeploys([{ name: "x".repeat(5000), target: "vercel" }]));
+
+    expect(reason.length).toBeLessThan(500);
+  });
+
+  it("keeps the good entries when a sibling is rejected", () => {
+    // Unlike `evaluators`, one bad deploy entry does not discard the rest — it
+    // is reported on its own so the others still ship.
+    const { accepted, rejected } = sanitizeDeploys([
+      { name: "prod", target: "vercel" },
+      { name: "broken", target: "netlify" },
+    ]);
+
+    expect(accepted.map((d) => d.name)).toEqual(["prod"]);
+    expect(rejected.map((r) => r.name)).toEqual(["broken"]);
+  });
+});
+
+describe("parsePolicyContent", () => {
+  it("parses YAML and JSON to the same policy without any fetch", () => {
+    const yaml = parsePolicyContent(
+      ["evaluators:", "  - type: diff", "deploys:", "  - name: prod", "    target: vercel"].join(
+        "\n",
+      ),
+      "yaml",
+      mockLogger,
+    );
+    const json = parsePolicyContent(
+      JSON.stringify({
+        evaluators: [{ type: "diff" }],
+        deploys: [{ name: "prod", target: "vercel" }],
+      }),
+      "json",
+      mockLogger,
+    );
+
+    expect(yaml.status).toBe("ok");
+    expect(json.status).toBe("ok");
+    if (yaml.status !== "ok" || json.status !== "ok") return;
+    expect(yaml.policy.deploys).toEqual([
+      { name: "prod", target: "vercel", requiresApproval: false },
+    ]);
+    expect(yaml.policy).toEqual(json.policy);
+  });
+
+  it("reports unparseable content as malformed rather than throwing", () => {
+    const result = parsePolicyContent("not { valid json", "json", mockLogger);
+
+    expect(result.status).toBe("malformed");
+  });
+
+  it("reports a missing evaluators list as malformed", () => {
+    const result = parsePolicyContent(JSON.stringify({ minScore: 0.5 }), "json", mockLogger);
+
+    expect(result).toEqual({ status: "malformed", reason: expect.stringMatching(/evaluators/) });
+  });
+
+  it("works without a logger argument", () => {
+    // The deploy runner parses policy bytes from a pinned tree; the signature
+    // must not force it to invent a logger.
+    const result = parsePolicyContent(JSON.stringify({ evaluators: [] }), "json");
+
+    expect(result.status).toBe("ok");
+  });
+});
+
+describe("loadPolicy — deploys wiring", () => {
+  beforeEach(() => {
+    mockReadFileFromRepo.mockReset();
+  });
+
+  /** Loads `config` as the policy file. */
+  async function loadConfig(config: unknown): Promise<EvalPolicy> {
+    mockReadFileFromRepo.mockResolvedValue({ success: true, data: JSON.stringify(config) });
+    return loadPolicy("https://repo.example.com", "tok", mockLogger);
+  }
+
+  it("carries sanitized deploys onto the policy", async () => {
+    const policy = await loadConfig({
+      evaluators: [{ type: "diff" }],
+      deploys: [{ name: "production", target: "vercel", secrets: ["VERCEL_TOKEN"] }],
+    });
+
+    expect(policy.configError).toBeUndefined();
+    expect(policy.deploys).toEqual([
+      {
+        name: "production",
+        target: "vercel",
+        secrets: ["VERCEL_TOKEN"],
+        requiresApproval: false,
+      },
+    ]);
+    expect(policy.deployRejections).toBeUndefined();
+  });
+
+  it("leaves deploys absent when the policy declares none", async () => {
+    const policy = await loadConfig({ evaluators: [{ type: "diff" }] });
+
+    expect(policy.deploys).toBeUndefined();
+    expect(policy.deployRejections).toBeUndefined();
+  });
+
+  it("does not let a raw deploys value bypass sanitization through the spread", async () => {
+    // Regression: the policy is built as `{...DEFAULT_POLICY, ...parsed}`, so
+    // once `deploys` exists on EvalPolicy the *parsed* value flows straight
+    // through — unsanitized and by reference — unless it is rebuilt. Each of
+    // these would be visible on the policy under that bug.
+    const notAList = await loadConfig({
+      evaluators: [{ type: "diff" }],
+      deploys: { name: "prod" },
+    });
+    expect(notAList.deploys).toBeUndefined();
+    expect(notAList.deployRejections?.[0]?.reason).toMatch(/must be a list/);
+
+    const withExtras = await loadConfig({
+      evaluators: [{ type: "diff" }],
+      deploys: [{ name: "prod", target: "vercel", token: "hunter2" }],
+    });
+    expect(withExtras.deploys).toBeUndefined();
+    expect(JSON.stringify(withExtras)).not.toContain("hunter2");
+
+    // `deployRejections` is loader-owned output, not policy-file input.
+    const forged = await loadConfig({
+      evaluators: [{ type: "diff" }],
+      deployRejections: [{ name: "fake", reason: "forged" }],
+    });
+    expect(forged.deployRejections).toBeUndefined();
+  });
+
+  it("returns entries that share no identity with the parsed policy file", async () => {
+    // A second load must not be able to observe a mutation made to the first.
+    const policy = await loadConfig({
+      evaluators: [{ type: "diff" }],
+      deploys: [{ name: "prod", target: "vercel", secrets: ["VERCEL_TOKEN"] }],
+    });
+    (policy.deploys as DeployConfig[])[0]?.secrets?.push("MUTATED");
+
+    const second = await loadConfig({
+      evaluators: [{ type: "diff" }],
+      deploys: [{ name: "prod", target: "vercel", secrets: ["VERCEL_TOKEN"] }],
+    });
+
+    expect(second.deploys?.[0]?.secrets).toEqual(["VERCEL_TOKEN"]);
+  });
+
+  it("reports a rejected entry without blocking merges", async () => {
+    // Deliberately unlike `evaluators`, where one unusable entry fails the file
+    // closed. A deploy runs after the merge, so a bad entry is reported as a
+    // failed deployment instead of changing the merge gate's behavior.
+    const policy = await loadConfig({
+      evaluators: [{ type: "diff" }],
+      deploys: [
+        { name: "prod", target: "vercel" },
+        { name: "staging", target: "netlify" },
+      ],
+    });
+
+    expect(policy.configError).toBeUndefined();
+    expect(policy.deploys?.map((d) => d.name)).toEqual(["prod"]);
+    expect(policy.deployRejections).toEqual([
+      { name: "staging", reason: expect.stringMatching(/unknown target/) },
+    ]);
+  });
+
+  it("surfaces a malformed policy file as a deploy rejection, not silence", async () => {
+    // malformedPolicy returns DEFAULT_POLICY, which declares no deploys — so a
+    // YAML typo would otherwise disable every deploy with nothing to show for it.
+    mockReadFileFromRepo.mockResolvedValue({ success: true, data: "evaluators: [ unclosed" });
+
+    const policy = await loadPolicy("https://repo.example.com", "tok", mockLogger);
+
+    expect(policy.configError).toBeDefined();
+    expect(policy.deploys).toBeUndefined();
+    expect(policy.deployRejections).toHaveLength(1);
+    expect(policy.deployRejections?.[0]?.name).toBeNull();
+    expect(policy.deployRejections?.[0]?.reason).toMatch(/\.stratum\/policy\.yaml/);
+  });
+
+  it("does not invent a deploy rejection when the policy file is simply absent", async () => {
+    mockReadFileFromRepo.mockResolvedValue({
+      success: false,
+      error: new AppError("missing", "NOT_FOUND", 404),
+    });
+
+    const policy = await loadPolicy("https://repo.example.com", "tok", mockLogger);
+
+    expect(policy.deployRejections).toBeUndefined();
+    expect(policy.deploys).toBeUndefined();
+  });
+});

--- a/tests/deploy-queue-typing.test.ts
+++ b/tests/deploy-queue-typing.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DeployQueueMessage } from "../src/deploy/runner";
+import type { Env } from "../src/types";
+
+/**
+ * `Env.DEPLOY_QUEUE` is parameterized with {@link DeployQueueMessage} rather than
+ * left as a bare `Queue`, so a malformed send is a compile error instead of a
+ * message the consumer discards at runtime.
+ *
+ * The `@ts-expect-error` lines below are the actual assertions: `tsc --noEmit`
+ * fails if the code beneath one turns out to be *valid*, so widening the binding
+ * back to `Queue<unknown>` breaks the typecheck gate, not just this suite.
+ */
+type DeployQueue = NonNullable<Env["DEPLOY_QUEUE"]>;
+
+function fakeQueue(): { queue: DeployQueue; send: ReturnType<typeof vi.fn> } {
+  const send = vi.fn(async () => {});
+  return { queue: { send, sendBatch: vi.fn(async () => {}) } as unknown as DeployQueue, send };
+}
+
+describe("DEPLOY_QUEUE binding typing", () => {
+  it("accepts a well-formed merge message", async () => {
+    const { queue, send } = fakeQueue();
+    const message: DeployQueueMessage = {
+      kind: "merge",
+      projectId: "prj_1",
+      changeId: "chg_1",
+      commitSha: "abcdef1234567890abcdef1234567890abcdef12",
+      mergedAt: "2026-09-01T10:00:00.000Z",
+    };
+
+    await queue.send(message);
+
+    expect(send).toHaveBeenCalledWith(message);
+  });
+
+  it("accepts a well-formed deployment message", async () => {
+    const { queue, send } = fakeQueue();
+
+    await queue.send({ kind: "deployment", projectId: "prj_1", deploymentId: "dep_1" });
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an unknown kind at compile time", async () => {
+    const { queue, send } = fakeQueue();
+
+    // @ts-expect-error - "deploy" is not one of the DeployQueueMessage kinds
+    await queue.send({ kind: "deploy", projectId: "prj_1", deploymentId: "dep_1" });
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a merge message missing its pinned commit at compile time", async () => {
+    const { queue, send } = fakeQueue();
+
+    // @ts-expect-error - a merge message must carry the commitSha it pins
+    await queue.send({ kind: "merge", projectId: "prj_1", changeId: "chg_1" });
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a deployment message missing its tenant scope at compile time", async () => {
+    const { queue, send } = fakeQueue();
+
+    // @ts-expect-error - projectId is the only tenant scope the runner accepts
+    await queue.send({ kind: "deployment", deploymentId: "dep_1" });
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/deploy-queue.test.ts
+++ b/tests/deploy-queue.test.ts
@@ -3,12 +3,24 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../src/deploy/runner", () => ({
   runDeployMessage: vi.fn(async () => ({ success: true, data: { deployments: [] } })),
 }));
+// The outbox recovery tests assert that an internal work row never reaches a
+// subscriber, so webhook delivery is observed rather than performed.
+vi.mock("../src/queue/webhook-delivery", () => ({
+  deliverEventToWebhooks: vi.fn(async () => {}),
+}));
 
 import { runDeployMessage } from "../src/deploy/runner";
-import { enqueueMergeDeploy, handleDeployQueue } from "../src/queue/deploy-queue";
+import {
+  DEPLOY_ENQUEUE_EVENT_TYPE,
+  enqueueMergeDeploy,
+  handleDeployQueue,
+} from "../src/queue/deploy-queue";
+import { sweepStaleEvents } from "../src/queue/event-consumer";
+import { deliverEventToWebhooks } from "../src/queue/webhook-delivery";
 import type { Env, Message, MessageBatch } from "../src/types";
 import { AppError } from "../src/utils/errors";
 import { createLogger } from "../src/utils/logger";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
 
 interface StubMessage {
   message: Message<unknown>;
@@ -328,5 +340,144 @@ describe("enqueueMergeDeploy", () => {
       }),
     ).resolves.toBeUndefined();
     expect(send).toHaveBeenCalled();
+  });
+});
+
+/**
+ * The durability half of this queue: a `send` that fails must not lose the
+ * request. Real SQLite, because the outbox row is the whole guarantee.
+ */
+describe("a deploy request whose send failed", () => {
+  let db: D1Database;
+  let raw: ReturnType<typeof makeSqliteD1>["raw"];
+
+  const rejects = () =>
+    vi.fn(async () => {
+      throw new Error("queue unavailable");
+    });
+
+  interface OutboxRow {
+    id: string;
+    type: string;
+    project: string;
+    project_id: string | null;
+    status: string;
+    payload: string;
+  }
+
+  function outbox(): OutboxRow[] {
+    return raw
+      .prepare("SELECT id, type, project, project_id, status, payload FROM events")
+      .all() as unknown as OutboxRow[];
+  }
+
+  beforeEach(() => {
+    const made = makeSqliteD1();
+    db = made.db;
+    raw = made.raw;
+    vi.clearAllMocks();
+  });
+
+  // The merge path is the one a sweep over `deployments` could never fix: the
+  // runner creates rows only *after* it consumes the message, so a dropped send
+  // leaves nothing at all behind.
+  it("is recorded in the outbox when the merge enqueue fails", async () => {
+    await enqueueMergeDeploy(
+      { DB: db, DEPLOY_QUEUE: { send: rejects() } } as unknown as Env,
+      logger,
+      {
+        projectId: "proj_1",
+        changeId: "chg_1",
+        commitSha: "sha_1",
+        postMergeStatus: "passed",
+        mergedAt: MERGED_AT,
+      },
+    );
+
+    const rows = outbox();
+    expect(rows).toHaveLength(1);
+    const row = rows[0] as OutboxRow;
+    expect(row.type).toBe(DEPLOY_ENQUEUE_EVENT_TYPE);
+    expect(row.status).toBe("pending");
+    expect(row.project_id).toBe("proj_1");
+    expect(JSON.parse(row.payload)).toEqual({
+      kind: "merge",
+      projectId: "proj_1",
+      changeId: "chg_1",
+      commitSha: "sha_1",
+      mergedAt: MERGED_AT,
+    });
+  });
+
+  it("writes nothing when the send succeeds", async () => {
+    await enqueueMergeDeploy(
+      { DB: db, DEPLOY_QUEUE: { send: vi.fn(async () => {}) } } as unknown as Env,
+      logger,
+      {
+        projectId: "proj_1",
+        changeId: "chg_1",
+        commitSha: "sha_1",
+        postMergeStatus: "passed",
+        mergedAt: MERGED_AT,
+      },
+    );
+
+    expect(outbox()).toHaveLength(0);
+  });
+
+  // End to end: the row the failed send left behind is what the five-minute
+  // sweep turns back into a deploy queue message. Nothing here runs the deploy
+  // on the events queue — the handler only forwards.
+  it("is recovered by the outbox sweep and forwarded to the deploy queue", async () => {
+    await enqueueMergeDeploy(
+      { DB: db, DEPLOY_QUEUE: { send: rejects() } } as unknown as Env,
+      logger,
+      {
+        projectId: "proj_1",
+        changeId: "chg_1",
+        commitSha: "sha_1",
+        postMergeStatus: "passed",
+        mergedAt: MERGED_AT,
+      },
+    );
+
+    // Age the row past the sweep's staleness window.
+    raw.prepare("UPDATE events SET created_at = ?").run("2026-01-01T00:00:00.000Z");
+
+    const send = vi.fn(async () => {});
+    // No EVENTS_QUEUE bound, so the sweep processes the row inline — the same
+    // handlers a queue delivery would run.
+    await sweepStaleEvents({ DB: db, DEPLOY_QUEUE: { send } } as unknown as Env, logger);
+
+    expect(send).toHaveBeenCalledWith({
+      kind: "merge",
+      projectId: "proj_1",
+      changeId: "chg_1",
+      commitSha: "sha_1",
+      mergedAt: MERGED_AT,
+    });
+    expect((outbox()[0] as OutboxRow).status).toBe("processed");
+    // An internal work row is not a notification: a `*` webhook subscriber must
+    // never see one.
+    expect(deliverEventToWebhooks).not.toHaveBeenCalled();
+  });
+
+  it("stays pending when the forward fails again, so a later sweep retries it", async () => {
+    await enqueueMergeDeploy(
+      { DB: db, DEPLOY_QUEUE: { send: rejects() } } as unknown as Env,
+      logger,
+      {
+        projectId: "proj_1",
+        changeId: "chg_1",
+        commitSha: "sha_1",
+        postMergeStatus: "passed",
+        mergedAt: MERGED_AT,
+      },
+    );
+    raw.prepare("UPDATE events SET created_at = ?").run("2026-01-01T00:00:00.000Z");
+
+    await sweepStaleEvents({ DB: db, DEPLOY_QUEUE: { send: rejects() } } as unknown as Env, logger);
+
+    expect((outbox()[0] as OutboxRow).status).toBe("pending");
   });
 });

--- a/tests/deploy-queue.test.ts
+++ b/tests/deploy-queue.test.ts
@@ -1,0 +1,332 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/deploy/runner", () => ({
+  runDeployMessage: vi.fn(async () => ({ success: true, data: { deployments: [] } })),
+}));
+
+import { runDeployMessage } from "../src/deploy/runner";
+import { enqueueMergeDeploy, handleDeployQueue } from "../src/queue/deploy-queue";
+import type { Env, Message, MessageBatch } from "../src/types";
+import { AppError } from "../src/utils/errors";
+import { createLogger } from "../src/utils/logger";
+
+interface StubMessage {
+  message: Message<unknown>;
+  ack: ReturnType<typeof vi.fn>;
+  retry: ReturnType<typeof vi.fn>;
+}
+
+function makeMessage(body: unknown): StubMessage {
+  const ack = vi.fn();
+  const retry = vi.fn();
+  return {
+    message: {
+      id: "msg_1",
+      timestamp: new Date(),
+      body,
+      attempts: 1,
+      ack,
+      retry,
+    } as unknown as Message<unknown>,
+    ack,
+    retry,
+  };
+}
+
+function makeBatch(messages: Message<unknown>[]): MessageBatch<unknown> {
+  return {
+    queue: "stratum-deploys",
+    messages,
+    ackAll: vi.fn(),
+    retryAll: vi.fn(),
+  } as unknown as MessageBatch<unknown>;
+}
+
+const env = {} as Env;
+const logger = createLogger({ component: "test" });
+
+const MERGED_AT = "2026-09-04T09:00:00.000Z";
+
+const mergeBody = { kind: "merge", projectId: "proj_1", changeId: "chg_1", commitSha: "sha_1" };
+
+describe("handleDeployQueue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(runDeployMessage).mockResolvedValue({ success: true, data: { deployments: [] } });
+  });
+
+  it("routes one message to one deployment run and acks it", async () => {
+    const msg = makeMessage(mergeBody);
+    await handleDeployQueue(makeBatch([msg.message]), env);
+
+    expect(runDeployMessage).toHaveBeenCalledTimes(1);
+    expect(runDeployMessage).toHaveBeenCalledWith(
+      env,
+      { kind: "merge", projectId: "proj_1", changeId: "chg_1", commitSha: "sha_1" },
+      expect.any(Object),
+    );
+    expect(msg.ack).toHaveBeenCalledTimes(1);
+    expect(msg.retry).not.toHaveBeenCalled();
+  });
+
+  it("carries the merge time through to the runner", async () => {
+    const msg = makeMessage({ ...mergeBody, mergedAt: MERGED_AT });
+    await handleDeployQueue(makeBatch([msg.message]), env);
+
+    expect(runDeployMessage).toHaveBeenCalledWith(
+      env,
+      { ...mergeBody, mergedAt: MERGED_AT },
+      expect.any(Object),
+    );
+  });
+
+  // A merge time the deployments columns would reject must not reach them: the
+  // insert would fail and the deploy would be stranded, where dropping the field
+  // costs only the ordering guarantee for this one message.
+  it.each([
+    ["SQLite's space-separated form", "2026-09-04 09:00:00"],
+    ["a non-timestamp", "yesterday"],
+    ["a number", 1_757_000_000_000],
+  ])("drops an unusable merge time (%s) rather than stranding the deploy", async (_l, mergedAt) => {
+    const msg = makeMessage({ ...mergeBody, mergedAt });
+    await handleDeployQueue(makeBatch([msg.message]), env);
+
+    expect(runDeployMessage).toHaveBeenCalledWith(env, mergeBody, expect.any(Object));
+    expect(msg.ack).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes a deployment message through unchanged", async () => {
+    const msg = makeMessage({ kind: "deployment", projectId: "proj_1", deploymentId: "dep_1" });
+    await handleDeployQueue(makeBatch([msg.message]), env);
+
+    expect(runDeployMessage).toHaveBeenCalledWith(
+      env,
+      { kind: "deployment", projectId: "proj_1", deploymentId: "dep_1" },
+      expect.any(Object),
+    );
+    expect(msg.ack).toHaveBeenCalled();
+  });
+
+  // An abort is the runner saying "no redelivery of this can ever succeed".
+  it("acks an aborted run instead of retrying it", async () => {
+    vi.mocked(runDeployMessage).mockResolvedValue({
+      success: true,
+      data: { deployments: [], aborted: "The change was reverted" },
+    });
+    const msg = makeMessage(mergeBody);
+    await handleDeployQueue(makeBatch([msg.message]), env);
+
+    expect(msg.ack).toHaveBeenCalledTimes(1);
+    expect(msg.retry).not.toHaveBeenCalled();
+  });
+
+  // A failed deployment row is a result, not a delivery failure.
+  it("acks a run that produced a failed deployment", async () => {
+    vi.mocked(runDeployMessage).mockResolvedValue({
+      success: true,
+      data: {
+        deployments: [
+          { deploymentId: "dep_1", name: "site", status: "failed", reason: "Missing secret TOKEN" },
+        ],
+      },
+    });
+    const msg = makeMessage(mergeBody);
+    await handleDeployQueue(makeBatch([msg.message]), env);
+
+    expect(msg.ack).toHaveBeenCalledTimes(1);
+    expect(msg.retry).not.toHaveBeenCalled();
+  });
+
+  it("retries when the run could not determine what happened", async () => {
+    vi.mocked(runDeployMessage).mockResolvedValue({
+      success: false,
+      error: new AppError("D1 unavailable", "INTERNAL_ERROR", 500),
+    });
+    const msg = makeMessage(mergeBody);
+    await handleDeployQueue(makeBatch([msg.message]), env);
+
+    expect(msg.retry).toHaveBeenCalledTimes(1);
+    expect(msg.ack).not.toHaveBeenCalled();
+  });
+
+  it("retries when the run throws despite its no-throw contract", async () => {
+    vi.mocked(runDeployMessage).mockRejectedValue(new Error("boom"));
+    const msg = makeMessage(mergeBody);
+    await handleDeployQueue(makeBatch([msg.message]), env);
+
+    expect(msg.retry).toHaveBeenCalledTimes(1);
+    expect(msg.ack).not.toHaveBeenCalled();
+  });
+
+  // Redelivering a message the consumer cannot parse changes nothing about it,
+  // so it is acked rather than burned through the retry budget.
+  it.each([
+    ["a non-object body", "not-a-message"],
+    ["a null body", null],
+    ["an unknown kind", { kind: "publish", projectId: "proj_1" }],
+    ["a merge without projectId", { kind: "merge", changeId: "chg_1", commitSha: "sha_1" }],
+    ["a merge with a blank projectId", { ...mergeBody, projectId: "   " }],
+    ["a merge without commitSha", { kind: "merge", projectId: "proj_1", changeId: "chg_1" }],
+    ["a deployment without deploymentId", { kind: "deployment", projectId: "proj_1" }],
+  ])("acks %s without running a deploy", async (_label, body) => {
+    const msg = makeMessage(body);
+    await handleDeployQueue(makeBatch([msg.message]), env);
+
+    expect(runDeployMessage).not.toHaveBeenCalled();
+    expect(msg.ack).toHaveBeenCalledTimes(1);
+    expect(msg.retry).not.toHaveBeenCalled();
+  });
+
+  it("handles every message in a batch independently", async () => {
+    vi.mocked(runDeployMessage)
+      .mockResolvedValueOnce({
+        success: false,
+        error: new AppError("D1 unavailable", "INTERNAL_ERROR", 500),
+      })
+      .mockResolvedValueOnce({ success: true, data: { deployments: [] } });
+    const first = makeMessage(mergeBody);
+    const second = makeMessage(mergeBody);
+    await handleDeployQueue(makeBatch([first.message, second.message]), env);
+
+    expect(first.retry).toHaveBeenCalledTimes(1);
+    expect(second.ack).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("enqueueMergeDeploy", () => {
+  function envWithQueue(send: ReturnType<typeof vi.fn>): Env {
+    return { DEPLOY_QUEUE: { send } } as unknown as Env;
+  }
+
+  it.each(["skipped", "passed"] as const)(
+    "enqueues after a %s post-merge check",
+    async (status) => {
+      const send = vi.fn(async () => {});
+      await enqueueMergeDeploy(envWithQueue(send), logger, {
+        projectId: "proj_1",
+        changeId: "chg_1",
+        commitSha: "sha_1",
+        postMergeStatus: status,
+        mergedAt: MERGED_AT,
+      });
+
+      expect(send).toHaveBeenCalledWith({
+        kind: "merge",
+        projectId: "proj_1",
+        changeId: "chg_1",
+        commitSha: "sha_1",
+        mergedAt: MERGED_AT,
+      });
+    },
+  );
+
+  // The queue merge path has no merge time in scope, so the change row is what
+  // the message is stamped from. Enqueue time will not do: `runPostMergeCheck`
+  // runs between the merge and this call and can spend minutes in a sandbox, so
+  // a slow-checked merge would be stamped *after* a later, faster one.
+  it("reads the merge time off the change when the caller has none", async () => {
+    const send = vi.fn(async () => {});
+    const db = {
+      prepare: () => ({
+        bind: () => ({
+          first: async () => ({
+            id: "chg_1",
+            project: "site",
+            status: "merged",
+            merged_at: MERGED_AT,
+          }),
+        }),
+      }),
+    } as unknown as D1Database;
+
+    await enqueueMergeDeploy({ DB: db, DEPLOY_QUEUE: { send } } as unknown as Env, logger, {
+      projectId: "proj_1",
+      changeId: "chg_1",
+      commitSha: "sha_1",
+      postMergeStatus: "passed",
+    });
+
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ mergedAt: MERGED_AT }));
+  });
+
+  // A merge with no readable `merged_at` still deploys. Enqueue time is an
+  // approximation, but it still orders correctly against every merge whose time
+  // *is* known, which a missing field would not.
+  it("falls back to enqueue time when the change carries no merge time", async () => {
+    const send = vi.fn(async () => {});
+    const db = {
+      prepare: () => ({
+        bind: () => ({
+          first: async () => {
+            throw new Error("D1 unavailable");
+          },
+        }),
+      }),
+    } as unknown as D1Database;
+
+    await enqueueMergeDeploy({ DB: db, DEPLOY_QUEUE: { send } } as unknown as Env, logger, {
+      projectId: "proj_1",
+      changeId: "chg_1",
+      commitSha: "sha_1",
+      postMergeStatus: "passed",
+    });
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ mergedAt: expect.any(String) as unknown as string }),
+    );
+    const [message] = send.mock.calls[0] as unknown as [{ mergedAt: string }];
+    expect(Number.isNaN(Date.parse(message.mergedAt))).toBe(false);
+  });
+
+  // The regression this whole ordering exists to prevent: a failed post-merge
+  // check reverts the merge, so deploying that commit publishes reverted code.
+  it.each(["reverted", "failed"] as const)("does not enqueue after a %s check", async (status) => {
+    const send = vi.fn(async () => {});
+    await enqueueMergeDeploy(envWithQueue(send), logger, {
+      projectId: "proj_1",
+      changeId: "chg_1",
+      commitSha: "sha_1",
+      postMergeStatus: status,
+    });
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("is inert when no deploy queue is bound", async () => {
+    await expect(
+      enqueueMergeDeploy({} as Env, logger, {
+        projectId: "proj_1",
+        changeId: "chg_1",
+        commitSha: "sha_1",
+        postMergeStatus: "passed",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not enqueue without a commit to deploy", async () => {
+    const send = vi.fn(async () => {});
+    await enqueueMergeDeploy(envWithQueue(send), logger, {
+      projectId: "proj_1",
+      changeId: "chg_1",
+      commitSha: "",
+      postMergeStatus: "passed",
+    });
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("swallows a queue-send failure", async () => {
+    const send = vi.fn(async () => {
+      throw new Error("queue unavailable");
+    });
+    await expect(
+      enqueueMergeDeploy(envWithQueue(send), logger, {
+        projectId: "proj_1",
+        changeId: "chg_1",
+        commitSha: "sha_1",
+        postMergeStatus: "passed",
+      }),
+    ).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalled();
+  });
+});

--- a/tests/deploy-runner.test.ts
+++ b/tests/deploy-runner.test.ts
@@ -1,0 +1,709 @@
+/**
+ * The deploy runner.
+ *
+ * The assertions that matter are about *honesty and containment*, not about
+ * whether a happy path works:
+ *
+ * - `skipped` appears only when nothing was configured. Every operator error —
+ *   a missing secret, an unset `DEPLOY_SECRET_KEY`, a rejected config entry, an
+ *   unreadable tree — has to land as `failed` with a reason naming the cause,
+ *   because reporting one as a calm grey state is failing open.
+ * - A message with no `projectId` resolves nothing. Project names are not
+ *   globally unique, so a name-based fallback would hand a deploy another
+ *   tenant's credentials.
+ * - A reverted change or a deleting project stops the deploy *before* the
+ *   provider is called, and a target that throws still leaves a terminal row.
+ * - No secret value reaches a persisted `reason` or `log_tail`, including on the
+ *   path where the provider's own error is what carries it.
+ *
+ * The runner's three seams (`readFiles`, `now`, `fetch`) are injected, so none
+ * of this needs git, a clock, or a provider account. D1 is real SQLite with the
+ * production migrations applied.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type DeployFilesReader,
+  type DeployQueueMessage,
+  type DeployRunnerDeps,
+  runDeployMessage,
+} from "../src/deploy/runner";
+import type { DeployFetch } from "../src/deploy/targets/index";
+import { type Deployment, insertDeployment } from "../src/storage/deployments";
+import { putSecret } from "../src/storage/project-secrets";
+import { setProject } from "../src/storage/state";
+import type { Env, ProjectEntry } from "../src/types";
+import { AppError } from "../src/utils/errors";
+import type { Logger } from "../src/utils/logger";
+import { ok } from "../src/utils/result";
+import { makeFakeKV } from "./helpers/fake-kv";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+};
+
+const PROJECT_ID = "prj_deployrunner";
+const PROJECT_NAME = "api";
+const CHANGE_ID = "chg_deployrunner";
+const SHA = "a".repeat(40);
+const OLD_SHA = "b".repeat(40);
+const NEWER_SHA = "c".repeat(40);
+const REMOTE = "https://acct.artifacts.cloudflare.net/git/acct/api.git";
+
+const VERCEL_TOKEN = "vercel-token-super-secret-value";
+const VERCEL_PROJECT = "prj_vercel_abc123";
+const DEPLOY_SECRET_KEY = "a-test-deploy-secret-key";
+
+/** `now` for the run itself; every fixture row is stamped earlier than this. */
+const T1 = Date.parse("2026-09-04T01:00:00.000Z");
+const T1_ISO = "2026-09-04T01:00:00.000Z";
+const T0 = "2026-09-04T00:00:00.000Z";
+
+/** A merge time between the fixtures and the run, for the ordering cases. */
+const MERGED_AT = "2026-09-04T00:15:00.000Z";
+
+const PROJECT: ProjectEntry = {
+  id: PROJECT_ID,
+  name: PROJECT_NAME,
+  slug: "api",
+  namespace: "@alice",
+  ownerId: "usr_alice",
+  ownerType: "org",
+  remote: REMOTE,
+  createdAt: T0,
+};
+
+const VERCEL_POLICY = `evaluators:
+  - type: diff
+
+deploys:
+  - name: production
+    target: vercel
+    secrets: [VERCEL_TOKEN, VERCEL_PROJECT_ID]
+`;
+
+let db: D1Database;
+let raw: ReturnType<typeof makeSqliteD1>["raw"];
+let kv: KVNamespace;
+
+beforeEach(async () => {
+  const made = makeSqliteD1();
+  db = made.db;
+  raw = made.raw;
+  kv = makeFakeKV();
+  vi.clearAllMocks();
+
+  const stored = await setProject(kv, PROJECT, logger);
+  if (!stored.success) throw stored.error;
+
+  raw
+    .prepare(
+      "INSERT INTO changes (id, project, project_id, workspace, status, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .run(CHANGE_ID, PROJECT_NAME, PROJECT_ID, "ws1", "merged", T0);
+});
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    DB: db,
+    STATE: kv,
+    ARTIFACTS: {
+      get: async () => ({ createToken: async () => ({ plaintext: "repo-token" }) }),
+    },
+    DEPLOY_SECRET_KEY,
+    ...overrides,
+  } as unknown as Env;
+}
+
+function tree(policy: string | null = VERCEL_POLICY): Map<string, Uint8Array> {
+  const encoder = new TextEncoder();
+  const files = new Map<string, Uint8Array>([["index.html", encoder.encode("<h1>hi</h1>")]]);
+  if (policy !== null) files.set(".stratum/policy.yaml", encoder.encode(policy));
+  return files;
+}
+
+function readsTree(files: Map<string, Uint8Array>): DeployFilesReader {
+  return vi.fn(async () => ok(files));
+}
+
+const unreadableTree: DeployFilesReader = vi.fn(async () => ({
+  success: false as const,
+  error: new AppError("commit not found after deepening", "EXTERNAL_SERVICE_ERROR", 502),
+}));
+
+/** A Vercel create-deployment response: accepted for build, not yet live. */
+function vercelAccepts(): DeployFetch {
+  return vi.fn(
+    async () =>
+      new Response(
+        JSON.stringify({ id: "dpl_abc", url: "api-abc123.vercel.app", readyState: "QUEUED" }),
+        { status: 200 },
+      ),
+  );
+}
+
+/** A provider that answers 4xx with the caller's own token echoed back at it. */
+function vercelRejectsEchoingTheToken(): DeployFetch {
+  return vi.fn(
+    async () =>
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "forbidden",
+            message: `token ${VERCEL_TOKEN} cannot deploy ${VERCEL_PROJECT}`,
+          },
+        }),
+        { status: 403 },
+      ),
+  );
+}
+
+async function storeSecrets(names: Record<string, string>): Promise<void> {
+  for (const [name, value] of Object.entries(names)) {
+    const result = await putSecret(
+      db,
+      logger,
+      { DEPLOY_SECRET_KEY },
+      {
+        projectId: PROJECT_ID,
+        name,
+        value,
+        actorId: "usr_alice",
+      },
+    );
+    if (!result.success) throw result.error;
+  }
+}
+
+/** Insert a deployment row directly, for fixtures the runner is expected to find. */
+async function insertFixture(
+  overrides: Partial<Parameters<typeof insertDeployment>[2]> = {},
+): Promise<Deployment> {
+  const result = await insertDeployment(db, logger, {
+    projectId: PROJECT_ID,
+    project: PROJECT_NAME,
+    commitSha: SHA,
+    name: "production",
+    target: "vercel",
+    requestedByType: "system",
+    now: T0,
+    ...overrides,
+  });
+  if (!result.success) throw result.error;
+  if (!result.data.inserted) throw new Error("fixture insert lost the unique index race");
+  return result.data.deployment;
+}
+
+const MERGE_MESSAGE: DeployQueueMessage = {
+  kind: "merge",
+  projectId: PROJECT_ID,
+  changeId: CHANGE_ID,
+  commitSha: SHA,
+};
+
+async function run(
+  message: DeployQueueMessage = MERGE_MESSAGE,
+  deps: DeployRunnerDeps = {},
+  env: Env = makeEnv(),
+) {
+  return runDeployMessage(env, message, logger, {
+    readFiles: readsTree(tree()),
+    now: () => T1,
+    fetch: vercelAccepts(),
+    ...deps,
+  });
+}
+
+interface Row {
+  id: string;
+  name: string;
+  target: string;
+  status: string;
+  reason: string | null;
+  url: string | null;
+  log_tail: string | null;
+  commit_sha: string;
+  duration_ms: number | null;
+  completed_at: string | null;
+  lease_expires_at: string | null;
+}
+
+function rows(): Row[] {
+  return raw
+    .prepare("SELECT * FROM deployments ORDER BY created_at ASC, id ASC")
+    .all() as unknown as Row[];
+}
+
+function onlyRow(): Row {
+  const all = rows();
+  expect(all).toHaveLength(1);
+  return all[0] as Row;
+}
+
+describe("the happy path", () => {
+  it("publishes the tree and records what the provider actually promised", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    const fetch = vercelAccepts();
+
+    const result = await run(MERGE_MESSAGE, { fetch });
+
+    expect(result.success).toBe(true);
+    const row = onlyRow();
+    expect(row.status).toBe("succeeded");
+    expect(row.name).toBe("production");
+    expect(row.target).toBe("vercel");
+    expect(row.url).toBe("https://api-abc123.vercel.app");
+    expect(row.commit_sha).toBe(SHA);
+    expect(row.lease_expires_at).toBeNull();
+    expect(row.completed_at).not.toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("qualifies a succeeded row with the provider's own readyState", async () => {
+    // Vercel returns as soon as it has *accepted* the deployment and builds
+    // afterwards; the runner does not poll. A bare `succeeded` would claim the
+    // commit is live when it may still be building.
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+
+    await run();
+
+    const row = onlyRow();
+    expect(row.status).toBe("succeeded");
+    expect(row.reason).toContain("QUEUED");
+    expect(row.reason).toContain("does not poll");
+  });
+
+  it("reads the tree at the pinned commit, never at a branch tip", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    const readFiles = readsTree(tree());
+
+    await run(MERGE_MESSAGE, { readFiles });
+
+    expect(readFiles).toHaveBeenCalledWith(REMOTE, "repo-token", logger, SHA, "main");
+  });
+
+  it("records the git cost of reading the tree", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+
+    await run();
+
+    const costs = raw
+      .prepare("SELECT kind, quantity, project_id, change_id FROM cost_records")
+      .all() as unknown as Array<{
+      kind: string;
+      quantity: number;
+      project_id: string;
+      change_id: string;
+    }>;
+    expect(costs).toEqual([
+      { kind: "git_ops", quantity: 1, project_id: PROJECT_ID, change_id: CHANGE_ID },
+    ]);
+  });
+
+  it("emits deployment.requested and deployment.succeeded", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+
+    await run();
+
+    const events = raw
+      .prepare("SELECT type FROM events ORDER BY created_at ASC, id ASC")
+      .all() as unknown as Array<{ type: string }>;
+    expect(events.map((event) => event.type)).toEqual([
+      "deployment.requested",
+      "deployment.succeeded",
+    ]);
+  });
+});
+
+describe("operator errors are failures, never 'skipped'", () => {
+  it("names the missing secret", async () => {
+    await storeSecrets({ VERCEL_TOKEN });
+    const fetch = vercelAccepts();
+
+    await run(MERGE_MESSAGE, { fetch });
+
+    const row = onlyRow();
+    expect(row.status).toBe("failed");
+    expect(row.reason).toContain("VERCEL_PROJECT_ID");
+    // Nothing may be uploaded when a credential is missing.
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("names an unset DEPLOY_SECRET_KEY rather than reporting a quiet skip", async () => {
+    const env = makeEnv({ DEPLOY_SECRET_KEY: undefined });
+
+    await run(MERGE_MESSAGE, {}, env);
+
+    const row = onlyRow();
+    expect(row.status).toBe("failed");
+    expect(row.reason).toContain("DEPLOY_SECRET_KEY");
+  });
+
+  it("fails a secret that exists but will not decrypt", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    // The remedy differs from a missing secret: this is a rotated key, so the
+    // reason has to say so rather than telling the owner to add a value they
+    // already added.
+    const env = makeEnv({ DEPLOY_SECRET_KEY: "a-different-deploy-secret-key" });
+
+    await run(MERGE_MESSAGE, {}, env);
+
+    const row = onlyRow();
+    expect(row.status).toBe("failed");
+    expect(row.reason).toContain("rotated");
+  });
+
+  it("persists a failed row when the tree cannot be read at the merge commit", async () => {
+    await run(MERGE_MESSAGE, { readFiles: unreadableTree });
+
+    const row = onlyRow();
+    expect(row.status).toBe("failed");
+    expect(row.reason).toContain("Could not read the tree");
+    expect(row.reason).toContain(SHA.slice(0, 7));
+  });
+
+  it("persists a rejected deploys entry as a failed row naming it", async () => {
+    const policy = `evaluators:
+  - type: diff
+
+deploys:
+  - name: production
+    target: netlify
+`;
+
+    await run(MERGE_MESSAGE, { readFiles: readsTree(tree(policy)) });
+
+    const row = onlyRow();
+    expect(row.status).toBe("failed");
+    expect(row.name).toBe("production");
+    expect(row.reason).toContain("netlify");
+  });
+
+  it("persists a failed row when the policy file itself is malformed", async () => {
+    // A YAML typo must not silently disable deploys — the quietest possible
+    // way for production to stop updating.
+    await run(MERGE_MESSAGE, { readFiles: readsTree(tree("deploys: [:::\n")) });
+
+    const row = onlyRow();
+    expect(row.status).toBe("failed");
+    expect(row.reason).toContain(".stratum/policy.yaml");
+  });
+});
+
+describe("'skipped' means only that nothing was configured", () => {
+  it("skips when no policy file exists at the commit", async () => {
+    await run(MERGE_MESSAGE, { readFiles: readsTree(tree(null)) });
+
+    const row = onlyRow();
+    expect(row.status).toBe("skipped");
+    expect(row.reason).toContain("no deploy is configured");
+  });
+
+  it("skips when the policy declares no deploys", async () => {
+    await run(MERGE_MESSAGE, { readFiles: readsTree(tree("evaluators:\n  - type: diff\n")) });
+
+    const row = onlyRow();
+    expect(row.status).toBe("skipped");
+  });
+});
+
+describe("tenant scoping", () => {
+  it("fails closed when the message carries no projectId", async () => {
+    const readFiles = readsTree(tree());
+    const message = { kind: "merge", projectId: "", changeId: CHANGE_ID, commitSha: SHA } as const;
+
+    const result = await run(message, { readFiles });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw result.error;
+    expect(result.data.aborted).toContain("projectId");
+    expect(result.data.deployments).toEqual([]);
+    // Nothing was resolved by name, so nothing was read and nothing was written.
+    expect(readFiles).not.toHaveBeenCalled();
+    expect(rows()).toEqual([]);
+  });
+
+  it("refuses a change that belongs to another project", async () => {
+    raw.prepare("UPDATE changes SET project_id = ? WHERE id = ?").run("prj_someoneelse", CHANGE_ID);
+    const readFiles = readsTree(tree());
+
+    const result = await run(MERGE_MESSAGE, { readFiles });
+
+    if (!result.success) throw result.error;
+    expect(result.data.aborted).toContain("different project");
+    expect(readFiles).not.toHaveBeenCalled();
+    expect(rows()).toEqual([]);
+  });
+});
+
+describe("aborting before the provider is called", () => {
+  it("does not deploy a change that was reverted after it was enqueued", async () => {
+    // The exact bug this guards: `runPostMergeCheck` auto-reverts, and the
+    // queue promises nothing about when the message arrives.
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    raw.prepare("UPDATE changes SET status = 'reverted' WHERE id = ?").run(CHANGE_ID);
+    const fetch = vercelAccepts();
+    const readFiles = readsTree(tree());
+
+    const result = await run(MERGE_MESSAGE, { fetch, readFiles });
+
+    if (!result.success) throw result.error;
+    expect(result.data.aborted).toContain("reverted");
+    expect(fetch).not.toHaveBeenCalled();
+    expect(readFiles).not.toHaveBeenCalled();
+    expect(rows()).toEqual([]);
+  });
+
+  it("does not deploy while the project is being deleted", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    raw
+      .prepare(
+        "INSERT INTO deletion_jobs (id, kind, target, state, created_at) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run("del_1", "project", JSON.stringify({ projectId: PROJECT_ID }), "running", T0);
+    const fetch = vercelAccepts();
+
+    const result = await run(MERGE_MESSAGE, { fetch });
+
+    if (!result.success) throw result.error;
+    expect(result.data.aborted).toContain("deleted");
+    expect(fetch).not.toHaveBeenCalled();
+    expect(rows()).toEqual([]);
+  });
+});
+
+describe("ordering and leases", () => {
+  it("supersedes an older queued deployment of the same name", async () => {
+    // Two merges in quick succession arrive in whatever order the queue
+    // chooses; without this the older commit can be the one left in production.
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    const older = await insertFixture({ commitSha: OLD_SHA });
+
+    await run();
+
+    const all = rows();
+    expect(all).toHaveLength(2);
+    const supersededRow = all.find((row) => row.id === older.id);
+    expect(supersededRow?.status).toBe("superseded");
+    expect(all.find((row) => row.commit_sha === SHA)?.status).toBe("succeeded");
+  });
+
+  // The bug this stamping exists to close: `created_at` used to be written when
+  // the *message* was processed. Cloudflare Queues promise no ordering and a
+  // retry reorders outright, so an older merge delivered second was stamped
+  // newer than the merge that beat it — and then published over it.
+  it("stamps rows with the merge time, not the time the message was processed", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+
+    await run({ ...MERGE_MESSAGE, mergedAt: MERGED_AT });
+
+    const row = raw.prepare("SELECT * FROM deployments").get() as unknown as Row & {
+      created_at: string;
+    };
+    expect(row.created_at).toBe(MERGED_AT);
+    // The clock still owns everything that really is about this run.
+    expect(row.completed_at).toBe(T1_ISO);
+  });
+
+  // Compatibility. A `merge` message enqueued by the previous deployment of the
+  // Worker carries no `mergedAt` at all, and losing a real deploy over a schema
+  // change is worse than losing the ordering guarantee for one message.
+  it("still deploys a legacy message that carries no merge time", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    const fetch = vercelAccepts();
+
+    await run(MERGE_MESSAGE, { fetch });
+
+    const row = raw.prepare("SELECT * FROM deployments").get() as unknown as Row & {
+      created_at: string;
+    };
+    expect(row.status).toBe("succeeded");
+    expect(fetch).toHaveBeenCalledTimes(1);
+    // Fell back to processing time, which is what the row was stamped with
+    // before this field existed.
+    expect(row.created_at).toBe(T1_ISO);
+  });
+
+  // The half `supersedeOlder` cannot cover: it only touches rows that have not
+  // started, so once the newer merge is `succeeded` there is nothing left for it
+  // to retire and the late older message would deploy straight over the top.
+  it("refuses to publish over a newer commit that already succeeded", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    const newer = await insertFixture({
+      commitSha: NEWER_SHA,
+      status: "succeeded",
+      now: "2026-09-04T00:30:00.000Z",
+    });
+    const fetch = vercelAccepts();
+
+    // The older merge, delivered second.
+    await run({ ...MERGE_MESSAGE, mergedAt: MERGED_AT }, { fetch });
+
+    const older = rows().find((row) => row.commit_sha === SHA) as Row;
+    expect(older.status).toBe("superseded");
+    expect(older.reason).toContain(NEWER_SHA.slice(0, 7));
+    expect(older.completed_at).not.toBeNull();
+    // The newer commit is untouched, and nothing was published over it.
+    expect(rows().find((row) => row.id === newer.id)?.status).toBe("succeeded");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  // A retry is the deliberate exception: it stamps the current time, so an
+  // operator re-running an older commit is not refused by the guard above.
+  it("lets a retry of an older commit through, because it is the newest intent", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    await insertFixture({
+      commitSha: NEWER_SHA,
+      status: "succeeded",
+      now: "2026-09-04T00:30:00.000Z",
+    });
+    // What `POST .../retry` inserts: the same old commit, attempt 2, stamped now.
+    const retry = await insertFixture({ attempt: 2, now: T1_ISO });
+    const fetch = vercelAccepts();
+
+    await run({ kind: "deployment", projectId: PROJECT_ID, deploymentId: retry.id }, { fetch });
+
+    expect(rows().find((row) => row.id === retry.id)?.status).toBe("succeeded");
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // Unlike the `supersedeOlder` bookkeeping, this check is the only thing
+  // standing between a reordered message and an older commit going live, so an
+  // unreadable answer fails the row rather than assuming the best.
+  it("fails the deploy rather than guessing when the ordering check cannot be read", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    const fetch = vercelAccepts();
+    const broken = {
+      prepare: (sql: string) => {
+        if (sql.includes("status = 'succeeded' AND created_at >")) {
+          throw new Error("D1 unavailable");
+        }
+        return db.prepare(sql);
+      },
+    } as unknown as D1Database;
+
+    await run({ ...MERGE_MESSAGE, mergedAt: MERGED_AT }, { fetch }, makeEnv({ DB: broken }));
+
+    const row = onlyRow();
+    expect(row.status).toBe("failed");
+    expect(row.reason).toContain("newer deployment");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("reclaims a running deployment whose lease has expired", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    const { id } = await insertFixture({ changeId: CHANGE_ID });
+    // A consumer that died mid-deploy: still `running`, lease long gone.
+    raw
+      .prepare("UPDATE deployments SET status = 'running', lease_expires_at = ? WHERE id = ?")
+      .run("2026-09-04T00:30:00.000Z", id);
+
+    const result = await run({ kind: "deployment", projectId: PROJECT_ID, deploymentId: id });
+
+    if (!result.success) throw result.error;
+    expect(result.data.deployments).toHaveLength(1);
+    const row = onlyRow();
+    expect(row.status).toBe("succeeded");
+    expect(row.lease_expires_at).toBeNull();
+  });
+
+  it("leaves a pending_approval row alone — it is not claimable", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    const pending = await insertFixture({ changeId: CHANGE_ID, status: "pending_approval" });
+    const fetch = vercelAccepts();
+
+    await run({ kind: "deployment", projectId: PROJECT_ID, deploymentId: pending.id }, { fetch });
+
+    expect(onlyRow().status).toBe("pending_approval");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("containment", () => {
+  it("writes a terminal row even when the target throws", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    // A provider response the target does not expect: reading `ok` throws, and
+    // that happens outside the target's own transport try/catch.
+    const exploding: DeployFetch = vi.fn(
+      async () =>
+        ({
+          get ok(): boolean {
+            throw new Error("kaboom");
+          },
+        }) as unknown as Response,
+    );
+
+    const result = await run(MERGE_MESSAGE, { fetch: exploding });
+
+    expect(result.success).toBe(true);
+    const row = onlyRow();
+    expect(row.status).toBe("failed");
+    expect(row.reason).toContain("kaboom");
+    // The row must not be left running with a live lease.
+    expect(row.lease_expires_at).toBeNull();
+    expect(row.completed_at).not.toBeNull();
+    expect(row.duration_ms).not.toBeNull();
+  });
+
+  it("keeps secret values out of every persisted reason and log tail", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+
+    await run(MERGE_MESSAGE, { fetch: vercelRejectsEchoingTheToken() });
+
+    const row = onlyRow();
+    expect(row.status).toBe("failed");
+    expect(row.reason).toContain("403");
+    for (const value of [row.reason, row.log_tail, JSON.stringify(rows())]) {
+      expect(value ?? "").not.toContain(VERCEL_TOKEN);
+      expect(value ?? "").not.toContain(VERCEL_PROJECT);
+    }
+  });
+
+  it("redacts a secret that escaped through a thrown error", async () => {
+    // The values are captured the moment they resolve, before anything can
+    // throw with one in hand, so the `finally` can redact a throw as well as a
+    // clean return.
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    const leaky: DeployFetch = vi.fn(
+      async () =>
+        ({
+          get ok(): boolean {
+            throw new Error(`upstream rejected ${VERCEL_TOKEN}`);
+          },
+        }) as unknown as Response,
+    );
+
+    await run(MERGE_MESSAGE, { fetch: leaky });
+
+    const row = onlyRow();
+    expect(row.status).toBe("failed");
+    expect(row.reason).not.toContain(VERCEL_TOKEN);
+    expect(row.reason).toContain("[redacted]");
+  });
+});
+
+describe("approval", () => {
+  it("creates a pending_approval row and does not run it", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    const policy = `evaluators:
+  - type: diff
+
+deploys:
+  - name: production
+    target: vercel
+    requiresApproval: true
+`;
+    const fetch = vercelAccepts();
+
+    await run(MERGE_MESSAGE, { readFiles: readsTree(tree(policy)), fetch });
+
+    expect(onlyRow().status).toBe("pending_approval");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/deploy-runner.test.ts
+++ b/tests/deploy-runner.test.ts
@@ -707,3 +707,101 @@ deploys:
     expect(fetch).not.toHaveBeenCalled();
   });
 });
+
+describe("the wall-clock deadline that keeps the lease honest", () => {
+  // The runner has to give up before `DEFAULT_DEPLOY_LEASE_MS` can expire.
+  // Otherwise the lease lapses under a live upload and `claimDeployment` hands
+  // the row to a second consumer — the same commit deployed twice.
+  it("abandons a provider that never answers, leaving a terminal row", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    let seen: RequestInit | undefined;
+    const hangs: DeployFetch = vi.fn(
+      (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          seen = init;
+          init.signal?.addEventListener("abort", () => reject(new Error("cut off")));
+        }),
+    );
+
+    // Long enough that the run is certainly inside the provider call when the
+    // deadline fires, short enough not to slow the suite down.
+    await run(MERGE_MESSAGE, { fetch: hangs, deadlineMs: 200 });
+
+    const row = onlyRow();
+    expect(row.status).toBe("failed");
+    expect(row.reason).toContain("did not finish");
+    // Terminal *and* unlocked: nothing is left for a reclaim to race.
+    expect(row.lease_expires_at).toBeNull();
+    expect(row.completed_at).not.toBeNull();
+    // The upload is genuinely cut off rather than left running behind a
+    // resolved race, so it cannot land after the row says it failed.
+    expect(seen?.signal?.aborted).toBe(true);
+  });
+
+  it("does not disturb a provider that answers in time", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+
+    await run(MERGE_MESSAGE, { deadlineMs: 60_000 });
+
+    expect(onlyRow().status).toBe("succeeded");
+  });
+});
+
+describe("every rejected deploys entry keeps its own row", () => {
+  // The PRD asks for one persisted `failed` row per rejected entry, each naming
+  // its entry and reason — that is the whole point of `sanitizeDeploys`
+  // returning rejections instead of dropping them. Two unnamed entries used to
+  // collapse into a single row on the unique index, and one reason was lost.
+  it("persists one failed row per rejection", async () => {
+    const policy = `evaluators:
+  - type: diff
+
+deploys:
+  - target: vercel
+  - target: netlify
+`;
+
+    await run(MERGE_MESSAGE, { readFiles: readsTree(tree(policy)) });
+
+    const all = rows();
+    expect(all).toHaveLength(2);
+    expect(all.every((row) => row.status === "failed")).toBe(true);
+    expect(new Set(all.map((row) => row.name)).size).toBe(2);
+
+    const reasons = all.map((row) => row.reason ?? "");
+    expect(reasons.some((reason) => reason.includes("deploys[0]"))).toBe(true);
+    expect(reasons.some((reason) => reason.includes("deploys[1]"))).toBe(true);
+    expect(reasons.some((reason) => reason.includes("netlify"))).toBe(true);
+  });
+
+  // The sharper case: a duplicate name is rejected *because* another entry is
+  // legitimately using it, so the rejection row and the accepted row want the
+  // same (project, name, commit, attempt) key. The rejection must not take it —
+  // the accepted deploy would then never be created, and never run.
+  it("never takes the row an accepted deploy of the same name needs", async () => {
+    await storeSecrets({ VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT });
+    const policy = `evaluators:
+  - type: diff
+
+deploys:
+  - name: production
+    target: vercel
+  - name: production
+    target: vercel
+`;
+    const fetch = vercelAccepts();
+
+    await run(MERGE_MESSAGE, { readFiles: readsTree(tree(policy)), fetch });
+
+    const all = rows();
+    expect(all).toHaveLength(2);
+
+    const accepted = all.find((row) => row.name === "production");
+    expect(accepted?.status).toBe("succeeded");
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const rejected = all.find((row) => row.name !== "production");
+    expect(rejected?.status).toBe("failed");
+    expect(rejected?.reason).toContain("duplicate deploy name");
+  });
+});

--- a/tests/deploy-targets.test.ts
+++ b/tests/deploy-targets.test.ts
@@ -1,0 +1,751 @@
+import { describe, expect, it, vi } from "vitest";
+import { MAX_FILES, MAX_FILE_BYTES, MAX_LOG_TAIL, MAX_TOTAL_BYTES } from "../src/deploy/limits";
+import { REDACTION_PLACEHOLDER, redactAndTruncate, redactSecrets } from "../src/deploy/redact";
+import {
+  cloudflarePagesTarget,
+  extensionOf,
+  manifestHash,
+} from "../src/deploy/targets/cloudflare-pages";
+import { cloudflareWorkersTarget } from "../src/deploy/targets/cloudflare-workers";
+import {
+  DEPLOY_TARGET_REGISTRY,
+  type DeployFetch,
+  type DeployOutcome,
+  type DeployTarget,
+  type DeployTargetInput,
+  getDeployTarget,
+} from "../src/deploy/targets/index";
+import { MAX_INLINE_BODY_BYTES, inlineBodyBytes, vercelTarget } from "../src/deploy/targets/vercel";
+import type { DeployConfig, DeployTargetName } from "../src/evaluation/types";
+import type { Logger } from "../src/utils/logger";
+import type { Result } from "../src/utils/result";
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+};
+
+const CF_TOKEN = "cf-token-super-secret-value";
+const CF_ACCOUNT = "acct-1234567890";
+const VERCEL_TOKEN = "vercel-token-super-secret-value";
+const VERCEL_PROJECT = "prj_abc123";
+
+const CLOUDFLARE_SECRETS = {
+  CLOUDFLARE_API_TOKEN: CF_TOKEN,
+  CLOUDFLARE_ACCOUNT_ID: CF_ACCOUNT,
+};
+
+const VERCEL_SECRETS = { VERCEL_TOKEN, VERCEL_PROJECT_ID: VERCEL_PROJECT };
+
+function tree(entries: Record<string, string>): Map<string, Uint8Array> {
+  const encoder = new TextEncoder();
+  return new Map(Object.entries(entries).map(([path, text]) => [path, encoder.encode(text)]));
+}
+
+function makeInput(overrides: Partial<DeployTargetInput> = {}): DeployTargetInput {
+  const config: DeployConfig = { name: "production", target: "vercel", requiresApproval: false };
+  return {
+    files: tree({ "index.html": "<h1>hi</h1>" }),
+    secrets: {},
+    config,
+    commitSha: "a".repeat(40),
+    logger,
+    fetch: vi.fn(async () => new Response("{}", { status: 200 })),
+    ...overrides,
+  };
+}
+
+/** A stub that answers each call from a queue, and records what it was asked for. */
+function stubFetch(responses: Response[]): DeployFetch & { calls: Array<[string, RequestInit]> } {
+  const calls: Array<[string, RequestInit]> = [];
+  const stub = vi.fn(async (url: string, init: RequestInit) => {
+    calls.push([url, init]);
+    const next = responses.shift();
+    if (!next) throw new Error(`unexpected extra fetch to ${url}`);
+    return next;
+  });
+  return Object.assign(stub as unknown as DeployFetch, { calls });
+}
+
+/** Read a multipart part as text, whichever way the runtime types `FormData.get`. */
+async function partText(form: FormData, name: string): Promise<string> {
+  const value: unknown = form.get(name);
+  if (typeof value === "string") return value;
+  if (value instanceof Blob) return value.text();
+  throw new Error(`form part "${name}" is missing`);
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Collect every string a target returned, so a leak cannot hide in a nested field. */
+function allStrings(result: Result<DeployOutcome, { reason: string; logTail?: string }>): string[] {
+  if (result.success) {
+    return [result.data.url, result.data.providerId, result.data.state, result.data.logTail].filter(
+      (value): value is string => typeof value === "string",
+    );
+  }
+  return [result.error.reason, result.error.logTail].filter(
+    (value): value is string => typeof value === "string",
+  );
+}
+
+function expectNoSecrets(
+  result: Result<DeployOutcome, { reason: string; logTail?: string }>,
+  secrets: readonly string[],
+): void {
+  for (const text of allStrings(result)) {
+    for (const secret of secrets) {
+      expect(text).not.toContain(secret);
+    }
+  }
+}
+
+describe("deploy limits", () => {
+  it("keeps the per-file cap below the total cap so one file cannot consume the budget", () => {
+    expect(MAX_FILE_BYTES).toBeLessThan(MAX_TOTAL_BYTES);
+  });
+});
+
+describe("redact", () => {
+  it("replaces every occurrence of a secret value", () => {
+    expect(redactSecrets(`token=${CF_TOKEN} again ${CF_TOKEN}`, [CF_TOKEN])).toBe(
+      `token=${REDACTION_PLACEHOLDER} again ${REDACTION_PLACEHOLDER}`,
+    );
+  });
+
+  it("ignores empty values rather than inserting a placeholder between every character", () => {
+    expect(redactSecrets("abc", [""])).toBe("abc");
+  });
+
+  it("prefers the longest match when one secret contains another", () => {
+    const redacted = redactSecrets("prefix-suffix", ["prefix", "prefix-suffix"]);
+    expect(redacted).toBe(REDACTION_PLACEHOLDER);
+  });
+
+  it("redacts before truncating, so a secret cannot survive by straddling the cut", () => {
+    // Positioned so the secret spans the truncation boundary: redacting after
+    // truncating would leave its first half in the retained text.
+    const secret = "S".repeat(40);
+    const head = "x".repeat(MAX_LOG_TAIL - 30);
+    const redacted = redactAndTruncate(`${head}${secret}${"y".repeat(100)}`, [secret]);
+
+    expect(redacted.length).toBeLessThanOrEqual(MAX_LOG_TAIL);
+    // Truncating first would have kept the secret's first 30 characters here.
+    expect(redacted).not.toContain("S");
+    expect(redacted).toContain(REDACTION_PLACEHOLDER);
+  });
+
+  it("leaves short text untouched", () => {
+    expect(redactAndTruncate("all fine", [])).toBe("all fine");
+  });
+});
+
+describe("target registry", () => {
+  it("resolves every policy target name to an implementation that declares that name", () => {
+    const names: DeployTargetName[] = ["cloudflare-pages", "cloudflare-workers", "vercel"];
+    for (const name of names) {
+      const target: DeployTarget = getDeployTarget(name);
+      expect(target.name).toBe(name);
+      expect(DEPLOY_TARGET_REGISTRY[name]).toBe(target);
+    }
+  });
+});
+
+describe("cloudflare static-asset manifest hashing", () => {
+  // Fixtures computed independently of the implementation:
+  //   sha256(base64(content) + extensionWithoutDot).hex().slice(0, 32)
+  it("hashes the base64 text concatenated with the extension, truncated to 32 hex chars", async () => {
+    expect(await manifestHash("aGVsbG8gd29ybGQ=", "html")).toBe("6c9e0757090736584b5a6e5c29b5a8c9");
+  });
+
+  it("uses an empty extension when the file has none", async () => {
+    expect(await manifestHash("aGVsbG8gd29ybGQ=", "")).toBe("dc9c1c09907c36f5379d615ae61c02b4");
+  });
+
+  it("reads the extension without its dot, and treats a dotfile as extensionless", () => {
+    expect(extensionOf("a/b/index.html")).toBe("html");
+    expect(extensionOf("LICENSE")).toBe("");
+    expect(extensionOf(".gitignore")).toBe("");
+  });
+});
+
+describe("cloudflare-pages target (Workers Static Assets)", () => {
+  it("registers a manifest, uploads the requested bucket, then deploys with the completion token", async () => {
+    const hash = "81f20b8a74d6ef9cdfa6039a9db5e33a";
+    const fetch = stubFetch([
+      json({ success: true, result: { jwt: "upload-jwt", buckets: [[hash]] } }),
+      json({ success: true, result: { jwt: "completion-jwt" } }, 201),
+      json({ success: true, result: { id: "worker-1" } }),
+    ]);
+
+    const result = await cloudflarePagesTarget.deploy(
+      makeInput({
+        fetch,
+        secrets: { ...CLOUDFLARE_SECRETS, CLOUDFLARE_WORKERS_SUBDOMAIN: "acme" },
+        config: { name: "site", target: "cloudflare-pages", requiresApproval: false },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.url).toBe("https://site.acme.workers.dev");
+    expect(result.data.providerId).toBe("worker-1");
+
+    expect(fetch.calls).toHaveLength(3);
+    const [sessionUrl, sessionInit] = fetch.calls[0] as [string, RequestInit];
+    expect(sessionUrl).toContain("/workers/scripts/site/assets-upload-session");
+    expect(JSON.parse(String(sessionInit.body))).toEqual({
+      manifest: { "/index.html": { hash, size: 11 } },
+    });
+
+    // `base64=true` is required; without it the API rejects the encoded parts.
+    expect(fetch.calls[1]?.[0]).toBe(
+      "https://api.cloudflare.com/client/v4/accounts/acct-1234567890/workers/assets/upload?base64=true",
+    );
+
+    const deployInit = fetch.calls[2]?.[1] as RequestInit;
+    expect(JSON.parse(await partText(deployInit.body as FormData, "metadata"))).toMatchObject({
+      assets: { jwt: "completion-jwt" },
+    });
+    expectNoSecrets(result, [CF_TOKEN]);
+  });
+
+  it("skips the upload phase and reuses the session token when nothing needs uploading", async () => {
+    const fetch = stubFetch([
+      json({ success: true, result: { jwt: "upload-jwt", buckets: [] } }),
+      json({ success: true, result: { id: "worker-2" } }),
+    ]);
+
+    const result = await cloudflarePagesTarget.deploy(
+      makeInput({ fetch, secrets: CLOUDFLARE_SECRETS }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(fetch.calls).toHaveLength(2);
+    expect(
+      JSON.parse(await partText(fetch.calls[1]?.[1].body as FormData, "metadata")),
+    ).toMatchObject({ assets: { jwt: "upload-jwt" } });
+  });
+
+  it("surfaces a 4xx as a non-retryable failure naming the provider's message", async () => {
+    const fetch = stubFetch([
+      json({ success: false, errors: [{ code: 10000, message: "Authentication error" }] }, 403),
+    ]);
+
+    const result = await cloudflarePagesTarget.deploy(
+      makeInput({ fetch, secrets: CLOUDFLARE_SECRETS }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("HTTP 403");
+    expect(result.error.reason).toContain("Authentication error");
+    expect(result.error.retryable).toBe(false);
+  });
+
+  it("surfaces a 5xx as retryable", async () => {
+    const fetch = stubFetch([new Response("upstream boom", { status: 503 })]);
+
+    const result = await cloudflarePagesTarget.deploy(
+      makeInput({ fetch, secrets: CLOUDFLARE_SECRETS }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("HTTP 503");
+    expect(result.error.retryable).toBe(true);
+  });
+
+  it("redacts the token out of a provider error payload that echoes it", async () => {
+    const fetch = stubFetch([
+      json({ errors: [{ message: `bad token ${CF_TOKEN} for ${CF_ACCOUNT}` }] }, 400),
+    ]);
+
+    const result = await cloudflarePagesTarget.deploy(
+      makeInput({ fetch, secrets: CLOUDFLARE_SECRETS }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.logTail).toContain(REDACTION_PLACEHOLDER);
+    expectNoSecrets(result, [CF_TOKEN, CF_ACCOUNT]);
+  });
+
+  it("rejects a missing secret before any request is made", async () => {
+    const fetch = stubFetch([]);
+
+    const result = await cloudflarePagesTarget.deploy(
+      makeInput({ fetch, secrets: { CLOUDFLARE_ACCOUNT_ID: CF_ACCOUNT } }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("CLOUDFLARE_API_TOKEN");
+    expect(fetch.calls).toHaveLength(0);
+  });
+
+  it("rejects a tree over MAX_FILES before any request is made", async () => {
+    const fetch = stubFetch([]);
+    const files = new Map<string, Uint8Array>();
+    for (let i = 0; i <= MAX_FILES; i++) files.set(`f${i}.txt`, new Uint8Array([1]));
+
+    const result = await cloudflarePagesTarget.deploy(
+      makeInput({ fetch, files, secrets: CLOUDFLARE_SECRETS }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("too many files");
+    expect(fetch.calls).toHaveLength(0);
+  });
+
+  it("rejects a file over MAX_FILE_BYTES before any request is made", async () => {
+    const fetch = stubFetch([]);
+    const files = new Map([["big.bin", new Uint8Array(MAX_FILE_BYTES + 1)]]);
+
+    const result = await cloudflarePagesTarget.deploy(
+      makeInput({ fetch, files, secrets: CLOUDFLARE_SECRETS }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("per-file deploy limit");
+    expect(fetch.calls).toHaveLength(0);
+  });
+
+  it("rejects a total over MAX_TOTAL_BYTES before any request is made", async () => {
+    const fetch = stubFetch([]);
+    const chunk = Math.floor(MAX_FILE_BYTES);
+    const files = new Map<string, Uint8Array>();
+    for (let i = 0; i * chunk <= MAX_TOTAL_BYTES; i++)
+      files.set(`f${i}.bin`, new Uint8Array(chunk));
+
+    const result = await cloudflarePagesTarget.deploy(
+      makeInput({ fetch, files, secrets: CLOUDFLARE_SECRETS }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("total limit");
+    expect(fetch.calls).toHaveLength(0);
+  });
+
+  it("rejects a dir that selects nothing before any request is made", async () => {
+    const fetch = stubFetch([]);
+
+    const result = await cloudflarePagesTarget.deploy(
+      makeInput({
+        fetch,
+        secrets: CLOUDFLARE_SECRETS,
+        config: {
+          name: "site",
+          target: "cloudflare-pages",
+          dir: "dist",
+          requiresApproval: false,
+        },
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain('under "dist"');
+    expect(fetch.calls).toHaveLength(0);
+  });
+
+  it("strips the dir prefix from the manifest paths it publishes", async () => {
+    const fetch = stubFetch([
+      json({ success: true, result: { jwt: "upload-jwt", buckets: [] } }),
+      json({ success: true, result: {} }),
+    ]);
+
+    const result = await cloudflarePagesTarget.deploy(
+      makeInput({
+        fetch,
+        files: tree({ "dist/index.html": "<h1>hi</h1>", "README.md": "ignored" }),
+        secrets: CLOUDFLARE_SECRETS,
+        config: {
+          name: "site",
+          target: "cloudflare-pages",
+          dir: "dist",
+          requiresApproval: false,
+        },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    const manifest = JSON.parse(String(fetch.calls[0]?.[1].body)) as {
+      manifest: Record<string, unknown>;
+    };
+    expect(Object.keys(manifest.manifest)).toEqual(["/index.html"]);
+  });
+});
+
+describe("cloudflare-workers target", () => {
+  const workerConfig: DeployConfig = {
+    name: "api",
+    target: "cloudflare-workers",
+    requiresApproval: false,
+  };
+
+  it("uploads every module with the entry point named in metadata", async () => {
+    const fetch = stubFetch([json({ success: true, result: { id: "script-1" } })]);
+
+    const result = await cloudflareWorkersTarget.deploy(
+      makeInput({
+        fetch,
+        files: tree({
+          "worker.js": "export default {};",
+          "lib/util.js": "export const a = 1;",
+          "README.md": "docs",
+        }),
+        secrets: CLOUDFLARE_SECRETS,
+        config: workerConfig,
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.providerId).toBe("script-1");
+    // The non-module file is reported, not silently dropped.
+    expect(result.data.logTail).toContain("skipped 1");
+
+    const [url, init] = fetch.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://api.cloudflare.com/client/v4/accounts/acct-1234567890/workers/scripts/api",
+    );
+    expect(init.method).toBe("PUT");
+
+    const form = init.body as FormData;
+    const metadata = JSON.parse(await partText(form, "metadata"));
+    expect(metadata.main_module).toBe("worker.js");
+    expect(metadata.compatibility_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(form.get("lib/util.js")).toBeInstanceOf(Blob);
+    expect(form.get("README.md")).toBeNull();
+    expectNoSecrets(result, [CF_TOKEN]);
+  });
+
+  it("prefers an explicit CLOUDFLARE_WORKER_MAIN_MODULE and the CLOUDFLARE_WORKER_NAME override", async () => {
+    const fetch = stubFetch([json({ success: true, result: {} })]);
+
+    const result = await cloudflareWorkersTarget.deploy(
+      makeInput({
+        fetch,
+        files: tree({ "worker.js": "export default {};", "src/entry.js": "export default {};" }),
+        secrets: {
+          ...CLOUDFLARE_SECRETS,
+          CLOUDFLARE_WORKER_MAIN_MODULE: "src/entry.js",
+          CLOUDFLARE_WORKER_NAME: "renamed",
+        },
+        config: workerConfig,
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(fetch.calls[0]?.[0]).toContain("/workers/scripts/renamed");
+    const form = fetch.calls[0]?.[1].body as FormData;
+    const metadata = JSON.parse(await partText(form, "metadata"));
+    expect(metadata.main_module).toBe("src/entry.js");
+  });
+
+  it("rejects an entry point that is not in the tree before any request is made", async () => {
+    const fetch = stubFetch([]);
+
+    const result = await cloudflareWorkersTarget.deploy(
+      makeInput({
+        fetch,
+        files: tree({ "worker.js": "export default {};" }),
+        secrets: { ...CLOUDFLARE_SECRETS, CLOUDFLARE_WORKER_MAIN_MODULE: "missing.js" },
+        config: workerConfig,
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("missing.js");
+    expect(fetch.calls).toHaveLength(0);
+  });
+
+  it("rejects a tree with no module before any request is made", async () => {
+    const fetch = stubFetch([]);
+
+    const result = await cloudflareWorkersTarget.deploy(
+      makeInput({
+        fetch,
+        files: tree({ "index.html": "<h1>hi</h1>" }),
+        secrets: CLOUDFLARE_SECRETS,
+        config: workerConfig,
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("no .js or .mjs module");
+    expect(fetch.calls).toHaveLength(0);
+  });
+
+  it("surfaces a 4xx with the provider's reason and no secret", async () => {
+    const fetch = stubFetch([
+      json({ success: false, errors: [{ message: `token ${CF_TOKEN} lacks permission` }] }, 401),
+    ]);
+
+    const result = await cloudflareWorkersTarget.deploy(
+      makeInput({
+        fetch,
+        files: tree({ "worker.js": "export default {};" }),
+        secrets: CLOUDFLARE_SECRETS,
+        config: workerConfig,
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("HTTP 401");
+    expect(result.error.retryable).toBe(false);
+    expectNoSecrets(result, [CF_TOKEN, CF_ACCOUNT]);
+  });
+
+  it("surfaces a 5xx as retryable", async () => {
+    const fetch = stubFetch([new Response("gateway", { status: 502 })]);
+
+    const result = await cloudflareWorkersTarget.deploy(
+      makeInput({
+        fetch,
+        files: tree({ "worker.js": "export default {};" }),
+        secrets: CLOUDFLARE_SECRETS,
+        config: workerConfig,
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.retryable).toBe(true);
+  });
+
+  it("treats a 200 carrying success:false as a failure", async () => {
+    const fetch = stubFetch([json({ success: false, errors: [{ message: "nope" }] })]);
+
+    const result = await cloudflareWorkersTarget.deploy(
+      makeInput({
+        fetch,
+        files: tree({ "worker.js": "export default {};" }),
+        secrets: CLOUDFLARE_SECRETS,
+        config: workerConfig,
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("rejected the script upload");
+  });
+
+  it("reports an unreachable provider as retryable without echoing the error", async () => {
+    const fetch = vi.fn(async () => {
+      throw new Error(`connect failed for Bearer ${CF_TOKEN}`);
+    }) as unknown as DeployFetch;
+
+    const result = await cloudflareWorkersTarget.deploy(
+      makeInput({
+        fetch,
+        files: tree({ "worker.js": "export default {};" }),
+        secrets: CLOUDFLARE_SECRETS,
+        config: workerConfig,
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.retryable).toBe(true);
+    expectNoSecrets(result, [CF_TOKEN]);
+  });
+});
+
+describe("vercel target", () => {
+  const vercelConfig: DeployConfig = {
+    name: "production",
+    target: "vercel",
+    requiresApproval: false,
+  };
+
+  it("inlines every file as base64 in a single production deployment request", async () => {
+    const fetch = stubFetch([
+      json({ id: "dpl_1", url: "site-abc.vercel.app", readyState: "QUEUED" }),
+    ]);
+
+    const result = await vercelTarget.deploy(
+      makeInput({
+        fetch,
+        files: tree({ "index.html": "<h1>hi</h1>" }),
+        secrets: { ...VERCEL_SECRETS, VERCEL_TEAM_ID: "team_1" },
+        config: vercelConfig,
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.url).toBe("https://site-abc.vercel.app");
+    expect(result.data.providerId).toBe("dpl_1");
+    expect(result.data.state).toBe("QUEUED");
+
+    expect(fetch.calls).toHaveLength(1);
+    const [url, init] = fetch.calls[0] as [string, RequestInit];
+    expect(url).toContain("https://api.vercel.com/v13/deployments?");
+    expect(url).toContain("forceNew=1");
+    expect(url).toContain("skipAutoDetectionConfirmation=1");
+    expect(url).toContain("teamId=team_1");
+
+    const body = JSON.parse(String(init.body));
+    expect(body.target).toBe("production");
+    expect(body.project).toBe(VERCEL_PROJECT);
+    expect(body.files).toEqual([
+      { file: "index.html", data: btoa("<h1>hi</h1>"), encoding: "base64" },
+    ]);
+    expectNoSecrets(result, [VERCEL_TOKEN]);
+  });
+
+  it("surfaces a 4xx with the provider's message and no secret", async () => {
+    const fetch = stubFetch([
+      json({ error: { code: "forbidden", message: `token ${VERCEL_TOKEN} rejected` } }, 403),
+    ]);
+
+    const result = await vercelTarget.deploy(
+      makeInput({ fetch, secrets: VERCEL_SECRETS, config: vercelConfig }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("HTTP 403");
+    expect(result.error.retryable).toBe(false);
+    expect(result.error.logTail).toContain(REDACTION_PLACEHOLDER);
+    expectNoSecrets(result, [VERCEL_TOKEN, VERCEL_PROJECT]);
+  });
+
+  it("surfaces a 5xx as retryable", async () => {
+    const fetch = stubFetch([json({ error: { message: "internal" } }, 500)]);
+
+    const result = await vercelTarget.deploy(
+      makeInput({ fetch, secrets: VERCEL_SECRETS, config: vercelConfig }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.retryable).toBe(true);
+  });
+
+  it("treats a 429 as retryable", async () => {
+    const fetch = stubFetch([json({ error: { message: "rate limited" } }, 429)]);
+
+    const result = await vercelTarget.deploy(
+      makeInput({ fetch, secrets: VERCEL_SECRETS, config: vercelConfig }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.retryable).toBe(true);
+  });
+
+  it("fails when the deployment comes back already in an error state", async () => {
+    const fetch = stubFetch([
+      json({ id: "dpl_2", readyState: "ERROR", errorMessage: "build failed" }),
+    ]);
+
+    const result = await vercelTarget.deploy(
+      makeInput({ fetch, secrets: VERCEL_SECRETS, config: vercelConfig }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("ERROR");
+    expect(result.error.reason).toContain("build failed");
+    expect(result.error.retryable).toBe(true);
+  });
+
+  it("does not treat a canceled deployment as retryable", async () => {
+    const fetch = stubFetch([json({ id: "dpl_3", readyState: "CANCELED" })]);
+
+    const result = await vercelTarget.deploy(
+      makeInput({ fetch, secrets: VERCEL_SECRETS, config: vercelConfig }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.retryable).toBe(false);
+  });
+
+  it("rejects a missing secret before any request is made", async () => {
+    const fetch = stubFetch([]);
+
+    const result = await vercelTarget.deploy(
+      makeInput({ fetch, secrets: { VERCEL_TOKEN }, config: vercelConfig }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("VERCEL_PROJECT_ID");
+    expect(fetch.calls).toHaveLength(0);
+  });
+
+  it("rejects a tree over MAX_FILES before any request is made", async () => {
+    const fetch = stubFetch([]);
+    const files = new Map<string, Uint8Array>();
+    for (let i = 0; i <= MAX_FILES; i++) files.set(`f${i}.txt`, new Uint8Array([1]));
+
+    const result = await vercelTarget.deploy(
+      makeInput({ fetch, files, secrets: VERCEL_SECRETS, config: vercelConfig }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("too many files");
+    expect(fetch.calls).toHaveLength(0);
+  });
+
+  it("rejects a file over MAX_FILE_BYTES before any request is made", async () => {
+    const fetch = stubFetch([]);
+    const files = new Map([["big.bin", new Uint8Array(MAX_FILE_BYTES + 1)]]);
+
+    const result = await vercelTarget.deploy(
+      makeInput({ fetch, files, secrets: VERCEL_SECRETS, config: vercelConfig }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("per-file deploy limit");
+    expect(fetch.calls).toHaveLength(0);
+  });
+
+  it("bounds the inlined request body at roughly a third above the byte limit", () => {
+    // The documented cost of resolving PRD Q1 in favour of inlining: this is
+    // the number to re-check if MAX_TOTAL_BYTES is ever raised.
+    expect(inlineBodyBytes(3)).toBe(4);
+    expect(MAX_INLINE_BODY_BYTES).toBe(inlineBodyBytes(MAX_TOTAL_BYTES));
+    expect(MAX_INLINE_BODY_BYTES).toBeGreaterThan(MAX_TOTAL_BYTES);
+  });
+
+  it("rejects an empty tree before any request is made", async () => {
+    const fetch = stubFetch([]);
+
+    const result = await vercelTarget.deploy(
+      makeInput({
+        fetch,
+        files: new Map(),
+        secrets: VERCEL_SECRETS,
+        config: vercelConfig,
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.reason).toContain("nothing to deploy");
+    expect(fetch.calls).toHaveLength(0);
+  });
+});

--- a/tests/deployments-schema.test.ts
+++ b/tests/deployments-schema.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Migration 047 (deployments + project_secrets) as a schema contract.
+ *
+ * Two of these assertions guard things that fail silently in production if they
+ * regress: the unique index IS the mutual exclusion a deploy relies on (drop it
+ * and every merge deploys twice), and the deletion cascade is the only thing
+ * that ever removes an encrypted provider credential from D1 (drop that and a
+ * deleted project's production tokens live forever, reachable by no UI).
+ *
+ * Constraint violations are asserted through the raw node:sqlite handle rather
+ * than the D1 wrapper: the engine throws synchronously there, so a constraint
+ * that has silently stopped being enforced cannot be mistaken for a rejected
+ * promise from somewhere else.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DELETED_USER_SENTINEL,
+  type DeletionTarget,
+  anonymizeUserContributions,
+  deleteProjectCascade,
+} from "../src/storage/deletion";
+import type { Env } from "../src/types";
+import type { Logger } from "../src/utils/logger";
+import { makeArtifactsStub, makeKvStub } from "./helpers/deletion-stubs";
+import { makeSqliteD1 } from "./helpers/sqlite-d1";
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+};
+
+let db: D1Database;
+let raw: ReturnType<typeof makeSqliteD1>["raw"];
+
+beforeEach(() => {
+  const made = makeSqliteD1();
+  db = made.db;
+  raw = made.raw;
+  vi.clearAllMocks();
+});
+
+const DEPLOYMENT_COLUMNS =
+  "id, project_id, project, change_id, commit_sha, name, target, attempt, status, " +
+  "requested_by_type, created_at";
+
+function insertDeployment(overrides: Partial<Record<string, unknown>> = {}): void {
+  const row = {
+    id: "dep_1",
+    project_id: "proj_1",
+    project: "api",
+    change_id: "chg_1",
+    commit_sha: "a".repeat(40),
+    name: "production",
+    target: "vercel",
+    attempt: 1,
+    status: "queued",
+    requested_by_type: "user",
+    created_at: "2026-09-04T00:00:00.000Z",
+    ...overrides,
+  };
+  raw
+    .prepare(
+      `INSERT INTO deployments (${DEPLOYMENT_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      row.id,
+      row.project_id,
+      row.project,
+      row.change_id,
+      row.commit_sha,
+      row.name,
+      row.target,
+      row.attempt,
+      row.status,
+      row.requested_by_type,
+      row.created_at,
+    );
+}
+
+function insertSecret(id: string, projectId: string, name: string): void {
+  raw
+    .prepare(
+      "INSERT INTO project_secrets " +
+        "(id, project_id, name, ciphertext, created_by, updated_by, created_at, updated_at) " +
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .run(
+      id,
+      projectId,
+      name,
+      "enc:opaque",
+      "usr_1",
+      "usr_1",
+      "2026-09-04T00:00:00.000Z",
+      "2026-09-04T00:00:00.000Z",
+    );
+}
+
+function objectNames(type: "table" | "index"): Set<string> {
+  const rows = raw.prepare("SELECT name FROM sqlite_master WHERE type = ?").all(type) as {
+    name: string;
+  }[];
+  return new Set(rows.map((r) => r.name));
+}
+
+describe("migration 047 schema", () => {
+  it("creates both tables and every declared index", () => {
+    const tables = objectNames("table");
+    expect(tables).toContain("deployments");
+    expect(tables).toContain("project_secrets");
+
+    const indexes = objectNames("index");
+    expect(indexes).toContain("ux_deployments_attempt");
+    expect(indexes).toContain("idx_deployments_project");
+    expect(indexes).toContain("ux_project_secrets_name");
+  });
+
+  it("accepts every status the deployment state machine can write", () => {
+    const statuses = [
+      "pending_approval",
+      "queued",
+      "running",
+      "succeeded",
+      "failed",
+      "superseded",
+      "skipped",
+    ];
+    for (const [i, status] of statuses.entries()) {
+      expect(() => insertDeployment({ id: `dep_${i}`, attempt: i + 1, status })).not.toThrow();
+    }
+  });
+
+  it("rejects a status outside the CHECK", () => {
+    expect(() => insertDeployment({ status: "in_progress" })).toThrow(/CHECK constraint/i);
+  });
+
+  it("rejects a duplicate (project_id, name, commit_sha, attempt)", () => {
+    insertDeployment();
+    // A different id and change_id: only the four indexed columns matter, which
+    // is what makes the insert itself the deploy's mutual exclusion.
+    expect(() => insertDeployment({ id: "dep_2", change_id: "chg_2" })).toThrow(
+      /UNIQUE constraint/i,
+    );
+  });
+
+  it("admits a retry of the same commit as a new attempt", () => {
+    insertDeployment();
+    expect(() => insertDeployment({ id: "dep_2", attempt: 2 })).not.toThrow();
+  });
+
+  it("rejects a duplicate secret name within a project but not across projects", () => {
+    insertSecret("sec_1", "proj_1", "VERCEL_TOKEN");
+    expect(() => insertSecret("sec_2", "proj_1", "VERCEL_TOKEN")).toThrow(/UNIQUE constraint/i);
+    expect(() => insertSecret("sec_3", "proj_2", "VERCEL_TOKEN")).not.toThrow();
+  });
+});
+
+describe("project deletion and migration 047 tables", () => {
+  function makeTarget(overrides: Partial<DeletionTarget> = {}): DeletionTarget {
+    return {
+      projectId: "proj_1",
+      namespace: "@alice",
+      slug: "api",
+      name: "api",
+      workspaceNames: [],
+      forkRepoNames: [],
+      projectRepoName: null,
+      changeIds: [],
+      webhookIds: [],
+      issueIds: [],
+      nameCollision: false,
+      ...overrides,
+    };
+  }
+
+  function makeEnv(): Env {
+    return {
+      DB: db,
+      STATE: makeKvStub().kv,
+      ARTIFACTS: makeArtifactsStub().artifacts,
+    } as Env;
+  }
+
+  it("destroys the project's deployments and encrypted secrets", async () => {
+    insertDeployment();
+    insertSecret("sec_1", "proj_1", "VERCEL_TOKEN");
+
+    const result = await deleteProjectCascade(makeEnv(), makeTarget(), logger);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.residuals).toEqual([]);
+    expect(raw.prepare("SELECT COUNT(*) AS n FROM deployments").get()).toEqual({ n: 0 });
+    expect(raw.prepare("SELECT COUNT(*) AS n FROM project_secrets").get()).toEqual({ n: 0 });
+  });
+
+  it("leaves another project's credentials alone", async () => {
+    insertDeployment({ id: "dep_other", project_id: "proj_2", project: "other" });
+    insertSecret("sec_other", "proj_2", "VERCEL_TOKEN");
+
+    await deleteProjectCascade(makeEnv(), makeTarget(), logger);
+
+    expect(raw.prepare("SELECT COUNT(*) AS n FROM deployments").get()).toEqual({ n: 1 });
+    expect(raw.prepare("SELECT COUNT(*) AS n FROM project_secrets").get()).toEqual({ n: 1 });
+  });
+
+  // project_secrets has no bare `project` column, so the name-collision branch
+  // of the project-scoped delete would be a `no such column` error there. It
+  // must still be scoped by project_id — and only by project_id.
+  it("still destroys secrets when the project name collides with another tenant's", async () => {
+    insertSecret("sec_1", "proj_1", "VERCEL_TOKEN");
+    insertSecret("sec_other", "proj_2", "VERCEL_TOKEN");
+
+    const result = await deleteProjectCascade(
+      makeEnv(),
+      makeTarget({ nameCollision: true }),
+      logger,
+    );
+
+    expect(result.success).toBe(true);
+    const remaining = raw.prepare("SELECT id FROM project_secrets").all() as { id: string }[];
+    expect(remaining.map((r) => r.id)).toEqual(["sec_other"]);
+  });
+});
+
+// An org-owned project survives its members' erasure, so these rows outlive the
+// account and would otherwise keep naming a deleted user forever.
+describe("account erasure and migration 047 tables", () => {
+  it("anonymizes the deploy identity columns without touching the rows", async () => {
+    insertSecret("sec_1", "proj_1", "VERCEL_TOKEN");
+    insertDeployment({ requested_by_type: "user" });
+    raw
+      .prepare("UPDATE deployments SET requested_by_id = ?, approved_by = ?")
+      .run("usr_1", "usr_1");
+
+    const result = await anonymizeUserContributions(db, "usr_1", logger);
+
+    expect(result.success).toBe(true);
+    expect(raw.prepare("SELECT created_by, updated_by FROM project_secrets").get()).toEqual({
+      created_by: DELETED_USER_SENTINEL,
+      updated_by: DELETED_USER_SENTINEL,
+    });
+    expect(raw.prepare("SELECT requested_by_id, approved_by FROM deployments").get()).toEqual({
+      requested_by_id: DELETED_USER_SENTINEL,
+      approved_by: DELETED_USER_SENTINEL,
+    });
+  });
+});

--- a/tests/deployments-storage.test.ts
+++ b/tests/deployments-storage.test.ts
@@ -903,3 +903,257 @@ describe("findDeploymentById", () => {
     expect(result.success).toBe(false);
   });
 });
+
+/**
+ * Every column in this module is compared as TEXT, so the storage layer has to
+ * collapse the several spellings ISO 8601 allows for one instant down to a
+ * single one. Left un-normalised, `2026-09-04T17:20:43-04:00` sorts *before*
+ * the identical instant `2026-09-04T21:20:43.000Z` and `...:43Z` sorts *after*
+ * `...:43.000Z` ('.' 0x2E < 'Z' 0x5A) — and both of the comparisons that stop a
+ * commit deploying twice, or an older commit deploying over a newer one, read
+ * that order.
+ *
+ * These cases exist because a merge time now reaches `created_at` over the
+ * queue, from a producer that is not the code writing the rows it will be
+ * compared against, so the spellings genuinely do meet inside one column.
+ */
+describe("timestamp canonicalisation", () => {
+  /** The same instant, 2026-09-04T21:20:43Z, in every form the module accepts. */
+  const SAME_INSTANT = [
+    "2026-09-04T21:20:43.000Z",
+    "2026-09-04T21:20:43Z",
+    "2026-09-04T17:20:43-04:00",
+    "2026-09-04T23:20:43+02:00",
+  ];
+  const CANONICAL = "2026-09-04T21:20:43.000Z";
+
+  function readTimestamps(id: string): {
+    created_at: string;
+    started_at: string | null;
+    completed_at: string | null;
+  } {
+    const row = raw
+      .prepare("SELECT created_at, started_at, completed_at FROM deployments WHERE id = ?")
+      .get(id) as
+      | { created_at: string; started_at: string | null; completed_at: string | null }
+      | undefined;
+    if (!row) throw new Error(`no deployment ${id}`);
+    return row;
+  }
+
+  it("collapses equivalent instants to byte-identical strings", async () => {
+    const written: string[] = [];
+    for (const [index, form] of SAME_INSTANT.entries()) {
+      const deployment = await insert({ commitSha: index.toString().repeat(40), createdAt: form });
+      expect(deployment.createdAt).toBe(CANONICAL);
+      written.push(readTimestamps(deployment.id).created_at);
+    }
+    // Byte identity, not just equal instants: TEXT ordering is what reads these.
+    expect(new Set(written)).toEqual(new Set([CANONICAL]));
+  });
+
+  it("canonicalises every column it writes, not just created_at", async () => {
+    const deployment = await insert({ createdAt: "2026-09-04T17:20:43-04:00" });
+    const claimed = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      leaseMs: 60_000,
+      now: "2026-09-04T23:20:43+02:00",
+    });
+    expect(claimed.success && claimed.data.claimed).toBe(true);
+    const written = await completeDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      status: "succeeded",
+      completedAt: "2026-09-04T21:21:43Z",
+    });
+    expect(written.success && written.data).toBe(true);
+
+    expect(readTimestamps(deployment.id)).toEqual({
+      created_at: CANONICAL,
+      started_at: CANONICAL,
+      completed_at: "2026-09-04T21:21:43.000Z",
+    });
+  });
+
+  describe("supersedeOlder", () => {
+    it("keeps the newer commit when the older rows arrived in offset form", async () => {
+      // Genuinely older than the keeper, and its string also sorts lower.
+      const older = await insert({
+        commitSha: "a".repeat(40),
+        createdAt: "2026-09-04T13:20:43-04:00", // 17:20:43Z
+      });
+      // Genuinely *newer* than the keeper, but its unnormalised string sorts
+      // lower ("18" < "21") — so without canonicalisation the keeper retires the
+      // very commit it should be losing to.
+      const newer = await insert({
+        commitSha: "b".repeat(40),
+        createdAt: "2026-09-04T18:20:43-04:00", // 22:20:43Z
+      });
+      const keeper = await insert({ commitSha: "c".repeat(40), createdAt: CANONICAL });
+
+      const result = await supersedeOlder(db, logger, {
+        projectId: PROJECT,
+        name: "production",
+        keepDeploymentId: keeper.id,
+        createdAt: keeper.createdAt,
+        now: CANONICAL,
+      });
+
+      expect(result.success && result.data).toBe(1);
+      expect(readStatus(older.id).status).toBe("superseded");
+      expect(readStatus(newer.id).status).toBe("queued");
+    });
+
+    it("supersedes an older Z row when the keeper's own merge time arrived in offset form", async () => {
+      const older = await insert({ commitSha: "a".repeat(40), createdAt: CANONICAL });
+      const keeper = await insert({
+        commitSha: "b".repeat(40),
+        createdAt: "2026-09-04T17:20:44-04:00", // 21:20:44Z, one second newer
+      });
+
+      const result = await supersedeOlder(db, logger, {
+        projectId: PROJECT,
+        name: "production",
+        keepDeploymentId: keeper.id,
+        createdAt: keeper.createdAt,
+        now: keeper.createdAt,
+      });
+
+      expect(result.success && result.data).toBe(1);
+      expect(readStatus(older.id).status).toBe("superseded");
+    });
+
+    it("orders a fraction-less timestamp against a fractional one by time, not by bytes", async () => {
+      // 'Z' (0x5A) sorts after '.' (0x2E), so unnormalised the older row looks
+      // newer than a keeper half a second after it.
+      const older = await insert({ commitSha: "a".repeat(40), createdAt: "2026-09-04T21:20:43Z" });
+      const keeper = await insert({
+        commitSha: "b".repeat(40),
+        createdAt: "2026-09-04T21:20:43.500Z",
+      });
+
+      const result = await supersedeOlder(db, logger, {
+        projectId: PROJECT,
+        name: "production",
+        keepDeploymentId: keeper.id,
+        createdAt: keeper.createdAt,
+        now: keeper.createdAt,
+      });
+
+      expect(result.success && result.data).toBe(1);
+      expect(readStatus(older.id).status).toBe("superseded");
+    });
+  });
+
+  describe("findNewerSucceededDeployment", () => {
+    it("finds a newer succeeded row that was written in offset form", async () => {
+      const newer = await insert({
+        commitSha: "b".repeat(40),
+        status: "succeeded",
+        createdAt: "2026-09-04T17:20:44-04:00", // 21:20:44Z
+      });
+      const candidate = await insert({ commitSha: "a".repeat(40), createdAt: CANONICAL });
+
+      const result = await findNewerSucceededDeployment(db, logger, {
+        projectId: PROJECT,
+        name: "production",
+        createdAt: candidate.createdAt,
+        excludeDeploymentId: candidate.id,
+      });
+
+      expect(result.success && result.data?.id).toBe(newer.id);
+    });
+
+    it("finds a newer succeeded row when the candidate carries no fractional part", async () => {
+      const newer = await insert({
+        commitSha: "b".repeat(40),
+        status: "succeeded",
+        createdAt: "2026-09-04T21:20:43.500Z",
+      });
+      const candidate = await insert({
+        commitSha: "a".repeat(40),
+        createdAt: "2026-09-04T21:20:43Z",
+      });
+
+      const result = await findNewerSucceededDeployment(db, logger, {
+        projectId: PROJECT,
+        name: "production",
+        createdAt: candidate.createdAt,
+        excludeDeploymentId: candidate.id,
+      });
+
+      expect(result.success && result.data?.id).toBe(newer.id);
+    });
+
+    it("still finds nothing when the only other row is genuinely older in another form", async () => {
+      await insert({
+        commitSha: "b".repeat(40),
+        status: "succeeded",
+        createdAt: "2026-09-04T19:20:43+02:00", // 17:20:43Z, older
+      });
+      const candidate = await insert({ commitSha: "a".repeat(40), createdAt: CANONICAL });
+
+      const result = await findNewerSucceededDeployment(db, logger, {
+        projectId: PROJECT,
+        name: "production",
+        createdAt: candidate.createdAt,
+        excludeDeploymentId: candidate.id,
+      });
+
+      expect(result.success && result.data).toBeNull();
+    });
+  });
+
+  describe("claimDeployment", () => {
+    /** Claims the row at 21:20:43Z with a one-minute lease, expiring 21:21:43Z. */
+    async function claimAt(now: string): Promise<Deployment> {
+      const deployment = await insert({ createdAt: CANONICAL });
+      const claimed = await claimDeployment(db, logger, {
+        projectId: PROJECT,
+        deploymentId: deployment.id,
+        leaseMs: 60_000,
+        now,
+      });
+      if (!claimed.success || !claimed.data.claimed) throw new Error("expected a claim");
+      expect(claimed.data.deployment.leaseExpiresAt).toBe("2026-09-04T21:21:43.000Z");
+      return deployment;
+    }
+
+    it("does not reclaim a live lease when the clock arrives in offset form", async () => {
+      // 06:21:13 on the 5th in +09:00 is 21:21:13Z on the 4th — thirty seconds
+      // *before* the lease expires, but a later-sorting string than it.
+      const deployment = await claimAt("2026-09-04T17:20:43-04:00");
+
+      const result = await claimDeployment(db, logger, {
+        projectId: PROJECT,
+        deploymentId: deployment.id,
+        now: "2026-09-05T06:21:13+09:00",
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success || result.data.claimed) throw new Error("reclaimed a live lease");
+      expect(result.data.reason).toBe("not_claimable");
+      expect(readStatus(deployment.id).lease_expires_at).toBe("2026-09-04T21:21:43.000Z");
+    });
+
+    it("reclaims an expired lease when the clock arrives in offset form", async () => {
+      // 13:22:43 in -08:00 is 21:22:43Z, a minute past expiry — but an
+      // earlier-sorting string than the lease it must be allowed to reclaim.
+      const deployment = await claimAt("2026-09-04T21:20:43Z");
+
+      const result = await claimDeployment(db, logger, {
+        projectId: PROJECT,
+        deploymentId: deployment.id,
+        leaseMs: 60_000,
+        now: "2026-09-04T13:22:43-08:00",
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success || !result.data.claimed) throw new Error("expected a reclaim");
+      expect(result.data.deployment.leaseExpiresAt).toBe("2026-09-04T21:23:43.000Z");
+      // The row changed hands rather than restarting.
+      expect(result.data.deployment.startedAt).toBe(CANONICAL);
+    });
+  });
+});

--- a/tests/deployments-storage.test.ts
+++ b/tests/deployments-storage.test.ts
@@ -8,6 +8,7 @@
  * database error, and a second claim of the same row must lose.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEPLOY_ATTEMPT_DEADLINE_MS } from "../src/deploy/limits";
 import {
   DEFAULT_DEPLOY_LEASE_MS,
   type Deployment,
@@ -322,6 +323,41 @@ describe("claimDeployment", () => {
     if (!stillLive.success || stillLive.data.claimed) throw new Error("expected no claim");
     expect(stillLive.data.reason).toBe("not_claimable");
     expect(readStatus(deployment.id).lease_expires_at).toBe("2026-09-04T00:01:00.000Z");
+  });
+
+  // The double-deploy this lease exists to prevent. A runner gives up at
+  // DEPLOY_ATTEMPT_DEADLINE_MS, so the whole window in which one can still be
+  // uploading has to be a window in which nobody else can claim its row.
+  it("cannot be reclaimed at any point where a runner may still hold it", async () => {
+    const deployment = await insert();
+    const claimed = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      now: T0,
+    });
+    if (!claimed.success || !claimed.data.claimed) throw new Error("expected a claim");
+
+    const start = Date.parse(T0);
+    for (const elapsed of [0, 1, DEPLOY_ATTEMPT_DEADLINE_MS - 1, DEPLOY_ATTEMPT_DEADLINE_MS]) {
+      const attempt = await claimDeployment(db, logger, {
+        projectId: PROJECT,
+        deploymentId: deployment.id,
+        now: new Date(start + elapsed).toISOString(),
+      });
+      expect(attempt.success).toBe(true);
+      if (!attempt.success || attempt.data.claimed) {
+        throw new Error(`reclaimed a live deployment ${elapsed}ms in`);
+      }
+      expect(attempt.data.reason).toBe("not_claimable");
+    }
+
+    // …and the lease does eventually release, or a dead runner would strand it.
+    const afterLease = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      now: new Date(start + DEFAULT_DEPLOY_LEASE_MS).toISOString(),
+    });
+    expect(afterLease.success && afterLease.data.claimed).toBe(true);
   });
 
   it("refuses a pending_approval row", async () => {

--- a/tests/deployments-storage.test.ts
+++ b/tests/deployments-storage.test.ts
@@ -1,0 +1,869 @@
+/**
+ * The deployment storage layer.
+ *
+ * The assertions that matter are the concurrency ones. `insertDeployment` and
+ * `claimDeployment` are the two places a deploy can be run twice, so the tests
+ * race them against a real SQLite engine rather than a stub: a duplicate insert
+ * must come back as a *distinguishable* "someone else owns this" and not as a
+ * database error, and a second claim of the same row must lose.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_DEPLOY_LEASE_MS,
+  type Deployment,
+  approveDeployment,
+  claimDeployment,
+  completeDeployment,
+  findDeploymentById,
+  findNewerSucceededDeployment,
+  getDeployment,
+  insertDeployment,
+  listDeployments,
+  supersedeOlder,
+} from "../src/storage/deployments";
+import type { Logger } from "../src/utils/logger";
+import { makeSqliteD1, makeThrowingD1 } from "./helpers/sqlite-d1";
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+};
+
+const PROJECT = "prj_aaaaaaaa";
+const OTHER_PROJECT = "prj_bbbbbbbb";
+const SHA = "a".repeat(40);
+const OTHER_SHA = "b".repeat(40);
+const T0 = "2026-09-04T00:00:00.000Z";
+
+let db: D1Database;
+let raw: ReturnType<typeof makeSqliteD1>["raw"];
+
+beforeEach(() => {
+  const made = makeSqliteD1();
+  db = made.db;
+  raw = made.raw;
+  vi.clearAllMocks();
+});
+
+type InsertOverrides = Partial<Parameters<typeof insertDeployment>[2]>;
+
+async function insert(overrides: InsertOverrides = {}): Promise<Deployment> {
+  const result = await insertDeployment(db, logger, {
+    projectId: PROJECT,
+    project: "api",
+    changeId: "chg_1",
+    commitSha: SHA,
+    name: "production",
+    target: "vercel",
+    requestedByType: "user",
+    requestedById: "usr_1",
+    now: T0,
+    ...overrides,
+  });
+  if (!result.success) throw result.error;
+  if (!result.data.inserted) throw new Error("expected the insert to win");
+  return result.data.deployment;
+}
+
+function readStatus(id: string): { status: string; lease_expires_at: string | null } {
+  const row = raw
+    .prepare("SELECT status, lease_expires_at FROM deployments WHERE id = ?")
+    .get(id) as { status: string; lease_expires_at: string | null } | undefined;
+  if (!row) throw new Error(`no deployment ${id}`);
+  return row;
+}
+
+describe("insertDeployment", () => {
+  it("writes a queued row with every field the caller supplied", async () => {
+    const deployment = await insert();
+
+    expect(deployment.status).toBe("queued");
+    expect(deployment.attempt).toBe(1);
+    expect(deployment.projectId).toBe(PROJECT);
+    expect(deployment.project).toBe("api");
+    expect(deployment.changeId).toBe("chg_1");
+    expect(deployment.commitSha).toBe(SHA);
+    expect(deployment.target).toBe("vercel");
+    expect(deployment.requestedByType).toBe("user");
+    expect(deployment.requestedById).toBe("usr_1");
+    expect(deployment.createdAt).toBe(T0);
+    expect(deployment.completedAt).toBeUndefined();
+
+    const stored = await getDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+    });
+    expect(stored.success && stored.data).toEqual(deployment);
+  });
+
+  // `created_at` is merge order, not write order — the queue promises neither,
+  // and every ordering decision in this module reads that column.
+  it("stamps created_at from the merge time while the clock owns completed_at", async () => {
+    const deployment = await insert({
+      createdAt: "2026-09-04T00:00:00.000Z",
+      now: "2026-09-04T09:00:00.000Z",
+      status: "failed",
+    });
+
+    expect(deployment.createdAt).toBe("2026-09-04T00:00:00.000Z");
+    expect(deployment.completedAt).toBe("2026-09-04T09:00:00.000Z");
+    const row = raw
+      .prepare("SELECT created_at, completed_at FROM deployments WHERE id = ?")
+      .get(deployment.id) as { created_at: string; completed_at: string };
+    expect(row.created_at).toBe("2026-09-04T00:00:00.000Z");
+    expect(row.completed_at).toBe("2026-09-04T09:00:00.000Z");
+  });
+
+  // A retry supplies no merge time on purpose: re-running an old commit is an
+  // assertion that it is the newest intent, and the guard reads this column.
+  it("falls back to the clock when no merge time is supplied", async () => {
+    const deployment = await insert({ now: "2026-09-04T09:00:00.000Z" });
+    expect(deployment.createdAt).toBe("2026-09-04T09:00:00.000Z");
+  });
+
+  it("rejects a non-ISO merge time", async () => {
+    const result = await insertDeployment(db, logger, {
+      projectId: PROJECT,
+      project: "api",
+      commitSha: SHA,
+      name: "production",
+      target: "vercel",
+      requestedByType: "system",
+      createdAt: "2026-09-04 00:00:00",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("omits change_id for a deploy not traceable to a change", async () => {
+    const deployment = await insert({ changeId: null });
+    expect(deployment.changeId).toBeUndefined();
+  });
+
+  it("stamps completed_at when the row is born terminal", async () => {
+    // A rejected `deploys:` entry is persisted as a failed row rather than
+    // dropped, and such a row never runs, so it is complete on arrival.
+    const deployment = await insert({
+      status: "failed",
+      reason: "unknown target 'netlify'",
+    });
+    expect(deployment.completedAt).toBe(T0);
+    expect(deployment.reason).toBe("unknown target 'netlify'");
+  });
+
+  it("reports a duplicate attempt as a lost race, not an error", async () => {
+    await insert();
+
+    const second = await insertDeployment(db, logger, {
+      projectId: PROJECT,
+      project: "api",
+      commitSha: SHA,
+      name: "production",
+      target: "vercel",
+      requestedByType: "system",
+      now: T0,
+    });
+
+    expect(second.success).toBe(true);
+    if (!second.success) return;
+    expect(second.data.inserted).toBe(false);
+    if (second.data.inserted) return;
+    expect(second.data.existing?.commitSha).toBe(SHA);
+    expect(second.data.existing?.requestedByType).toBe("user");
+
+    const count = raw.prepare("SELECT COUNT(*) AS n FROM deployments").get() as { n: number };
+    expect(count.n).toBe(1);
+  });
+
+  it("distinguishes a genuine database failure from a duplicate", async () => {
+    const result = await insertDeployment(makeThrowingD1("disk is on fire"), logger, {
+      projectId: PROJECT,
+      project: "api",
+      commitSha: SHA,
+      name: "production",
+      target: "vercel",
+      requestedByType: "system",
+      now: T0,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe("DATABASE_ERROR");
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("admits attempt + 1 for the same commit", async () => {
+    await insert();
+    const retry = await insert({ attempt: 2 });
+    expect(retry.attempt).toBe(2);
+
+    const count = raw.prepare("SELECT COUNT(*) AS n FROM deployments").get() as { n: number };
+    expect(count.n).toBe(2);
+  });
+
+  it("admits the same name and commit in another project", async () => {
+    await insert();
+    const other = await insert({ projectId: OTHER_PROJECT });
+    expect(other.projectId).toBe(OTHER_PROJECT);
+  });
+
+  it("rejects a non-ISO timestamp rather than corrupting range comparisons", async () => {
+    const result = await insertDeployment(db, logger, {
+      projectId: PROJECT,
+      project: "api",
+      commitSha: SHA,
+      name: "production",
+      target: "vercel",
+      requestedByType: "system",
+      now: "2026-09-04 00:00:00",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+describe("claimDeployment", () => {
+  it("succeeds exactly once for two consumers racing the same row", async () => {
+    const deployment = await insert();
+
+    const first = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      now: T0,
+    });
+    const second = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      now: T0,
+    });
+
+    expect(first.success && first.data.claimed).toBe(true);
+    expect(second.success && second.data.claimed).toBe(false);
+    if (second.success && !second.data.claimed) {
+      expect(second.data.reason).toBe("not_claimable");
+    }
+  });
+
+  it("marks the row running with a lease and a start time", async () => {
+    const deployment = await insert();
+    const result = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      leaseMs: 60_000,
+      now: T0,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success || !result.data.claimed) throw new Error("expected a claim");
+    expect(result.data.deployment.status).toBe("running");
+    expect(result.data.deployment.startedAt).toBe(T0);
+    expect(result.data.deployment.leaseExpiresAt).toBe("2026-09-04T00:01:00.000Z");
+  });
+
+  it("defaults the lease to DEFAULT_DEPLOY_LEASE_MS", async () => {
+    const deployment = await insert();
+    const result = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      now: T0,
+    });
+    if (!result.success || !result.data.claimed) throw new Error("expected a claim");
+    expect(result.data.deployment.leaseExpiresAt).toBe(
+      new Date(Date.parse(T0) + DEFAULT_DEPLOY_LEASE_MS).toISOString(),
+    );
+  });
+
+  it("reclaims a running row whose lease has passed", async () => {
+    const deployment = await insert();
+    const claimed = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      leaseMs: 60_000,
+      now: T0,
+    });
+    expect(claimed.success && claimed.data.claimed).toBe(true);
+
+    const afterExpiry = "2026-09-04T00:02:00.000Z";
+    const reclaimed = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      leaseMs: 60_000,
+      now: afterExpiry,
+    });
+
+    expect(reclaimed.success).toBe(true);
+    if (!reclaimed.success || !reclaimed.data.claimed) throw new Error("expected a reclaim");
+    expect(reclaimed.data.deployment.leaseExpiresAt).toBe("2026-09-04T00:03:00.000Z");
+    // The original start time survives: the deployment did not restart, it changed hands.
+    expect(reclaimed.data.deployment.startedAt).toBe(T0);
+  });
+
+  it("refuses a running row whose lease is still live", async () => {
+    const deployment = await insert();
+    await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      leaseMs: 60_000,
+      now: T0,
+    });
+
+    const stillLive = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      now: "2026-09-04T00:00:59.000Z",
+    });
+
+    expect(stillLive.success).toBe(true);
+    if (!stillLive.success || stillLive.data.claimed) throw new Error("expected no claim");
+    expect(stillLive.data.reason).toBe("not_claimable");
+    expect(readStatus(deployment.id).lease_expires_at).toBe("2026-09-04T00:01:00.000Z");
+  });
+
+  it("refuses a pending_approval row", async () => {
+    const deployment = await insert({ status: "pending_approval" });
+    const result = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      now: T0,
+    });
+    if (!result.success || result.data.claimed) throw new Error("expected no claim");
+    expect(result.data.reason).toBe("not_claimable");
+    expect(readStatus(deployment.id).status).toBe("pending_approval");
+  });
+
+  it("refuses a terminal row", async () => {
+    const deployment = await insert({ status: "succeeded" });
+    const result = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      now: T0,
+    });
+    if (!result.success || result.data.claimed) throw new Error("expected no claim");
+    expect(result.data.reason).toBe("not_claimable");
+  });
+
+  it("cannot claim a deployment belonging to another project", async () => {
+    const deployment = await insert();
+    const result = await claimDeployment(db, logger, {
+      projectId: OTHER_PROJECT,
+      deploymentId: deployment.id,
+      now: T0,
+    });
+    if (!result.success || result.data.claimed) throw new Error("expected no claim");
+    expect(result.data.reason).toBe("not_found");
+    expect(readStatus(deployment.id).status).toBe("queued");
+  });
+
+  it("returns a database error rather than throwing", async () => {
+    const result = await claimDeployment(makeThrowingD1(), logger, {
+      projectId: PROJECT,
+      deploymentId: "dep_missing",
+      now: T0,
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe("DATABASE_ERROR");
+  });
+});
+
+describe("completeDeployment", () => {
+  it("writes the terminal status, its detail, and releases the lease", async () => {
+    const deployment = await insert();
+    await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      now: T0,
+    });
+
+    const written = await completeDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      status: "succeeded",
+      url: "https://api.example.com",
+      durationMs: 4200,
+      completedAt: "2026-09-04T00:00:05.000Z",
+    });
+    expect(written.success && written.data).toBe(true);
+
+    const stored = await getDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+    });
+    if (!stored.success || !stored.data) throw new Error("expected the deployment");
+    expect(stored.data.status).toBe("succeeded");
+    expect(stored.data.url).toBe("https://api.example.com");
+    expect(stored.data.durationMs).toBe(4200);
+    expect(stored.data.completedAt).toBe("2026-09-04T00:00:05.000Z");
+    expect(stored.data.leaseExpiresAt).toBeUndefined();
+  });
+
+  it("records a failure with its reason and log tail", async () => {
+    const deployment = await insert();
+    await completeDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      status: "failed",
+      reason: "missing secret VERCEL_TOKEN",
+      logTail: "401 Unauthorized",
+      completedAt: T0,
+    });
+
+    const stored = await getDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+    });
+    if (!stored.success || !stored.data) throw new Error("expected the deployment");
+    expect(stored.data.status).toBe("failed");
+    expect(stored.data.reason).toBe("missing secret VERCEL_TOKEN");
+    expect(stored.data.logTail).toBe("401 Unauthorized");
+  });
+
+  it("will not overwrite a row that is already terminal", async () => {
+    const deployment = await insert();
+    await completeDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      status: "succeeded",
+      completedAt: T0,
+    });
+
+    // The consumer that lost its lease mid-deploy must not clobber the winner.
+    const late = await completeDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: deployment.id,
+      status: "failed",
+      reason: "lease expired",
+      completedAt: "2026-09-04T00:10:00.000Z",
+    });
+
+    expect(late.success && late.data).toBe(false);
+    expect(readStatus(deployment.id).status).toBe("succeeded");
+  });
+
+  it("will not complete a deployment in another project", async () => {
+    const deployment = await insert();
+    const result = await completeDeployment(db, logger, {
+      projectId: OTHER_PROJECT,
+      deploymentId: deployment.id,
+      status: "failed",
+      completedAt: T0,
+    });
+    expect(result.success && result.data).toBe(false);
+    expect(readStatus(deployment.id).status).toBe("queued");
+  });
+});
+
+describe("supersedeOlder", () => {
+  const T1 = "2026-09-04T00:01:00.000Z";
+  const T2 = "2026-09-04T00:02:00.000Z";
+
+  it("supersedes only older queued and pending_approval rows of the same name", async () => {
+    const olderQueued = await insert({ commitSha: SHA, now: T0 });
+    const olderPending = await insert({
+      commitSha: OTHER_SHA,
+      now: T0,
+      status: "pending_approval",
+    });
+    const olderRunning = await insert({ commitSha: "c".repeat(40), now: T0, status: "running" });
+    const olderDone = await insert({ commitSha: "d".repeat(40), now: T0, status: "succeeded" });
+    const otherName = await insert({ commitSha: SHA, name: "staging", now: T0 });
+    const otherProject = await insert({ projectId: OTHER_PROJECT, commitSha: SHA, now: T0 });
+    const newer = await insert({ commitSha: "e".repeat(40), now: T2 });
+
+    const keeper = await insert({ commitSha: "f".repeat(40), now: T1 });
+
+    const result = await supersedeOlder(db, logger, {
+      projectId: PROJECT,
+      name: "production",
+      keepDeploymentId: keeper.id,
+      createdAt: keeper.createdAt,
+      now: T1,
+    });
+
+    expect(result.success && result.data).toBe(2);
+    expect(readStatus(olderQueued.id).status).toBe("superseded");
+    expect(readStatus(olderPending.id).status).toBe("superseded");
+    expect(readStatus(olderRunning.id).status).toBe("running");
+    expect(readStatus(olderDone.id).status).toBe("succeeded");
+    expect(readStatus(otherName.id).status).toBe("queued");
+    expect(readStatus(otherProject.id).status).toBe("queued");
+    expect(readStatus(newer.id).status).toBe("queued");
+    expect(readStatus(keeper.id).status).toBe("queued");
+  });
+
+  it("stamps a reason and a completion time on each superseded row", async () => {
+    const older = await insert({ now: T0 });
+    const keeper = await insert({ commitSha: OTHER_SHA, now: T1 });
+
+    await supersedeOlder(db, logger, {
+      projectId: PROJECT,
+      name: "production",
+      keepDeploymentId: keeper.id,
+      createdAt: keeper.createdAt,
+      now: T1,
+    });
+
+    const stored = await getDeployment(db, logger, { projectId: PROJECT, deploymentId: older.id });
+    if (!stored.success || !stored.data) throw new Error("expected the deployment");
+    expect(stored.data.reason).toMatch(/superseded/i);
+    expect(stored.data.completedAt).toBe(T1);
+  });
+
+  it("supersedes nothing when the keeper is the only row", async () => {
+    const keeper = await insert({ now: T1 });
+    const result = await supersedeOlder(db, logger, {
+      projectId: PROJECT,
+      name: "production",
+      keepDeploymentId: keeper.id,
+      createdAt: keeper.createdAt,
+      now: T1,
+    });
+    expect(result.success && result.data).toBe(0);
+  });
+
+  it("returns a database error rather than throwing", async () => {
+    const result = await supersedeOlder(makeThrowingD1(), logger, {
+      projectId: PROJECT,
+      name: "production",
+      keepDeploymentId: "dep_x",
+      createdAt: T0,
+      now: T0,
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe("DATABASE_ERROR");
+  });
+});
+
+describe("findNewerSucceededDeployment", () => {
+  const later = "2026-09-04T00:10:00.000Z";
+
+  async function find(deployment: Deployment) {
+    const result = await findNewerSucceededDeployment(db, logger, {
+      projectId: PROJECT,
+      name: deployment.name,
+      createdAt: deployment.createdAt,
+      excludeDeploymentId: deployment.id,
+    });
+    if (!result.success) throw result.error;
+    return result.data;
+  }
+
+  // The case `supersedeOlder` cannot reach: by the time the older message is
+  // delivered the newer deploy is already terminal, so nothing retires it and
+  // the older commit would publish over the top.
+  it("finds a newer succeeded deployment of the same name", async () => {
+    const newer = await insert({ commitSha: OTHER_SHA, status: "succeeded", now: later });
+    const older = await insert({ commitSha: SHA, now: T0 });
+
+    expect((await find(older))?.id).toBe(newer.id);
+  });
+
+  it("ignores a newer deployment that has not succeeded", async () => {
+    await insert({ commitSha: OTHER_SHA, status: "failed", now: later });
+    await insert({ commitSha: "c".repeat(40), status: "running", now: later });
+    const older = await insert({ commitSha: SHA, now: T0 });
+
+    expect(await find(older)).toBeNull();
+  });
+
+  it("ignores an older succeeded deployment, which is what this one replaces", async () => {
+    await insert({ commitSha: OTHER_SHA, status: "succeeded", now: T0 });
+    const newer = await insert({ commitSha: SHA, now: later });
+
+    expect(await find(newer)).toBeNull();
+  });
+
+  // Siblings of one merge share a timestamp but never a name, and a retry can
+  // land in the same millisecond as the row it retries; refusing on equality
+  // would make that retry unrunnable for nothing.
+  it("ignores a deployment stamped at the same instant", async () => {
+    await insert({ commitSha: OTHER_SHA, status: "succeeded", now: T0 });
+    const same = await insert({ commitSha: SHA, now: T0 });
+
+    expect(await find(same)).toBeNull();
+  });
+
+  it("ignores another deploy name and another project", async () => {
+    await insert({ name: "staging", status: "succeeded", now: later });
+    await insert({ projectId: OTHER_PROJECT, status: "succeeded", now: later });
+    const older = await insert({ commitSha: SHA, now: T0 });
+
+    expect(await find(older)).toBeNull();
+  });
+
+  it("never counts the deployment as its own superseder", async () => {
+    const only = await insert({ status: "succeeded", now: T0 });
+    const result = await findNewerSucceededDeployment(db, logger, {
+      projectId: PROJECT,
+      name: only.name,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      excludeDeploymentId: only.id,
+    });
+    if (!result.success) throw result.error;
+    expect(result.data).toBeNull();
+  });
+
+  it("rejects a non-ISO timestamp", async () => {
+    const result = await findNewerSucceededDeployment(db, logger, {
+      projectId: PROJECT,
+      name: "production",
+      createdAt: "2026-09-04 00:00:00",
+      excludeDeploymentId: "dep_1",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("returns a database error rather than throwing", async () => {
+    const result = await findNewerSucceededDeployment(makeThrowingD1(), logger, {
+      projectId: PROJECT,
+      name: "production",
+      createdAt: T0,
+      excludeDeploymentId: "dep_1",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("listDeployments", () => {
+  it("returns a project's deployments newest first", async () => {
+    const oldest = await insert({ commitSha: SHA, now: T0 });
+    const middle = await insert({ commitSha: OTHER_SHA, now: "2026-09-04T00:01:00.000Z" });
+    const newest = await insert({ commitSha: "c".repeat(40), now: "2026-09-04T00:02:00.000Z" });
+
+    const result = await listDeployments(db, logger, { projectId: PROJECT });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.map((d) => d.id)).toEqual([newest.id, middle.id, oldest.id]);
+  });
+
+  // Deploys fanned out from one merge are stamped from that merge's timestamp,
+  // so they always tie on `created_at`. Without `name` behind it a random hex id
+  // decided the order and the page rendered differently on each request.
+  it("orders siblings of one merge by name, not by their random ids", async () => {
+    const siblings = ["staging", "production", "site"];
+    for (const name of siblings) await insert({ name, now: T0 });
+
+    const result = await listDeployments(db, logger, { projectId: PROJECT });
+    if (!result.success) throw result.error;
+    expect(result.data.map((d) => d.name)).toEqual(["production", "site", "staging"]);
+  });
+
+  it("still orders by merge time before it falls back to the name", async () => {
+    await insert({ name: "alpha", now: T0 });
+    await insert({ name: "zulu", now: "2026-09-04T00:05:00.000Z" });
+
+    const result = await listDeployments(db, logger, { projectId: PROJECT });
+    if (!result.success) throw result.error;
+    expect(result.data.map((d) => d.name)).toEqual(["zulu", "alpha"]);
+  });
+
+  it("never returns another project's deployments", async () => {
+    await insert({ projectId: OTHER_PROJECT });
+    const mine = await insert();
+
+    const result = await listDeployments(db, logger, { projectId: PROJECT });
+    if (!result.success) throw result.error;
+    expect(result.data.map((d) => d.id)).toEqual([mine.id]);
+  });
+
+  it("filters by deploy name and by status", async () => {
+    const production = await insert({ name: "production" });
+    const staging = await insert({ name: "staging", status: "failed" });
+
+    const byName = await listDeployments(db, logger, { projectId: PROJECT, name: "staging" });
+    if (!byName.success) throw byName.error;
+    expect(byName.data.map((d) => d.id)).toEqual([staging.id]);
+
+    const byStatus = await listDeployments(db, logger, { projectId: PROJECT, status: "queued" });
+    if (!byStatus.success) throw byStatus.error;
+    expect(byStatus.data.map((d) => d.id)).toEqual([production.id]);
+  });
+
+  it("pages with limit and offset", async () => {
+    const first = await insert({ commitSha: SHA, now: "2026-09-04T00:02:00.000Z" });
+    const second = await insert({ commitSha: OTHER_SHA, now: "2026-09-04T00:01:00.000Z" });
+
+    const page1 = await listDeployments(db, logger, { projectId: PROJECT, limit: 1 });
+    if (!page1.success) throw page1.error;
+    expect(page1.data.map((d) => d.id)).toEqual([first.id]);
+
+    const page2 = await listDeployments(db, logger, { projectId: PROJECT, limit: 1, offset: 1 });
+    if (!page2.success) throw page2.error;
+    expect(page2.data.map((d) => d.id)).toEqual([second.id]);
+  });
+
+  it("returns a database error rather than throwing", async () => {
+    const result = await listDeployments(makeThrowingD1(), logger, { projectId: PROJECT });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("getDeployment", () => {
+  it("returns null for a deployment in another project", async () => {
+    const deployment = await insert();
+    const result = await getDeployment(db, logger, {
+      projectId: OTHER_PROJECT,
+      deploymentId: deployment.id,
+    });
+    expect(result.success && result.data).toBeNull();
+  });
+
+  it("returns null for an unknown id", async () => {
+    const result = await getDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: "dep_nope",
+    });
+    expect(result.success && result.data).toBeNull();
+  });
+
+  it("returns a database error rather than throwing", async () => {
+    const result = await getDeployment(makeThrowingD1(), logger, {
+      projectId: PROJECT,
+      deploymentId: "dep_nope",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("approveDeployment", () => {
+  it("moves a pending row to queued and stamps the approver", async () => {
+    const pending = await insert({ status: "pending_approval" });
+
+    const result = await approveDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: pending.id,
+      approvedBy: "usr_2",
+    });
+
+    expect(result.success && result.data.approved).toBe(true);
+    if (result.success && result.data.approved) {
+      expect(result.data.deployment.status).toBe("queued");
+      expect(result.data.deployment.approvedBy).toBe("usr_2");
+    }
+    expect(readStatus(pending.id).status).toBe("queued");
+  });
+
+  it("closes the gap that would otherwise strand an approved deploy forever", async () => {
+    // claimDeployment refuses pending_approval by design, so without the
+    // transition this function performs the row is unreachable for good.
+    const pending = await insert({ status: "pending_approval" });
+
+    const before = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: pending.id,
+      now: T0,
+    });
+    expect(before.success && before.data.claimed).toBe(false);
+
+    await approveDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: pending.id,
+      approvedBy: "usr_2",
+    });
+
+    const after = await claimDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: pending.id,
+      now: T0,
+    });
+    expect(after.success && after.data.claimed).toBe(true);
+  });
+
+  it("lets only one of two concurrent approvals win, so a double-approve cannot enqueue twice", async () => {
+    const pending = await insert({ status: "pending_approval" });
+
+    const [first, second] = await Promise.all([
+      approveDeployment(db, logger, {
+        projectId: PROJECT,
+        deploymentId: pending.id,
+        approvedBy: "usr_2",
+      }),
+      approveDeployment(db, logger, {
+        projectId: PROJECT,
+        deploymentId: pending.id,
+        approvedBy: "usr_3",
+      }),
+    ]);
+
+    const outcomes = [first, second].map((r) => r.success && r.data.approved);
+    expect(outcomes.filter(Boolean)).toHaveLength(1);
+    // The loser is told why, so the route can answer 409 rather than enqueue.
+    const loser = [first, second].find((r) => r.success && !r.data.approved);
+    expect(loser?.success && !loser.data.approved && loser.data.reason).toBe("not_pending");
+  });
+
+  it.each(["queued", "running", "succeeded", "failed", "superseded", "skipped"] as const)(
+    "refuses a %s row",
+    async (status) => {
+      const row = await insert({ status });
+
+      const result = await approveDeployment(db, logger, {
+        projectId: PROJECT,
+        deploymentId: row.id,
+        approvedBy: "usr_2",
+      });
+
+      expect(result.success && result.data.approved).toBe(false);
+      expect(result.success && !result.data.approved && result.data.reason).toBe("not_pending");
+      expect(readStatus(row.id).status).toBe(status);
+    },
+  );
+
+  it("reports not_found for a row in another project", async () => {
+    const pending = await insert({ status: "pending_approval" });
+
+    const result = await approveDeployment(db, logger, {
+      projectId: OTHER_PROJECT,
+      deploymentId: pending.id,
+      approvedBy: "usr_2",
+    });
+
+    expect(result.success && !result.data.approved && result.data.reason).toBe("not_found");
+    expect(readStatus(pending.id).status).toBe("pending_approval");
+  });
+
+  it("rejects a non-ISO timestamp", async () => {
+    const result = await approveDeployment(db, logger, {
+      projectId: PROJECT,
+      deploymentId: "dep_nope",
+      approvedBy: "usr_2",
+      now: "2026-09-04 00:00:00",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("returns a database error rather than throwing", async () => {
+    const result = await approveDeployment(makeThrowingD1(), logger, {
+      projectId: PROJECT,
+      deploymentId: "dep_nope",
+      approvedBy: "usr_2",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("findDeploymentById", () => {
+  it("finds a row without knowing its project, so a route can authorize on the row's own project", async () => {
+    const row = await insert();
+
+    const result = await findDeploymentById(db, logger, row.id);
+
+    expect(result.success && result.data?.projectId).toBe(PROJECT);
+  });
+
+  it("returns null for an unknown id", async () => {
+    const result = await findDeploymentById(db, logger, "dep_nope");
+    expect(result.success && result.data).toBeNull();
+  });
+
+  it("returns a database error rather than throwing", async () => {
+    const result = await findDeploymentById(makeThrowingD1(), logger, "dep_nope");
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/integration/deploy-flow.test.ts
+++ b/tests/integration/deploy-flow.test.ts
@@ -1,0 +1,849 @@
+/**
+ * Post-merge deployments, end to end.
+ *
+ * This suite deliberately starts one layer above `runDeployMessage`: the unit
+ * tests in `tests/deploy-runner.test.ts` drive the runner directly with all
+ * three seams injected, which proves the runner's own logic but says nothing
+ * about the *wiring*. Everything that has actually gone wrong in this feature
+ * lives in the wiring:
+ *
+ * - **The trigger is the post-merge result, not the `change.merged` event.**
+ *   `change.merged` is emitted *before* `runPostMergeCheck` runs, and a failed
+ *   check auto-reverts the merge. A deploy hung off that event would publish
+ *   the exact commit Stratum had just decided to revert. The reverted-merge
+ *   test below runs the real `runPostMergeCheck` against a failing sandbox and
+ *   asserts that **no deployment row is created at all** — not a `failed` one,
+ *   not a `skipped` one, none.
+ * - **The consumer runs the real runner with its production defaults.** So the
+ *   messages `enqueueMergeDeploy` produces are fed to `handleDeployQueue`
+ *   verbatim, and nothing here passes `DeployRunnerDeps`. The two seams that
+ *   would otherwise reach the network — the git remote and the provider — are
+ *   replaced at the module and global boundary instead: `readRepoFiles` and the
+ *   Artifacts token mint are mocked, and `fetch` is stubbed globally. `Date` is
+ *   faked rather than injected for the same reason: `handleDeployQueue` has no
+ *   `now` parameter, and a wall-clock-dependent assertion is not worth having.
+ * - **Two provider shapes, because they fail differently.** `cloudflare-pages`
+ *   is a three-phase upload (manifest session → asset buckets → script PUT)
+ *   whose middle phase authenticates with a JWT the provider handed back, and
+ *   `vercel` is a single inline POST. A stub that only ever answers one request
+ *   would not notice a target that stopped making the other two.
+ *
+ * Every provider call goes through the stubbed `fetch`; nothing here touches
+ * the network, and D1 is real SQLite with the production migrations applied.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted above the imports by Vitest. Only the two functions that talk to a
+// real git remote are replaced; the rest of the module is passed through
+// because `state.ts`, `deletion.ts` and `policy-loader.ts` import from it too.
+vi.mock("../../src/storage/git-ops", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/storage/git-ops")>();
+  return {
+    ...actual,
+    freshRepoToken: vi.fn(),
+    readRepoFiles: vi.fn(),
+    getCommitParent: vi.fn(),
+    revertToCommit: vi.fn(),
+  };
+});
+
+import type { EvalPolicy } from "../../src/evaluation/types";
+import { runPostMergeCheck } from "../../src/merge/post-merge";
+import { enqueueMergeDeploy, handleDeployQueue } from "../../src/queue/deploy-queue";
+import {
+  SUPERSEDED_REASON,
+  approveDeployment,
+  listDeployments,
+} from "../../src/storage/deployments";
+import {
+  freshRepoToken,
+  getCommitParent,
+  readRepoFiles,
+  revertToCommit,
+} from "../../src/storage/git-ops";
+import { putSecret } from "../../src/storage/project-secrets";
+import { setProject } from "../../src/storage/state";
+import type {
+  Env,
+  Message,
+  MessageBatch,
+  ProjectEntry,
+  Queue,
+  SandboxBinding,
+} from "../../src/types";
+import type { Logger } from "../../src/utils/logger";
+import { ok } from "../../src/utils/result";
+import { makeFakeKV } from "../helpers/fake-kv";
+import { makeSqliteD1 } from "../helpers/sqlite-d1";
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+};
+
+const PROJECT_ID = "prj_deployflow";
+const PROJECT_NAME = "site";
+const REMOTE = "https://acct.artifacts.cloudflare.net/git/acct/site.git";
+
+const CHANGE_A = "chg_deployflow_a";
+const CHANGE_B = "chg_deployflow_b";
+const SHA_A = "a".repeat(40);
+const SHA_B = "b".repeat(40);
+
+const DEPLOY_SECRET_KEY = "an-integration-test-deploy-secret-key";
+
+/**
+ * Deliberately long, distinctive values. A short secret would match by accident
+ * all over a JSON payload and make the redaction assertions meaningless.
+ */
+const SECRETS = {
+  CLOUDFLARE_API_TOKEN: "cf-api-token-0123456789abcdef-super-secret",
+  CLOUDFLARE_ACCOUNT_ID: "cfacct0123456789abcdef0123456789",
+  CLOUDFLARE_WORKERS_SUBDOMAIN: "acme-team",
+  VERCEL_TOKEN: "vercel-token-0123456789abcdef-super-secret",
+  VERCEL_PROJECT_ID: "prj_vercel_0123456789abcdef",
+} as const;
+
+const SECRET_VALUES = Object.values(SECRETS);
+
+/**
+ * The subset that must never appear anywhere at all.
+ *
+ * `CLOUDFLARE_WORKERS_SUBDOMAIN` is stored as a project secret but is not a
+ * credential — it is the public hostname the site is served from, and
+ * `cloudflare-pages` builds the deployment's `url` out of it on purpose. Every
+ * other value here is a bearer credential.
+ */
+const CREDENTIAL_VALUES = SECRET_VALUES.filter(
+  (value) => value !== SECRETS.CLOUDFLARE_WORKERS_SUBDOMAIN,
+);
+
+/** Frozen clock. Every assertion that touches a timestamp derives from these. */
+const T0_ISO = "2026-09-04T09:00:00.000Z";
+const T1_ISO = "2026-09-04T09:05:00.000Z";
+const T0 = Date.parse(T0_ISO);
+const T1 = Date.parse(T1_ISO);
+
+const PROJECT: ProjectEntry = {
+  id: PROJECT_ID,
+  name: PROJECT_NAME,
+  slug: "site",
+  namespace: "@acme",
+  ownerId: "org_acme",
+  // `org`, not `user`: `isTargetDeleting` only reads the `users` table for
+  // user-owned projects, and this suite has no user rows.
+  ownerType: "org",
+  remote: REMOTE,
+  createdAt: "2026-09-01T00:00:00.000Z",
+};
+
+/** Both targets in one policy, so a single merge exercises both provider shapes. */
+const BOTH_TARGETS_POLICY = `evaluators:
+  - type: diff
+
+deploys:
+  - name: site
+    target: cloudflare-pages
+    secrets: [CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID]
+  - name: production
+    target: vercel
+    secrets: [VERCEL_TOKEN, VERCEL_PROJECT_ID]
+`;
+
+const VERCEL_ONLY_POLICY = `evaluators:
+  - type: diff
+
+deploys:
+  - name: production
+    target: vercel
+    secrets: [VERCEL_TOKEN, VERCEL_PROJECT_ID]
+`;
+
+const GATED_POLICY = `evaluators:
+  - type: diff
+
+deploys:
+  - name: production
+    target: vercel
+    secrets: [VERCEL_TOKEN, VERCEL_PROJECT_ID]
+    requiresApproval: true
+`;
+
+let db: D1Database;
+let raw: ReturnType<typeof makeSqliteD1>["raw"];
+let kv: KVNamespace;
+let sent: unknown[];
+let env: Env;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function tree(policy: string): Map<string, Uint8Array> {
+  const encoder = new TextEncoder();
+  return new Map<string, Uint8Array>([
+    ["index.html", encoder.encode("<h1>hello</h1>")],
+    ["assets/app.css", encoder.encode("body{margin:0}")],
+    [".stratum/policy.yaml", encoder.encode(policy)],
+  ]);
+}
+
+/** Serve one tree for every ref. */
+function servesTree(policy: string): void {
+  const files = tree(policy);
+  vi.mocked(readRepoFiles).mockImplementation(async () => ok(new Map(files)));
+}
+
+/** Serve a different tree per commit, for the two-merge ordering cases. */
+function servesTreePerCommit(byRef: Record<string, string>): void {
+  vi.mocked(readRepoFiles).mockImplementation(async (_remote, _token, _log, ref) => {
+    const policy = ref === undefined ? undefined : byRef[ref];
+    if (policy === undefined) throw new Error(`no fixture tree for ref ${String(ref)}`);
+    return ok(tree(policy));
+  });
+}
+
+/**
+ * `mergedAt` is what `enqueueMergeDeploy` stamps on the message and what every
+ * deployment row is then ordered by, so the two-merge cases below set it
+ * explicitly rather than leaning on the frozen clock.
+ */
+function insertChange(id: string, status: string, mergedAt?: string): void {
+  raw
+    .prepare(
+      "INSERT INTO changes (id, project, project_id, workspace, status, created_at, merged_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .run(id, PROJECT_NAME, PROJECT_ID, "ws1", status, PROJECT.createdAt, mergedAt ?? null);
+}
+
+async function storeSecrets(): Promise<void> {
+  for (const [name, value] of Object.entries(SECRETS)) {
+    const result = await putSecret(
+      db,
+      logger,
+      { DEPLOY_SECRET_KEY },
+      { projectId: PROJECT_ID, name, value, actorId: "usr_admin" },
+    );
+    if (!result.success) throw result.error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The stubbed provider
+// ---------------------------------------------------------------------------
+
+interface ProviderCall {
+  url: string;
+  method: string;
+  authorization: string | null;
+  /** Present only for the JSON-bodied calls; the multipart phases carry FormData. */
+  jsonBody?: string;
+}
+
+interface ProviderStub {
+  calls: ProviderCall[];
+  /** Overrides the Vercel response, for the failure case. */
+  vercelResponds: (response: Response) => void;
+}
+
+/** The upload token phase 1 hands out; phase 2 must authenticate with it, not the API token. */
+const CF_UPLOAD_JWT = "cf-upload-jwt-phase-one";
+const CF_COMPLETION_JWT = "cf-completion-jwt-phase-two";
+const CF_WORKER_ID = "worker_abc123";
+const VERCEL_DEPLOYMENT_ID = "dpl_abc123";
+const VERCEL_HOST = "site-abc123.vercel.app";
+
+function stubProvider(): ProviderStub {
+  const calls: ProviderCall[] = [];
+  let vercelResponse: Response | null = null;
+
+  const json = (body: unknown, status = 200): Response =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  const handler = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    const body = init?.body;
+    const call: ProviderCall = {
+      url,
+      method,
+      authorization: new Headers(init?.headers ?? {}).get("authorization"),
+    };
+    if (typeof body === "string") call.jsonBody = body;
+    calls.push(call);
+
+    // Cloudflare phase 1: register the manifest, ask for every hash back so
+    // phase 2 actually has to upload something.
+    if (url.includes("/assets-upload-session")) {
+      const manifest = JSON.parse(call.jsonBody ?? "{}").manifest as Record<
+        string,
+        { hash: string }
+      >;
+      const hashes = Object.values(manifest).map((entry) => entry.hash);
+      return json({ success: true, result: { jwt: CF_UPLOAD_JWT, buckets: [hashes] } });
+    }
+
+    // Cloudflare phase 2: the bucket upload that completes the manifest.
+    if (url.includes("/workers/assets/upload")) {
+      return json({ success: true, result: { jwt: CF_COMPLETION_JWT } });
+    }
+
+    // Cloudflare phase 3: the script PUT that publishes the assets.
+    if (url.includes("/workers/scripts/")) {
+      return json({ success: true, result: { id: CF_WORKER_ID } });
+    }
+
+    if (url.startsWith("https://api.vercel.com/v13/deployments")) {
+      return (
+        vercelResponse ?? json({ id: VERCEL_DEPLOYMENT_ID, url: VERCEL_HOST, readyState: "QUEUED" })
+      );
+    }
+
+    throw new Error(`the deploy path made an unexpected request: ${method} ${url}`);
+  };
+
+  vi.stubGlobal("fetch", vi.fn(handler));
+  return {
+    calls,
+    vercelResponds: (response: Response) => {
+      vercelResponse = response;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The queue
+// ---------------------------------------------------------------------------
+
+interface DrainResult {
+  acked: number;
+  retried: number;
+}
+
+/**
+ * Hand everything `enqueueMergeDeploy` (or a test) has put on the queue to the
+ * real consumer, exactly as the queue would.
+ *
+ * @param order - Delivery order. Cloudflare Queues promise none, and a retry
+ *   reorders outright, so `"reversed"` is a routine delivery and not a
+ *   contrived one.
+ */
+async function drainQueue(order: "sent" | "reversed" = "sent"): Promise<DrainResult> {
+  const bodies = sent.splice(0, sent.length);
+  if (order === "reversed") bodies.reverse();
+  const ack = vi.fn();
+  const retry = vi.fn();
+  const messages = bodies.map(
+    (body, index) =>
+      ({
+        id: `msg_${index}`,
+        timestamp: new Date(),
+        body,
+        attempts: 1,
+        ack,
+        retry,
+      }) as unknown as Message<unknown>,
+  );
+
+  await handleDeployQueue(
+    {
+      queue: "stratum-deploys",
+      messages,
+      ackAll: vi.fn(),
+      retryAll: vi.fn(),
+    } as unknown as MessageBatch<unknown>,
+    env,
+  );
+
+  return { acked: ack.mock.calls.length, retried: retry.mock.calls.length };
+}
+
+/** Merge one change: what `src/routes/changes.ts` does once the post-merge check has answered. */
+async function mergeAndEnqueue(
+  changeId: string,
+  commitSha: string,
+  postMergeStatus: "skipped" | "passed" | "failed" | "reverted",
+): Promise<void> {
+  await enqueueMergeDeploy(env, logger, {
+    projectId: PROJECT_ID,
+    changeId,
+    commitSha,
+    postMergeStatus,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Reading back what landed
+// ---------------------------------------------------------------------------
+
+interface Row {
+  id: string;
+  name: string;
+  target: string;
+  status: string;
+  reason: string | null;
+  url: string | null;
+  log_tail: string | null;
+  commit_sha: string;
+  change_id: string | null;
+  approved_by: string | null;
+  lease_expires_at: string | null;
+  completed_at: string | null;
+}
+
+/**
+ * Ordered by `name`, not by `created_at`.
+ *
+ * Two deploys fanned out from one merge are stamped from the same `Date.now()`
+ * — certainly here, where the clock is frozen, and in production too when both
+ * inserts land in the same millisecond — so `created_at` does not order
+ * siblings and the row id (random hex) would decide. Sorting by name keeps the
+ * assertions below about *what* landed rather than about which id sorted first.
+ */
+function rows(): Row[] {
+  const all = raw.prepare("SELECT * FROM deployments").all() as unknown as Row[];
+  return [...all].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+}
+
+function rowNamed(name: string): Row {
+  const matching = rows().filter((row) => row.name === name);
+  expect(matching).toHaveLength(1);
+  return matching[0] as Row;
+}
+
+/**
+ * The containment assertion this feature exists to keep true: nothing a
+ * provider said, and nothing the runner wrote, may carry a credential into a
+ * column the UI renders.
+ */
+function expectNoSecretsPersisted(): void {
+  for (const row of rows()) {
+    for (const value of SECRET_VALUES) {
+      expect(row.reason ?? "").not.toContain(value);
+      expect(row.log_tail ?? "").not.toContain(value);
+    }
+    for (const value of CREDENTIAL_VALUES) {
+      expect(row.url ?? "").not.toContain(value);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  // Only `Date` is faked: the runner and the storage layer stamp every row from
+  // `Date.now()`, and faking timers wholesale would stall the awaits.
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(T0);
+
+  const made = makeSqliteD1();
+  db = made.db;
+  raw = made.raw;
+  kv = makeFakeKV();
+  sent = [];
+
+  vi.mocked(freshRepoToken).mockResolvedValue(ok("artifacts-repo-token"));
+  servesTree(BOTH_TARGETS_POLICY);
+
+  const stored = await setProject(kv, PROJECT, logger);
+  if (!stored.success) throw stored.error;
+
+  insertChange(CHANGE_A, "merged");
+  insertChange(CHANGE_B, "merged");
+
+  env = {
+    DB: db,
+    STATE: kv,
+    ARTIFACTS: {} as unknown,
+    DEPLOY_SECRET_KEY,
+    DEPLOY_QUEUE: {
+      send: async (body: unknown) => {
+        sent.push(body);
+      },
+    } as unknown as Queue,
+  } as unknown as Env;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+// ---------------------------------------------------------------------------
+// 9.1 — the full path
+// ---------------------------------------------------------------------------
+
+describe("a clean merge deploys through the queue", () => {
+  it("carries a merge from enqueue to a succeeded row on both provider shapes", async () => {
+    await storeSecrets();
+    const provider = stubProvider();
+
+    await mergeAndEnqueue(CHANGE_A, SHA_A, "skipped");
+
+    // The trigger produced exactly one message; it names the commit that merged
+    // — not a branch the runner would have to resolve later — and the time the
+    // merge happened, which is what the row is ordered by.
+    expect(sent).toEqual([
+      {
+        kind: "merge",
+        projectId: PROJECT_ID,
+        changeId: CHANGE_A,
+        commitSha: SHA_A,
+        mergedAt: T0_ISO,
+      },
+    ]);
+
+    const drained = await drainQueue();
+    expect(drained).toEqual({ acked: 1, retried: 0 });
+
+    // One row per declared deploy, both terminal, both holding no lease.
+    expect(rows().map((row) => [row.name, row.status])).toEqual([
+      ["production", "succeeded"],
+      ["site", "succeeded"],
+    ]);
+    for (const row of rows()) {
+      expect(row.lease_expires_at).toBeNull();
+      expect(row.completed_at).not.toBeNull();
+      expect(row.commit_sha).toBe(SHA_A);
+      expect(row.change_id).toBe(CHANGE_A);
+    }
+
+    // Cloudflare's three phases each happened, in order, and the middle one
+    // authenticated with the JWT phase 1 returned rather than the API token.
+    const cloudflare = provider.calls.filter((call) =>
+      call.url.startsWith("https://api.cloudflare.com/"),
+    );
+    expect(cloudflare.map((call) => call.method)).toEqual(["POST", "POST", "PUT"]);
+    expect(cloudflare[0]?.url).toContain(
+      `/accounts/${SECRETS.CLOUDFLARE_ACCOUNT_ID}/workers/scripts/site/assets-upload-session`,
+    );
+    expect(cloudflare[0]?.authorization).toBe(`Bearer ${SECRETS.CLOUDFLARE_API_TOKEN}`);
+    expect(cloudflare[1]?.url).toContain("/workers/assets/upload?base64=true");
+    expect(cloudflare[1]?.authorization).toBe(`Bearer ${CF_UPLOAD_JWT}`);
+    expect(cloudflare[2]?.authorization).toBe(`Bearer ${SECRETS.CLOUDFLARE_API_TOKEN}`);
+
+    // Vercel is a single inline POST carrying the whole tree.
+    const vercel = provider.calls.filter((call) => call.url.startsWith("https://api.vercel.com/"));
+    expect(vercel).toHaveLength(1);
+    expect(vercel[0]?.authorization).toBe(`Bearer ${SECRETS.VERCEL_TOKEN}`);
+    const vercelBody = JSON.parse(vercel[0]?.jsonBody ?? "{}");
+    expect(vercelBody.project).toBe(SECRETS.VERCEL_PROJECT_ID);
+    expect(vercelBody.target).toBe("production");
+    expect(vercelBody.gitMetadata.commitSha).toBe(SHA_A);
+    expect(vercelBody.files.map((file: { file: string }) => file.file).sort()).toEqual([
+      ".stratum/policy.yaml",
+      "assets/app.css",
+      "index.html",
+    ]);
+
+    // The optional secret is what produced the URL, so a row with it proves the
+    // optional half of the secret set was resolved too.
+    expect(rowNamed("site").url).toBe(
+      `https://site.${SECRETS.CLOUDFLARE_WORKERS_SUBDOMAIN}.workers.dev`,
+    );
+    expect(rowNamed("production").url).toBe(`https://${VERCEL_HOST}`);
+    // Vercel builds asynchronously; the row must not claim more than the
+    // provider promised.
+    expect(rowNamed("production").reason).toContain("provider state at hand-off: QUEUED");
+    expect(rowNamed("production").reason).toContain(VERCEL_DEPLOYMENT_ID);
+
+    expectNoSecretsPersisted();
+
+    // The same rows through the storage layer the API reads them with.
+    const listed = await listDeployments(db, logger, { projectId: PROJECT_ID });
+    expect(listed.success).toBe(true);
+    if (listed.success) {
+      expect(listed.data.map((deployment) => deployment.status)).toEqual([
+        "succeeded",
+        "succeeded",
+      ]);
+    }
+  });
+
+  it("keeps a provider error that echoes the token out of the persisted row", async () => {
+    await storeSecrets();
+    const provider = stubProvider();
+    provider.vercelResponds(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "forbidden",
+            message: `token ${SECRETS.VERCEL_TOKEN} may not deploy ${SECRETS.VERCEL_PROJECT_ID}`,
+          },
+        }),
+        { status: 403 },
+      ),
+    );
+    servesTree(VERCEL_ONLY_POLICY);
+
+    await mergeAndEnqueue(CHANGE_A, SHA_A, "passed");
+    // A `failed` deployment is a result, not a delivery failure: the message is
+    // acked, not retried, or the operator's fix would race the retry budget.
+    expect(await drainQueue()).toEqual({ acked: 1, retried: 0 });
+
+    const row = rowNamed("production");
+    expect(row.status).toBe("failed");
+    expect(row.reason).toContain("Vercel returned HTTP 403");
+    expect(row.reason).toContain("[redacted]");
+    expect(row.log_tail).toContain("[redacted]");
+    expectNoSecretsPersisted();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9.2 — the reverted merge
+// ---------------------------------------------------------------------------
+
+describe("a merge the post-merge check reverts", () => {
+  /** A sandbox whose smoke command fails, which is what makes the check revert. */
+  const failingSandbox = {
+    create: async () => ({
+      writeFile: async () => {},
+      run: async () => ({ exitCode: 1, stdout: "smoke: 1 failing\n", stderr: "" }),
+      destroy: async () => {},
+    }),
+  } as unknown as SandboxBinding;
+
+  const POST_MERGE_POLICY: EvalPolicy = {
+    evaluators: [],
+    merge: { postMergeCommand: "./smoke.sh" },
+  };
+
+  it("creates no deployment at all", async () => {
+    await storeSecrets();
+    const provider = stubProvider();
+    vi.mocked(getCommitParent).mockResolvedValue(ok("c".repeat(40)));
+    vi.mocked(revertToCommit).mockResolvedValue(ok("d".repeat(40)));
+
+    const postMerge = await runPostMergeCheck(
+      { ...env, SANDBOX: failingSandbox } as Env,
+      PROJECT,
+      { changeId: CHANGE_A, mergeCommit: SHA_A, policy: POST_MERGE_POLICY },
+      logger,
+    );
+
+    expect(postMerge.status).toBe("reverted");
+    // The check reverted the merge and said so on the change itself.
+    const change = raw.prepare("SELECT status FROM changes WHERE id = ?").get(CHANGE_A) as {
+      status: string;
+    };
+    expect(change.status).toBe("reverted");
+
+    await mergeAndEnqueue(CHANGE_A, SHA_A, postMerge.status);
+
+    // The gate is the whole point: nothing is enqueued, so nothing runs, so no
+    // row exists. Not a `failed` row, not a `skipped` one — none.
+    expect(sent).toEqual([]);
+    await drainQueue();
+    expect(rows()).toEqual([]);
+    expect(provider.calls).toEqual([]);
+  });
+
+  it("still refuses if a message for the reverted change reaches the consumer anyway", async () => {
+    await storeSecrets();
+    const provider = stubProvider();
+    // The state an event-driven trigger would have left: `change.merged` is
+    // emitted before the check, so a deploy wired to it would already have a
+    // message in flight by the time the revert lands.
+    raw.prepare("UPDATE changes SET status = 'reverted' WHERE id = ?").run(CHANGE_A);
+    sent.push({ kind: "merge", projectId: PROJECT_ID, changeId: CHANGE_A, commitSha: SHA_A });
+
+    // Acked, not retried: no redelivery can make a reverted change deployable.
+    expect(await drainQueue()).toEqual({ acked: 1, retried: 0 });
+    expect(rows()).toEqual([]);
+    expect(provider.calls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The approval gate
+// ---------------------------------------------------------------------------
+
+describe("an approval-gated deploy", () => {
+  it("lands pending_approval, runs nothing, and deploys only once approved", async () => {
+    await storeSecrets();
+    const provider = stubProvider();
+    servesTree(GATED_POLICY);
+
+    await mergeAndEnqueue(CHANGE_A, SHA_A, "passed");
+    await drainQueue();
+
+    const pending = rowNamed("production");
+    expect(pending.status).toBe("pending_approval");
+    expect(pending.approved_by).toBeNull();
+    expect(provider.calls).toEqual([]);
+
+    const approved = await approveDeployment(db, logger, {
+      projectId: PROJECT_ID,
+      deploymentId: pending.id,
+      approvedBy: "usr_admin",
+    });
+    expect(approved.success).toBe(true);
+    if (!approved.success || !approved.data.approved) throw new Error("approval did not take");
+
+    // What the approve route enqueues: the row, not the merge — re-deriving it
+    // from the policy could pick a different set of deploys.
+    sent.push({ kind: "deployment", projectId: PROJECT_ID, deploymentId: pending.id });
+    expect(await drainQueue()).toEqual({ acked: 1, retried: 0 });
+
+    const done = rowNamed("production");
+    expect(done.status).toBe("succeeded");
+    expect(done.approved_by).toBe("usr_admin");
+    expect(done.url).toBe(`https://${VERCEL_HOST}`);
+    expect(provider.calls).toHaveLength(1);
+    expectNoSecretsPersisted();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ordering under out-of-order delivery
+// ---------------------------------------------------------------------------
+
+describe("two merges whose messages arrive out of order", () => {
+  /** Stamp the change rows so the merges are unambiguously A-then-B. */
+  function mergedAtInOrder(): void {
+    raw.prepare("UPDATE changes SET merged_at = ? WHERE id = ?").run(T0_ISO, CHANGE_A);
+    raw.prepare("UPDATE changes SET merged_at = ? WHERE id = ?").run(T1_ISO, CHANGE_B);
+  }
+
+  /**
+   * The regression this whole task exists for.
+   *
+   * `created_at` used to be stamped when the *message* was processed. Cloudflare
+   * Queues promise no ordering and a retry reorders outright, so B delivered
+   * first meant B deployed, then A was created with a *later* `created_at`,
+   * superseded nothing (B was already terminal, and `supersedeOlder` only
+   * touches rows that have not started), and published the older commit over the
+   * newer one.
+   */
+  it("lands the newer commit, not whichever message was delivered last", async () => {
+    await storeSecrets();
+    const provider = stubProvider();
+    servesTreePerCommit({ [SHA_A]: VERCEL_ONLY_POLICY, [SHA_B]: VERCEL_ONLY_POLICY });
+    mergedAtInOrder();
+
+    // Merged A then B, and both messages carry the time their merge happened.
+    await mergeAndEnqueue(CHANGE_A, SHA_A, "passed");
+    vi.setSystemTime(T1);
+    await mergeAndEnqueue(CHANGE_B, SHA_B, "passed");
+    expect(sent.map((body) => (body as { mergedAt: string }).mergedAt)).toEqual([T0_ISO, T1_ISO]);
+
+    // Delivered B first, A second — which is the whole problem.
+    expect(await drainQueue("reversed")).toEqual({ acked: 2, retried: 0 });
+
+    const newer = rows().find((row) => row.commit_sha === SHA_B) as Row;
+    const older = rows().find((row) => row.commit_sha === SHA_A) as Row;
+    expect(newer.status).toBe("succeeded");
+    // Refused *before* the claim, so the older commit never reached a provider.
+    expect(older.status).toBe("superseded");
+    expect(older.reason).toContain(SUPERSEDED_REASON);
+    expect(older.reason).toContain(SHA_B.slice(0, 7));
+    expect(older.completed_at).not.toBeNull();
+
+    // One publish, and it was the newer commit.
+    const vercel = provider.calls.filter((call) => call.url.startsWith("https://api.vercel.com/"));
+    expect(vercel).toHaveLength(1);
+    expect(JSON.parse(vercel[0]?.jsonBody ?? "{}").gitMetadata.commitSha).toBe(SHA_B);
+
+    // And the history reads in merge order, not delivery order — the row written
+    // second is the one that sorts last.
+    const listed = await listDeployments(db, logger, { projectId: PROJECT_ID });
+    if (!listed.success) throw listed.error;
+    expect(listed.data.map((deployment) => deployment.commitSha)).toEqual([SHA_B, SHA_A]);
+  });
+
+  // Compatibility: a message enqueued by the previous deployment of the Worker
+  // is still in flight and carries no `mergedAt` at all. Dropping it would lose
+  // a real deploy over a schema change.
+  it("still deploys a legacy message that carries no merge time", async () => {
+    await storeSecrets();
+    const provider = stubProvider();
+    servesTree(VERCEL_ONLY_POLICY);
+
+    sent.push({ kind: "merge", projectId: PROJECT_ID, changeId: CHANGE_A, commitSha: SHA_A });
+    expect(await drainQueue()).toEqual({ acked: 1, retried: 0 });
+
+    const row = rowNamed("production");
+    expect(row.status).toBe("succeeded");
+    expect(provider.calls).not.toEqual([]);
+  });
+
+  // Siblings of one merge are stamped from that merge's timestamp, so they tie
+  // on `created_at` and only `name` keeps the page from reshuffling per request.
+  it("orders the deploys fanned out from one merge by name", async () => {
+    await storeSecrets();
+    stubProvider();
+
+    await mergeAndEnqueue(CHANGE_A, SHA_A, "passed");
+    await drainQueue();
+
+    const listed = await listDeployments(db, logger, { projectId: PROJECT_ID });
+    if (!listed.success) throw listed.error;
+    expect(listed.data.map((deployment) => deployment.createdAt)).toEqual([T0_ISO, T0_ISO]);
+    expect(listed.data.map((deployment) => deployment.name)).toEqual(["production", "site"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Supersession
+// ---------------------------------------------------------------------------
+
+describe("two merges in quick succession", () => {
+  it("does not let the older commit be the one that lands", async () => {
+    await storeSecrets();
+    const provider = stubProvider();
+    servesTreePerCommit({ [SHA_A]: GATED_POLICY, [SHA_B]: GATED_POLICY });
+
+    await mergeAndEnqueue(CHANGE_A, SHA_A, "passed");
+    await drainQueue();
+
+    vi.setSystemTime(T1);
+    await mergeAndEnqueue(CHANGE_B, SHA_B, "passed");
+    await drainQueue();
+
+    const older = rows().find((row) => row.commit_sha === SHA_A) as Row;
+    const newer = rows().find((row) => row.commit_sha === SHA_B) as Row;
+    expect(older.status).toBe("pending_approval");
+    expect(newer.status).toBe("pending_approval");
+
+    // Approve and run only the newer commit. Running it must retire the older
+    // one, so a later delivery of the older message cannot publish it over the
+    // top.
+    const approved = await approveDeployment(db, logger, {
+      projectId: PROJECT_ID,
+      deploymentId: newer.id,
+      approvedBy: "usr_admin",
+    });
+    if (!approved.success || !approved.data.approved) throw new Error("approval did not take");
+
+    sent.push({ kind: "deployment", projectId: PROJECT_ID, deploymentId: newer.id });
+    await drainQueue();
+
+    expect(rows().find((row) => row.commit_sha === SHA_B)?.status).toBe("succeeded");
+    const retired = rows().find((row) => row.commit_sha === SHA_A) as Row;
+    expect(retired.status).toBe("superseded");
+    expect(retired.reason).toBe(SUPERSEDED_REASON);
+    expect(retired.completed_at).not.toBeNull();
+
+    // Exactly one commit reached the provider, and it was the newer one.
+    expect(provider.calls).toHaveLength(1);
+    expect(JSON.parse(provider.calls[0]?.jsonBody ?? "{}").gitMetadata.commitSha).toBe(SHA_B);
+
+    // The superseded row can never be claimed afterwards: replaying its message
+    // leaves it exactly where it is.
+    sent.push({ kind: "deployment", projectId: PROJECT_ID, deploymentId: retired.id });
+    await drainQueue();
+    expect(rows().find((row) => row.commit_sha === SHA_A)?.status).toBe("superseded");
+    expect(provider.calls).toHaveLength(1);
+  });
+});

--- a/tests/project-secrets.test.ts
+++ b/tests/project-secrets.test.ts
@@ -1,0 +1,620 @@
+/**
+ * The encrypted deploy-secret store.
+ *
+ * The assertions that matter most here are the negative ones: AES-GCM binds
+ * `(project_id, name)` as AAD, so a ciphertext lifted into another project or
+ * renamed must fail to decrypt rather than quietly authenticate against the
+ * wrong provider account. Those cases are exercised by writing a transplanted
+ * row through the raw SQLite handle, because no code path in the store can
+ * produce one.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEPLOY_SECRET_KEY_MISSING,
+  MAX_SECRET_VALUE_BYTES,
+  deleteSecret,
+  listSecretNames,
+  loadSecretValues,
+  putSecret,
+} from "../src/storage/project-secrets";
+import { decryptSecret, deriveSecretKey, encryptSecret } from "../src/utils/crypto";
+import type { Logger } from "../src/utils/logger";
+import { makeSqliteD1, makeThrowingD1 } from "./helpers/sqlite-d1";
+
+const logger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => logger),
+};
+
+const ENV = { DEPLOY_SECRET_KEY: "test-deploy-key" };
+const PROJECT = "prj_aaaaaaaa";
+const OTHER_PROJECT = "prj_bbbbbbbb";
+
+let db: D1Database;
+let raw: ReturnType<typeof makeSqliteD1>["raw"];
+
+beforeEach(() => {
+  const made = makeSqliteD1();
+  db = made.db;
+  raw = made.raw;
+  vi.clearAllMocks();
+});
+
+function readCiphertext(projectId: string, name: string): string {
+  const row = raw
+    .prepare("SELECT ciphertext FROM project_secrets WHERE project_id = ? AND name = ?")
+    .get(projectId, name) as { ciphertext: string } | undefined;
+  if (!row) throw new Error(`no secret ${name} in ${projectId}`);
+  return row.ciphertext;
+}
+
+describe("encryptSecret / decryptSecret", () => {
+  it("round-trips a value under the same key and scope", async () => {
+    const key = await deriveSecretKey("k");
+    const scope = { projectId: PROJECT, name: "VERCEL_TOKEN" };
+    const ciphertext = await encryptSecret("hunter2", key, scope);
+
+    expect(ciphertext).not.toContain("hunter2");
+    expect(await decryptSecret(ciphertext, key, scope)).toBe("hunter2");
+  });
+
+  it("round-trips an empty value, which is distinct from a decryption failure", async () => {
+    const key = await deriveSecretKey("k");
+    const scope = { projectId: PROJECT, name: "EMPTY" };
+    expect(await decryptSecret(await encryptSecret("", key, scope), key, scope)).toBe("");
+  });
+
+  it("produces a different ciphertext each time for the same plaintext", async () => {
+    const key = await deriveSecretKey("k");
+    const scope = { projectId: PROJECT, name: "VERCEL_TOKEN" };
+    const a = await encryptSecret("same", key, scope);
+    const b = await encryptSecret("same", key, scope);
+    expect(a).not.toBe(b);
+  });
+
+  it("fails when the project_id in the AAD differs", async () => {
+    const key = await deriveSecretKey("k");
+    const ciphertext = await encryptSecret("hunter2", key, {
+      projectId: PROJECT,
+      name: "VERCEL_TOKEN",
+    });
+
+    expect(
+      await decryptSecret(ciphertext, key, { projectId: OTHER_PROJECT, name: "VERCEL_TOKEN" }),
+    ).toBeNull();
+  });
+
+  it("fails when the secret name in the AAD differs", async () => {
+    const key = await deriveSecretKey("k");
+    const ciphertext = await encryptSecret("hunter2", key, {
+      projectId: PROJECT,
+      name: "VERCEL_TOKEN",
+    });
+
+    expect(
+      await decryptSecret(ciphertext, key, { projectId: PROJECT, name: "CF_API_TOKEN" }),
+    ).toBeNull();
+  });
+
+  it("fails when the split between project id and name shifts", async () => {
+    // The NUL separator is what makes this fail: with a bare concatenation
+    // "prj_1" + "AB" and "prj_1A" + "B" produce the same AAD.
+    const key = await deriveSecretKey("k");
+    const ciphertext = await encryptSecret("hunter2", key, { projectId: "prj_1", name: "AB" });
+
+    expect(await decryptSecret(ciphertext, key, { projectId: "prj_1A", name: "B" })).toBeNull();
+  });
+
+  it("fails under a key derived from a different DEPLOY_SECRET_KEY", async () => {
+    const scope = { projectId: PROJECT, name: "VERCEL_TOKEN" };
+    const ciphertext = await encryptSecret("hunter2", await deriveSecretKey("k"), scope);
+
+    expect(await decryptSecret(ciphertext, await deriveSecretKey("rotated"), scope)).toBeNull();
+  });
+
+  it("returns null rather than throwing on non-base64 input", async () => {
+    const key = await deriveSecretKey("k");
+    expect(
+      await decryptSecret("!!!not base64!!!", key, { projectId: PROJECT, name: "X" }),
+    ).toBeNull();
+  });
+});
+
+describe("putSecret", () => {
+  it("stores a secret and returns metadata without the value", async () => {
+    const result = await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "hunter2",
+      actorId: "usr_a",
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toMatchObject({
+      name: "VERCEL_TOKEN",
+      createdBy: "usr_a",
+      updatedBy: "usr_a",
+    });
+    expect(JSON.stringify(result.data)).not.toContain("hunter2");
+    expect(readCiphertext(PROJECT, "VERCEL_TOKEN")).not.toContain("hunter2");
+  });
+
+  it("writes application ISO-8601 timestamps, not SQLite's space-separated form", async () => {
+    await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "v",
+      actorId: "usr_a",
+    });
+
+    const row = raw
+      .prepare("SELECT created_at, updated_at FROM project_secrets WHERE project_id = ?")
+      .get(PROJECT) as { created_at: string; updated_at: string };
+    expect(row.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+    expect(row.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+  });
+
+  it("overwrites in place, keeping created_by while updating updated_by and updated_at", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      const first = await putSecret(db, logger, ENV, {
+        projectId: PROJECT,
+        name: "VERCEL_TOKEN",
+        value: "old",
+        actorId: "usr_a",
+      });
+      expect(first.success).toBe(true);
+
+      vi.setSystemTime(new Date("2026-02-02T00:00:00.000Z"));
+      const second = await putSecret(db, logger, ENV, {
+        projectId: PROJECT,
+        name: "VERCEL_TOKEN",
+        value: "new",
+        actorId: "usr_b",
+      });
+
+      expect(second.success).toBe(true);
+      if (!second.success) return;
+      expect(second.data.createdBy).toBe("usr_a");
+      expect(second.data.updatedBy).toBe("usr_b");
+      expect(second.data.createdAt).toBe("2026-01-01T00:00:00.000Z");
+      expect(second.data.updatedAt).toBe("2026-02-02T00:00:00.000Z");
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const count = raw
+      .prepare("SELECT COUNT(*) AS n FROM project_secrets WHERE project_id = ?")
+      .get(PROJECT) as { n: number };
+    expect(Number(count.n)).toBe(1);
+
+    const loaded = await loadSecretValues(db, logger, ENV, {
+      projectId: PROJECT,
+      names: ["VERCEL_TOKEN"],
+    });
+    expect(loaded.success && loaded.data.values.get("VERCEL_TOKEN")).toBe("new");
+  });
+
+  it("keeps same-named secrets in different projects independent", async () => {
+    await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "mine",
+      actorId: "usr_a",
+    });
+    await putSecret(db, logger, ENV, {
+      projectId: OTHER_PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "theirs",
+      actorId: "usr_b",
+    });
+
+    const loaded = await loadSecretValues(db, logger, ENV, {
+      projectId: PROJECT,
+      names: ["VERCEL_TOKEN"],
+    });
+    expect(loaded.success && loaded.data.values.get("VERCEL_TOKEN")).toBe("mine");
+  });
+
+  it.each([
+    ["lowercase", "vercel_token"],
+    ["leading digit", "1TOKEN"],
+    ["leading underscore", "_TOKEN"],
+    ["a hyphen", "VERCEL-TOKEN"],
+    ["a dot", "VERCEL.TOKEN"],
+    ["empty", ""],
+    ["over 64 characters", `A${"B".repeat(64)}`],
+  ])("rejects a name with %s", async (_label, name) => {
+    const result = await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name,
+      value: "v",
+      actorId: "usr_a",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it.each([
+    ["a single uppercase letter", "A"],
+    ["exactly 64 characters", `A${"B".repeat(63)}`],
+    ["digits and underscores after the first character", "CF_ACCOUNT_ID_2"],
+  ])("accepts a name that is %s", async (_label, name) => {
+    const result = await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name,
+      value: "v",
+      actorId: "usr_a",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a value of exactly the cap", async () => {
+    const result = await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "BIG",
+      value: "x".repeat(MAX_SECRET_VALUE_BYTES),
+      actorId: "usr_a",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a value one byte over the cap", async () => {
+    const result = await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "BIG",
+      value: "x".repeat(MAX_SECRET_VALUE_BYTES + 1),
+      actorId: "usr_a",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("measures the cap in UTF-8 bytes, not UTF-16 code units", async () => {
+    // "é" is one UTF-16 code unit but two UTF-8 bytes: 2100 of them are under
+    // the cap by `String.length` and over it on the wire.
+    const value = "é".repeat(2100);
+    expect(value.length).toBeLessThan(MAX_SECRET_VALUE_BYTES);
+
+    const result = await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "BIG",
+      value,
+      actorId: "usr_a",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an empty value: there is deliberately no minimum length", async () => {
+    const result = await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "EMPTY",
+      value: "",
+      actorId: "usr_a",
+    });
+    expect(result.success).toBe(true);
+
+    const loaded = await loadSecretValues(db, logger, ENV, {
+      projectId: PROJECT,
+      names: ["EMPTY"],
+    });
+    expect(loaded.success && loaded.data.values.get("EMPTY")).toBe("");
+    expect(loaded.success && loaded.data.missing).toEqual([]);
+  });
+
+  it("returns a typed error when DEPLOY_SECRET_KEY is unset", async () => {
+    const result = await putSecret(
+      db,
+      logger,
+      {},
+      { projectId: PROJECT, name: "VERCEL_TOKEN", value: "v", actorId: "usr_a" },
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe(DEPLOY_SECRET_KEY_MISSING);
+
+    const count = raw.prepare("SELECT COUNT(*) AS n FROM project_secrets").get() as { n: number };
+    expect(Number(count.n)).toBe(0);
+  });
+
+  it("wraps a database failure instead of throwing", async () => {
+    const result = await putSecret(makeThrowingD1(), logger, ENV, {
+      projectId: PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "v",
+      actorId: "usr_a",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe("DATABASE_ERROR");
+  });
+});
+
+describe("listSecretNames", () => {
+  it("returns names and metadata but never a value", async () => {
+    await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "hunter2",
+      actorId: "usr_a",
+    });
+    await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "CF_API_TOKEN",
+      value: "swordfish",
+      actorId: "usr_a",
+    });
+
+    const result = await listSecretNames(db, logger, PROJECT);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.map((s) => s.name)).toEqual(["CF_API_TOKEN", "VERCEL_TOKEN"]);
+    const serialized = JSON.stringify(result.data);
+    expect(serialized).not.toContain("hunter2");
+    expect(serialized).not.toContain("swordfish");
+    expect(serialized).not.toContain("ciphertext");
+  });
+
+  it("does not list another project's secrets", async () => {
+    await putSecret(db, logger, ENV, {
+      projectId: OTHER_PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "theirs",
+      actorId: "usr_b",
+    });
+
+    const result = await listSecretNames(db, logger, PROJECT);
+    expect(result.success && result.data).toEqual([]);
+  });
+
+  it("wraps a database failure instead of throwing", async () => {
+    const result = await listSecretNames(makeThrowingD1(), logger, PROJECT);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("deleteSecret", () => {
+  it("removes the row and reports that it did", async () => {
+    await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "hunter2",
+      actorId: "usr_a",
+    });
+
+    const result = await deleteSecret(db, logger, { projectId: PROJECT, name: "VERCEL_TOKEN" });
+
+    expect(result.success && result.data).toBe(true);
+    const count = raw.prepare("SELECT COUNT(*) AS n FROM project_secrets").get() as { n: number };
+    expect(Number(count.n)).toBe(0);
+  });
+
+  it("reports false for a name the project does not have", async () => {
+    const result = await deleteSecret(db, logger, { projectId: PROJECT, name: "ABSENT" });
+    expect(result.success && result.data).toBe(false);
+  });
+
+  it("cannot delete another project's same-named secret", async () => {
+    await putSecret(db, logger, ENV, {
+      projectId: OTHER_PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "theirs",
+      actorId: "usr_b",
+    });
+
+    const result = await deleteSecret(db, logger, { projectId: PROJECT, name: "VERCEL_TOKEN" });
+
+    expect(result.success && result.data).toBe(false);
+    const count = raw.prepare("SELECT COUNT(*) AS n FROM project_secrets").get() as { n: number };
+    expect(Number(count.n)).toBe(1);
+  });
+
+  it("rejects a malformed name rather than issuing the delete", async () => {
+    const result = await deleteSecret(db, logger, { projectId: PROJECT, name: "vercel_token" });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+describe("loadSecretValues", () => {
+  it("resolves every requested name", async () => {
+    await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "hunter2",
+      actorId: "usr_a",
+    });
+    await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "CF_API_TOKEN",
+      value: "swordfish",
+      actorId: "usr_a",
+    });
+
+    const result = await loadSecretValues(db, logger, ENV, {
+      projectId: PROJECT,
+      names: ["VERCEL_TOKEN", "CF_API_TOKEN"],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.values.get("VERCEL_TOKEN")).toBe("hunter2");
+    expect(result.data.values.get("CF_API_TOKEN")).toBe("swordfish");
+    expect(result.data.missing).toEqual([]);
+    expect(result.data.undecryptable).toEqual([]);
+  });
+
+  it("names the secrets it could not find rather than failing the batch", async () => {
+    await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "hunter2",
+      actorId: "usr_a",
+    });
+
+    const result = await loadSecretValues(db, logger, ENV, {
+      projectId: PROJECT,
+      names: ["VERCEL_TOKEN", "ABSENT"],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.missing).toEqual(["ABSENT"]);
+    expect(result.data.values.has("ABSENT")).toBe(false);
+  });
+
+  it("returns nothing for a cross-project read", async () => {
+    await putSecret(db, logger, ENV, {
+      projectId: OTHER_PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "theirs",
+      actorId: "usr_b",
+    });
+
+    const result = await loadSecretValues(db, logger, ENV, {
+      projectId: PROJECT,
+      names: ["VERCEL_TOKEN"],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.values.size).toBe(0);
+    expect(result.data.missing).toEqual(["VERCEL_TOKEN"]);
+  });
+
+  it("refuses a ciphertext transplanted from another project", async () => {
+    await putSecret(db, logger, ENV, {
+      projectId: OTHER_PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "theirs",
+      actorId: "usr_b",
+    });
+    // A direct row write is the only way to construct this: putSecret always
+    // binds the AAD to the project it is writing into.
+    raw
+      .prepare(
+        "INSERT INTO project_secrets (id, project_id, name, ciphertext, created_by, updated_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      )
+      .run(
+        "psec_stolen",
+        PROJECT,
+        "VERCEL_TOKEN",
+        readCiphertext(OTHER_PROJECT, "VERCEL_TOKEN"),
+        "usr_evil",
+        "usr_evil",
+        "2026-01-01T00:00:00.000Z",
+        "2026-01-01T00:00:00.000Z",
+      );
+
+    const result = await loadSecretValues(db, logger, ENV, {
+      projectId: PROJECT,
+      names: ["VERCEL_TOKEN"],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.values.size).toBe(0);
+    expect(result.data.undecryptable).toEqual(["VERCEL_TOKEN"]);
+  });
+
+  it("refuses a ciphertext renamed within the same project", async () => {
+    await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "hunter2",
+      actorId: "usr_a",
+    });
+    raw
+      .prepare("UPDATE project_secrets SET name = ? WHERE project_id = ? AND name = ?")
+      .run("CF_API_TOKEN", PROJECT, "VERCEL_TOKEN");
+
+    const result = await loadSecretValues(db, logger, ENV, {
+      projectId: PROJECT,
+      names: ["CF_API_TOKEN"],
+    });
+
+    expect(result.success && result.data.undecryptable).toEqual(["CF_API_TOKEN"]);
+  });
+
+  it("reports a rotated DEPLOY_SECRET_KEY as undecryptable, not missing", async () => {
+    await putSecret(db, logger, ENV, {
+      projectId: PROJECT,
+      name: "VERCEL_TOKEN",
+      value: "hunter2",
+      actorId: "usr_a",
+    });
+
+    const result = await loadSecretValues(
+      db,
+      logger,
+      { DEPLOY_SECRET_KEY: "a-different-key" },
+      { projectId: PROJECT, names: ["VERCEL_TOKEN"] },
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.undecryptable).toEqual(["VERCEL_TOKEN"]);
+    expect(result.data.missing).toEqual([]);
+  });
+
+  it("returns a typed error when DEPLOY_SECRET_KEY is unset", async () => {
+    const result = await loadSecretValues(db, logger, {}, { projectId: PROJECT, names: ["ANY"] });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe(DEPLOY_SECRET_KEY_MISSING);
+  });
+
+  it("resolves an empty request without touching the key or the database", async () => {
+    const result = await loadSecretValues(
+      makeThrowingD1(),
+      logger,
+      {},
+      {
+        projectId: PROJECT,
+        names: [],
+      },
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.values.size).toBe(0);
+  });
+
+  it("deduplicates repeated names", async () => {
+    const result = await loadSecretValues(db, logger, ENV, {
+      projectId: PROJECT,
+      names: ["ABSENT", "ABSENT"],
+    });
+
+    expect(result.success && result.data.missing).toEqual(["ABSENT"]);
+  });
+
+  it("wraps a database failure instead of throwing", async () => {
+    const result = await loadSecretValues(makeThrowingD1(), logger, ENV, {
+      projectId: PROJECT,
+      names: ["VERCEL_TOKEN"],
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe("DATABASE_ERROR");
+  });
+});

--- a/tests/queue-dispatch.test.ts
+++ b/tests/queue-dispatch.test.ts
@@ -9,7 +9,12 @@ vi.mock("../src/queue/event-consumer", () => ({
 vi.mock("../src/queue/import-queue", () => ({
   handleImportQueue: vi.fn(async () => {}),
 }));
+vi.mock("../src/queue/deploy-queue", () => ({
+  handleDeployQueue: vi.fn(async () => {}),
+  enqueueMergeDeploy: vi.fn(async () => {}),
+}));
 
+import { handleDeployQueue } from "../src/queue/deploy-queue";
 import { handleEventQueue } from "../src/queue/event-consumer";
 import { handleImportQueue } from "../src/queue/import-queue";
 
@@ -57,11 +62,36 @@ describe("worker queue dispatch", () => {
     },
   );
 
+  it.each(["stratum-deploys", "stratum-deploys-staging"])(
+    "routes %s to the deploy consumer, leaving the events consumer untouched",
+    async (name) => {
+      const batch = makeBatch(name);
+      await worker.queue(batch, env);
+      expect(handleDeployQueue).toHaveBeenCalledWith(batch, env);
+      expect(handleEventQueue).not.toHaveBeenCalled();
+      expect(handleImportQueue).not.toHaveBeenCalled();
+      expect(batch.ackAll).not.toHaveBeenCalled();
+    },
+  );
+
+  // The event queue predates deploys and must keep behaving identically; a
+  // prefix that also matched "stratum-events" would silently reroute it.
+  it.each(["stratum-events", "stratum-events-staging"])(
+    "never hands %s to the deploy consumer",
+    async (name) => {
+      const batch = makeBatch(name);
+      await worker.queue(batch, env);
+      expect(handleEventQueue).toHaveBeenCalledWith(batch, env);
+      expect(handleDeployQueue).not.toHaveBeenCalled();
+    },
+  );
+
   it("acks batches from unknown queues without invoking a consumer", async () => {
     const batch = makeBatch("some-other-queue");
     await worker.queue(batch, env);
     expect(handleEventQueue).not.toHaveBeenCalled();
     expect(handleImportQueue).not.toHaveBeenCalled();
+    expect(handleDeployQueue).not.toHaveBeenCalled();
     expect(batch.ackAll).toHaveBeenCalled();
   });
 });

--- a/tests/routes-deployments.test.ts
+++ b/tests/routes-deployments.test.ts
@@ -1,0 +1,912 @@
+/**
+ * The deployment and deploy-secret HTTP surface.
+ *
+ * The assertions that matter are the authorization ones. Three of them encode
+ * decisions that are easy to undo by accident:
+ *
+ * - No response body carries a secret value. Asserted against every route on
+ *   this surface for a reader, and against the secret routes for a writer — a
+ *   deployment's `reason`/`logTail` is provider text that once held a
+ *   credential, and only a writer is meant to see it at all.
+ * - Agent identities are refused on the secret routes and on approve. Both
+ *   would otherwise pass: an agent owned by the project owner is a project
+ *   admin, and `canWriteProject` grants an agent its owner's write access.
+ * - `log_tail` is a writer-only field, while list metadata follows read access
+ *   — and read access is unconditional on a public project.
+ */
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authMiddleware } from "../src/middleware/auth";
+import {
+  canManageSecrets,
+  deploymentsRouter,
+  projectDeploymentsRouter,
+  secretErrorMessage,
+} from "../src/routes/deployments";
+import type { Env, ProjectEntry } from "../src/types";
+import { AppError } from "../src/utils/errors";
+
+vi.mock("../src/storage/deployments", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/deployments")>();
+  return {
+    ...actual,
+    approveDeployment: vi.fn(),
+    findDeploymentById: vi.fn(),
+    insertDeployment: vi.fn(),
+    listDeployments: vi.fn(),
+  };
+});
+vi.mock("../src/storage/project-secrets", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/project-secrets")>();
+  return {
+    ...actual,
+    putSecret: vi.fn(),
+    listSecretNames: vi.fn(),
+    deleteSecret: vi.fn(),
+  };
+});
+vi.mock("../src/storage/state", () => ({ getProjectByPath: vi.fn(), getProjectById: vi.fn() }));
+vi.mock("../src/storage/audit", () => ({ recordAudit: vi.fn(async () => ({ success: true })) }));
+vi.mock("../src/storage/users", () => ({ getUserByToken: vi.fn(), getUser: vi.fn() }));
+vi.mock("../src/storage/agents", () => ({ getAgentByToken: vi.fn() }));
+
+import { getAgentByToken } from "../src/storage/agents";
+import { recordAudit } from "../src/storage/audit";
+import {
+  type Deployment,
+  approveDeployment,
+  findDeploymentById,
+  insertDeployment,
+  listDeployments,
+} from "../src/storage/deployments";
+import {
+  DEPLOY_SECRET_KEY_MISSING,
+  deleteSecret,
+  listSecretNames,
+  putSecret,
+} from "../src/storage/project-secrets";
+import { getProjectById, getProjectByPath } from "../src/storage/state";
+import { getUser, getUserByToken } from "../src/storage/users";
+
+const OWNER_TOKEN = "stratum_user_owner0000000000000000000";
+const OUTSIDER_TOKEN = "stratum_user_outsider00000000000000";
+const AGENT_TOKEN = "stratum_agent_bot00000000000000000000";
+
+const asOwner = { Authorization: `Bearer ${OWNER_TOKEN}` };
+const asOutsider = { Authorization: `Bearer ${OUTSIDER_TOKEN}` };
+const asAgent = { Authorization: `Bearer ${AGENT_TOKEN}` };
+
+/**
+ * The one string that must never appear in a response. Planted as a secret
+ * value and as provider log text so both leak paths are covered.
+ */
+const SECRET_VALUE = "vercel_live_TOKEN_MUST_NOT_LEAK";
+
+// Public on purpose: `canReadProject` short-circuits to true for a public
+// project, so this is the shape in which a log-tail leak would actually happen.
+const PROJECT: ProjectEntry = {
+  id: "prj_owner",
+  name: "site",
+  slug: "site",
+  namespace: "@owner",
+  ownerId: "usr_owner",
+  ownerType: "user",
+  visibility: "public",
+  remote: "https://acct.artifacts.cloudflare.net/git/@owner/site.git",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+// A different tenant's project, private, so an id from it is unreadable here.
+const OTHER_PROJECT: ProjectEntry = {
+  ...PROJECT,
+  id: "prj_other",
+  namespace: "@other",
+  ownerId: "usr_other",
+  visibility: "private",
+};
+
+function deployment(overrides: Partial<Deployment> = {}): Deployment {
+  return {
+    id: "dep_1",
+    projectId: PROJECT.id,
+    project: PROJECT.name,
+    changeId: "chg_1",
+    commitSha: "a".repeat(40),
+    name: "production",
+    target: "vercel",
+    attempt: 1,
+    status: "failed",
+    reason: "Provider rejected the upload",
+    logTail: `provider said: ${SECRET_VALUE}`,
+    requestedByType: "user",
+    requestedById: "usr_owner",
+    createdAt: "2026-01-02T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const send = vi.fn(async () => {});
+const env = {
+  DB: {} as D1Database,
+  STATE: {} as KVNamespace,
+  DEPLOY_QUEUE: { send } as unknown as Queue,
+} as Env;
+
+function makeApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", authMiddleware);
+  app.route("/api/projects", projectDeploymentsRouter);
+  app.route("/api/deployments", deploymentsRouter);
+  return app;
+}
+
+async function call(path: string, init: RequestInit = {}): Promise<Response> {
+  return await makeApp().fetch(new Request(`http://localhost${path}`, init), env);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(getUserByToken).mockImplementation(async (_db, token) => {
+    const id = token === OWNER_TOKEN ? "usr_owner" : "usr_outsider";
+    return {
+      success: true,
+      data: {
+        id,
+        email: `${id}@x.io`,
+        username: id,
+        tokenHash: "h",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    };
+  });
+  vi.mocked(getAgentByToken).mockResolvedValue({
+    success: true,
+    data: {
+      id: "agt_bot",
+      name: "bot",
+      // Owned by the project owner: without an explicit refusal this agent is
+      // a project admin and a project writer.
+      ownerId: "usr_owner",
+      tokenHash: "h",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    },
+  });
+  vi.mocked(getUser).mockResolvedValue({
+    success: true,
+    data: {
+      id: "usr_owner",
+      email: "owner@x.io",
+      username: "owner",
+      tokenHash: "h",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    },
+  });
+
+  vi.mocked(getProjectByPath).mockResolvedValue({ success: true, data: PROJECT });
+  vi.mocked(getProjectById).mockResolvedValue({ success: true, data: PROJECT });
+});
+
+describe("deploy secret routes", () => {
+  it("lists names and metadata, never a value", async () => {
+    vi.mocked(listSecretNames).mockResolvedValue({
+      success: true,
+      data: [
+        {
+          name: "VERCEL_TOKEN",
+          createdBy: "usr_owner",
+          updatedBy: "usr_owner",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const res = await call("/api/projects/@owner/site/secrets", { headers: asOwner });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { secrets: Array<Record<string, unknown>> };
+    expect(body.secrets[0]).toMatchObject({ name: "VERCEL_TOKEN" });
+    expect(body.secrets[0]).not.toHaveProperty("value");
+    expect(listSecretNames).toHaveBeenCalledWith(env.DB, expect.any(Object), "prj_owner");
+  });
+
+  it("stores a value, echoes only metadata, and audits the write", async () => {
+    vi.mocked(putSecret).mockResolvedValue({
+      success: true,
+      data: {
+        name: "VERCEL_TOKEN",
+        createdBy: "usr_owner",
+        updatedBy: "usr_owner",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      },
+    });
+
+    const res = await call("/api/projects/@owner/site/secrets/VERCEL_TOKEN", {
+      method: "PUT",
+      headers: { ...asOwner, "content-type": "application/json" },
+      body: JSON.stringify({ value: SECRET_VALUE }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).not.toContain(SECRET_VALUE);
+    expect(putSecret).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      env,
+      expect.objectContaining({
+        projectId: "prj_owner",
+        name: "VERCEL_TOKEN",
+        value: SECRET_VALUE,
+      }),
+    );
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({ action: "secret.written", actorId: "usr_owner" }),
+    );
+    // The audited detail is the name; the value has no business in the trail.
+    const audited = vi.mocked(recordAudit).mock.calls[0]?.[2];
+    expect(JSON.stringify(audited)).not.toContain(SECRET_VALUE);
+  });
+
+  it("rejects a non-string value", async () => {
+    const res = await call("/api/projects/@owner/site/secrets/VERCEL_TOKEN", {
+      method: "PUT",
+      headers: { ...asOwner, "content-type": "application/json" },
+      body: JSON.stringify({ value: 42 }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(putSecret).not.toHaveBeenCalled();
+  });
+
+  it("404s a delete of a name the project does not have", async () => {
+    vi.mocked(deleteSecret).mockResolvedValue({ success: true, data: false });
+
+    const res = await call("/api/projects/@owner/site/secrets/NOPE", {
+      method: "DELETE",
+      headers: asOwner,
+    });
+
+    expect(res.status).toBe(404);
+    expect(recordAudit).not.toHaveBeenCalled();
+  });
+
+  it("deletes a secret and audits it", async () => {
+    vi.mocked(deleteSecret).mockResolvedValue({ success: true, data: true });
+
+    const res = await call("/api/projects/@owner/site/secrets/VERCEL_TOKEN", {
+      method: "DELETE",
+      headers: asOwner,
+    });
+
+    expect(res.status).toBe(200);
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({ action: "secret.deleted" }),
+    );
+  });
+
+  // The form aliases are on this list deliberately: they exist so the browser
+  // can reach these routes, and an alias that skipped the agent refusal would
+  // hand an agent the one credential it is never trusted with (PRD G3).
+  it("refuses an agent token on every secret route, form aliases included", async () => {
+    const responses = await Promise.all([
+      call("/api/projects/@owner/site/secrets", { headers: asAgent }),
+      call("/api/projects/@owner/site/secrets/VERCEL_TOKEN", {
+        method: "PUT",
+        headers: { ...asAgent, "content-type": "application/json" },
+        body: JSON.stringify({ value: SECRET_VALUE }),
+      }),
+      call("/api/projects/@owner/site/secrets/VERCEL_TOKEN", {
+        method: "DELETE",
+        headers: asAgent,
+      }),
+      call("/api/projects/@owner/site/secrets", {
+        method: "POST",
+        headers: asAgent,
+        body: new URLSearchParams({ name: "VERCEL_TOKEN", value: SECRET_VALUE }),
+      }),
+      call("/api/projects/@owner/site/secrets/VERCEL_TOKEN/delete", {
+        method: "POST",
+        headers: asAgent,
+        body: new URLSearchParams(),
+      }),
+    ]);
+
+    // Refused outright — never a redirect back to the page, which would read as
+    // "done" to the browser that posted it.
+    for (const res of responses) expect(res.status).toBe(403);
+    expect(listSecretNames).not.toHaveBeenCalled();
+    expect(putSecret).not.toHaveBeenCalled();
+    expect(deleteSecret).not.toHaveBeenCalled();
+  });
+
+  it("refuses a non-admin user on every secret route, form aliases included", async () => {
+    const responses = await Promise.all([
+      call("/api/projects/@owner/site/secrets", { headers: asOutsider }),
+      call("/api/projects/@owner/site/secrets/VERCEL_TOKEN", {
+        method: "PUT",
+        headers: { ...asOutsider, "content-type": "application/json" },
+        body: JSON.stringify({ value: SECRET_VALUE }),
+      }),
+      call("/api/projects/@owner/site/secrets/VERCEL_TOKEN", {
+        method: "DELETE",
+        headers: asOutsider,
+      }),
+      call("/api/projects/@owner/site/secrets", {
+        method: "POST",
+        headers: asOutsider,
+        body: new URLSearchParams({ name: "VERCEL_TOKEN", value: SECRET_VALUE }),
+      }),
+      call("/api/projects/@owner/site/secrets/VERCEL_TOKEN/delete", {
+        method: "POST",
+        headers: asOutsider,
+        body: new URLSearchParams(),
+      }),
+    ]);
+
+    for (const res of responses) expect(res.status).toBe(403);
+    expect(putSecret).not.toHaveBeenCalled();
+    expect(deleteSecret).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The browser half of the secret routes. An HTML form can only issue GET or
+ * POST and cannot read a JSON body, so these aliases exist — behind the same
+ * guard — and answer with a redirect. The failure codes are a closed set so a
+ * caller-supplied string is never round-tripped into the page.
+ */
+describe("deploy secret form aliases", () => {
+  const SETTINGS = "/@owner/site/settings";
+
+  function form(path: string, fields: Record<string, string> = {}): Promise<Response> {
+    return call(path, {
+      method: "POST",
+      headers: asOwner,
+      body: new URLSearchParams(fields),
+    });
+  }
+
+  it("stores a value posted as a form and returns to the settings page", async () => {
+    vi.mocked(putSecret).mockResolvedValue({
+      success: true,
+      data: {
+        name: "VERCEL_TOKEN",
+        createdBy: "usr_owner",
+        updatedBy: "usr_owner",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      },
+    });
+
+    const res = await form("/api/projects/@owner/site/secrets", {
+      name: "VERCEL_TOKEN",
+      value: SECRET_VALUE,
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(`${SETTINGS}#secrets`);
+    expect(await res.text()).not.toContain(SECRET_VALUE);
+    expect(putSecret).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      env,
+      expect.objectContaining({
+        projectId: "prj_owner",
+        name: "VERCEL_TOKEN",
+        value: SECRET_VALUE,
+      }),
+    );
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({ action: "secret.written" }),
+    );
+  });
+
+  it("reports a bad name and an empty value as fixed codes, not as text", async () => {
+    const badName = await form("/api/projects/@owner/site/secrets", {
+      name: "<script>lower case</script>",
+      value: SECRET_VALUE,
+    });
+    expect(badName.status).toBe(302);
+    expect(badName.headers.get("location")).toBe(`${SETTINGS}?secretError=name#secrets`);
+
+    const noValue = await form("/api/projects/@owner/site/secrets", {
+      name: "VERCEL_TOKEN",
+      value: "",
+    });
+    expect(noValue.status).toBe(302);
+    expect(noValue.headers.get("location")).toBe(`${SETTINGS}?secretError=value#secrets`);
+
+    expect(putSecret).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes an unconfigured instance from a storage failure", async () => {
+    vi.mocked(putSecret).mockResolvedValue({
+      success: false,
+      error: new AppError("no key", DEPLOY_SECRET_KEY_MISSING, 500),
+    });
+    const noKey = await form("/api/projects/@owner/site/secrets", {
+      name: "VERCEL_TOKEN",
+      value: SECRET_VALUE,
+    });
+    expect(noKey.headers.get("location")).toBe(`${SETTINGS}?secretError=key#secrets`);
+
+    vi.mocked(putSecret).mockResolvedValue({
+      success: false,
+      error: new AppError("boom", "DATABASE_ERROR", 500),
+    });
+    const failed = await form("/api/projects/@owner/site/secrets", {
+      name: "VERCEL_TOKEN",
+      value: SECRET_VALUE,
+    });
+    expect(failed.headers.get("location")).toBe(`${SETTINGS}?secretError=failed#secrets`);
+  });
+
+  it("deletes through the POST alias and audits it", async () => {
+    vi.mocked(deleteSecret).mockResolvedValue({ success: true, data: true });
+
+    const res = await form("/api/projects/@owner/site/secrets/VERCEL_TOKEN/delete");
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(`${SETTINGS}#secrets`);
+    expect(deleteSecret).toHaveBeenCalledWith(env.DB, expect.any(Object), {
+      projectId: "prj_owner",
+      name: "VERCEL_TOKEN",
+    });
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({ action: "secret.deleted" }),
+    );
+  });
+
+  it("audits nothing when the delete removed nothing", async () => {
+    vi.mocked(deleteSecret).mockResolvedValue({ success: true, data: false });
+
+    const res = await form("/api/projects/@owner/site/secrets/NOPE/delete");
+
+    expect(res.status).toBe(302);
+    expect(recordAudit).not.toHaveBeenCalled();
+  });
+});
+
+describe("canManageSecrets", () => {
+  // The one definition the routes and the settings page both consult. An agent
+  // owned by the project owner is a project admin, so "admin" alone is not the
+  // rule — this is what stops the section from rendering, and the routes from
+  // acting, for a `stratum_agent_` identity.
+  it("grants an admin user and refuses an agent owned by that same user", async () => {
+    expect(
+      await canManageSecrets(env.DB, PROJECT, { userId: "usr_owner", agentId: undefined }),
+    ).toBe(true);
+    expect(
+      await canManageSecrets(env.DB, PROJECT, { userId: "usr_owner", agentId: "agt_bot" }),
+    ).toBe(false);
+    expect(await canManageSecrets(env.DB, PROJECT, { userId: undefined, agentId: "agt_bot" })).toBe(
+      false,
+    );
+    expect(
+      await canManageSecrets(env.DB, PROJECT, { userId: "usr_outsider", agentId: undefined }),
+    ).toBe(false);
+  });
+});
+
+describe("secretErrorMessage", () => {
+  it("resolves only the codes the routes emit", () => {
+    for (const code of ["name", "value", "key", "failed"]) {
+      expect(secretErrorMessage(code)).toBeTypeOf("string");
+    }
+  });
+
+  it("resolves nothing for anything else, inherited keys included", () => {
+    expect(secretErrorMessage(undefined)).toBeUndefined();
+    expect(secretErrorMessage("<img src=x onerror=boom>")).toBeUndefined();
+    // `in` would answer true here and hand the page a function.
+    expect(secretErrorMessage("toString")).toBeUndefined();
+    expect(secretErrorMessage("constructor")).toBeUndefined();
+  });
+});
+
+describe("deployment list and detail", () => {
+  beforeEach(() => {
+    vi.mocked(listDeployments).mockResolvedValue({ success: true, data: [deployment()] });
+    vi.mocked(findDeploymentById).mockResolvedValue({ success: true, data: deployment() });
+  });
+
+  it("gives a writer the log tail", async () => {
+    const res = await call("/api/projects/@owner/site/deployments", { headers: asOwner });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { deployments: Array<Record<string, unknown>> };
+    expect(body.deployments[0]).toHaveProperty("logTail");
+  });
+
+  it("lists metadata for a public-project reader but withholds the log tail", async () => {
+    const list = await call("/api/projects/@owner/site/deployments", { headers: asOutsider });
+    const detail = await call("/api/deployments/dep_1", { headers: asOutsider });
+
+    expect(list.status).toBe(200);
+    const listBody = (await list.json()) as { deployments: Array<Record<string, unknown>> };
+    expect(listBody.deployments[0]).toMatchObject({ id: "dep_1", status: "failed" });
+    expect(listBody.deployments[0]).not.toHaveProperty("logTail");
+
+    expect(detail.status).toBe(200);
+    const detailBody = (await detail.json()) as { deployment: Record<string, unknown> };
+    expect(detailBody.deployment).not.toHaveProperty("logTail");
+  });
+
+  it("rejects an unknown status filter", async () => {
+    const res = await call("/api/projects/@owner/site/deployments?status=nope", {
+      headers: asOwner,
+    });
+
+    expect(res.status).toBe(400);
+    expect(listDeployments).not.toHaveBeenCalled();
+  });
+
+  it("404s an id from another project rather than confirming it exists", async () => {
+    vi.mocked(findDeploymentById).mockResolvedValue({
+      success: true,
+      data: deployment({ id: "dep_other", projectId: OTHER_PROJECT.id }),
+    });
+    vi.mocked(getProjectById).mockResolvedValue({ success: true, data: OTHER_PROJECT });
+
+    const res = await call("/api/deployments/dep_other", { headers: asOwner });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("approve", () => {
+  const pending = deployment({ status: "pending_approval", logTail: undefined });
+
+  beforeEach(() => {
+    vi.mocked(findDeploymentById).mockResolvedValue({ success: true, data: pending });
+    vi.mocked(approveDeployment).mockResolvedValue({
+      success: true,
+      data: {
+        approved: true,
+        deployment: { ...pending, status: "queued", approvedBy: "usr_owner" },
+      },
+    });
+  });
+
+  it("queues the deployment once and audits the approval", async () => {
+    const res = await call("/api/deployments/dep_1/approve", {
+      method: "POST",
+      headers: { ...asOwner, "content-type": "application/json" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith({
+      kind: "deployment",
+      projectId: "prj_owner",
+      deploymentId: "dep_1",
+    });
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({ action: "deployment.approved", actorId: "usr_owner" }),
+    );
+  });
+
+  it("answers a form submission with a redirect back to the deployment", async () => {
+    const res = await call("/api/deployments/dep_1/approve", {
+      method: "POST",
+      headers: asOwner,
+      body: new URLSearchParams(),
+    });
+
+    // Every page in this UI has to work with JavaScript disabled, so the button
+    // that posts here must land back on a page, never on a JSON body.
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/@owner/site/deployments/dep_1");
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses an agent token", async () => {
+    const res = await call("/api/deployments/dep_1/approve", { method: "POST", headers: asAgent });
+
+    expect(res.status).toBe(401);
+    expect(approveDeployment).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("refuses a reader who cannot write the project", async () => {
+    const res = await call("/api/deployments/dep_1/approve", {
+      method: "POST",
+      headers: asOutsider,
+    });
+
+    expect(res.status).toBe(403);
+    expect(approveDeployment).not.toHaveBeenCalled();
+  });
+
+  it("cannot enqueue twice when the row is already approved", async () => {
+    // What the conditional UPDATE reports to the loser of a double-approve.
+    vi.mocked(approveDeployment).mockResolvedValue({
+      success: true,
+      data: { approved: false, reason: "not_pending" },
+    });
+
+    const res = await call("/api/deployments/dep_1/approve", { method: "POST", headers: asOwner });
+
+    expect(res.status).toBe(409);
+    expect(send).not.toHaveBeenCalled();
+    expect(recordAudit).not.toHaveBeenCalled();
+  });
+
+  it("rejects approval of a superseded row", async () => {
+    vi.mocked(findDeploymentById).mockResolvedValue({
+      success: true,
+      data: deployment({ status: "superseded", logTail: undefined }),
+    });
+    vi.mocked(approveDeployment).mockResolvedValue({
+      success: true,
+      data: { approved: false, reason: "not_pending" },
+    });
+
+    const res = await call("/api/deployments/dep_1/approve", { method: "POST", headers: asOwner });
+
+    expect(res.status).toBe(409);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("rejects approval of a terminal row", async () => {
+    vi.mocked(findDeploymentById).mockResolvedValue({
+      success: true,
+      data: deployment({ status: "succeeded", logTail: undefined }),
+    });
+    vi.mocked(approveDeployment).mockResolvedValue({
+      success: true,
+      data: { approved: false, reason: "not_pending" },
+    });
+
+    const res = await call("/api/deployments/dep_1/approve", { method: "POST", headers: asOwner });
+
+    expect(res.status).toBe(409);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("404s an id from another project", async () => {
+    vi.mocked(findDeploymentById).mockResolvedValue({
+      success: true,
+      data: deployment({
+        id: "dep_other",
+        projectId: OTHER_PROJECT.id,
+        status: "pending_approval",
+      }),
+    });
+    vi.mocked(getProjectById).mockResolvedValue({ success: true, data: OTHER_PROJECT });
+
+    const res = await call("/api/deployments/dep_other/approve", {
+      method: "POST",
+      headers: asOwner,
+    });
+
+    expect(res.status).toBe(404);
+    expect(approveDeployment).not.toHaveBeenCalled();
+  });
+});
+
+describe("retry", () => {
+  beforeEach(() => {
+    vi.mocked(findDeploymentById).mockResolvedValue({
+      success: true,
+      data: deployment({ attempt: 2, status: "failed" }),
+    });
+    vi.mocked(insertDeployment).mockResolvedValue({
+      success: true,
+      data: {
+        inserted: true,
+        deployment: deployment({ id: "dep_2", attempt: 3, status: "queued" }),
+      },
+    });
+  });
+
+  it("inserts the next attempt for the same commit and queues it", async () => {
+    const res = await call("/api/deployments/dep_1/retry", {
+      method: "POST",
+      headers: { ...asOwner, "content-type": "application/json" },
+    });
+
+    expect(res.status).toBe(201);
+    expect(insertDeployment).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({
+        projectId: "prj_owner",
+        commitSha: "a".repeat(40),
+        name: "production",
+        attempt: 3,
+        status: "queued",
+      }),
+    );
+    expect(send).toHaveBeenCalledWith({
+      kind: "deployment",
+      projectId: "prj_owner",
+      deploymentId: "dep_2",
+    });
+    expect(recordAudit).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({ action: "deployment.retried" }),
+    );
+  });
+
+  it("accepts an agent, which retry does not gate on a user identity", async () => {
+    const res = await call("/api/deployments/dep_1/retry", {
+      method: "POST",
+      headers: { ...asAgent, "content-type": "application/json" },
+    });
+
+    expect(res.status).toBe(201);
+    expect(insertDeployment).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({ requestedByType: "agent", requestedById: "agt_bot" }),
+    );
+  });
+
+  it("answers a form submission with a redirect to the new attempt", async () => {
+    const res = await call("/api/deployments/dep_1/retry", {
+      method: "POST",
+      headers: asOwner,
+      body: new URLSearchParams(),
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/@owner/site/deployments/dep_2");
+    expect(insertDeployment).toHaveBeenCalled();
+  });
+
+  it("refuses a form caller exactly as it refuses a JSON one", async () => {
+    // The terminal-status check is the gate that keeps a retry from routing
+    // around approval; posting as a form must not slip past it.
+    vi.mocked(findDeploymentById).mockResolvedValue({
+      success: true,
+      data: deployment({ status: "pending_approval" }),
+    });
+
+    const res = await call("/api/deployments/dep_1/retry", {
+      method: "POST",
+      headers: asOwner,
+      body: new URLSearchParams(),
+    });
+
+    expect(res.status).toBe(409);
+    expect(insertDeployment).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("refuses to retry a deployment that has not finished", async () => {
+    vi.mocked(findDeploymentById).mockResolvedValue({
+      success: true,
+      data: deployment({ status: "running" }),
+    });
+
+    const res = await call("/api/deployments/dep_1/retry", { method: "POST", headers: asOwner });
+
+    expect(res.status).toBe(409);
+    expect(insertDeployment).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("refuses to retry a row still awaiting approval", async () => {
+    vi.mocked(findDeploymentById).mockResolvedValue({
+      success: true,
+      data: deployment({ status: "pending_approval" }),
+    });
+
+    const res = await call("/api/deployments/dep_1/retry", { method: "POST", headers: asOwner });
+
+    expect(res.status).toBe(409);
+    expect(insertDeployment).not.toHaveBeenCalled();
+  });
+
+  it("409s when that attempt already exists", async () => {
+    vi.mocked(insertDeployment).mockResolvedValue({
+      success: true,
+      data: { inserted: false, existing: deployment({ id: "dep_2", attempt: 3 }) },
+    });
+
+    const res = await call("/api/deployments/dep_1/retry", { method: "POST", headers: asOwner });
+
+    expect(res.status).toBe(409);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("refuses a reader who cannot write the project", async () => {
+    const res = await call("/api/deployments/dep_1/retry", { method: "POST", headers: asOutsider });
+
+    expect(res.status).toBe(403);
+    expect(insertDeployment).not.toHaveBeenCalled();
+  });
+});
+
+describe("secret values never reach a response body", () => {
+  it("holds across every route on this surface", async () => {
+    vi.mocked(listSecretNames).mockResolvedValue({
+      success: true,
+      data: [
+        {
+          name: "VERCEL_TOKEN",
+          createdBy: "usr_owner",
+          updatedBy: "usr_owner",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+    vi.mocked(putSecret).mockResolvedValue({
+      success: true,
+      data: {
+        name: "VERCEL_TOKEN",
+        createdBy: "usr_owner",
+        updatedBy: "usr_owner",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      },
+    });
+    vi.mocked(deleteSecret).mockResolvedValue({ success: true, data: true });
+    vi.mocked(listDeployments).mockResolvedValue({ success: true, data: [deployment()] });
+    vi.mocked(findDeploymentById).mockResolvedValue({ success: true, data: deployment() });
+    vi.mocked(insertDeployment).mockResolvedValue({
+      success: true,
+      data: { inserted: true, deployment: deployment({ id: "dep_2", attempt: 2 }) },
+    });
+    vi.mocked(approveDeployment).mockResolvedValue({
+      success: true,
+      data: { approved: false, reason: "not_pending" },
+    });
+
+    const routes = (headers: Record<string, string>): Array<Promise<Response>> => [
+      call("/api/projects/@owner/site/secrets", { headers }),
+      call("/api/projects/@owner/site/secrets/VERCEL_TOKEN", {
+        method: "PUT",
+        headers: { ...headers, "content-type": "application/json" },
+        body: JSON.stringify({ value: SECRET_VALUE }),
+      }),
+      call("/api/projects/@owner/site/secrets/VERCEL_TOKEN", { method: "DELETE", headers }),
+      call("/api/projects/@owner/site/secrets", {
+        method: "POST",
+        headers,
+        body: new URLSearchParams({ name: "VERCEL_TOKEN", value: SECRET_VALUE }),
+      }),
+      call("/api/projects/@owner/site/secrets/VERCEL_TOKEN/delete", {
+        method: "POST",
+        headers,
+        body: new URLSearchParams(),
+      }),
+      call("/api/projects/@owner/site/deployments", { headers }),
+      call("/api/deployments/dep_1", { headers }),
+      call("/api/deployments/dep_1/approve", { method: "POST", headers }),
+      call("/api/deployments/dep_1/retry", { method: "POST", headers }),
+    ];
+
+    // The fixture's `logTail` deliberately still contains the value: redaction
+    // (`src/deploy/redact.ts`) is literal-substring matching and is stated to
+    // miss encoded forms, so the reader gate has to hold on its own even when
+    // redaction missed. A writer legitimately receives that field, so only the
+    // secret routes are checked for them.
+    const readerBodies = await Promise.all(
+      routes(asOutsider).map(async (pending) => (await pending).text()),
+    );
+    for (const body of readerBodies) expect(body).not.toContain(SECRET_VALUE);
+
+    const writerBodies = await Promise.all(
+      routes(asOwner)
+        .slice(0, 5)
+        .map(async (pending) => (await pending).text()),
+    );
+    for (const body of writerBodies) expect(body).not.toContain(SECRET_VALUE);
+  });
+});

--- a/tests/routes-deployments.test.ts
+++ b/tests/routes-deployments.test.ts
@@ -47,6 +47,13 @@ vi.mock("../src/storage/project-secrets", async (importActual) => {
 });
 vi.mock("../src/storage/state", () => ({ getProjectByPath: vi.fn(), getProjectById: vi.fn() }));
 vi.mock("../src/storage/audit", () => ({ recordAudit: vi.fn(async () => ({ success: true })) }));
+// The outbox that makes a failed enqueue recoverable. Mocked rather than run
+// against a real database because what these routes owe the caller is *that*
+// the request was made durable, not how the row is shaped.
+vi.mock("../src/storage/events", async (importActual) => {
+  const actual = await importActual<typeof import("../src/storage/events")>();
+  return { ...actual, insertEvent: vi.fn() };
+});
 vi.mock("../src/storage/users", () => ({ getUserByToken: vi.fn(), getUser: vi.fn() }));
 vi.mock("../src/storage/agents", () => ({ getAgentByToken: vi.fn() }));
 
@@ -59,6 +66,7 @@ import {
   insertDeployment,
   listDeployments,
 } from "../src/storage/deployments";
+import { insertEvent } from "../src/storage/events";
 import {
   DEPLOY_SECRET_KEY_MISSING,
   deleteSecret,
@@ -146,6 +154,20 @@ async function call(path: string, init: RequestInit = {}): Promise<Response> {
 
 beforeEach(() => {
   vi.clearAllMocks();
+
+  vi.mocked(insertEvent).mockResolvedValue({
+    success: true,
+    data: {
+      id: "evt_1",
+      type: "deploy.enqueue",
+      project: PROJECT.name,
+      actorType: "system",
+      payload: {},
+      status: "pending",
+      attempts: 0,
+      createdAt: "2026-01-02T00:00:00.000Z",
+    },
+  });
 
   vi.mocked(getUserByToken).mockImplementation(async (_db, token) => {
     const id = token === OWNER_TOKEN ? "usr_owner" : "usr_outsider";
@@ -676,6 +698,46 @@ describe("approve", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  // The row has already left `pending_approval` by the time the send is
+  // attempted, and only a queue message can move it any further: approve
+  // refuses a `queued` row and `claimDeployment` runs from the consumer. The
+  // old "retry it" was advice that could not succeed, so the request has to be
+  // made durable instead.
+  it("records the request for recovery when the queue refuses it", async () => {
+    send.mockRejectedValueOnce(new Error("queue unavailable"));
+
+    const res = await call("/api/deployments/dep_1/approve", {
+      method: "POST",
+      headers: { ...asOwner, "content-type": "application/json" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(insertEvent).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({
+        type: "deploy.enqueue",
+        projectId: "prj_owner",
+        payload: { kind: "deployment", projectId: "prj_owner", deploymentId: "dep_1" },
+      }),
+    );
+  });
+
+  it("reports the failure only when the request could not be recorded either", async () => {
+    send.mockRejectedValueOnce(new Error("queue unavailable"));
+    vi.mocked(insertEvent).mockResolvedValue({
+      success: false,
+      error: new AppError("D1 unavailable", "DATABASE_ERROR", 500),
+    });
+
+    const res = await call("/api/deployments/dep_1/approve", {
+      method: "POST",
+      headers: { ...asOwner, "content-type": "application/json" },
+    });
+
+    expect(res.status).toBe(500);
+  });
+
   it("404s an id from another project", async () => {
     vi.mocked(findDeploymentById).mockResolvedValue({
       success: true,
@@ -739,6 +801,29 @@ describe("retry", () => {
       env.DB,
       expect.any(Object),
       expect.objectContaining({ action: "deployment.retried" }),
+    );
+  });
+
+  // The retry row exists and is `queued`, so "try again" would only be refused
+  // by the unique index on (project, name, commit, attempt). The outbox row is
+  // what can still start it.
+  it("records the request for recovery when the queue refuses it", async () => {
+    send.mockRejectedValueOnce(new Error("queue unavailable"));
+
+    const res = await call("/api/deployments/dep_1/retry", {
+      method: "POST",
+      headers: { ...asOwner, "content-type": "application/json" },
+    });
+
+    expect(res.status).toBe(201);
+    expect(insertEvent).toHaveBeenCalledWith(
+      env.DB,
+      expect.any(Object),
+      expect.objectContaining({
+        type: "deploy.enqueue",
+        projectId: "prj_owner",
+        payload: { kind: "deployment", projectId: "prj_owner", deploymentId: "dep_2" },
+      }),
     );
   });
 

--- a/tests/ui-deployments.test.tsx
+++ b/tests/ui-deployments.test.tsx
@@ -1,0 +1,266 @@
+/** @jsxImportSource hono/jsx */
+import { renderToString } from "hono/jsx/dom/server";
+import { describe, expect, it } from "vitest";
+import type { Deployment, DeploymentStatus } from "../src/storage/deployments";
+import type { ProjectSecretSummary } from "../src/storage/project-secrets";
+import {
+  DeploymentDetailPage,
+  DeploymentsPage,
+  deploymentStatusClass,
+  formatDuration,
+} from "../src/ui/pages/deployments";
+import { ProjectSettingsPage } from "../src/ui/pages/project-settings";
+
+// Task 8 of the post-merge deployments feature. Three properties this suite
+// exists to hold: a secret value can never reach the HTML, the Approve button
+// is the approval gate's visible half (so it must not render for someone who
+// cannot pass it), and a provider `reason` is attacker-influenced text.
+
+const project = { name: "my-repo", namespace: "@alice", slug: "my-repo" };
+const user = { id: "u1", email: "alice@example.com", username: "alice" };
+
+function makeDeployment(overrides: Partial<Deployment> = {}): Deployment {
+  return {
+    id: "dep_1",
+    projectId: "prj_1",
+    project: "my-repo",
+    commitSha: "abcdef1234567890abcdef1234567890abcdef12",
+    name: "production",
+    target: "vercel",
+    attempt: 1,
+    status: "succeeded",
+    requestedByType: "system",
+    createdAt: "2026-09-01T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function renderList(deployments: Deployment[], canWrite: boolean): string {
+  return renderToString(
+    <DeploymentsPage project={project} deployments={deployments} canWrite={canWrite} user={user} />,
+  );
+}
+
+describe("formatDuration", () => {
+  it("renders an em dash when the deployment has not finished", () => {
+    expect(formatDuration(undefined)).toBe("—");
+  });
+
+  it("scales from milliseconds to minutes", () => {
+    expect(formatDuration(450)).toBe("450ms");
+    expect(formatDuration(1500)).toBe("1.5s");
+    expect(formatDuration(95_000)).toBe("1m 35s");
+  });
+});
+
+describe("deploymentStatusClass", () => {
+  // "skipped" means nothing was configured to deploy, which is the normal state
+  // of most projects — it must not borrow the failure palette.
+  it("does not style skipped or superseded as failures", () => {
+    expect(deploymentStatusClass("skipped")).toBe("badge-skipped");
+    expect(deploymentStatusClass("superseded")).toBe("badge-superseded");
+    expect(deploymentStatusClass("failed")).toBe("badge-failed");
+    expect(deploymentStatusClass("skipped")).not.toBe(deploymentStatusClass("failed"));
+  });
+
+  it("gives every status its own visual treatment class", () => {
+    const statuses: DeploymentStatus[] = [
+      "pending_approval",
+      "queued",
+      "running",
+      "succeeded",
+      "failed",
+      "superseded",
+      "skipped",
+    ];
+    for (const status of statuses) {
+      expect(deploymentStatusClass(status)).toMatch(/^badge-/);
+    }
+  });
+});
+
+describe("DeploymentsPage — empty state", () => {
+  const html = renderList([], true);
+
+  it("explains how to configure a deployment instead of rendering a blank table", () => {
+    expect(html).not.toContain("<table");
+    expect(html).toContain("No deployments yet");
+    expect(html).toContain(".stratum/policy.yaml");
+    expect(html).toContain("deploys:");
+  });
+});
+
+describe("DeploymentsPage — actions", () => {
+  it("offers Approve only on a pending_approval row", () => {
+    const pending = renderList([makeDeployment({ status: "pending_approval" })], true);
+    expect(pending).toContain(">Approve<");
+    expect(pending).toContain('action="/api/deployments/dep_1/approve"');
+
+    for (const status of ["queued", "running", "succeeded", "failed", "skipped"] as const) {
+      expect(renderList([makeDeployment({ status })], true)).not.toContain(">Approve<");
+    }
+  });
+
+  it("hides Approve from a reader who could not pass the gate", () => {
+    const html = renderList([makeDeployment({ status: "pending_approval" })], false);
+    expect(html).not.toContain(">Approve<");
+    expect(html).not.toContain("/approve");
+  });
+
+  it("offers Retry only on a terminal row", () => {
+    for (const status of ["succeeded", "failed", "superseded", "skipped"] as const) {
+      const html = renderList([makeDeployment({ status })], true);
+      expect(html, status).toContain(">Retry<");
+      expect(html, status).toContain('action="/api/deployments/dep_1/retry"');
+    }
+    // A queued, running or pending row still has a future; retrying one would
+    // publish the same commit twice or route around the approval gate.
+    for (const status of ["queued", "running", "pending_approval"] as const) {
+      expect(renderList([makeDeployment({ status })], true), status).not.toContain(">Retry<");
+    }
+  });
+
+  it("hides Retry from a non-writer", () => {
+    expect(renderList([makeDeployment({ status: "failed" })], false)).not.toContain(">Retry<");
+  });
+});
+
+describe("DeploymentsPage — rows", () => {
+  const html = renderList(
+    [makeDeployment({ status: "failed", durationMs: 2500, attempt: 2 })],
+    true,
+  );
+
+  it("shows status, name, target, short commit and duration", () => {
+    expect(html).toContain("badge-failed");
+    expect(html).toContain("production");
+    expect(html).toContain("vercel");
+    expect(html).toContain("abcdef1");
+    expect(html).toContain("2.5s");
+    expect(html).toContain("attempt 2");
+  });
+
+  it("links each row to its detail view", () => {
+    expect(html).toContain('href="/@alice/my-repo/deployments/dep_1"');
+  });
+});
+
+describe("DeploymentDetailPage", () => {
+  function renderDetail(deployment: Deployment, canWrite = true): string {
+    return renderToString(
+      <DeploymentDetailPage
+        project={project}
+        deployment={deployment}
+        canWrite={canWrite}
+        user={user}
+      />,
+    );
+  }
+
+  it("escapes a reason containing HTML rather than injecting it", () => {
+    const html = renderDetail(
+      makeDeployment({ status: "failed", reason: '<script>alert("xss")</script>' }),
+    );
+    expect(html).not.toContain("<script>alert");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("escapes a log tail containing HTML", () => {
+    const html = renderDetail(
+      makeDeployment({ status: "failed", logTail: "<img src=x onerror=boom>" }),
+    );
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;img src=x");
+  });
+
+  it("renders the log tail only when the caller was served one", () => {
+    // The route strips `logTail` for non-writers, so the page must render
+    // correctly with the field simply absent.
+    const withoutTail = renderDetail(makeDeployment({ status: "failed" }), false);
+    expect(withoutTail).not.toContain("Log tail");
+    expect(withoutTail).not.toContain("deploy-log");
+
+    const withTail = renderDetail(makeDeployment({ status: "failed", logTail: "boom" }));
+    expect(withTail).toContain("Log tail");
+    expect(withTail).toContain("boom");
+  });
+
+  it("shows the deployment URL and the full commit", () => {
+    const html = renderDetail(makeDeployment({ url: "https://example.vercel.app" }));
+    expect(html).toContain("https://example.vercel.app");
+    expect(html).toContain("abcdef1234567890abcdef1234567890abcdef12");
+  });
+
+  it("offers Approve on a pending row and Retry on a terminal one", () => {
+    expect(renderDetail(makeDeployment({ status: "pending_approval" }))).toContain(">Approve<");
+    expect(renderDetail(makeDeployment({ status: "failed" }))).toContain(">Retry<");
+    expect(renderDetail(makeDeployment({ status: "running" }))).not.toContain(">Retry<");
+  });
+});
+
+describe("ProjectSettingsPage — deploy secrets", () => {
+  const secrets: ProjectSecretSummary[] = [
+    {
+      name: "VERCEL_TOKEN",
+      createdBy: "u1",
+      updatedBy: "u1",
+      createdAt: "2026-09-01T10:00:00.000Z",
+      updatedAt: "2026-09-02T10:00:00.000Z",
+    },
+  ];
+  const settingsProject = { ...project, createdAt: "2026-01-01T00:00:00.000Z" };
+
+  function renderSettings(canManageSecrets: boolean): string {
+    return renderToString(
+      <ProjectSettingsPage
+        project={settingsProject}
+        isOwner={true}
+        secrets={secrets}
+        canManageSecrets={canManageSecrets}
+        user={user}
+      />,
+    );
+  }
+
+  it("lists names and metadata but never a value", () => {
+    const html = renderSettings(true);
+    expect(html).toContain("VERCEL_TOKEN");
+    expect(html).toContain("2026-09-02T10:00:00.000Z");
+    // The add form's value field is write-only: no `value=` attribute anywhere
+    // on it, because nothing in the codebase can read a stored secret back.
+    expect(html).toContain('type="password"');
+    expect(html).not.toMatch(/name="value"[^>]*\svalue=/);
+  });
+
+  it("offers add and delete, and nothing that could reveal a value", () => {
+    const html = renderSettings(true);
+    expect(html).toContain('action="/api/projects/@alice/my-repo/secrets"');
+    expect(html).toContain('action="/api/projects/@alice/my-repo/secrets/VERCEL_TOKEN/delete"');
+    expect(html).not.toContain("Reveal");
+    expect(html).not.toContain("Show value");
+  });
+
+  it("hides the whole section from someone who may not manage secrets", () => {
+    const html = renderSettings(false);
+    expect(html).not.toContain("Deploy secrets");
+    expect(html).not.toContain("VERCEL_TOKEN");
+  });
+
+  it("links to the deployments page", () => {
+    expect(renderSettings(true)).toContain('href="/@alice/my-repo/deployments"');
+  });
+
+  it("surfaces a failed add without echoing anything the caller supplied", () => {
+    const html = renderToString(
+      <ProjectSettingsPage
+        project={settingsProject}
+        isOwner={true}
+        secrets={[]}
+        canManageSecrets={true}
+        secretError="A secret value is required."
+        user={user}
+      />,
+    );
+    expect(html).toContain("A secret value is required.");
+  });
+});

--- a/tests/ui-deployments.test.tsx
+++ b/tests/ui-deployments.test.tsx
@@ -263,4 +263,55 @@ describe("ProjectSettingsPage — deploy secrets", () => {
     );
     expect(html).toContain("A secret value is required.");
   });
+
+  // A failed listing rendered as "no secrets" reads as "you have none" when the
+  // truth is "we could not tell" — an admin acting on it would re-paste
+  // credentials that are already stored.
+  it("distinguishes a failed secret listing from an empty one", () => {
+    const html = renderToString(
+      <ProjectSettingsPage
+        project={settingsProject}
+        isOwner={true}
+        secrets={[]}
+        secretsUnavailable={true}
+        canManageSecrets={true}
+        user={user}
+      />,
+    );
+
+    expect(html).not.toContain("No deploy secrets stored for this project.");
+    expect(html).toContain("Could not load this project");
+    expect(html).toContain("settings-help-error");
+  });
+
+  it("still says 'none stored' when the listing succeeded and was empty", () => {
+    const html = renderToString(
+      <ProjectSettingsPage
+        project={settingsProject}
+        isOwner={true}
+        secrets={[]}
+        canManageSecrets={true}
+        user={user}
+      />,
+    );
+
+    expect(html).toContain("No deploy secrets stored for this project.");
+    expect(html).not.toContain("Could not load this project");
+  });
+
+  it("prefers the stored names over the error state when the listing worked", () => {
+    const html = renderToString(
+      <ProjectSettingsPage
+        project={settingsProject}
+        isOwner={true}
+        secrets={secrets}
+        secretsUnavailable={false}
+        canManageSecrets={true}
+        user={user}
+      />,
+    );
+
+    expect(html).toContain("VERCEL_TOKEN");
+    expect(html).not.toContain("Could not load this project");
+  });
 });

--- a/tests/webhook-event-coverage.test.ts
+++ b/tests/webhook-event-coverage.test.ts
@@ -1,0 +1,58 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+// Read via Vite's raw import rather than node:fs, so the guard type-checks under
+// the Workers tsconfig (the same trick tests/wrangler-migration-chain.test.ts uses).
+import eventsSource from "../src/queue/events.ts?raw";
+import { SUBSCRIBABLE_EVENTS } from "../src/routes/webhooks";
+
+/**
+ * Webhook event-coverage drift guard.
+ *
+ * `SUBSCRIBABLE_EVENTS` is derived from a `Record<StratumEvent["type"], true>`,
+ * so the compiler already refuses a list that omits an event or names one that
+ * does not exist. This is the runtime half of the same guarantee: it reads the
+ * event union out of its source of truth and asserts the exported list matches
+ * exactly, so the check still fires for anyone reading test output rather than
+ * a `tsc` diagnostic — and it names the drifting event, which the type error
+ * does only obliquely.
+ */
+function eventTypesInUnion(): string[] {
+  const source: string = eventsSource;
+  const start = source.indexOf("export type StratumEvent =");
+  expect(start).toBeGreaterThanOrEqual(0);
+  // The union ends at the first blank line followed by a new top-level
+  // declaration; every variant before that opens with `type: "…"`.
+  const end = source.indexOf("\n\nexport ", start);
+  expect(end).toBeGreaterThan(start);
+
+  const union = source.slice(start, end);
+  return [...union.matchAll(/\btype:\s*"([^"]+)"/g)].map((match) => match[1] as string);
+}
+
+describe("subscribable webhook events", () => {
+  const unionTypes = eventTypesInUnion();
+
+  it("finds the event union to compare against", () => {
+    expect(unionTypes.length).toBeGreaterThan(10);
+  });
+
+  it("offers every StratumEvent type as a webhook subscription", () => {
+    const missing = unionTypes.filter((type) => !SUBSCRIBABLE_EVENTS.includes(type));
+    expect(missing).toEqual([]);
+  });
+
+  it("does not advertise an event that can never fire", () => {
+    const phantom = SUBSCRIBABLE_EVENTS.filter((type) => !unionTypes.includes(type));
+    expect(phantom).toEqual([]);
+  });
+
+  it("lists each event exactly once", () => {
+    expect(new Set(SUBSCRIBABLE_EVENTS).size).toBe(SUBSCRIBABLE_EVENTS.length);
+  });
+
+  it("includes the deployment events, which are the newest additions", () => {
+    expect(SUBSCRIBABLE_EVENTS).toEqual(
+      expect.arrayContaining(["deployment.requested", "deployment.succeeded", "deployment.failed"]),
+    );
+  });
+});

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -114,6 +114,7 @@ export default defineConfig({
             { label: "Code review", slug: "guides/code-review" },
             { label: "Issues", slug: "guides/issues" },
             { label: "CI integration", slug: "guides/ci-integration" },
+            { label: "Deployments", slug: "guides/deployments" },
             { label: "CLI", slug: "guides/cli" },
             { label: "MCP server", slug: "guides/mcp" },
             { label: "Troubleshooting", slug: "guides/troubleshooting" },

--- a/website/public/webmcp.js
+++ b/website/public/webmcp.js
@@ -31,6 +31,7 @@
     ["/guides/code-review/", "Comment threads, line anchors, and review verdicts"],
     ["/guides/issues/", "The built-in issue tracker"],
     ["/guides/ci-integration/", "Bring your own CI via the webhook evaluator"],
+    ["/guides/deployments/", "Post-merge deploys to Cloudflare and Vercel"],
     ["/guides/cli/", "The Stratum CLI — the change flow from the terminal"],
     ["/guides/mcp/", "The MCP server — the eval-gated change flow for any MCP client"],
     ["/guides/troubleshooting/", "Troubleshooting"],

--- a/website/scripts/mirror-docs.mjs
+++ b/website/scripts/mirror-docs.mjs
@@ -23,6 +23,7 @@ const GUIDES = [
   ["code-review", "Line-anchored comment threads, replies, resolve/unresolve, and the three review verdicts."],
   ["issues", "Open, triage, search, and link issues — and how a merged change closes them."],
   ["ci-integration", "Bring your own CI: run evaluations on your existing infrastructure and report verdicts back."],
+  ["deployments", "Publish the merged tree to Cloudflare or Vercel after a change lands — the deploys: policy block, encrypted project secrets, the approval gate, limits, and what v1 does not do."],
   ["cli", "Install and use @stratum/cli — projects, workspaces, commits, and the change flow from the terminal."],
   ["mcp", "Connect any MCP-capable agent or editor to the evaluation-gated change flow over the hosted /mcp endpoint — OAuth 2.1, nothing to install."],
   ["troubleshooting", "Symptoms and fixes for auth, imports, evaluation, merges, and access."],

--- a/website/src/content/docs/guides/ci-integration.md
+++ b/website/src/content/docs/guides/ci-integration.md
@@ -6,14 +6,16 @@ editUrl: "https://github.com/stratum-eng/stratum/edit/main/docs/user-guide/ci-in
 
 Stratum has **no native CI runner** — there are no workflow files, no hosted
 build agents, and no GitHub Actions replacement. What Stratum *does* run for
-you is its evaluation and merge pipeline, and it gives you exactly three ways
-to execute code as part of that pipeline. This page inventories them honestly
-and shows how to wire an external CI system you host into the evaluation gate.
+you is its evaluation and merge pipeline, and it gives you a small, fixed set
+of ways to get code executed as part of that pipeline. This page inventories
+them honestly and shows how to wire an external CI system you host into the
+evaluation gate.
 
 ## The complete code-execution inventory
 
-Stratum can execute code in exactly three places, all driven by
-`.stratum/policy.yaml`:
+Stratum causes code to run in exactly four places, all driven by
+`.stratum/policy.yaml`. The first three run inside Stratum's own pipeline; the
+fourth hands your code to a hosting provider that runs it:
 
 ### 1. The sandbox evaluator
 
@@ -85,8 +87,24 @@ automatically reverted unless `merge.autoRevert: false`. Like the sandbox
 evaluator, this requires the `SANDBOX` binding; without it the check is
 skipped with a warning.
 
-That's it. Everything else — building artifacts, deploying, scheduled jobs —
-must live in a system you run outside Stratum.
+### 4. `deploys:` — publishing the merged tree to a provider
+
+After a merge survives the post-merge check, each entry in the policy's
+`deploys:` list uploads the merged tree to a hosting provider —
+Cloudflare (static assets or a Worker script) or Vercel — using credentials
+stored in the project's encrypted secret store. Stratum does not execute that
+code itself; the provider does, once it is published.
+
+There is **no build step**: the tree is deployed exactly as committed. Commit
+your built output, or use the `vercel` target, which builds the uploaded source
+remotely. A deploy can be gated behind an approval
+(`requiresApproval: true`), and a failed one can be retried, but there is no
+rollback and no preview environment. See
+[Deployments](/guides/deployments/) for the full configuration reference, the
+per-target secrets, and the limits.
+
+That's it. Everything else — building artifacts, scheduled jobs, matrix runs,
+artifact retention — must live in a system you run outside Stratum.
 
 ## The webhook evaluator contract
 
@@ -271,8 +289,16 @@ To set expectations, Stratum has none of the following today:
 - Build artifacts (upload/download/retention)
 - Dependency/build caching
 - Scheduled jobs (cron workflows)
-- A secrets store for CI (the webhook `secret` lives in the policy file)
-- Deployment environments, approvals-per-environment, or deploy gates
+- A secrets store *for evaluators*. Stratum does have an encrypted per-project
+  secret store, but it is **deploy-only**: the deploy runner is the sole reader,
+  and nothing interpolates it into a policy file. The webhook evaluator's
+  `secret` still lives literally in `.stratum/policy.yaml`.
+- Deployment *environments* — no staging/production separation, no
+  per-environment variables, no environment protection rules. What exists is a
+  flat list of named deploys, each optionally gated by a single approval
+  (`requiresApproval: true`), plus a retry. There is no rollback, no preview
+  deploy of an unmerged change, and no build step. See
+  [Deployments](/guides/deployments/).
 - Status-check aggregation — Stratum does not collect external CI check
   results the way a GitHub PR's checks tab does. An external system reports a
   verdict only by answering the webhook evaluator synchronously; a check that
@@ -283,5 +309,6 @@ evaluator (for gating) or via GitHub sync in layer mode (for everything else).
 
 ## See also
 
+- [Deployments](/guides/deployments/) — the `deploys:` policy block, targets, secrets, and limits
 - [FAQ: Does Stratum replace GitHub Actions?](/guides/faq/#does-stratum-replace-github-actions)
 - `docs/CURRENT_CAPABILITIES.md` — the authoritative current state

--- a/website/src/content/docs/guides/deployments.md
+++ b/website/src/content/docs/guides/deployments.md
@@ -1,0 +1,461 @@
+---
+title: "Deployments"
+description: "Publish the merged tree to Cloudflare or Vercel after a change lands — the deploys: policy block, encrypted project secrets, the approval gate, limits, and what v1 does not do."
+editUrl: "https://github.com/stratum-eng/stratum/edit/main/docs/user-guide/deployments.md"
+---
+
+Stratum can publish the merged tree to a hosting provider after a change lands.
+You declare deploys in the same `.stratum/policy.yaml` that gates your merges,
+store the provider credential once as a project secret, and every subsequent
+merge that survives the post-merge check publishes automatically.
+
+This is deliberately small. It is **not a CI system**: there is no build step,
+no preview environment, and no rollback. Read
+[Limitations](#limitations-read-this-before-you-rely-on-it) before you point
+production at it.
+
+## Contents
+
+- [Before you start: your policy still needs `evaluators:`](#before-you-start-your-policy-still-needs-evaluators)
+- [How a deploy is triggered](#how-a-deploy-is-triggered)
+- [The `deploys:` configuration reference](#the-deploys-configuration-reference)
+- [Targets and their secrets](#targets-and-their-secrets)
+- [Storing a secret](#storing-a-secret)
+- [The approval gate](#the-approval-gate)
+- [Retry](#retry)
+- [Deployment statuses](#deployment-statuses)
+- [Limits](#limits)
+- [Operating a Stratum instance with deploys enabled](#operating-a-stratum-instance-with-deploys-enabled)
+- [API](#api)
+- [Limitations](#limitations-read-this-before-you-rely-on-it)
+
+## Before you start: your policy still needs `evaluators:`
+
+**A `.stratum/policy.yaml` that has a `deploys:` block but no top-level
+`evaluators:` array is treated as malformed, and a malformed policy blocks
+every merge in the project.** The policy parser requires `evaluators` to be
+present and to be an array; anything else is a parse failure, and a parse
+failure fails the merge gate closed:
+
+> Policy file .stratum/policy.yaml is present but invalid (missing or non-array
+> 'evaluators'); merges are blocked until it is fixed.
+
+That is intended behaviour for the merge gate, but it means "I only want
+deploys" is not a configuration you can write. If you have no opinion about
+evaluation, declare the cheap default explicitly:
+
+```yaml
+# The minimum viable deploy-only policy. `evaluators:` is REQUIRED — a policy
+# file without it is malformed and blocks all merges.
+evaluators:
+  - type: diff
+
+deploys:
+  - name: site
+    target: cloudflare-pages
+    dir: public
+```
+
+The secret scanner runs on every change regardless of what this file says, so a
+lone `diff` evaluator is not "no gate at all".
+
+The same rule applies to the JSON form, `stratum.config.json`. Stratum reads
+`.stratum/policy.yaml` first and, only if it is absent, `stratum.config.json`.
+A file that is present but broken is an answer — Stratum does not fall through
+to the other one.
+
+## How a deploy is triggered
+
+1. A change merges.
+2. The post-merge smoke check runs (if the policy configures one). A failing
+   check auto-reverts the merge.
+3. **Only if the post-merge check did not revert or fail**, Stratum enqueues a
+   deploy of the merge commit. A deploy is never triggered from the
+   `change.merged` event, because that event fires before the check runs.
+4. The deploy consumer reads the tree **at the pinned merge commit** and parses
+   the policy out of *those* bytes. Configuration and code are therefore always
+   from the same commit: a policy change that lands after your merge cannot
+   retroactively change how your merge deploys.
+5. One `deployments` row is created per `deploys:` entry, and each entry is run
+   in turn.
+
+Things that do **not** trigger a deploy:
+
+- A merge that the post-merge check reverted.
+- `POST /api/projects/{name}/changes/merge-batch` — batch merges run neither the
+  post-merge check nor a deploy.
+- A push straight to the project's default branch (deploys hang off the change
+  merge path).
+- An instance with no `DEPLOY_QUEUE` binding configured.
+
+Before it runs, the deploy re-reads the change's status and the project's
+deletion state. A change that was reverted between the merge and the deploy is
+refused, and so is a project that is being deleted.
+
+## The `deploys:` configuration reference
+
+`deploys:` is a top-level list in `.stratum/policy.yaml`. Each entry is a
+mapping:
+
+```yaml
+deploys:
+  - name: marketing-site        # required
+    target: cloudflare-pages    # required
+    dir: dist                   # optional
+    secrets:                    # optional
+      - CLOUDFLARE_API_TOKEN
+      - CLOUDFLARE_ACCOUNT_ID
+    requiresApproval: false     # optional, default false
+```
+
+| Field | Required | Rules |
+|---|---|---|
+| `name` | yes | `^[a-z][a-z0-9-]{0,31}$` — lowercase letters, digits and dashes, max 32 characters. It is this deploy's stable identity across merges, and it is what supersession and the deployments list group by. Must be unique within the file. |
+| `target` | yes | One of `cloudflare-pages`, `cloudflare-workers`, `vercel`. |
+| `dir` | no | Repo-relative directory to publish. Must be relative (no leading `/`), contain no `..` segment and no null byte, max 255 characters. The prefix is stripped, so `dir: dist` publishes `dist/index.html` as `index.html`. Omit it to publish the whole tree. |
+| `secrets` | no | Up to 16 secret names, each `^[A-Z][A-Z0-9_]{0,63}$`. Naming a secret here makes it **required**: a declared name that is not stored fails the deploy. You do not have to list the target's own secrets — they are loaded either way. |
+| `requiresApproval` | no | Boolean (a quoted `"false"` is rejected, not coerced). `true` holds the deployment at `pending_approval` until someone approves it. |
+
+**Unknown fields are rejected, not ignored.** An entry containing
+`requireApproval` (missing the "s") is refused with a reason naming the field,
+rather than being silently rebuilt without it — which would turn a deploy you
+gated behind an approval into one that ships straight to production.
+
+### A rejected entry becomes a visible failed deployment
+
+Bad `deploys:` configuration does not block your merge, and it is not dropped
+in silence either: each rejected entry is recorded as a `failed` deployment row
+carrying the reason (`deploys[0]: unknown target "netlify" (expected one of
+cloudflare-pages, cloudflare-workers, vercel)`). A deploy that was written and
+never runs means production quietly stopped updating, so it is reported where
+you will see it — on the project's Deployments page.
+
+A policy file that fails to parse at all produces one `failed` row pointing at
+the file, in addition to blocking merges.
+
+## Targets and their secrets
+
+All three targets are first-class. Secrets are read from the project's secret
+store by these exact names.
+
+### `cloudflare-pages` — a static site on Cloudflare
+
+| Secret | | Meaning |
+|---|---|---|
+| `CLOUDFLARE_API_TOKEN` | **required** | API token with Workers Scripts edit permission on the account. |
+| `CLOUDFLARE_ACCOUNT_ID` | **required** | The account that owns the Worker. |
+| `CLOUDFLARE_WORKER_NAME` | optional | Script name to publish as. Defaults to the deploy's `name`. |
+| `CLOUDFLARE_WORKERS_SUBDOMAIN` | optional | Your account's `workers.dev` subdomain. Without it the deployment **succeeds with no URL** (see below). |
+
+**This target is implemented against Workers Static Assets, not Pages Direct
+Upload.** The `target:` name is the user-facing name for "publish my static
+site on Cloudflare" and is unchanged, but the implementation uploads an asset
+manifest and publishes a Worker with an `assets` binding and no `main_module`.
+Two reasons: Pages Direct Upload's asset endpoints (the upload-token,
+check-missing and asset-upload calls Wrangler drives) are not in Cloudflare's
+public API reference, so implementing it would mean guessing at a surface that
+carries a production credential; and Cloudflare itself steers new projects to
+Workers rather than Pages. The practical consequences are that the deployment
+appears in your Cloudflare account as a **Worker**, not as a Pages project, and
+that Pages-specific features (preview branches, the Pages dashboard) do not
+apply.
+
+Content types are set at upload time from the file extension, which is what
+visitors are served. An unrecognized extension is uploaded as
+`application/octet-stream`.
+
+### `cloudflare-workers` — a Worker script
+
+| Secret | | Meaning |
+|---|---|---|
+| `CLOUDFLARE_API_TOKEN` | **required** | As above. |
+| `CLOUDFLARE_ACCOUNT_ID` | **required** | As above. |
+| `CLOUDFLARE_WORKER_NAME` | optional | Script name. Defaults to the deploy's `name`. |
+| `CLOUDFLARE_WORKER_MAIN_MODULE` | optional | Entry-point path within the deployed tree. |
+| `CLOUDFLARE_WORKERS_SUBDOMAIN` | optional | Your `workers.dev` subdomain; without it the deployment succeeds with no URL. |
+
+Only `.js` and `.mjs` files are uploaded, as ES modules. Everything else in the
+selected tree (a README, a lockfile) is skipped, and the count of skipped files
+is reported on the deployment. If no module is found, the deploy fails.
+
+Without `CLOUDFLARE_WORKER_MAIN_MODULE`, the entry point is the first of
+`worker.js`, `worker.mjs`, `index.js`, `index.mjs`, `src/index.js`,
+`src/index.mjs` present in the tree; if none is, the deploy fails and names the
+candidates. When you do set it, it is validated against the tree — a typo fails
+with a reason instead of deploying some other file.
+
+The upload sends a pinned `compatibility_date` (currently `2026-08-20`) rather
+than the current date, so redeploying the same commit cannot silently change
+its runtime behaviour.
+
+### `vercel` — build and host on Vercel
+
+| Secret | | Meaning |
+|---|---|---|
+| `VERCEL_TOKEN` | **required** | Vercel API token. |
+| `VERCEL_PROJECT_ID` | **required** | The Vercel project to deploy into. |
+| `VERCEL_TEAM_ID` | optional | Required in practice for a team-scoped token — without it the API resolves the token against your personal account. |
+
+The whole tree is inlined (base64) into a single `POST /v13/deployments` with
+`target: production`, rather than uploaded file-by-file: one provider request
+instead of one per file, which is what the Worker's subrequest budget can
+afford. Base64 inflates the payload by about a third, so the 25 MB tree limit
+becomes roughly a 33 MB request body — that is this target's binding
+constraint.
+
+**A `vercel` deployment recorded as `succeeded` means "accepted for build".**
+Vercel answers as soon as it has queued the deployment (`readyState: QUEUED`)
+and builds asynchronously; Stratum does **not** poll for the result, because
+polling would hold a queue message open for the length of somebody else's
+build. The provider's state at hand-off and its deployment id are recorded in
+the row's reason, e.g. `provider state at hand-off: QUEUED (the provider
+finishes asynchronously; Stratum does not poll it); provider deployment
+dpl_…`. A build that fails **after** hand-off is visible in Vercel, not in
+Stratum. If the API returns `ERROR`, `CANCELED` or `BLOCKED` outright, the
+deployment is recorded as `failed`.
+
+### When a deployment has no URL
+
+The Cloudflare targets derive the deployment URL from
+`CLOUDFLARE_WORKERS_SUBDOMAIN`, because the account's `workers.dev` subdomain
+is not part of the API surface these targets were written against and inventing
+a lookup for it would be a guess. **If you do not store that secret, the deploy
+still succeeds — it just records no URL.** Store it if you want a clickable
+link on the deployments page.
+
+Note that `CLOUDFLARE_WORKERS_SUBDOMAIN` lives in the secrets table for
+uniformity, but it is not confidential: it is a public hostname component,
+written verbatim into the deployment's `url`. Treat it as configuration that
+happens to be stored beside your credentials, not as a credential.
+
+## Storing a secret
+
+Secrets are per project, encrypted at rest (AES-GCM, with the project id and
+secret name bound as additional authenticated data), and there is **no read
+path** — no API, UI or CLI surface returns a stored value. Only the deploy
+runner decrypts them.
+
+- **In the UI:** *Project → Settings → Deploy secrets*. Add by name and value;
+  delete by name. Values are never rendered back.
+- **Over the API:**
+
+  ```bash
+  curl -X PUT https://app.usestratum.dev/api/projects/acme/site/secrets/CLOUDFLARE_API_TOKEN \
+    -H "Authorization: Bearer $STRATUM_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"value":"…"}'
+  ```
+
+Rules:
+
+- Names must match `^[A-Z][A-Z0-9_]{0,63}$`.
+- Values are capped at 4096 bytes. There is no minimum — some providers
+  legitimately accept an empty value.
+- Writing an existing name replaces it.
+- Every write and delete is recorded in the audit trail (`secret.written`,
+  `secret.deleted`).
+
+**Only a project admin who is not an agent may manage secrets.** An agent token
+is refused on every secret route, even when the agent's owner is the project
+owner: deploy credentials are the one thing an agent identity is never trusted
+with. Deleting the project deletes its secrets and its deployment history.
+
+## The approval gate
+
+With `requiresApproval: true`, the merge creates the deployment at
+`pending_approval` and nothing is uploaded. Someone then presses **Approve** on
+the deployment page, or calls `POST /api/deployments/{id}/approve`; the row
+moves to `queued`, is enqueued, and runs.
+
+Approving requires project **write** access and a **user** identity. An agent
+token (`stratum_agent_…`) sets no user id and is refused.
+
+**Be precise about what that buys you.** The guarantee is "not an agent
+identity" — exactly the same guarantee, and the same limitation, as a human
+review verdict. A user's scoped API token and an MCP OAuth grant both
+authenticate as the user and are both accepted. It is therefore **not**
+evidence that a human was at a keyboard: an automation running under your token
+can approve a deploy. If your threat model needs a real human, this gate does
+not provide one.
+
+Approval is single-use and safe to double-click: the status flip is a
+conditional update, so a second approver gets `409 DEPLOYMENT_NOT_PENDING`
+rather than a second deployment of the same commit.
+
+## Retry
+
+A finished deployment can be re-run from the **Retry** button or
+`POST /api/deployments/{id}/retry`. This creates a *new attempt row* for the
+same commit with `attempt` incremented, and enqueues it; the original row is
+kept, so the history shows both.
+
+- Only a terminal deployment (`succeeded`, `failed`, `superseded`, `skipped`)
+  can be retried. Retrying a `queued`, `running` or `pending_approval` row is
+  refused with `409 DEPLOYMENT_NOT_RETRYABLE` — for `pending_approval` in
+  particular, allowing it would route straight around the approval gate,
+  because a retry row starts `queued`.
+- Retry requires project write access, and unlike approve it **does** accept an
+  agent identity.
+- The originating change id is carried onto the retry, so the "was this change
+  reverted?" check still applies. Retrying a change that has since been
+  reverted is refused.
+- Two people retrying at once is safe: the second gets
+  `409 DEPLOYMENT_RETRY_EXISTS`.
+- A retry counts as the *newest* intent for that deploy name, even when the
+  commit it re-runs is old — an operator re-running an earlier commit is
+  asserting that they want it live.
+
+Retry is also the closest thing to a rollback — see
+[Limitations](#limitations-read-this-before-you-rely-on-it).
+
+## Deployment statuses
+
+| Status | Meaning |
+|---|---|
+| `pending_approval` | `requiresApproval: true` and nobody has approved it yet. Nothing has been uploaded. |
+| `queued` | Waiting for the deploy consumer to pick it up. |
+| `running` | A consumer holds a lease on the row and is uploading. |
+| `succeeded` | The provider accepted the deployment. For `vercel`, this means **accepted for build**, not "live" — see above. |
+| `failed` | Anything that went wrong, with a reason: a rejected `deploys:` entry, an unreadable tree, a missing or undecryptable secret, `DEPLOY_SECRET_KEY` unset, a limit exceeded, a provider 4xx/5xx, an unreachable provider. |
+| `superseded` | A newer merge of the same deploy `name` took over. Either this row had not started when the newer one ran, or the newer one had already succeeded by the time this one reached the front of the queue — in which case this deployment is refused rather than published, so an out-of-order delivery cannot put the older commit back into production. |
+| `skipped` | **Only one thing:** there was nothing configured to deploy — no policy file at that commit, or a policy with no `deploys:` entries. Every operator error is `failed`, never `skipped`. |
+
+`succeeded`, `failed`, `superseded` and `skipped` are terminal.
+
+A deploy that hits a provider error also stores a **log tail**: the provider's
+response, with every secret value substituted out, truncated to 16 KiB.
+Redaction always runs on the full text before truncation, so a secret cannot
+survive by straddling the cut. The log tail is served **only to project
+writers** — never on the public read path, and never in a list response for a
+reader who cannot write.
+
+Deployments also emit events you can subscribe to with a project webhook:
+`deployment.requested`, `deployment.succeeded`, `deployment.failed`.
+
+## Limits
+
+Every limit is checked **before the first provider request goes out** — a
+deploy that uploaded half a tree and then failed would leave the site in a
+state nobody asked for. Limits are applied to the tree *after* `dir` narrowing,
+so they judge the bytes actually being uploaded.
+
+| Limit | Value |
+|---|---|
+| Files per deployment | 2,000 |
+| Total bytes per deployment | 25 MiB |
+| Bytes per file | 10 MiB |
+| Provider HTTP requests per deployment | 2,048 |
+| Stored log tail | 16 KiB |
+| Deployment lease / queue visibility timeout | 15 minutes |
+| Secret value | 4,096 bytes |
+| Secrets named per deploy entry | 16 |
+
+Exceeding one is a `failed` deployment naming the number, e.g. `too many files:
+2431 exceeds the 2000-file deploy limit`. An empty selection is also a failure
+(`no files found under "dist" at this commit — check the deploy's "dir"`), not
+a silent no-op.
+
+Sibling deploys from one merge run **sequentially**, not concurrently: they
+share one Worker invocation's CPU, memory and subrequest budget.
+
+## Operating a Stratum instance with deploys enabled
+
+Self-hosters need three things beyond the default deployment:
+
+1. **`DEPLOY_SECRET_KEY` must be set as a Wrangler secret.** It is the master
+   key every project secret is derived from. Without it, storing a secret fails
+   and every deploy fails with `DEPLOY_SECRET_KEY is not configured on this
+   instance, so deploy secrets cannot be decrypted.`
+
+   ```bash
+   wrangler secret put DEPLOY_SECRET_KEY --env production
+   ```
+
+   **Rotating it makes every stored secret undecryptable.** There is no
+   re-encryption path: after a rotation, deploys fail with `Could not decrypt
+   project secret…` and every project must re-enter its values.
+
+2. **The queues must exist**, and the `DEPLOY_QUEUE` binding must be
+   configured. Without the binding, merges simply never enqueue a deploy, and
+   approve/retry answer `503 DEPLOY_QUEUE_UNAVAILABLE`.
+
+   ```bash
+   wrangler queues create stratum-deploys
+   wrangler queues create stratum-deploys-dlq
+   ```
+
+3. **The dead-letter queue has no consumer.** `stratum-deploys-dlq` is
+   configured as the DLQ for `stratum-deploys`, but nothing reads it: a message
+   that exhausts its retries lands there and **sits for manual inspection**.
+   Nothing alerts, and no deployment row is written by the DLQ itself. This is
+   a deliberate v1 choice, not an oversight — but it means "the queue is
+   healthy" is something an operator has to check, not something Stratum
+   reports.
+
+   In practice a message only reaches the DLQ for an *indeterminate* failure
+   (D1 or KV unavailable, the project unreadable). A failed deployment is a
+   result, not a delivery failure, and is acked with a `failed` row rather than
+   retried; a malformed message is acked and logged.
+
+The staging environment uses `stratum-deploys-staging` and
+`stratum-deploys-dlq-staging` so its messages can never be handed to the
+production consumer.
+
+## API
+
+| Route | Access |
+|---|---|
+| `GET /api/projects/{namespace}/{slug}/secrets` | Project admin, agents refused. Names and metadata only — never values. |
+| `PUT /api/projects/{namespace}/{slug}/secrets/{name}` | Project admin, agents refused. |
+| `POST /api/projects/{namespace}/{slug}/secrets` | Form-friendly create/replace (`name`, `value` in the body). |
+| `DELETE /api/projects/{namespace}/{slug}/secrets/{name}` | Project admin, agents refused. |
+| `POST /api/projects/{namespace}/{slug}/secrets/{name}/delete` | Form-friendly delete. |
+| `GET /api/projects/{namespace}/{slug}/deployments` | Anyone who can read the project. `log_tail` is included only for writers. Filters: `name`, `status`, `limit` (default 50, max 200), `offset`. |
+| `GET /api/deployments/{id}` | Anyone who can read the deployment's project; unknown or unreadable ids answer 404 alike. |
+| `POST /api/deployments/{id}/approve` | Project writer, **user identity required**. |
+| `POST /api/deployments/{id}/retry` | Project writer; agents allowed. |
+
+In the UI, deployments live at `/{namespace}/{slug}/deployments`, and secrets
+under *Settings*.
+
+Full request and response schemas are in the
+[OpenAPI specification](/reference/openapi/); see also
+[the endpoint reference](/reference/endpoints/).
+
+## Limitations (read this before you rely on it)
+
+These are design boundaries of v1, not bugs:
+
+- **No build step.** Stratum deploys the tree **exactly as committed**. There
+  is no `npm install`, no bundler, no framework build. If your site needs a
+  build, commit the built output (and point `dir:` at it) or use a provider
+  that builds for you — `vercel` builds the uploaded source remotely, the two
+  Cloudflare targets do not.
+- **No preview deploys.** Only merged commits deploy. There is no way to
+  publish an unmerged change for review.
+- **No rollback.** There is no "revert to the previous deployment" button. The
+  recovery path is to **retry an earlier successful deployment** of the same
+  commit, or to merge a revert change and let that deploy. Neither is
+  instantaneous.
+- **Netlify is not supported.** The three targets above are the whole list.
+- **The approval gate refuses agent identities, not automation.** It accepts a
+  user's scoped API token and MCP OAuth grants. See
+  [The approval gate](#the-approval-gate).
+- **A deploy-only project still needs an `evaluators:` block**, or every merge
+  is blocked. See
+  [the top of this page](#before-you-start-your-policy-still-needs-evaluators).
+- **Secret redaction is literal-substring matching.** A provider that echoes a
+  credential back in some encoded or transformed form (URL-encoded, hashed,
+  split across a JSON boundary) would not be caught, which is part of why the
+  log tail is writers-only.
+- **No per-project deploy quota.** Nothing rate-limits how often a project
+  deploys beyond the limits table above.
+- **Deployment history has no retention policy.** Rows accumulate until the
+  project is deleted.
+
+## See also
+
+- [CI Integration (Bring Your Own CI)](/guides/ci-integration/) — what Stratum does
+  and does not execute
+- [Getting Started](/guides/getting-started/) — the policy file and the merge gate
+- [FAQ](/guides/faq/)

--- a/website/src/content/docs/guides/deployments.md
+++ b/website/src/content/docs/guides/deployments.md
@@ -116,6 +116,11 @@ deploys:
 | `secrets` | no | Up to 16 secret names, each `^[A-Z][A-Z0-9_]{0,63}$`. Naming a secret here makes it **required**: a declared name that is not stored fails the deploy. You do not have to list the target's own secrets — they are loaded either way. |
 | `requiresApproval` | no | Boolean (a quoted `"false"` is rejected, not coerced). `true` holds the deployment at `pending_approval` until someone approves it. |
 
+**A policy file may declare at most 16 `deploys:` entries.** Anything beyond
+the sixteenth is not run and is reported as a single `failed` deployment row
+naming how many were declared — siblings run sequentially inside one Worker
+invocation, so an unbounded list would be an unbounded merge.
+
 **Unknown fields are rejected, not ignored.** An entry containing
 `requireApproval` (missing the "s") is refused with a reason naming the field,
 rather than being silently rebuilt without it — which would turn a deploy you
@@ -130,8 +135,30 @@ cloudflare-pages, cloudflare-workers, vercel)`). A deploy that was written and
 never runs means production quietly stopped updating, so it is reported where
 you will see it — on the project's Deployments page.
 
-A policy file that fails to parse at all produces one `failed` row pointing at
-the file, in addition to blocking merges.
+### The malformed-policy row is a post-merge fallback, not the merge block
+
+A policy file that fails to parse at all produces one `failed` deployment row
+(named `(unresolved)`) pointing at the file. That row is **not** the merge gate
+reporting itself — it is a separate, later check, and the distinction matters
+because the two look at different commits:
+
+- **Before the merge**, the gate parses the project's *current* policy. A file
+  that does not parse blocks the merge outright, and no deployment row exists
+  because no merge happened.
+- **After a merge**, the deploy runner re-parses the policy out of the *pinned
+  merge commit's* tree, so configuration and code always come from the same
+  commit. If **that** commit's policy is the unparseable one, there is nothing
+  to deploy and nothing to name, so the failure is recorded as an
+  `(unresolved)` row reading `Policy file .stratum/policy.yaml is present but
+  invalid (…); no deploy configuration could be read from it.` rather than
+  being dropped in silence.
+
+The two reads happen at different times against different trees, so they can
+disagree — which is exactly when this row shows up. Treat it as "the commit
+that was deployed had a broken policy", not as a second copy of the merge
+error. Fixing the project's current policy unblocks merges; it does not
+retroactively change a row already recorded against an older commit, and it
+does not re-run that deploy. Retry it once the fix is merged.
 
 ## Targets and their secrets
 
@@ -240,7 +267,7 @@ runner decrypts them.
 - **Over the API:**
 
   ```bash
-  curl -X PUT https://app.usestratum.dev/api/projects/acme/site/secrets/CLOUDFLARE_API_TOKEN \
+  curl -X PUT https://app.usestratum.dev/api/projects/@acme/site/secrets/CLOUDFLARE_API_TOKEN \
     -H "Authorization: Bearer $STRATUM_TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"value":"…"}'
@@ -349,6 +376,7 @@ so they judge the bytes actually being uploaded.
 | Deployment lease / queue visibility timeout | 15 minutes |
 | Secret value | 4,096 bytes |
 | Secrets named per deploy entry | 16 |
+| `deploys:` entries per policy file | 16 |
 
 Exceeding one is a `failed` deployment naming the number, e.g. `too many files:
 2431 exceeds the 2000-file deploy limit`. An empty selection is also a failure
@@ -410,7 +438,7 @@ production consumer.
 | `POST /api/projects/{namespace}/{slug}/secrets` | Form-friendly create/replace (`name`, `value` in the body). |
 | `DELETE /api/projects/{namespace}/{slug}/secrets/{name}` | Project admin, agents refused. |
 | `POST /api/projects/{namespace}/{slug}/secrets/{name}/delete` | Form-friendly delete. |
-| `GET /api/projects/{namespace}/{slug}/deployments` | Anyone who can read the project. `log_tail` is included only for writers. Filters: `name`, `status`, `limit` (default 50, max 200), `offset`. |
+| `GET /api/projects/{namespace}/{slug}/deployments` | Anyone who can read the project. `logTail` is included only for writers. Filters: `name`, `status`, `limit` (default 50, max 200), `offset`. |
 | `GET /api/deployments/{id}` | Anyone who can read the deployment's project; unknown or unreadable ids answer 404 alike. |
 | `POST /api/deployments/{id}/approve` | Project writer, **user identity required**. |
 | `POST /api/deployments/{id}/retry` | Project writer; agents allowed. |

--- a/website/src/content/docs/guides/faq.md
+++ b/website/src/content/docs/guides/faq.md
@@ -39,16 +39,24 @@ invariants GitHub doesn't have:
 ## Does Stratum replace GitHub Actions?
 
 No. Stratum has no native CI runner — no workflows, hosted runners, matrix
-builds, artifacts, caching, scheduled jobs, CI secrets store, deployment
-environments, or status-check aggregation (it does not collect external CI
-check results the way a GitHub PR's checks tab does). Its code execution is
-limited to the evaluation pipeline: the
-sandbox evaluator (needs the optional `SANDBOX` binding; fails closed without
-it), the `webhook` evaluator (a synchronous call-out to CI *you* host, which
-must answer within the request timeout — default 10s), and the post-merge
-smoke command run in a sandbox. Bring your own CI and wire it in via the
-webhook evaluator, or use layer mode and keep running GitHub Actions on the
+builds, artifacts, caching, scheduled jobs, deployment environments, or
+status-check aggregation (it does not collect external CI check results the way
+a GitHub PR's checks tab does). Its code execution is limited to the evaluation
+pipeline: the sandbox evaluator (needs the optional `SANDBOX` binding; fails
+closed without it), the `webhook` evaluator (a synchronous call-out to CI *you*
+host, which must answer within the request timeout — default 10s), and the
+post-merge smoke command run in a sandbox. Bring your own CI and wire it in via
+the webhook evaluator, or use layer mode and keep running GitHub Actions on the
 promoted PRs. See [CI Integration](/guides/ci-integration/).
+
+Two things on that list have since arrived in a narrow form. Stratum now has an
+**encrypted per-project secret store** — but it is deploy-only: the deploy
+runner is its sole reader, and the webhook evaluator's `secret` still lives
+literally in the policy file. And it can **deploy the merged tree** to
+Cloudflare or Vercel from a `deploys:` block, with an optional approval gate
+and a retry. That is not deployment environments: there is no
+staging/production separation, no per-environment variables, no build step, no
+preview deploy, and no rollback. See [Deployments](/guides/deployments/).
 
 ## Do I have to leave GitHub to use it?
 

--- a/website/src/content/docs/reference/endpoints.md
+++ b/website/src/content/docs/reference/endpoints.md
@@ -1,6 +1,6 @@
 ---
 title: Endpoints
-description: "The Stratum REST API surface — projects, branches, workspaces, changes, reviews, issues, agents, users, and organizations."
+description: "The Stratum REST API surface — projects, branches, workspaces, changes, reviews, issues, deployments, agents, users, and organizations."
 ---
 
 An overview of the REST API by resource. The complete, authoritative surface —
@@ -227,6 +227,58 @@ Issues linked to a change close **automatically** when that change merges.
 
 `POST /api/projects/{namespace}/{slug}/issues/{number}/comments`
 `GET /api/projects/{namespace}/{slug}/issues/{number}/comments`
+
+## Deployments and deploy secrets
+
+Post-merge deployments and the encrypted per-project secret store that feeds
+them. See [Deployments](/guides/deployments/) for the `deploys:` policy block,
+the targets, and the limits.
+
+**No endpoint returns a stored secret value**, and every secret route refuses
+agent identities — even an agent whose owner is a project admin.
+
+### List secret names
+
+`GET /api/projects/{namespace}/{slug}/secrets`
+
+Project admin only. Names and metadata, never values.
+
+### Create or replace a secret
+
+`PUT /api/projects/{namespace}/{slug}/secrets/{name}`
+`POST /api/projects/{namespace}/{slug}/secrets` (form-friendly)
+
+Names match `^[A-Z][A-Z0-9_]{0,63}$`; values are capped at 4096 bytes.
+
+### Delete a secret
+
+`DELETE /api/projects/{namespace}/{slug}/secrets/{name}`
+`POST /api/projects/{namespace}/{slug}/secrets/{name}/delete` (form-friendly)
+
+### List deployments
+
+`GET /api/projects/{namespace}/{slug}/deployments`
+
+Readable by anyone who can read the project. Filter with `name`, `status`,
+`limit` (default 50, max 200) and `offset`. `logTail` is included only for
+project writers.
+
+### Get a deployment
+
+`GET /api/deployments/{id}`
+
+### Approve a deployment
+
+`POST /api/deployments/{id}/approve`
+
+Releases a `pending_approval` deployment. Requires project write access and a
+**user** identity — agent tokens are refused.
+
+### Retry a deployment
+
+`POST /api/deployments/{id}/retry`
+
+Re-runs a finished deployment as a new attempt. Agents are allowed here.
 
 ## Agents
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -123,10 +123,17 @@ retry_delay = 30    # Wait 30 seconds between retries
 # for a tree of up to MAX_TOTAL_BYTES, both in `src/deploy/limits.ts`. Raise
 # those limits and this MUST rise with them — a run that outlives its lease is
 # redelivered while still uploading, and the second copy races the first.
+#
+# max_concurrency is 1, and must stay 1: concurrent invocations share one
+# isolate's 128 MiB, one Vercel deploy peaks near 92 MiB of that (the tree, its
+# base64 copy, and the request body), and an OOM kill happens *before* the
+# runner's `finally` can write a terminal status. See MAX_DEPLOY_CONCURRENCY in
+# `src/deploy/limits.ts` for the arithmetic and for the price — this serializes
+# Cloudflare deploys too.
 [[queues.consumers]]
 queue = "stratum-deploys"
 max_batch_size = 1
-max_concurrency = 2
+max_concurrency = 1
 max_retries = 2
 retry_delay = 60
 visibility_timeout_ms = 900000  # 15 min; see src/deploy/limits.ts
@@ -283,11 +290,12 @@ max_retries = 3
 retry_delay = 30
 
 # See the top-level stratum-deploys consumer for why each knob is set:
-# visibility_timeout_ms is tied to the bounds in `src/deploy/limits.ts`.
+# visibility_timeout_ms is tied to the bounds in `src/deploy/limits.ts`, and
+# max_concurrency = 1 is the isolate-memory bound (MAX_DEPLOY_CONCURRENCY).
 [[env.production.queues.consumers]]
 queue = "stratum-deploys"
 max_batch_size = 1
-max_concurrency = 2
+max_concurrency = 1
 max_retries = 2
 retry_delay = 60
 visibility_timeout_ms = 900000  # 15 min; see src/deploy/limits.ts
@@ -432,11 +440,12 @@ retry_delay = 30
 # "stratum-deploys" would hand staging's deploy messages to the production
 # consumer, whose D1 has no matching deployments row. Its DLQ is suffixed too.
 # See the top-level consumer for the knobs; visibility_timeout_ms is tied to
-# the bounds in `src/deploy/limits.ts`.
+# the bounds in `src/deploy/limits.ts`, and max_concurrency = 1 is the
+# isolate-memory bound (MAX_DEPLOY_CONCURRENCY).
 [[env.staging.queues.consumers]]
 queue = "stratum-deploys-staging"
 max_batch_size = 1
-max_concurrency = 2
+max_concurrency = 1
 max_retries = 2
 retry_delay = 60
 visibility_timeout_ms = 900000  # 15 min; see src/deploy/limits.ts

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -98,6 +98,13 @@ queue = "stratum-events"
 binding = "IMPORT_QUEUE"
 queue = "stratum-imports"
 
+# Post-merge deployments. Create both queues before the first deploy:
+#   wrangler queues create stratum-deploys
+#   wrangler queues create stratum-deploys-dlq
+[[queues.producers]]
+binding = "DEPLOY_QUEUE"
+queue = "stratum-deploys"
+
 [[queues.consumers]]
 queue = "stratum-events"
 
@@ -106,6 +113,24 @@ queue = "stratum-imports"
 max_batch_size = 1  # Process imports one at a time for resource management
 max_retries = 3     # Retry failed imports up to 3 times
 retry_delay = 30    # Wait 30 seconds between retries
+
+# Every knob is set explicitly because the defaults are wrong for a deploy:
+# a batch of 10 would share one invocation's subrequest budget between ten
+# provider uploads, and 3 retries on a message the consumer only ever retries
+# for an *indeterminate* failure just delays the DLQ.
+#
+# visibility_timeout_ms bounds one deployment: MAX_SUBREQUESTS provider requests
+# for a tree of up to MAX_TOTAL_BYTES, both in `src/deploy/limits.ts`. Raise
+# those limits and this MUST rise with them — a run that outlives its lease is
+# redelivered while still uploading, and the second copy races the first.
+[[queues.consumers]]
+queue = "stratum-deploys"
+max_batch_size = 1
+max_concurrency = 2
+max_retries = 2
+retry_delay = 60
+visibility_timeout_ms = 900000  # 15 min; see src/deploy/limits.ts
+dead_letter_queue = "stratum-deploys-dlq"
 
 # "0 4 * * *"   — daily backup, on its OWN trigger so the ~15-min invocation
 #                 budget is never shared with (and starved by) the sync/TTL work
@@ -168,6 +193,7 @@ OAUTH_REDIRECT_URI = "http://localhost:8787/auth/github/callback"
 # GOOGLE_CLIENT_SECRET =
 # EMAIL_FROM_ADDRESS = "noreply@yourdomain.com"  # for magic link emails
 # REFERRAL_SERVICE_SECRET =  # closed-beta gate shared secret (must match the referral service)
+# DEPLOY_SECRET_KEY =  # master key for per-project deploy secrets; rotating it makes every stored secret undecryptable
 
 # =============================================================================
 # [env.production] — the maintainer's hosted instance (app.usestratum.dev).
@@ -243,6 +269,10 @@ queue = "stratum-events"
 binding = "IMPORT_QUEUE"
 queue = "stratum-imports"
 
+[[env.production.queues.producers]]
+binding = "DEPLOY_QUEUE"
+queue = "stratum-deploys"
+
 [[env.production.queues.consumers]]
 queue = "stratum-events"
 
@@ -251,6 +281,17 @@ queue = "stratum-imports"
 max_batch_size = 1
 max_retries = 3
 retry_delay = 30
+
+# See the top-level stratum-deploys consumer for why each knob is set:
+# visibility_timeout_ms is tied to the bounds in `src/deploy/limits.ts`.
+[[env.production.queues.consumers]]
+queue = "stratum-deploys"
+max_batch_size = 1
+max_concurrency = 2
+max_retries = 2
+retry_delay = 60
+visibility_timeout_ms = 900000  # 15 min; see src/deploy/limits.ts
+dead_letter_queue = "stratum-deploys-dlq"
 
 [env.production.triggers]
 crons = ["0 4 * * *", "0 6 * * *", "*/5 * * * *"]
@@ -374,6 +415,10 @@ queue = "stratum-events-staging"
 binding = "IMPORT_QUEUE"
 queue = "stratum-imports-staging"
 
+[[env.staging.queues.producers]]
+binding = "DEPLOY_QUEUE"
+queue = "stratum-deploys-staging"
+
 [[env.staging.queues.consumers]]
 queue = "stratum-events-staging"
 
@@ -382,6 +427,20 @@ queue = "stratum-imports-staging"
 max_batch_size = 1
 max_retries = 3
 retry_delay = 30
+
+# Suffixed like the queues above, and for the same reason: a shared
+# "stratum-deploys" would hand staging's deploy messages to the production
+# consumer, whose D1 has no matching deployments row. Its DLQ is suffixed too.
+# See the top-level consumer for the knobs; visibility_timeout_ms is tied to
+# the bounds in `src/deploy/limits.ts`.
+[[env.staging.queues.consumers]]
+queue = "stratum-deploys-staging"
+max_batch_size = 1
+max_concurrency = 2
+max_retries = 2
+retry_delay = 60
+visibility_timeout_ms = 900000  # 15 min; see src/deploy/limits.ts
+dead_letter_queue = "stratum-deploys-dlq-staging"
 
 [[env.staging.send_email]]
 name = "EMAIL"


### PR DESCRIPTION
## What and why

A project hosted only on Stratum had no way to get merged code onto the internet. `docs/user-guide/ci-integration.md` said so plainly: Stratum executes code in exactly three places, and none of them can publish.

This adds a `deploys:` key to `.stratum/policy.yaml`. After a merge survives the post-merge check, each entry uploads the merged tree to **Cloudflare static assets**, a **Cloudflare Worker script**, or **Vercel**, using credentials from a new encrypted per-project secret store.

## The design decision that shaped everything

The obvious implementation — run `wrangler deploy` in a sandbox with the token in env — is [ruled out by Cloudflare's own guidance](https://developers.cloudflare.com/sandbox/1-0-preview/environment/): *"Do not put live API keys or other long-lived credentials into the sandbox."*

So the untrusted step and the credentialed step are separated instead. Building is untrusted and needs no credential; deploying needs a credential and no untrusted code. The Worker calls the provider HTTP API directly and the secret never leaves it.

Three things fall out of that:

- No CLI is invoked, so there is no `npx` → `node_modules/.bin` hijack path where a repo-supplied `wrangler` runs with the token in env.
- `target: command` was dropped. It was the only in-repo way to echo a secret back out, and the only reason a credential would ever need to reach a sandbox.
- **v1 needs no `SANDBOX` binding.** `[[sandboxes]]` is commented out in every env block in `wrangler.toml`, so a sandbox-based design would have shipped inert. The cost is that v1 has no build step and deploys the tree as committed; `vercel` builds the uploaded source remotely.

## Correctness properties worth reviewing

- **Deploys trigger after `runPostMergeCheck` resolves, not from `change.merged`.** The event is emitted at `changes.ts` *before* the check, and a failed check auto-reverts the merge — so triggering on the event would publish code Stratum had just decided to revert. The integration test runs the real post-merge check against a failing sandbox and asserts **zero** deployment rows.
- **Rows are stamped with merge time, not queue-processing time.** Queues promise no ordering and a retry reorders outright, so processing time would let an older commit land over a newer one. A second guard refuses any deploy whose merge predates an already-succeeded one for the same target.
- **Deploys run on their own `stratum-deploys` queue** with a DLQ and every knob set explicitly, so a slow deploy cannot stall webhook delivery for other tenants sharing the events queue.
- **Retry is refused on non-terminal rows** — otherwise retrying a `pending_approval` row creates a `queued` row and routes around the approval gate.
- **Secrets** are AES-GCM with `(project_id, name)` bound as AAD, the key derived once per deployment, redacted from provider output *before* truncation, and never returned by any route. Both new tables are in the project-deletion cascade.

## Known limitations (all documented in `docs/user-guide/deployments.md`)

- No build step; no preview deploys; no rollback (retry an earlier successful commit); no Netlify.
- The approval gate refuses **agent identities** but accepts a user's scoped API token and MCP OAuth grants — it means "not an agent", not "a human at a keyboard". Stated as such in code and docs rather than overclaimed.
- A `vercel` deploy recorded as `succeeded` means *accepted for build*; Stratum does not poll. (Same shape as GitHub's Deployments API, except GitHub keeps updating status until terminal.)
- **A deploy-only user must still write an `evaluators:` block**, since a policy file without one is treated as malformed and blocks all merges. Prominent in the docs; fixing it means changing the merge gate, which is out of scope here.
- `merge-batch` runs neither the post-merge check nor a deploy — a pre-existing asymmetry, now documented. Fails closed.
- Rotating `DEPLOY_SECRET_KEY` makes every stored secret undecryptable, with no re-encryption path.

`target: cloudflare-pages` is implemented against **Workers Static Assets**, not Pages Direct Upload: the Pages asset endpoints are not in Cloudflare's public API reference, and Cloudflare steers new projects to Workers. Recorded in a comment at the top of the target.

## Verification

- `npm run typecheck` clean · `npm run lint` clean · `npm run release:check` clean
- `npm test`: 3435 passed, 43 failed — all 43 pre-existing in `tests/issues*.test.ts`, confirmed identical at clean `main` in a throwaway worktree
- `npm run check:guides`: all 12 docs mirrors in sync
- Coverage thresholds in `vitest.config.ts` untouched
- ~330 new tests across 10 files, including an integration suite that drives the real queue consumer with a stubbed provider `fetch` and a real D1

## Operator notes

Requires a new `DEPLOY_SECRET_KEY` Wrangler secret, and the `stratum-deploys` / `stratum-deploys-dlq` queues (the staging creation loop in `ci.yml` is updated). The DLQ has no consumer — dead-lettered deploys sit there for manual inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7WYa6vdedajKQaqmUDhmA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added post-merge deployments to Cloudflare Pages, Cloudflare Workers, and Vercel.
  - Added deployment history, status details, approval, retry, provider links, and redacted logs.
  - Added encrypted, project-scoped deployment secret management.
  - Added deployment webhooks for requested, succeeded, and failed events.
  - Added asynchronous queue processing with retries and dead-letter handling.
  - Added validation and clear rejection details for invalid deployment configurations.

- **Documentation**
  - Added deployment guides, API references, configuration details, limitations, and operational requirements.
  - Updated CI integration and FAQ documentation to describe deployment capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->