### PR TITLE
Create the production queues before deploying to production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,14 +120,19 @@ jobs:
           npx wrangler d1 migrations apply stratum-staging --remote --env=staging
           echo "✓ Migrations applied successfully"
 
-      # Staging binds its own -staging queues (see wrangler.toml); a deploy
-      # fails if a bound queue doesn't exist, so create them idempotently.
+      # A deploy fails outright on a bound queue that does not exist. The names
+      # come from wrangler.toml rather than a copy kept here, so binding a new
+      # queue cannot leave a deploy path un-provisioned.
       - name: Ensure Staging Queues Exist
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          for queue in stratum-events-staging stratum-imports-staging stratum-deploys-staging stratum-deploys-dlq-staging; do
+          node scripts/wrangler-queues.mjs staging > /tmp/queues-staging.txt
+          # Redirect, not a pipe: a `while ... | read` loop runs in a subshell,
+          # where `exit 1` would end the subshell and let the step pass.
+          while read -r queue; do
+            [ -z "$queue" ] && continue
             if out=$(npx wrangler queues create "$queue" 2>&1); then
               echo "✓ Created queue $queue"
             elif echo "$out" | grep -qiE "already (exists|taken)|11009"; then
@@ -136,7 +141,7 @@ jobs:
               echo "$out"
               exit 1
             fi
-          done
+          done < /tmp/queues-staging.txt
 
       - name: Deploy to Cloudflare Staging
         id: deploy
@@ -207,16 +212,18 @@ jobs:
 
       # Production had no such step until deploys added two new queues: its
       # original queues predated CI, so nothing ever created one here and the
-      # gap stayed invisible. `wrangler deploy` fails outright on a bound queue
-      # that does not exist, which is how it surfaced — staging deployed and
-      # production did not. Lists every production queue, not just the new
-      # ones, so the next addition cannot reopen the same hole.
+      # gap stayed invisible until a bound queue was missing and the deploy
+      # failed. Names come from wrangler.toml so the two cannot drift.
       - name: Ensure Production Queues Exist
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          for queue in stratum-events stratum-imports stratum-deploys stratum-deploys-dlq; do
+          node scripts/wrangler-queues.mjs production > /tmp/queues-production.txt
+          # Redirect, not a pipe: a `while ... | read` loop runs in a subshell,
+          # where `exit 1` would end the subshell and let the step pass.
+          while read -r queue; do
+            [ -z "$queue" ] && continue
             if out=$(npx wrangler queues create "$queue" 2>&1); then
               echo "✓ Created queue $queue"
             elif echo "$out" | grep -qiE "already (exists|taken)|11009"; then
@@ -225,7 +232,7 @@ jobs:
               echo "$out"
               exit 1
             fi
-          done
+          done < /tmp/queues-production.txt
 
       - name: Deploy to Cloudflare Production
         id: deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,28 @@ jobs:
           npx wrangler d1 migrations apply stratum --remote --env=production
           echo "✓ Migrations applied successfully"
 
+      # Production had no such step until deploys added two new queues: its
+      # original queues predated CI, so nothing ever created one here and the
+      # gap stayed invisible. `wrangler deploy` fails outright on a bound queue
+      # that does not exist, which is how it surfaced — staging deployed and
+      # production did not. Lists every production queue, not just the new
+      # ones, so the next addition cannot reopen the same hole.
+      - name: Ensure Production Queues Exist
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          for queue in stratum-events stratum-imports stratum-deploys stratum-deploys-dlq; do
+            if out=$(npx wrangler queues create "$queue" 2>&1); then
+              echo "✓ Created queue $queue"
+            elif echo "$out" | grep -qiE "already (exists|taken)|11009"; then
+              echo "✓ Queue $queue already exists"
+            else
+              echo "$out"
+              exit 1
+            fi
+          done
+
       - name: Deploy to Cloudflare Production
         id: deploy
         env:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -42,7 +42,11 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          for queue in stratum-events stratum-imports stratum-deploys stratum-deploys-dlq; do
+          node scripts/wrangler-queues.mjs production > /tmp/queues-production.txt
+          # Redirect, not a pipe: a `while ... | read` loop runs in a subshell,
+          # where `exit 1` would end the subshell and let the step pass.
+          while read -r queue; do
+            [ -z "$queue" ] && continue
             if out=$(npx wrangler queues create "$queue" 2>&1); then
               echo "✓ Created queue $queue"
             elif echo "$out" | grep -qiE "already (exists|taken)|11009"; then
@@ -51,7 +55,7 @@ jobs:
               echo "$out"
               exit 1
             fi
-          done
+          done < /tmp/queues-production.txt
 
       - name: Deploy to Cloudflare
         env:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -33,6 +33,26 @@ jobs:
           npx wrangler d1 migrations apply stratum --remote --env=production
           echo "✓ Migrations applied successfully"
 
+      # Mirrors ci.yml. This is the manual redeploy path, so it hits the same
+      # wall: `wrangler deploy` fails outright on a bound queue that does not
+      # exist, and a redeploy is exactly what someone reaches for when
+      # production is already unhappy.
+      - name: Ensure Production Queues Exist
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          for queue in stratum-events stratum-imports stratum-deploys stratum-deploys-dlq; do
+            if out=$(npx wrangler queues create "$queue" 2>&1); then
+              echo "✓ Created queue $queue"
+            elif echo "$out" | grep -qiE "already (exists|taken)|11009"; then
+              echo "✓ Queue $queue already exists"
+            else
+              echo "$out"
+              exit 1
+            fi
+          done
+
       - name: Deploy to Cloudflare
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/scripts/wrangler-queues.mjs
+++ b/scripts/wrangler-queues.mjs
@@ -1,0 +1,71 @@
+/**
+ * Print the queue names `wrangler.toml` binds for one environment, one per line.
+ *
+ * Usage: node scripts/wrangler-queues.mjs [env]   (env omitted = top-level config)
+ *
+ * Exists because a deploy fails outright on a bound queue that does not exist,
+ * and the CI jobs that provision queues used to carry their own hardcoded
+ * copies of the list. Production had no such job at all until deploys added
+ * `stratum-deploys`, so the first deploy after that merge failed — the queue was
+ * bound and never created. A second copy of the list only moves that failure
+ * rather than removing it: bind a queue in `wrangler.toml`, forget the
+ * workflow, and the next deploy breaks the same way. The TOML is therefore the
+ * single source, and CI reads it.
+ *
+ * Hand-rolled rather than parsed with a library: no TOML parser is on the
+ * dependency list, and pulling one in to read a file this repo controls is a
+ * worse trade than ~30 lines. It understands only what it needs — section
+ * headers and `key = "value"` — which is all the queue blocks use.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const SECTION = /^\s*\[{1,2}\s*([^\]]+?)\s*\]{1,2}\s*$/;
+/** Both keys name a queue that must exist before a deploy: a consumer's
+ *  `dead_letter_queue` is provisioned exactly like its `queue`. */
+const QUEUE_KEY = /^\s*(queue|dead_letter_queue)\s*=\s*"([^"]+)"/;
+
+/**
+ * @param {string} toml Raw `wrangler.toml` contents.
+ * @param {string} env Environment name; empty string means the top-level config.
+ * @returns {string[]} Sorted, de-duplicated queue names.
+ */
+export function queueNamesFor(toml, env) {
+  const prefix = env ? `env.${env}.queues.` : "queues.";
+  const names = new Set();
+  let inQueueSection = false;
+
+  for (const line of toml.split("\n")) {
+    const section = line.match(SECTION);
+    if (section) {
+      // A named env's blocks are `env.<name>.queues.*`, which also start with
+      // the top-level `queues.` prefix only after the env part is stripped —
+      // so match the whole prefix, never a substring, or the top-level lookup
+      // would sweep up every environment's queues.
+      inQueueSection = section[1].startsWith(prefix);
+      continue;
+    }
+    if (!inQueueSection) continue;
+    const key = line.match(QUEUE_KEY);
+    if (key) names.add(key[2]);
+  }
+
+  return [...names].sort();
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  const env = process.argv[2] ?? "";
+  const here = dirname(fileURLToPath(import.meta.url));
+  const toml = readFileSync(join(here, "..", "wrangler.toml"), "utf8");
+  const names = queueNamesFor(toml, env);
+
+  if (names.length === 0) {
+    // Silence here would mean "provision nothing", and the deploy that follows
+    // would fail on the first bound queue. A typo'd env name must be loud.
+    console.error(`No queues found for env "${env || "(top-level)"}" in wrangler.toml`);
+    process.exit(1);
+  }
+  console.log(names.join("\n"));
+}

--- a/tests/wrangler-queues.test.ts
+++ b/tests/wrangler-queues.test.ts
@@ -1,0 +1,81 @@
+/// <reference types="vite/client" />
+
+/**
+ * Guard: every queue `wrangler.toml` binds is one CI will provision.
+ *
+ * `wrangler deploy` fails outright on a bound queue that does not exist, and it
+ * fails at deploy time — after migrations have already been applied. That is
+ * how post-merge deployments broke production: `stratum-deploys` was bound in
+ * `wrangler.toml`, the staging job's hardcoded list was updated, and the
+ * production job had no such list at all because its queues predated CI.
+ *
+ * The fix made `scripts/wrangler-queues.mjs` the single source, reading the
+ * TOML the deploy itself reads. This asserts the reader actually sees what is
+ * bound — a silent miss would restore the original failure, and nothing else
+ * notices until a deploy dies.
+ */
+
+import { describe, expect, it } from "vitest";
+// @ts-expect-error - plain .mjs helper shared with CI; no types, and adding a
+// .d.ts for one exported function would be more indirection than it saves.
+import { queueNamesFor } from "../scripts/wrangler-queues.mjs";
+// Raw import rather than node:fs, so the guard type-checks under the Workers
+// tsconfig — the same trick tests/wrangler-migration-chain.test.ts uses.
+import wranglerToml from "../wrangler.toml?raw";
+
+const namesFor = (env: string): string[] => queueNamesFor(wranglerToml, env) as string[];
+
+/**
+ * Every queue name mentioned anywhere in the file, found without the section
+ * tracking the extractor uses. If the extractor's per-env results don't add up
+ * to this, it is skipping a block shape.
+ */
+function everyQueueNameInFile(): Set<string> {
+  const names = new Set<string>();
+  for (const line of wranglerToml.split("\n")) {
+    const match = line.match(/^\s*(?:queue|dead_letter_queue)\s*=\s*"([^"]+)"/);
+    if (match?.[1]) names.add(match[1]);
+  }
+  return names;
+}
+
+describe("wrangler.toml queue provisioning", () => {
+  it("finds the production queues, including the deploy DLQ", () => {
+    const production = namesFor("production");
+
+    // The DLQ is named only by a consumer's `dead_letter_queue`, never by its
+    // own block, so an extractor that reads `queue = ` alone would miss it and
+    // the deploy would fail on exactly that one.
+    expect(production).toContain("stratum-deploys");
+    expect(production).toContain("stratum-deploys-dlq");
+    expect(production).toContain("stratum-events");
+    expect(production).toContain("stratum-imports");
+  });
+
+  it("keeps environments separate", () => {
+    const production = namesFor("production");
+    const staging = namesFor("staging");
+
+    // Queue names are account-level: staging and production sharing one
+    // delivered staging's messages to the production consumer (see the comment
+    // in wrangler.toml). Provisioning must not blur them either.
+    expect(staging.every((name) => name.endsWith("-staging"))).toBe(true);
+    expect(production.some((name) => name.endsWith("-staging"))).toBe(false);
+    expect(production).not.toEqual(staging);
+  });
+
+  it("attributes every queue in the file to some environment", () => {
+    const seen = new Set([...namesFor(""), ...namesFor("production"), ...namesFor("staging")]);
+
+    // The real assertion: nothing bound anywhere is invisible to the reader.
+    // A new `[[env.<name>.queues.*]]` block that CI never provisions would
+    // otherwise ship silently and break that environment's next deploy.
+    expect([...everyQueueNameInFile()].sort()).toEqual([...seen].sort());
+  });
+
+  it("returns nothing for an unknown environment rather than guessing", () => {
+    // The CLI turns this into a hard failure. Silence would mean "provision
+    // nothing", and the deploy right after would fail on the first bound queue.
+    expect(namesFor("nonexistent")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The failure

The first push to main after #359 deployed staging and then failed production:

```
✘ [ERROR] Queue "stratum-deploys" does not exist.
```

[Run 33927843126](https://github.com/stratum-eng/stratum/actions/runs/33927843126). **Production is currently un-deployable** until this lands (or the queues are created by hand).

## Why staging survived and production didn't

#359 added two production queues, `stratum-deploys` and `stratum-deploys-dlq`, and `wrangler deploy` fails outright on a bound queue that does not exist.

Staging already had an `Ensure Staging Queues Exist` step, so it created them and deployed fine. Production never had one — its original queues predated CI, so nothing ever created a queue on that path and the gap stayed invisible until a new queue was bound. #359 added the staging entries to an existing step and, reasonably but wrongly, assumed production had the same safety net.

## The fix

Adds the equivalent step to **both** production deploy paths:

- `ci.yml` — the automatic deploy on push to main
- `deploy-production.yml` — the manual redeploy, which hits the same wall and is exactly what someone reaches for when production is already unhappy

Both loops list **every** production queue rather than only the two new ones, so binding the next queue cannot reopen the same hole. Creation is idempotent — an "already exists" response counts as success — and any other failure still stops the deploy rather than proceeding to a broken release.

## Note on ordering

The step runs after D1 migrations and before `wrangler deploy`, mirroring staging. Verified both workflows parse and the step lands in the right position in all three jobs.

PR previews are unaffected: `pr-preview.yml` generates its own `wrangler.preview.toml`, which binds no queues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7WYa6vdedajKQaqmUDhmA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Production deployments now automatically provision the required message queues before deployment.
  - Existing queues are handled safely without interrupting the deployment process.
  - Unexpected queue-provisioning errors now stop the workflow, helping prevent incomplete or misconfigured production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->