### PR TITLE
Record what post-merge deployments left out

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,8 +26,12 @@ been complete since 2026-06-11.
 | 4 (code) | Audit trail, backup/restore, deletion jobs, gated `git push` (ADR 005), security hardening |
 
 What remains is Phase 4's **operational** half — the work required to run Stratum as a
-hosted, multi-tenant service — plus engineering debt and one feature gap. None of it blocks
-single-tenant self-hosted usage.
+hosted, multi-tenant service — plus engineering debt and the feature gaps below. None of it
+blocks single-tenant self-hosted usage.
+
+Post-merge deployments shipped on 2026-09-04 (`deploys:` in `.stratum/policy.yaml`,
+targeting Cloudflare and Vercel). What that first version deliberately left out is tracked
+under [Deployments](#deployments).
 
 ## Operational / scale (Stratum Cloud)
 
@@ -65,6 +69,44 @@ single-tenant self-hosted usage.
       server no longer needs publishing at all — it is served by the Worker at `/mcp`.)
 
 ## Feature gaps
+
+### Deployments
+
+Post-merge deploys ship; what follows is what the first version left out. Ordered by how
+much each unblocks — the build step gates everything below it, because until a deploy can
+build, the set of projects this serves stays small. Rationale for each in
+[`docs/REMAINING_WORK.md`](docs/REMAINING_WORK.md#deployments).
+
+- [ ] **A build step.** v1 deploys the tree *as committed*, so it serves static sites,
+      single-file Workers, and `vercel` (which builds the uploaded source remotely) — not
+      the median project that runs `npm run build` first. The design is already drawn: build
+      in a sandbox with **no credentials** and egress denied, then let the Worker upload the
+      artifact, so the untrusted step and the credentialed step stay apart. Two
+      prerequisites: enable the `[[sandboxes]]` binding (still commented out in
+      `wrangler.toml`, so nothing that executes code runs on any deploy today), and replace
+      `materializeTree`'s file-by-file base64 write with a `git clone` inside the sandbox.
+- [ ] **Deployment status that reflects the provider.** A `vercel` row reads `succeeded`
+      when Vercel has only *accepted* the upload; a deploy that later fails to build still
+      reads green. Needs a non-terminal state completed by polling or a provider webhook.
+- [ ] **Rollback.** Retrying an earlier successful commit is the only recovery today, and it
+      rebuilds rather than reverting. Both Cloudflare and Vercel can promote a previous
+      deployment by id, so storing that id turns rollback into one API call.
+- [ ] **Environments and promotion.** `deploys:` is a flat list of names. The model people
+      expect is staging → production, where production is a *promotion* of an artifact that
+      already passed staging, gated by an approval an agent cannot supply. Every piece
+      exists — the approval gate, the deployment record, the audit trail, the
+      agents-cannot-approve invariant — except the environment as a first-class object and a
+      "what is live where" view.
+- [ ] **Preview deploys for unmerged changes.** The most-requested and the most dangerous:
+      it publishes agent-authored code that no human has approved. Needs the build step
+      first and a **separate preview-scoped credential**, never the production token behind
+      a flag.
+- [ ] **Netlify target.** The provider interface takes it; nobody has written it.
+- [ ] **Operational gaps.** A batch merge (`changes/merge-batch`) triggers neither the
+      post-merge check nor a deploy. Outbox recovery fires when a failed enqueue is
+      *observed*, so an isolate that dies between the status write and the send still strands
+      a `queued` row that nothing reclaims — a stale-queued sweep would close it. Rotating
+      `DEPLOY_SECRET_KEY` makes every stored secret undecryptable with no re-encryption path.
 
 ### Git LFS support
 

--- a/docs/REMAINING_WORK.md
+++ b/docs/REMAINING_WORK.md
@@ -1,6 +1,7 @@
 # Remaining Work
 
-Last updated: 2026-08-25 — adds the Git LFS feature gap recorded below.
+Last updated: 2026-09-04 — records what post-merge deployments left out, now
+that they ship.
 
 The master-plan feature roadmap (Phases 0–3 plus the code-level Phase 4
 hardening items) is complete as of 2026-06-11. See
@@ -81,6 +82,117 @@ Both packages live in the repo at full API parity but are not yet published,
 so consumers must install from source.
 
 ## Feature gaps
+
+### Deployments
+
+Post-merge deploys shipped on 2026-09-04: `deploys:` in `.stratum/policy.yaml`
+publishes the merged tree to Cloudflare static assets, a Cloudflare Worker
+script, or Vercel, using per-project encrypted secrets. See
+[user-guide/deployments.md](./user-guide/deployments.md) for what exists.
+
+The shape of that first version is worth stating, because it explains every gap
+below. Cloudflare's guidance for Sandboxes is explicit that live API keys must
+not be passed into one, so the design separates the untrusted step from the
+credentialed step: **the Worker calls the provider's HTTP API directly and the
+credential never leaves it.** That is why there is no CLI in the deploy path
+(and so no `npx` resolving a repo-supplied `node_modules/.bin/wrangler` with the
+token in its environment), why the `command` escape hatch was cut, and why v1
+needs no `SANDBOX` binding at all.
+
+#### A build step
+
+The single biggest limit. v1 deploys the tree *as committed*, which serves
+static sites, single-file Workers, and `vercel` (whose API builds the uploaded
+source remotely) — but not the median project, which runs `npm run build`.
+
+The deploy half does not change: build in a sandbox with **no credentials** and
+egress denied, then have the Worker upload the artifact. Two prerequisites:
+
+- **Enable `[[sandboxes]]`.** It is still commented out in `wrangler.toml`, so
+  nothing that executes code runs on any deployed instance — not the `sandbox`
+  evaluator, not `merge.postMergeCommand`, and not a build.
+- **`git clone` inside the sandbox** instead of `materializeTree`, which reads
+  the tree into the Worker and writes it back file-by-file, base64-encoding
+  binaries. Tolerable for uploading a committed `dist/`; not viable once
+  `node_modules` is involved. Authenticated smart HTTP already exists
+  (`src/routes/git-http.ts`), so a short-lived read token is enough.
+
+If a build ever needs a private registry credential, that is the case for
+Sandbox **outbound Workers**: the handler runs in the Workers runtime, holds the
+secret, and attaches it to requests on the way out, so the container never sees
+it.
+
+#### Deployment status that reflects the provider
+
+A `vercel` deployment is recorded `succeeded` when Vercel has *accepted* the
+upload — its `readyState` is carried into the row's reason, but Stratum does not
+poll, so a deploy that later fails to build still reads green. The same shape
+will apply to any provider that builds asynchronously.
+
+The fix is a non-terminal state completed by polling or a provider webhook,
+which is the same machinery an async check-reporting API would need.
+
+#### Rollback
+
+Not modelled. Retrying an earlier successful commit is the only recovery, and it
+re-runs the deploy rather than reverting to a known-good artifact. Both
+Cloudflare and Vercel can promote a previous deployment by id, so recording that
+id turns rollback into a single API call.
+
+#### Environments and promotion
+
+`deploys:` is a flat list of names with no relationship between them. The model
+users expect is staging → production, where production is a **promotion** of an
+artifact that already passed staging rather than a fresh deploy of the same
+commit.
+
+This is the item most worth doing for reasons beyond parity. The approval gate,
+the deployment record, the audit trail, and the invariant that agent credentials
+cannot approve all already exist; what is missing is the environment as a
+first-class object and a "what is live where" view. Together they finish the
+sentence the product has been writing since branch protection: an agent can
+write code, open a change, and land it — and cannot ship it to customers.
+
+Build provenance follows cheaply from the same records: which agent, model and
+prompt produced the commit is already stored, so attesting that an artifact was
+built from that commit and deployed by a named human is an extension rather than
+new infrastructure.
+
+#### Preview deploys for unmerged changes
+
+The most-requested and the most dangerous, because it publishes agent-authored
+code that no human has approved — the case v1 deliberately excluded by running
+only after merge. It needs the build step first, and a **separate
+preview-scoped credential**; reusing the production token behind a flag would
+undo the reason the credential never enters a sandbox.
+
+#### Netlify
+
+The `DeployTarget` interface accommodates it and nothing else blocks it.
+
+#### Operational gaps
+
+- **`changes/merge-batch` triggers neither the post-merge check nor a deploy.**
+  Batch-merged changes silently never deploy. Pre-existing asymmetry in that
+  endpoint, surfaced by the deploy work rather than caused by it.
+- **The outbox recovery window.** A failed `DEPLOY_QUEUE.send` is recorded to the
+  event outbox and re-enqueued by the five-minute sweep — but only when the
+  failure is *observed*. An isolate that dies between the status write and the
+  send leaves a `queued` row nothing reclaims. A stale-queued sweep over
+  `deployments` would close it.
+- **`DEPLOY_SECRET_KEY` rotation.** Rotating it makes every stored secret
+  undecryptable, with no re-encryption path; the runbook says so, but the fix is
+  a re-encrypt job.
+- **Approval strength.** The gate refuses agent identities, but a user's scoped
+  API token and MCP OAuth grants both set `userId` and are accepted, so it means
+  "not an agent" rather than "a human at a keyboard". `cannotMintLegacyCredential`
+  in `src/middleware/auth.ts` shows the stronger session-vs-token distinction the
+  routes would need.
+- **A deploy-only policy still needs an `evaluators:` block.** A policy file
+  without one is treated as malformed, which blocks *all* merges with an error
+  about evaluators — a poor first-hour experience for someone who only wanted a
+  deploy. Relaxing it changes when the merge gate fails closed, so it needs its
+  own decision rather than being folded in.
 
 ### Git LFS support
 


### PR DESCRIPTION
## Why

#359 updated eleven docs but not the two that track *unshipped* work. `ROADMAP.md` and `docs/REMAINING_WORK.md` never mentioned deploys at all — before or after they shipped — so the roadmap described a product that no longer matched.

Docs-only. No code, no mirrors.

## What

`ROADMAP.md` gains a **Deployments** entry under Feature gaps, ordered by what each item unblocks. The build step leads because it gates everything below it: until a deploy can build, the set of projects this serves stays small. `REMAINING_WORK.md` carries the rationale, as it does for every other roadmap item.

The entries are limitations the feature shipped with **deliberately**, not defects:

- **A build step** — v1 deploys the tree as committed, so it serves static sites, single-file Workers, and `vercel` (which builds remotely), not the median project. Prerequisites: enable `[[sandboxes]]` (still commented out, so nothing that executes code runs on any deploy today) and replace `materializeTree` with `git clone` in the sandbox.
- **Status that reflects the provider** — a `vercel` row reads `succeeded` when Vercel has only *accepted* the upload.
- **Rollback**, **environments and promotion**, **preview deploys**, **Netlify**.

Plus the operational gaps the work surfaced: `merge-batch` triggering neither the post-merge check nor a deploy; the outbox recovery window when an isolate dies between the status write and the send; `DEPLOY_SECRET_KEY` rotation having no re-encryption path; an approval gate that means "not an agent" rather than "a human at a keyboard"; and a deploy-only policy still needing an `evaluators:` block or all merges block.

## One thing worth reading

The rationale leads with *why the feature is shaped the way it is*, because it explains every gap. Cloudflare's guidance is explicit that live API keys must not enter a sandbox, so the untrusted step and the credentialed step are kept apart and the Worker calls the provider API itself. That is why no CLI runs in the deploy path, why the `command` escape hatch was cut, and why v1 needs no `SANDBOX` binding — which is also why enabling that binding is a *prerequisite* for the build step rather than an implementation detail.

## Also

Corrects "plus engineering debt and one feature gap" in the roadmap intro, which was already inaccurate when three gaps were listed below it.

## Verification

Both cross-links resolve to real headings. `npm run check:guides` — 12 mirrors in sync (neither file is mirrored; only `docs/user-guide` and the API reference are). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7WYa6vdedajKQaqmUDhmA