### PR TITLE
Make PostHog analytics answer product questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or free-text message. `docs/user-guide/faq.md` lists every event and every
   property exhaustively, and a test fails the build if that list and the code
   disagree.
+- **An agent no longer counts as a person in analytics.** Every agent token had
+  its own `distinctId`, so PostHog minted a person profile per credential —
+  splitting one human's history across several profiles, inflating the billed
+  person count, and making every user count, funnel, and retention curve wrong
+  by however many agents happened to be running. An agent acts under its
+  owner's account (the owner's opt-out already governs it), so its events are
+  now attributed to that owner, with the agent's own id carried as `agent_id`
+  so the breakdown is not lost.
+- **Domain events are dated from when the activity happened.** They were dated
+  from when the queue consumer exported them, which a retry or the five-minute
+  stale sweep can delay well past the fact — skewing every time series toward
+  whenever the queue drained. The outbox row's own timestamp is now sent.
+- **Every event carries `$lib_version`**, so a change in a metric can be tied to
+  the release that caused it instead of guessed against deploy times.
+- **A person profile now has something on it.** `signup_provider` is recorded
+  once per account, as `$set_once`, so a cohort like "accounts that signed up
+  with GitHub in August" is expressible — previously a person was an opaque id
+  with no properties at all. Email, username, and display name are still never
+  sent.
 - **Analytics property names are now consistently snake_case.** The `stratum.*`
   events sent `projectId` and `actorType`; they now send `project_id` and
   `actor_type`, matching `latency_ms` and every new property. Dashboards built

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Product analytics now answers questions instead of just counting requests.**
+  Telemetry sent two events with almost no properties: a request event carrying
+  a route pattern, and a repository-activity event carrying only its type, the
+  actor type, and a project id. It could count merges; it could not say what
+  fraction of changes pass evaluation, what reviewers decide, which deploy
+  targets fail, which MCP tools agents actually call, or how anyone signed up.
+  Four new events (`mcp_request`, `auth_completed`, `error_occurred`,
+  `background_job_completed`) and per-type properties on the `stratum.*` events
+  close that. `api_request` gains `surface` and `actor_type`, and every event
+  now carries an `environment` label so staging traffic stops polluting
+  production's numbers — set `STRATUM_ENVIRONMENT` in each `[env.<name>.vars]`
+  block (named environments do not inherit top-level `[vars]`). The privacy
+  rule is unchanged and now enforced in one place: every property is either a
+  source-code literal or a bounded value, never a name, path, URL, title, ref,
+  or free-text message. `docs/user-guide/faq.md` lists every event and every
+  property exhaustively, and a test fails the build if that list and the code
+  disagree.
+- **Analytics property names are now consistently snake_case.** The `stratum.*`
+  events sent `projectId` and `actorType`; they now send `project_id` and
+  `actor_type`, matching `latency_ms` and every new property. Dashboards built
+  on the old names need updating — an insight can bridge the gap with
+  `coalesce(properties.project_id, properties.projectId)`.
+- **The per-account telemetry opt-out is now structurally impossible to skip.**
+  It lived at each `capture()` call site rather than in the client, which is how
+  the queue exporter originally shipped without honouring it at all. A new
+  `AnalyticsTracker` cannot be constructed without a resolved preference, so a
+  call site cannot forget one it never has to know about. Behaviour for existing
+  call sites is unchanged, including failing closed when the preference cannot
+  be read.
 - **`stratum login --host <url>` without `--key` now opens a browser** instead of
   prompting for a key. Scripts that piped a key into the prompt must pass
   `--key` (or set `STRATUM_HOST` and `STRATUM_API_KEY`). Without a TTY the

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -502,10 +502,12 @@ Set in `wrangler.toml`:
 POSTHOG_HOST = "https://app.posthog.com"
 OAUTH_REDIRECT_URI = "https://your-instance.workers.dev/auth/github/callback"
 STRATUM_TELEMETRY_DISABLED = "false"
+STRATUM_ENVIRONMENT = "production"
 
 [env.staging.vars]
 OAUTH_REDIRECT_URI = "https://your-instance-staging.workers.dev/auth/github/callback"
 STRATUM_TELEMETRY_DISABLED = "true"
+STRATUM_ENVIRONMENT = "staging"
 ```
 
 > **Named environments do not inherit top-level `[vars]` — they replace them.**
@@ -513,6 +515,11 @@ STRATUM_TELEMETRY_DISABLED = "true"
 > `wrangler deploy --env=production` or `--env=staging` (what `npm run
 > deploy:production` and `deploy:staging` run). Declare it in **each**
 > `[env.<name>.vars]` block you actually deploy, or the switch stays off.
+>
+> The same applies to `STRATUM_ENVIRONMENT`, which labels every analytics event
+> so staging traffic can be told apart from production's in one PostHog
+> project. An instance that leaves it unset reports `environment: "unknown"` —
+> harmless, but every funnel built across both deployments is then wrong.
 
 ### Per-Environment Configuration
 

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -272,9 +272,10 @@ all.
 - **`mcp_request` carries the one free-text field.** `client_name` and
   `client_version` are whatever the connecting software calls itself in the MCP
   handshake, capped at 64 characters. They answer "which editors and agents
-  connect to Stratum". `tool` is reported only when it names a tool this build
-  defines; an unrecognised name is reported as `unknown` rather than echoed
-  back.
+  connect to Stratum". Everything else on the event is bounded: `tool` and
+  `mcp_method` are reported only when they name a tool or a JSON-RPC method
+  this build actually implements, and anything else — both are strings a client
+  can put anything in — is reported as `unknown` rather than echoed back.
 - **`error_occurred` never carries the exception message.** Messages quote
   their input. Only the error's type name (`TypeError`) is sent; the message
   stays in your own Workers logs.

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -212,23 +212,71 @@ top-level `[vars]`, so a top-level-only setting never reaches
 `wrangler deploy --env=production`. The instance switch always wins over an
 individual account's preference.
 
-Two kinds of event are sent, and only these:
+### What exactly is sent
 
-- **`api_request`**, one per request. Its properties are limited to the matched
-  route pattern (e.g. `/:namespace/:slug/files`), method, status, and latency —
-  never the concrete URL, so namespaces, repo slugs, change ids, and file paths
-  are not sent to PostHog. A request that never reached a registered route is
-  captured with `route: "*"`; a 404 is excluded entirely rather than captured as
-  `"*"`.
-- **`stratum.<event type>`**, one per repository activity (a change opening, a
-  merge). Its properties are limited to the event type, the actor type, and an
-  opaque project id — never the project's name.
+Every property on every event is either a **source-code literal** (a route
+pattern, an event type, a tool name) or a **bounded value** (a status code, a
+duration, a score, an enum). Names, paths, URLs, titles, refs, diffs, file
+contents, and request payloads are never sent. The one exception is noted
+against `mcp_request` below.
 
-Neither carries diffs, file contents, or request payloads.
+The list is exhaustive — `src/analytics/events.ts` is its single source of
+truth, and a test fails the build if this table and that file disagree.
+
+| Event | Sent when | Properties |
+|-------|-----------|------------|
+| `api_request` | Once per request that matched a route | `method`, `route`, `status`, `latency_ms`, `surface`, `actor_type` |
+| `mcp_request` | Once per JSON-RPC message handled at `/mcp` | `mcp_method`, `outcome`, `tool`, `client_name`, `client_version`, `protocol_version` |
+| `auth_completed` | Once per completed sign-up or sign-in | `kind` (`signup`/`signin`), `provider` (`github`/`google`/`email`) |
+| `error_occurred` | Once per unhandled exception | `route`, `method`, `error_type` |
+| `background_job_completed` | Once per background job reaching a terminal state | `job`, `outcome`, `attempts` |
+| `stratum.<event type>` | Once per repository activity (a change opening, a merge, a deploy) | `project_id`, `actor_type`, plus the per-type properties below |
+
+Every event additionally carries `environment` — the label the operator set in
+`STRATUM_ENVIRONMENT`, so staging traffic can be told apart from production.
+
+The per-type properties on `stratum.*` events are the whole reason they are
+worth collecting, and they are whitelisted per event type:
+
+| Event type | Extra properties |
+|------------|------------------|
+| `stratum.change.evaluated` | `score`, `passed` |
+| `stratum.change.reviewed` | `verdict` (`approve`/`request_changes`/`comment`) |
+| `stratum.project.imported` | `source_provider` (`github`/`gitlab`/`bitbucket`/`other`) |
+| `stratum.issue.closed` | `linked_change` (boolean) |
+| `stratum.deployment.*` | `target` (`cloudflare`/`vercel`), `linked_change` (boolean) |
+
+Everything else in an event's payload is dropped: workspace names, commit
+shas, issue titles, import URLs, and deployment failure text all stay on your
+instance. An event type not listed above contributes no extra properties at
+all.
+
+### The details worth knowing
+
+- **Route patterns, never URLs.** `api_request` reports
+  `/:namespace/:slug/files`, not the path that was actually requested, so
+  namespaces, repo slugs, change ids, and file paths are not sent. A request
+  that never reached a registered route is captured with `route: "*"`; a 404 is
+  excluded entirely rather than captured as `"*"`.
+- **`surface`** says which part of Stratum served the request — `api`, `ui`,
+  `git`, `mcp`, `auth`, `admin`, or `internal`. It is derived from the route
+  pattern, so it inherits the same guarantee.
+- **`mcp_request` carries the one free-text field.** `client_name` and
+  `client_version` are whatever the connecting software calls itself in the MCP
+  handshake, capped at 64 characters. They answer "which editors and agents
+  connect to Stratum". `tool` is reported only when it names a tool this build
+  defines; an unrecognised name is reported as `unknown` rather than echoed
+  back.
+- **`error_occurred` never carries the exception message.** Messages quote
+  their input. Only the error's type name (`TypeError`) is sent; the message
+  stays in your own Workers logs.
+- **Project ids, never project names.** A name identifies private source as
+  surely as a repo slug in a URL does. The opaque id groups events just as
+  well.
 
 Events also carry identity attribution: the `distinctId` is the acting user or
-agent id (or `server` for unattributed requests, which are marked personless) so
-usage can be counted per account.
+agent id (or `server` for unattributed requests, and `system` for events no
+person caused — both marked personless) so usage can be counted per account.
 
 ## Where are my invite codes?
 

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -233,7 +233,15 @@ truth, and a test fails the build if this table and that file disagree.
 | `stratum.<event type>` | Once per repository activity (a change opening, a merge, a deploy) | `project_id`, `actor_type`, plus the per-type properties below |
 
 Every event additionally carries `environment` — the label the operator set in
-`STRATUM_ENVIRONMENT`, so staging traffic can be told apart from production.
+`STRATUM_ENVIRONMENT`, so staging traffic can be told apart from production —
+and `$lib_version`, the Stratum version that sent it, so a change in a metric
+can be tied to the release that caused it. An event caused by an agent also
+carries `agent_id`.
+
+One person property is ever set: `signup_provider`, recorded once when an
+account is created. It is what lets a question like "accounts that signed up
+with GitHub in August" be asked at all. Your email address, username, and
+display name are never sent.
 
 The per-type properties on `stratum.*` events are the whole reason they are
 worth collecting, and they are whitelisted per event type:
@@ -274,9 +282,18 @@ all.
   surely as a repo slug in a URL does. The opaque id groups events just as
   well.
 
-Events also carry identity attribution: the `distinctId` is the acting user or
-agent id (or `server` for unattributed requests, and `system` for events no
-person caused — both marked personless) so usage can be counted per account.
+Events also carry identity attribution: the `distinctId` is the acting user's
+id (or `server` for unattributed requests, and `system` for events no person
+caused — both marked personless) so usage can be counted per account.
+
+**An agent is attributed to the person who owns it**, not to itself. An agent
+token is a credential you minted, acting under your account — your opt-out
+already governs it, so your identity is what "who did this" means. The agent's
+own id rides along as `agent_id`, so the two stay distinguishable without an
+agent counting as a separate person.
+
+Domain events are dated from when the activity happened, not from when the
+queue got round to exporting them.
 
 ## Where are my invite codes?
 

--- a/src/analytics/auth.ts
+++ b/src/analytics/auth.ts
@@ -1,0 +1,67 @@
+/**
+ * The acquisition funnel's one instrumentation point.
+ *
+ * Sign-up and sign-in are spread across five handlers in three files — GitHub
+ * and Google callbacks, the shared OAuth username step, and magic-link verify
+ * for both intents. Each of them ends the same way and each of them would
+ * otherwise grow its own copy of "resolve the preference, build a tracker,
+ * schedule the send", which is how five copies become four correct ones.
+ *
+ * So the whole thing is one call: `await captureAuthCompleted(...)` next to
+ * the `recordAudit` that already marks the same moment.
+ */
+import type { Context } from "hono";
+import type { Env } from "../types";
+import { getWaitUntil } from "../utils/execution-ctx";
+import type { Logger } from "../utils/logger";
+import type { AuthKind, AuthProvider } from "./events";
+import { trackerForUser } from "./tracker";
+
+export interface AuthOutcome {
+  /** Whether this created an account or resumed one. The funnel's whole point. */
+  kind: AuthKind;
+  provider: AuthProvider;
+  /** The account that now holds the session. */
+  userId: string;
+}
+
+/**
+ * Record a completed authentication.
+ *
+ * The preference has to be read from D1 rather than lifted off the request:
+ * this runs *before* any middleware has an authenticated context to publish,
+ * and on the sign-up path the account did not exist when the request started.
+ * A brand-new account has never expressed a preference, which is the opt-in
+ * default — the same default the settings page starts from.
+ *
+ * Scheduled past the response where an ExecutionContext exists and awaited
+ * inline where none does (tests), matching how this codebase handles every
+ * other best-effort write on an auth path: nobody waits longer to be signed in
+ * because analytics is enabled.
+ */
+export async function captureAuthCompleted(
+  c: Context<{ Bindings: Env }>,
+  logger: Logger,
+  outcome: AuthOutcome,
+): Promise<void> {
+  const deliver = (async () => {
+    const tracker = await trackerForUser(c.env, outcome.userId, logger);
+    await tracker.capture("auth_completed", {
+      kind: outcome.kind,
+      provider: outcome.provider,
+    });
+  })().catch((error: unknown) => {
+    // Analytics must never be able to fail a sign-in. `capture` already cannot
+    // reject; this covers the preference lookup, which touches D1.
+    logger.warn("Auth analytics capture failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+
+  const waitUntil = getWaitUntil(c);
+  if (waitUntil) {
+    waitUntil(deliver);
+    return;
+  }
+  await deliver;
+}

--- a/src/analytics/auth.ts
+++ b/src/analytics/auth.ts
@@ -46,10 +46,20 @@ export async function captureAuthCompleted(
 ): Promise<void> {
   const deliver = (async () => {
     const tracker = await trackerForUser(c.env, outcome.userId, logger);
-    await tracker.capture("auth_completed", {
-      kind: outcome.kind,
-      provider: outcome.provider,
-    });
+    await tracker.capture(
+      "auth_completed",
+      { kind: outcome.kind, provider: outcome.provider },
+      // Person properties, and only on the sign-up. `$set_once` is the point:
+      // "how did this person arrive" has one true answer, and a later sign-in
+      // through a different provider must not rewrite it.
+      //
+      // Without these a person profile is an opaque id with nothing on it, so
+      // no cohort can ask "accounts that signed up with GitHub in August" —
+      // the question every retention and activation comparison starts from.
+      // Deliberately not the email, username, or display name: the whole
+      // export is built on not sending those.
+      outcome.kind === "signup" ? { signup_provider: outcome.provider } : undefined,
+    );
   })().catch((error: unknown) => {
     // Analytics must never be able to fail a sign-in. `capture` already cannot
     // reject; this covers the preference lookup, which touches D1.

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -1,0 +1,303 @@
+/**
+ * The catalog of every event Stratum can export to PostHog, and the exact
+ * properties each one carries.
+ *
+ * This file exists because Stratum is open source and self-hosted. "What
+ * leaves my instance?" has to be answerable by reading ONE file, not by
+ * grepping for `capture(` and trusting that nobody added a sixth call site
+ * with a project name in it. `tests/analytics-catalog.test.ts` asserts that
+ * the public FAQ documents exactly the names declared here, so the answer a
+ * self-hoster reads cannot drift from the code that sends.
+ *
+ * The privacy rule every entry obeys: **a property is either a source-code
+ * literal or a bounded enum**. Never a name, path, URL, title, ref, or
+ * free-text message. Opaque ids (project UUIDs, the actor id used as
+ * `distinctId`) are the sole exception — they group events without describing
+ * anything, and the FAQ says so. When adding a property, ask what a stranger
+ * holding only the PostHog project could learn; if the answer names a private
+ * repository, it does not go in.
+ */
+import type { StratumEvent } from "../queue/events";
+import type { EventRecord } from "../storage/events";
+
+/** A property bag PostHog accepts. Deliberately scalar-only — see the file docblock. */
+export type AnalyticsProperties = Record<string, string | number | boolean>;
+
+/**
+ * Which surface served a request.
+ *
+ * Cheap to derive from the matched route pattern and the single most useful
+ * split in the whole dataset: "is Stratum being driven by humans in the UI, by
+ * scripts against the REST API, by git itself, or by a model over MCP" is the
+ * product question, and `route` alone answers it only if you already know
+ * every prefix by heart.
+ */
+export type RequestSurface = "api" | "ui" | "git" | "mcp" | "auth" | "admin" | "internal";
+
+/** How a caller was identified, for segmenting human vs agent vs public traffic. */
+export type ActorKind = "user" | "agent" | "anonymous";
+
+/** The outcome of one MCP exchange, mirroring `describeMcpOutcome`'s classification. */
+export type McpOutcomeKind = "ok" | "tool_error" | "rejected";
+
+/** Whether an authentication attempt created an account or resumed one. */
+export type AuthKind = "signup" | "signin";
+
+/** Identity providers Stratum can authenticate against. */
+export type AuthProvider = "github" | "google" | "email";
+
+/** Terminal state of a background job, for reliability dashboards. */
+export type JobOutcome = "succeeded" | "failed" | "abandoned";
+
+/**
+ * Events that describe a *surface* — something a caller did to the instance,
+ * as opposed to something that happened to a repository.
+ *
+ * Keys are the literal event names sent to PostHog.
+ */
+export interface SurfaceEventProperties {
+  /** One per served request that matched a route. See `analyticsMiddleware`. */
+  api_request: {
+    method: string;
+    /** The matched route PATTERN (`/:namespace/:slug/files`), never the concrete path. */
+    route: string;
+    status: number;
+    latency_ms: number;
+    surface: RequestSurface;
+    actor_type: ActorKind;
+  };
+  /** One per JSON-RPC message handled by the remote MCP endpoint. */
+  mcp_request: {
+    /** JSON-RPC method: `initialize`, `tools/call`, `tools/list`, … */
+    mcp_method: string;
+    outcome: McpOutcomeKind;
+    /** Tool name for `tools/call`. A source-code literal from `buildTools`. */
+    tool?: string;
+    /** Self-reported client identity from the `initialize` handshake. */
+    client_name?: string;
+    client_version?: string;
+    protocol_version?: string;
+  };
+  /** One per completed sign-up or sign-in, for the acquisition funnel. */
+  auth_completed: {
+    kind: AuthKind;
+    provider: AuthProvider;
+  };
+  /** One per unhandled exception reaching the error boundary. */
+  error_occurred: {
+    /** Matched route pattern, or `"*"` when the failure preceded routing. */
+    route: string;
+    method: string;
+    /** Constructor name only (`TypeError`), never the message — messages quote input. */
+    error_type: string;
+  };
+  /** One per background job reaching a terminal state, for reliability dashboards. */
+  background_job_completed: {
+    /** Stable job name, a source-code literal (`event-consumer`, `webhook-delivery`). */
+    job: string;
+    outcome: JobOutcome;
+    /** Attempts made before this terminal state, where the job tracks them. */
+    attempts?: number;
+  };
+}
+
+export type SurfaceEventName = keyof SurfaceEventProperties;
+
+/** Every domain event name, derived from the outbox registry so the two cannot drift. */
+export type DomainEventName = `stratum.${StratumEvent["type"]}`;
+
+/** The analytics name for an outbox event type. */
+export function domainEventName(type: string): string {
+  return `stratum.${type}`;
+}
+
+/**
+ * Every event name this instance can send.
+ *
+ * Domain names are spelled out rather than derived at runtime because a type
+ * cannot be enumerated at runtime and the docs test needs the list. The
+ * `DomainEventName` annotation is what keeps it honest: add a member to
+ * `StratumEvent` without listing it here and this file stops typechecking.
+ */
+export const DOMAIN_EVENT_NAMES: readonly DomainEventName[] = [
+  "stratum.change.created",
+  "stratum.change.evaluated",
+  "stratum.change.merged",
+  "stratum.change.rejected",
+  "stratum.change.reverted",
+  "stratum.change.commented",
+  "stratum.change.reviewed",
+  "stratum.project.created",
+  "stratum.project.imported",
+  "stratum.workspace.created",
+  "stratum.sync.completed",
+  "stratum.issue.opened",
+  "stratum.issue.commented",
+  "stratum.issue.closed",
+  "stratum.deployment.requested",
+  "stratum.deployment.succeeded",
+  "stratum.deployment.failed",
+];
+
+export const SURFACE_EVENT_NAMES: readonly SurfaceEventName[] = [
+  "api_request",
+  "mcp_request",
+  "auth_completed",
+  "error_occurred",
+  "background_job_completed",
+];
+
+/** Every event name, for the docs-drift test and for operator reference. */
+export const ALL_EVENT_NAMES: readonly string[] = [...SURFACE_EVENT_NAMES, ...DOMAIN_EVENT_NAMES];
+
+/** Git hosts Stratum imports from. Anything else is reported as `other`. */
+const KNOWN_SOURCE_HOSTS: ReadonlyMap<string, string> = new Map([
+  ["github.com", "github"],
+  ["www.github.com", "github"],
+  ["gitlab.com", "gitlab"],
+  ["www.gitlab.com", "gitlab"],
+  ["bitbucket.org", "bitbucket"],
+  ["www.bitbucket.org", "bitbucket"],
+]);
+
+/**
+ * Which hosted provider an import came from.
+ *
+ * The URL itself never ships: it names a repository, and often a private one.
+ * The provider does ship, because "are imports mostly GitHub" is a real
+ * roadmap question. A self-hosted GitLab collapses to `other` rather than
+ * reporting its hostname, which would identify the company running it.
+ */
+export function importSourceProvider(sourceUrl: unknown): string {
+  if (typeof sourceUrl !== "string" || sourceUrl === "") return "other";
+  try {
+    return KNOWN_SOURCE_HOSTS.get(new URL(sourceUrl).hostname.toLowerCase()) ?? "other";
+  } catch {
+    return "other";
+  }
+}
+
+/** Reads a boolean out of an untyped outbox payload, or nothing if it is absent/wrong-typed. */
+function boolProp(payload: Record<string, unknown>, key: string): boolean | undefined {
+  const value = payload[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+/** Reads a finite number out of an untyped outbox payload. */
+function numberProp(payload: Record<string, unknown>, key: string): number | undefined {
+  const value = payload[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Reads a payload field that is a closed set of source-code literals.
+ *
+ * The `allowed` list is the privacy control, not a validation nicety: it is
+ * what guarantees a field can only ever emit a value this repository already
+ * contains. A row written by an older deploy, or corrupted, contributes
+ * nothing rather than contributing its contents.
+ */
+function enumProp(
+  payload: Record<string, unknown>,
+  key: string,
+  allowed: readonly string[],
+): string | undefined {
+  const value = payload[key];
+  return typeof value === "string" && allowed.includes(value) ? value : undefined;
+}
+
+const REVIEW_VERDICTS = ["approve", "request_changes", "comment"] as const;
+const DEPLOY_TARGETS = ["cloudflare", "vercel"] as const;
+
+/**
+ * Project the safe, useful part of an outbox event's payload into analytics
+ * properties.
+ *
+ * This function is the whole reason domain events are worth exporting. Before
+ * it, every `stratum.*` event carried only its type and actor, so the data
+ * could count merges but could not answer the questions the events exist to
+ * answer: what fraction of changes pass evaluation, what reviewers decide,
+ * which deploy targets fail, whether issues close through linked changes.
+ *
+ * Everything not named here is dropped by construction — workspace names,
+ * commit shas, issue titles, import URLs and failure text all stay home. The
+ * default is exclusion: an event type with no case below contributes no
+ * payload properties at all.
+ */
+export function domainEventProperties(event: EventRecord): AnalyticsProperties {
+  const payload = event.payload ?? {};
+  const props: AnalyticsProperties = {};
+
+  switch (event.type) {
+    case "change.evaluated": {
+      const score = numberProp(payload, "score");
+      const passed = boolProp(payload, "passed");
+      if (score !== undefined) props.score = score;
+      if (passed !== undefined) props.passed = passed;
+      break;
+    }
+    case "change.reviewed": {
+      const verdict = enumProp(payload, "verdict", REVIEW_VERDICTS);
+      if (verdict !== undefined) props.verdict = verdict;
+      break;
+    }
+    case "project.imported": {
+      props.source_provider = importSourceProvider(payload.sourceUrl);
+      break;
+    }
+    case "issue.closed": {
+      // Whether the close came from a linked change is the interesting bit —
+      // it measures whether the auto-close path is actually used. The change
+      // id itself is not sent.
+      props.linked_change = typeof payload.changeId === "string";
+      break;
+    }
+    case "deployment.requested":
+    case "deployment.succeeded":
+    case "deployment.failed": {
+      const target = enumProp(payload, "target", DEPLOY_TARGETS);
+      if (target !== undefined) props.target = target;
+      props.linked_change = typeof payload.changeId === "string";
+      break;
+    }
+    default:
+      break;
+  }
+
+  return props;
+}
+
+/** Route prefixes that identify a surface, longest-match first. */
+const SURFACE_PREFIXES: ReadonlyArray<readonly [string, RequestSurface]> = [
+  ["/api/admin", "admin"],
+  ["/api", "api"],
+  ["/auth", "auth"],
+  ["/mcp", "mcp"],
+  ["/oauth", "auth"],
+  ["/.well-known", "auth"],
+];
+
+/**
+ * Classify a matched route pattern into a surface.
+ *
+ * Operates on the PATTERN, never the concrete path, so it inherits the
+ * middleware's privacy guarantee for free. Git's smart-HTTP routes are matched
+ * by their suffixes because they live at the root alongside the UI's
+ * `/:namespace/:slug` pages and share its prefix exactly.
+ */
+export function surfaceForRoute(route: string): RequestSurface {
+  if (
+    route.includes("/info/refs") ||
+    route.includes("/git-upload-pack") ||
+    route.includes("/git-receive-pack")
+  ) {
+    return "git";
+  }
+  for (const [prefix, surface] of SURFACE_PREFIXES) {
+    if (route === prefix || route.startsWith(`${prefix}/`)) return surface;
+  }
+  // `/health`, `/csp-report`, and the unmatched-route sentinel are not product
+  // traffic; keeping them out of `ui` stops them inflating the page-view story.
+  if (route === "*" || route === "/health" || route === "/csp-report") return "internal";
+  return "ui";
+}

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -112,32 +112,43 @@ export function domainEventName(type: string): string {
 }
 
 /**
- * Every event name this instance can send.
+ * Every domain event name this instance can send, as an exhaustive map.
  *
- * Domain names are spelled out rather than derived at runtime because a type
- * cannot be enumerated at runtime and the docs test needs the list. The
- * `DomainEventName` annotation is what keeps it honest: add a member to
- * `StratumEvent` without listing it here and this file stops typechecking.
+ * The names are spelled out because a type cannot be enumerated at runtime and
+ * the docs-drift test needs the list. `satisfies Record<DomainEventName, true>`
+ * is what keeps the list honest, and it has to be a Record rather than an
+ * array: an array annotated `DomainEventName[]` only checks that each entry is
+ * *a* valid name, so a new member of `StratumEvent` could be added, exported by
+ * `captureDomainEvent` (which derives the name from `event.type` at runtime),
+ * and never appear here or in the public FAQ. A Record demands every key.
+ *
+ * So: add a member to `StratumEvent` without adding it here, and this file
+ * stops compiling — which is the only reason the catalog can be trusted as the
+ * answer to "what leaves my instance".
  */
-export const DOMAIN_EVENT_NAMES: readonly DomainEventName[] = [
-  "stratum.change.created",
-  "stratum.change.evaluated",
-  "stratum.change.merged",
-  "stratum.change.rejected",
-  "stratum.change.reverted",
-  "stratum.change.commented",
-  "stratum.change.reviewed",
-  "stratum.project.created",
-  "stratum.project.imported",
-  "stratum.workspace.created",
-  "stratum.sync.completed",
-  "stratum.issue.opened",
-  "stratum.issue.commented",
-  "stratum.issue.closed",
-  "stratum.deployment.requested",
-  "stratum.deployment.succeeded",
-  "stratum.deployment.failed",
-];
+const DOMAIN_EVENTS = {
+  "stratum.change.created": true,
+  "stratum.change.evaluated": true,
+  "stratum.change.merged": true,
+  "stratum.change.rejected": true,
+  "stratum.change.reverted": true,
+  "stratum.change.commented": true,
+  "stratum.change.reviewed": true,
+  "stratum.project.created": true,
+  "stratum.project.imported": true,
+  "stratum.workspace.created": true,
+  "stratum.sync.completed": true,
+  "stratum.issue.opened": true,
+  "stratum.issue.commented": true,
+  "stratum.issue.closed": true,
+  "stratum.deployment.requested": true,
+  "stratum.deployment.succeeded": true,
+  "stratum.deployment.failed": true,
+} as const satisfies Record<DomainEventName, true>;
+
+export const DOMAIN_EVENT_NAMES: readonly DomainEventName[] = Object.keys(
+  DOMAIN_EVENTS,
+) as DomainEventName[];
 
 export const SURFACE_EVENT_NAMES: readonly SurfaceEventName[] = [
   "api_request",

--- a/src/analytics/posthog.ts
+++ b/src/analytics/posthog.ts
@@ -7,10 +7,31 @@
  * instance-wide switch. Reaching for `createPostHogClient` directly is how the
  * per-user opt-out gets skipped — see the docblock on `AnalyticsTracker`.
  */
+import { STRATUM_VERSION } from "../version";
+
 export interface PostHogEvent {
   event: string;
   distinctId: string;
   properties?: Record<string, string | number | boolean>;
+  /**
+   * When the thing being reported actually happened, ISO-8601.
+   *
+   * Omit for anything captured inline with a request, where "now" is right.
+   * Supply it for anything captured from the queue: an outbox row is exported
+   * when a consumer gets to it, which a retry or the five-minute stale sweep
+   * can delay well past the minute the change was actually merged. Without
+   * this, those events land in the wrong bucket and every time series built on
+   * them is quietly skewed toward whenever the queue drained.
+   */
+  timestamp?: string;
+  /**
+   * Person properties to set on first sight only (`$set_once`).
+   *
+   * Not stored on the event itself — PostHog consumes them during ingestion to
+   * update the person, so they are queryable as `person.properties.*` and not
+   * as event properties.
+   */
+  setOnce?: Record<string, string | number | boolean>;
 }
 
 export class PostHogClient {
@@ -31,7 +52,15 @@ export class PostHogClient {
           api_key: this.apiKey,
           event: event.event,
           distinct_id: event.distinctId,
-          properties: { $lib: "stratum-server", ...event.properties },
+          ...(event.timestamp !== undefined ? { timestamp: event.timestamp } : {}),
+          properties: {
+            $lib: "stratum-server",
+            // Lets a metric change be attributed to the release that caused it,
+            // which is otherwise guesswork against deploy times.
+            $lib_version: STRATUM_VERSION,
+            ...event.properties,
+            ...(event.setOnce !== undefined ? { $set_once: event.setOnce } : {}),
+          },
         }),
       });
     } catch {

--- a/src/analytics/posthog.ts
+++ b/src/analytics/posthog.ts
@@ -1,3 +1,12 @@
+/**
+ * The PostHog transport.
+ *
+ * Deliberately thin, and deliberately not the thing you should be calling.
+ * Product code goes through `AnalyticsTracker` (`./tracker`), which is what
+ * resolves the acting user's opt-out; this file knows only about the
+ * instance-wide switch. Reaching for `createPostHogClient` directly is how the
+ * per-user opt-out gets skipped — see the docblock on `AnalyticsTracker`.
+ */
 export interface PostHogEvent {
   event: string;
   distinctId: string;
@@ -11,6 +20,7 @@ export class PostHogClient {
     private disabled: boolean,
   ) {}
 
+  /** Never rejects: a telemetry failure must not surface in a request or a queue handler. */
   async capture(event: PostHogEvent): Promise<void> {
     if (this.disabled || !this.apiKey) return;
     try {
@@ -31,19 +41,12 @@ export class PostHogClient {
 }
 
 /**
- * Build a PostHog client for this environment.
+ * Build a PostHog client for this environment, carrying the **instance** gate:
+ * `STRATUM_TELEMETRY_DISABLED`, or the absence of an API key.
  *
- * Two independent gates govern export, and only ONE of them lives in here:
- *
- * - The **instance** switch (`STRATUM_TELEMETRY_DISABLED`) travels with the
- *   client, so every call site inherits it for free.
- * - The **per-user** opt-out (#257) does NOT. Each call site must consult the
- *   acting user's preference itself — `src/middleware/analytics.ts` reads it
- *   from the auth context, `src/queue/event-consumer.ts` looks it up.
- *
- * That asymmetry is exactly how the queue exporter shipped without an opt-out.
- * If you add a third `capture()` call site, gate it on the actor's preference
- * or you will reintroduce the same hole.
+ * The **per-user** opt-out (#257) is not here and must not be added here — it
+ * needs an actor, and this function has none. `AnalyticsTracker` owns it, and
+ * owns it in a way a new call site cannot bypass.
  */
 export function createPostHogClient(env: {
   POSTHOG_API_KEY?: string;

--- a/src/analytics/tracker.ts
+++ b/src/analytics/tracker.ts
@@ -55,9 +55,25 @@ import { type PostHogClient, createPostHogClient } from "./posthog";
  * is why nothing outside this module builds a tracker without one.
  */
 export interface AnalyticsActor {
-  /** PostHog `distinct_id`. An opaque id, or a sentinel for unattributed traffic. */
+  /**
+   * PostHog `distinct_id` — always the **person**, never a credential.
+   *
+   * An agent is not a person. It is a token a human minted, acting under that
+   * human's account: the owner's opt-out already governs it, and their identity
+   * is what "who did this" means. Giving each agent its own distinct id would
+   * mint a person profile per token, which splits one human's history across
+   * several profiles, inflates the billed person count, and makes every user
+   * count, funnel, and retention curve wrong by however many agents happen to
+   * be running. So an agent's events are attributed to its owner, and
+   * `agentId` below preserves the breakdown that would otherwise be lost.
+   */
   distinctId: string;
   kind: ActorKind | "system";
+  /**
+   * The acting agent, when one is acting. Rides every event as `agent_id` so
+   * "which agent did this" stays answerable without agents becoming people.
+   */
+  agentId?: string;
   /** The resolved preference. `true` suppresses every capture on this tracker. */
   optedOut: boolean;
   /**
@@ -106,8 +122,16 @@ export class AnalyticsTracker {
   capture<K extends SurfaceEventName>(
     name: K,
     properties: SurfaceEventProperties[K],
+    /**
+     * Person properties to record the first time this person is seen.
+     *
+     * `$set_once`, never `$set`: these describe how someone arrived, so the
+     * first answer is the true one and a later event must not overwrite it.
+     * Only ever non-identifying — see `captureAuthCompleted`, the one caller.
+     */
+    setOnce?: AnalyticsProperties,
   ): Promise<void> {
-    return this.send(name, properties as AnalyticsProperties);
+    return this.send(name, properties as AnalyticsProperties, { ...(setOnce ? { setOnce } : {}) });
   }
 
   /**
@@ -118,25 +142,38 @@ export class AnalyticsTracker {
    * dropped by construction.
    */
   captureDomainEvent(event: EventRecord): Promise<void> {
-    return this.send(domainEventName(event.type), {
-      // The concrete project name is never sent: it identifies private source
-      // as surely as a repo slug in a URL does, which the request path already
-      // redacts. The opaque id groups just as well — except on rows written
-      // before dual-write, which have no projectId and group under nothing.
-      ...(event.projectId !== undefined ? { project_id: event.projectId } : {}),
-      actor_type: event.actorType,
-      ...domainEventProperties(event),
-    });
+    return this.send(
+      domainEventName(event.type),
+      {
+        // The concrete project name is never sent: it identifies private source
+        // as surely as a repo slug in a URL does, which the request path already
+        // redacts. The opaque id groups just as well — except on rows written
+        // before dual-write, which have no projectId and group under nothing.
+        ...(event.projectId !== undefined ? { project_id: event.projectId } : {}),
+        actor_type: event.actorType,
+        ...domainEventProperties(event),
+        // `createdAt`, not "now": see PostHogEvent.timestamp. A retry or the
+        // stale sweep can export this minutes to hours after the fact.
+      },
+      { timestamp: event.createdAt },
+    );
   }
 
-  private send(name: string, properties: AnalyticsProperties): Promise<void> {
+  private send(
+    name: string,
+    properties: AnalyticsProperties,
+    options: { timestamp?: string; setOnce?: AnalyticsProperties } = {},
+  ): Promise<void> {
     if (this.actor.optedOut) return Promise.resolve();
 
     const capture = this.client.capture({
       event: name,
       distinctId: this.actor.distinctId,
+      ...(options.timestamp !== undefined ? { timestamp: options.timestamp } : {}),
+      ...(options.setOnce !== undefined ? { setOnce: options.setOnce } : {}),
       properties: {
         ...this.instance,
+        ...(this.actor.agentId !== undefined ? { agent_id: this.actor.agentId } : {}),
         ...properties,
         ...(this.actor.attributed ? {} : { $process_person_profile: false }),
       },
@@ -192,14 +229,26 @@ function instanceProperties(env: Env): AnalyticsProperties {
 export function trackerForRequest(c: Context<{ Bindings: Env }>): AnalyticsTracker {
   const userId = c.get("userId") as string | undefined;
   const agentId = c.get("agentId") as string | undefined;
+  // `authMiddleware` resolves the owner to read their opt-out, and publishes it
+  // — so the person behind an agent request is already in hand here.
+  const agentOwnerId = c.get("agentOwnerId") as string | undefined;
   const optedOut = c.get("telemetryOptOut") === true;
 
-  const distinctId = userId ?? agentId ?? ANONYMOUS_DISTINCT_ID;
+  const distinctId = userId ?? agentOwnerId ?? ANONYMOUS_DISTINCT_ID;
   const kind: ActorKind = userId ? "user" : agentId ? "agent" : "anonymous";
+  // An agent whose owner could not be resolved has no person to attribute to.
+  // It is captured personless rather than minting a profile for a credential.
+  const attributed = distinctId !== ANONYMOUS_DISTINCT_ID;
 
   return AnalyticsTracker.create(
     c.env,
-    { distinctId, kind, optedOut, attributed: kind !== "anonymous" },
+    {
+      distinctId,
+      kind,
+      optedOut,
+      attributed,
+      ...(agentId !== undefined ? { agentId } : {}),
+    },
     getWaitUntil(c),
   );
 }
@@ -294,13 +343,14 @@ export async function trackerForEventActor(
   return AnalyticsTracker.create(
     env,
     {
-      // Attribution stays on the acting agent, not its owner: "which agent did
-      // this" is the question the id answers, and the owner's identity is
-      // already reachable from the agent record.
-      distinctId: event.actorId,
+      // The owner, not the acting agent — see `AnalyticsActor.distinctId`. For
+      // a user-authored event `ownerId` is the actor itself, so this is the
+      // same id either way.
+      distinctId: ownerId,
       kind: event.actorType,
       optedOut: owner.data.telemetryOptOut === true,
       attributed: true,
+      ...(event.actorType === "agent" ? { agentId: event.actorId } : {}),
     },
     waitUntil,
   );

--- a/src/analytics/tracker.ts
+++ b/src/analytics/tracker.ts
@@ -100,7 +100,7 @@ const SUPPRESSED_ACTOR: AnalyticsActor = {
   attributed: false,
 };
 
-export class AnalyticsTracker {
+class AnalyticsTracker {
   private constructor(
     private readonly client: PostHogClient,
     private readonly actor: AnalyticsActor,
@@ -186,8 +186,16 @@ export class AnalyticsTracker {
     return capture;
   }
 
-  /** @internal Exposed for the factories below and for tests asserting suppression. */
-  static create(
+  /**
+   * The single construction seam, deliberately not reachable from outside this
+   * module: the class value is not exported (only its type is), so every
+   * tracker in the codebase comes from one of the preference-resolving
+   * factories below. A `static create` taking a caller-built actor would have
+   * let any module pass `optedOut: false` and skip the resolution this class
+   * exists to make unskippable — which is the comment-not-code version of the
+   * guarantee, and the exact failure this design replaced.
+   */
+  static build(
     env: Env,
     actor: AnalyticsActor,
     waitUntil?: (promise: Promise<unknown>) => void,
@@ -199,6 +207,18 @@ export class AnalyticsTracker {
       waitUntil,
     );
   }
+}
+
+/** The type is public — `webhook-delivery` and the MCP route pass trackers around. */
+export type { AnalyticsTracker };
+
+/** Module-private construction. See `AnalyticsTracker.build`. */
+function createTracker(
+  env: Env,
+  actor: AnalyticsActor,
+  waitUntil?: (promise: Promise<unknown>) => void,
+): AnalyticsTracker {
+  return AnalyticsTracker.build(env, actor, waitUntil);
 }
 
 /**
@@ -240,7 +260,7 @@ export function trackerForRequest(c: Context<{ Bindings: Env }>): AnalyticsTrack
   // It is captured personless rather than minting a profile for a credential.
   const attributed = distinctId !== ANONYMOUS_DISTINCT_ID;
 
-  return AnalyticsTracker.create(
+  return createTracker(
     c.env,
     {
       distinctId,
@@ -271,9 +291,9 @@ export async function trackerForUser(
   const user = await getUser(env.DB, userId, logger);
   if (!user.success) {
     logger.warn("User lookup failed for telemetry preference; suppressing event", { userId });
-    return AnalyticsTracker.create(env, SUPPRESSED_ACTOR, waitUntil);
+    return createTracker(env, SUPPRESSED_ACTOR, waitUntil);
   }
-  return AnalyticsTracker.create(
+  return createTracker(
     env,
     {
       distinctId: userId,
@@ -305,8 +325,8 @@ export async function trackerForEventActor(
   logger: Logger,
   waitUntil?: (promise: Promise<unknown>) => void,
 ): Promise<AnalyticsTracker> {
-  if (event.actorType === "system" || !event.actorId) {
-    return AnalyticsTracker.create(
+  if (event.actorType === "system") {
+    return createTracker(
       env,
       {
         distinctId: SYSTEM_DISTINCT_ID,
@@ -318,6 +338,20 @@ export async function trackerForEventActor(
     );
   }
 
+  // A user- or agent-authored row with no actor id: `change-flow.ts` builds
+  // `{ type: "user" }` with the id omitted when it has none. Treating that as
+  // system-authored would export a real person's activity under the `system`
+  // sentinel with no preference consulted — the opt-out defeated by a missing
+  // field. There is an actor and no way to reach their choice, so fail closed,
+  // exactly as an unresolvable lookup does below.
+  if (!event.actorId) {
+    logger.warn("Event actor has no id; suppressing analytics export", {
+      eventId: event.id,
+      actorType: event.actorType,
+    });
+    return createTracker(env, SUPPRESSED_ACTOR, waitUntil);
+  }
+
   let ownerId = event.actorId;
   if (event.actorType === "agent") {
     const agent = await getAgent(env.DB, event.actorId, logger);
@@ -326,7 +360,7 @@ export async function trackerForEventActor(
         eventId: event.id,
         actorId: event.actorId,
       });
-      return AnalyticsTracker.create(env, SUPPRESSED_ACTOR, waitUntil);
+      return createTracker(env, SUPPRESSED_ACTOR, waitUntil);
     }
     ownerId = agent.data.ownerId;
   }
@@ -337,10 +371,10 @@ export async function trackerForEventActor(
       eventId: event.id,
       ownerId,
     });
-    return AnalyticsTracker.create(env, SUPPRESSED_ACTOR, waitUntil);
+    return createTracker(env, SUPPRESSED_ACTOR, waitUntil);
   }
 
-  return AnalyticsTracker.create(
+  return createTracker(
     env,
     {
       // The owner, not the acting agent — see `AnalyticsActor.distinctId`. For
@@ -368,7 +402,7 @@ export function trackerForSystem(
   env: Env,
   waitUntil?: (promise: Promise<unknown>) => void,
 ): AnalyticsTracker {
-  return AnalyticsTracker.create(
+  return createTracker(
     env,
     { distinctId: SYSTEM_DISTINCT_ID, kind: "system", optedOut: false, attributed: false },
     waitUntil,

--- a/src/analytics/tracker.ts
+++ b/src/analytics/tracker.ts
@@ -1,0 +1,329 @@
+/**
+ * The one way to send product analytics.
+ *
+ * ## Why this class exists
+ *
+ * Export is governed by two independent gates, and until this file they lived
+ * in two different places:
+ *
+ * - The **instance** switch (`STRATUM_TELEMETRY_DISABLED`, or simply no
+ *   `POSTHOG_API_KEY`) travelled with the transport, so every call site got it
+ *   for free.
+ * - The **per-user opt-out** (#257) did not. Each call site had to remember to
+ *   consult the acting user's preference itself.
+ *
+ * That asymmetry is exactly how the queue exporter once shipped without an
+ * opt-out at all: it was a second `capture()` call site, and second call sites
+ * do not inherit a rule that lives in the first one's body.
+ *
+ * `AnalyticsTracker` closes that hole structurally rather than by comment.
+ * There is no public constructor, and every factory below must produce an
+ * `AnalyticsActor` — a value that cannot be built without an opt-out decision
+ * already made. A caller therefore cannot reach `capture()` without having
+ * resolved the preference, and no future call site can reintroduce the bug by
+ * forgetting a rule it never had to know about.
+ *
+ * ## Failing closed
+ *
+ * Where the preference must be looked up (queue and cron paths, which have no
+ * request and no auth context), an unresolved lookup suppresses the event. A
+ * privacy control that exports whenever D1 hiccups is not a privacy control.
+ */
+import type { Context } from "hono";
+import { getAgent } from "../storage/agents";
+import type { EventRecord } from "../storage/events";
+import { getUser } from "../storage/users";
+import type { Env } from "../types";
+import { getWaitUntil } from "../utils/execution-ctx";
+import type { Logger } from "../utils/logger";
+import { createLogger } from "../utils/logger";
+import {
+  type ActorKind,
+  type AnalyticsProperties,
+  type SurfaceEventName,
+  type SurfaceEventProperties,
+  domainEventName,
+  domainEventProperties,
+} from "./events";
+import { type PostHogClient, createPostHogClient } from "./posthog";
+
+/**
+ * Who an event is attributed to, with their telemetry preference already
+ * resolved.
+ *
+ * Constructing one is the act of deciding whether export is permitted, which
+ * is why nothing outside this module builds a tracker without one.
+ */
+export interface AnalyticsActor {
+  /** PostHog `distinct_id`. An opaque id, or a sentinel for unattributed traffic. */
+  distinctId: string;
+  kind: ActorKind | "system";
+  /** The resolved preference. `true` suppresses every capture on this tracker. */
+  optedOut: boolean;
+  /**
+   * Whether this actor is a real, identified person or agent.
+   *
+   * Unattributed traffic (`server`, `system`) would otherwise accrete onto one
+   * shared person profile that means nothing and inflates billed person count,
+   * so those events are captured personless.
+   */
+  attributed: boolean;
+}
+
+/** The sentinel distinct id for an unauthenticated request. */
+export const ANONYMOUS_DISTINCT_ID = "server";
+
+/** The sentinel distinct id for an event no person caused. */
+export const SYSTEM_DISTINCT_ID = "system";
+
+/** An actor that permits nothing. Returned wherever a preference cannot be established. */
+const SUPPRESSED_ACTOR: AnalyticsActor = {
+  distinctId: SYSTEM_DISTINCT_ID,
+  kind: "system",
+  optedOut: true,
+  attributed: false,
+};
+
+export class AnalyticsTracker {
+  private constructor(
+    private readonly client: PostHogClient,
+    private readonly actor: AnalyticsActor,
+    /** Instance-wide properties attached to every event; see `instanceProperties`. */
+    private readonly instance: AnalyticsProperties,
+    /** Schedules background work when the runtime offers it. */
+    private readonly waitUntil: ((promise: Promise<unknown>) => void) | undefined,
+  ) {}
+
+  /**
+   * Send one surface event.
+   *
+   * Never rejects and never throws: analytics must not be able to fail a
+   * request or a queue handler. The returned promise is there for callers that
+   * genuinely want to await delivery (the queue consumer, and tests); request
+   * paths can ignore it, because when a `waitUntil` is available the tracker
+   * has already handed the promise to it.
+   */
+  capture<K extends SurfaceEventName>(
+    name: K,
+    properties: SurfaceEventProperties[K],
+  ): Promise<void> {
+    return this.send(name, properties as AnalyticsProperties);
+  }
+
+  /**
+   * Send the analytics twin of a durable outbox event.
+   *
+   * Property selection lives in `domainEventProperties`, which whitelists the
+   * safe and useful fields per event type; everything else in the payload is
+   * dropped by construction.
+   */
+  captureDomainEvent(event: EventRecord): Promise<void> {
+    return this.send(domainEventName(event.type), {
+      // The concrete project name is never sent: it identifies private source
+      // as surely as a repo slug in a URL does, which the request path already
+      // redacts. The opaque id groups just as well — except on rows written
+      // before dual-write, which have no projectId and group under nothing.
+      ...(event.projectId !== undefined ? { project_id: event.projectId } : {}),
+      actor_type: event.actorType,
+      ...domainEventProperties(event),
+    });
+  }
+
+  private send(name: string, properties: AnalyticsProperties): Promise<void> {
+    if (this.actor.optedOut) return Promise.resolve();
+
+    const capture = this.client.capture({
+      event: name,
+      distinctId: this.actor.distinctId,
+      properties: {
+        ...this.instance,
+        ...properties,
+        ...(this.actor.attributed ? {} : { $process_person_profile: false }),
+      },
+    });
+
+    // `getWaitUntil` already returns undefined outside Workers, so this is the
+    // only branch: schedule it, or leave the caller holding a promise that
+    // cannot reject.
+    this.waitUntil?.(capture);
+    return capture;
+  }
+
+  /** @internal Exposed for the factories below and for tests asserting suppression. */
+  static create(
+    env: Env,
+    actor: AnalyticsActor,
+    waitUntil?: (promise: Promise<unknown>) => void,
+  ): AnalyticsTracker {
+    return new AnalyticsTracker(
+      createPostHogClient(env),
+      actor,
+      instanceProperties(env),
+      waitUntil,
+    );
+  }
+}
+
+/**
+ * Properties describing the instance, attached to every event.
+ *
+ * `environment` is the one that earns its place operationally: without it a
+ * staging deploy's traffic is indistinguishable from production's in the same
+ * PostHog project, and every funnel is quietly wrong. It is a plain var an
+ * operator sets, defaulting to `unknown` rather than guessing.
+ */
+function instanceProperties(env: Env): AnalyticsProperties {
+  // `$lib` is not here: it identifies the transport, and the transport sets it.
+  return { environment: env.STRATUM_ENVIRONMENT ?? "unknown" };
+}
+
+/**
+ * A tracker for the current request.
+ *
+ * The preference is already in the request context: every path that
+ * authenticates a caller publishes it alongside the identity — `authMiddleware`
+ * for the API and UI, and git-http's own `authenticate` for the smart-HTTP
+ * surface it owns. The latter sets the preference WITHOUT a userId, so
+ * suppression must not be gated on attribution.
+ *
+ * An unauthenticated caller has no preference to honor and is captured
+ * personless under the `server` sentinel.
+ */
+export function trackerForRequest(c: Context<{ Bindings: Env }>): AnalyticsTracker {
+  const userId = c.get("userId") as string | undefined;
+  const agentId = c.get("agentId") as string | undefined;
+  const optedOut = c.get("telemetryOptOut") === true;
+
+  const distinctId = userId ?? agentId ?? ANONYMOUS_DISTINCT_ID;
+  const kind: ActorKind = userId ? "user" : agentId ? "agent" : "anonymous";
+
+  return AnalyticsTracker.create(
+    c.env,
+    { distinctId, kind, optedOut, attributed: kind !== "anonymous" },
+    getWaitUntil(c),
+  );
+}
+
+/**
+ * A tracker for a specific user, for flows that establish an identity rather
+ * than arrive with one.
+ *
+ * Sign-up and sign-in run before any middleware has an authenticated context
+ * to publish, so the preference is read directly. A brand-new account has
+ * never expressed one, which is the opt-in default — the same default the
+ * settings page starts from.
+ */
+export async function trackerForUser(
+  env: Env,
+  userId: string,
+  logger: Logger,
+  waitUntil?: (promise: Promise<unknown>) => void,
+): Promise<AnalyticsTracker> {
+  const user = await getUser(env.DB, userId, logger);
+  if (!user.success) {
+    logger.warn("User lookup failed for telemetry preference; suppressing event", { userId });
+    return AnalyticsTracker.create(env, SUPPRESSED_ACTOR, waitUntil);
+  }
+  return AnalyticsTracker.create(
+    env,
+    {
+      distinctId: userId,
+      kind: "user",
+      optedOut: user.data.telemetryOptOut === true,
+      attributed: true,
+    },
+    waitUntil,
+  );
+}
+
+/**
+ * A tracker for the actor recorded on a durable outbox event.
+ *
+ * Unlike the request path — where the flag rides the `users` row the auth
+ * middleware already loaded — a queue consumer has no request and no auth
+ * context, so it must look the actor up. That costs one read for a
+ * user-authored event and two for an agent-authored one, against the 4+ D1
+ * operations the consumer already performs per message.
+ *
+ * An agent acts under its owner's account, so the owner's choice governs it.
+ * A system-authored event has no person behind it: there is no preference to
+ * honor and nothing person-identifying to suppress, so it is captured
+ * personless under the `system` sentinel.
+ */
+export async function trackerForEventActor(
+  env: Env,
+  event: EventRecord,
+  logger: Logger,
+  waitUntil?: (promise: Promise<unknown>) => void,
+): Promise<AnalyticsTracker> {
+  if (event.actorType === "system" || !event.actorId) {
+    return AnalyticsTracker.create(
+      env,
+      {
+        distinctId: SYSTEM_DISTINCT_ID,
+        kind: "system",
+        optedOut: false,
+        attributed: false,
+      },
+      waitUntil,
+    );
+  }
+
+  let ownerId = event.actorId;
+  if (event.actorType === "agent") {
+    const agent = await getAgent(env.DB, event.actorId, logger);
+    if (!agent.success) {
+      logger.warn("Agent lookup failed for telemetry preference; suppressing event", {
+        eventId: event.id,
+        actorId: event.actorId,
+      });
+      return AnalyticsTracker.create(env, SUPPRESSED_ACTOR, waitUntil);
+    }
+    ownerId = agent.data.ownerId;
+  }
+
+  const owner = await getUser(env.DB, ownerId, logger);
+  if (!owner.success) {
+    logger.warn("User lookup failed for telemetry preference; suppressing event", {
+      eventId: event.id,
+      ownerId,
+    });
+    return AnalyticsTracker.create(env, SUPPRESSED_ACTOR, waitUntil);
+  }
+
+  return AnalyticsTracker.create(
+    env,
+    {
+      // Attribution stays on the acting agent, not its owner: "which agent did
+      // this" is the question the id answers, and the owner's identity is
+      // already reachable from the agent record.
+      distinctId: event.actorId,
+      kind: event.actorType,
+      optedOut: owner.data.telemetryOptOut === true,
+      attributed: true,
+    },
+    waitUntil,
+  );
+}
+
+/**
+ * A tracker for work no person initiated — cron sweeps, queue consumers
+ * reporting on themselves.
+ *
+ * There is no actor and therefore no preference to consult, so this is the one
+ * factory that needs no lookup. Everything it sends is personless and must
+ * describe the instance's own behaviour, never a user's.
+ */
+export function trackerForSystem(
+  env: Env,
+  waitUntil?: (promise: Promise<unknown>) => void,
+): AnalyticsTracker {
+  return AnalyticsTracker.create(
+    env,
+    { distinctId: SYSTEM_DISTINCT_ID, kind: "system", optedOut: false, attributed: false },
+    waitUntil,
+  );
+}
+
+/** A logger for analytics call sites that have none of their own. */
+export const analyticsLogger = createLogger({ component: "Analytics" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { setCookie } from "hono/cookie";
+import { routePath } from "hono/route";
+import { trackerForRequest } from "./analytics/tracker";
 import { githubWebhookRouter } from "./github/webhooks";
 import { analyticsMiddleware } from "./middleware/analytics";
 import { authMiddleware } from "./middleware/auth";
@@ -54,6 +57,22 @@ export { MagicLinkRateLimiter } from "./queue/magic-link-limiter";
 export { RepoDO } from "./queue/repo-do";
 
 const app = new Hono<{ Bindings: Env }>();
+
+/**
+ * The matched route pattern for an error, or `"*"` when there is none.
+ *
+ * `routePath` reads the matched-route registry, which a failure raised before
+ * routing (a middleware throwing) never populated. Falling back to the literal
+ * `"*"` keeps the concrete path — namespaces, slugs, file paths — out of the
+ * export, which is the same guarantee `analyticsMiddleware` makes.
+ */
+function errorRoute(c: Context<{ Bindings: Env }>): string {
+  try {
+    return routePath(c, -1);
+  } catch {
+    return "*";
+  }
+}
 
 app.use("*", securityHeadersMiddleware);
 app.use("*", configGuardMiddleware);
@@ -220,6 +239,20 @@ app.onError((err, c) => {
   logger.error(`Unhandled error: ${err.message}`, err instanceof Error ? err : undefined, {
     path: c.req.path,
     method: c.req.method,
+  });
+  // An unhandled exception never reaches `analyticsMiddleware`'s post-`next()`
+  // body — the rejection propagates straight past it to here — so a 500 born
+  // this way is invisible in `api_request` entirely. That is the gap this
+  // fills, and why it is a distinct event rather than a status code.
+  //
+  // The message is deliberately absent: exception messages quote their input,
+  // which on this codebase means SQL fragments, tokens, and file paths. The
+  // constructor name is the bounded part, and the message stays in the log
+  // line above where an operator can read it and a third party cannot.
+  trackerForRequest(c).capture("error_occurred", {
+    route: errorRoute(c),
+    method: c.req.method,
+    error_type: err instanceof Error ? err.constructor.name : "unknown",
   });
   // Belt-and-suspenders: the middleware registers headers before next(), but the
   // error boundary builds a fresh response, so re-assert the full set here via the

--- a/src/mcp/outcome.ts
+++ b/src/mcp/outcome.ts
@@ -130,7 +130,7 @@ export function describeMcpAnalytics(
   if (!isJsonRpcRequest(message) || reply === null) return null;
 
   const props: SurfaceEventProperties["mcp_request"] = {
-    mcp_method: message.method,
+    mcp_method: boundedMethod(message.method),
     outcome: "ok",
   };
 
@@ -169,6 +169,30 @@ export function describeMcpAnalytics(
   }
 
   return props;
+}
+
+/**
+ * The JSON-RPC methods this server implements — the `handleMessage` switch in
+ * `./protocol`, spelled out so analytics can bound the value it exports.
+ *
+ * A request's `method` is caller-supplied free text: an authenticated client
+ * can POST any string and get `METHOD_NOT_FOUND` back, so exporting it verbatim
+ * would put arbitrary caller text in the analytics payload — the one thing the
+ * catalog's privacy rule forbids. Unrecognised methods collapse to `unknown`,
+ * which still answers the question worth asking ("are clients calling things we
+ * do not implement") without carrying whatever they typed.
+ */
+const KNOWN_MCP_METHODS: ReadonlySet<string> = new Set([
+  "initialize",
+  "notifications/initialized",
+  "notifications/cancelled",
+  "ping",
+  "tools/list",
+  "tools/call",
+]);
+
+function boundedMethod(method: string): string {
+  return KNOWN_MCP_METHODS.has(method) ? method : "unknown";
 }
 
 /** Cap on a client's self-reported name or version before it is exported. */

--- a/src/mcp/outcome.ts
+++ b/src/mcp/outcome.ts
@@ -13,6 +13,7 @@
  * Kept as a pure function, separate from the transport-agnostic protocol
  * layer, so it is testable by handing it plain objects.
  */
+import type { SurfaceEventProperties } from "../analytics/events";
 import { type JsonRpcResponse, isJsonRpcRequest } from "./protocol";
 
 export interface McpOutcome {
@@ -104,4 +105,76 @@ export function describeMcpOutcome(message: unknown, reply: JsonRpcResponse | nu
     };
   }
   return { level: "debug", message: "MCP message handled", meta: { method } };
+}
+
+/**
+ * What to *export* about one MCP exchange, as opposed to what to log.
+ *
+ * Separate from `describeMcpOutcome` because the two answer different
+ * questions with different rules. A log line stays on the operator's own
+ * instance and may quote the error a model was shown; an analytics event
+ * leaves for a third party and may carry only bounded values. The overlap is
+ * real but the constraint is not shared, so merging them would mean one
+ * function whose output is safe for exactly one of its two consumers.
+ *
+ * Returns `null` for anything that did not run: a malformed message, and a
+ * notification (which `handleMessage` answers with no reply, without invoking
+ * the tool). Counting those as tool calls would overstate MCP usage with
+ * traffic that never reached a tool.
+ */
+export function describeMcpAnalytics(
+  message: unknown,
+  reply: JsonRpcResponse | null,
+  knownTools: ReadonlySet<string>,
+): SurfaceEventProperties["mcp_request"] | null {
+  if (!isJsonRpcRequest(message) || reply === null) return null;
+
+  const props: SurfaceEventProperties["mcp_request"] = {
+    mcp_method: message.method,
+    outcome: "ok",
+  };
+
+  if (message.method === "initialize") {
+    const params = (message.params ?? {}) as {
+      protocolVersion?: unknown;
+      clientInfo?: { name?: unknown; version?: unknown };
+    };
+    // Self-reported by the connecting software, so it is capped rather than
+    // trusted: "which editors and agents connect to Stratum" is the question
+    // the handshake answers, and a client that names itself at length is not
+    // going to make it more answerable. Documented in the public FAQ as the
+    // one free-text field any event carries.
+    const name = clientLabel(params.clientInfo?.name);
+    const version = clientLabel(params.clientInfo?.version);
+    const protocol = clientLabel(
+      (reply.result as { protocolVersion?: unknown } | undefined)?.protocolVersion,
+    );
+    if (name !== undefined) props.client_name = name;
+    if (version !== undefined) props.client_version = version;
+    if (protocol !== undefined) props.protocol_version = protocol;
+  }
+
+  if (message.method === "tools/call") {
+    // Reported only when it names a tool this build actually defines. An
+    // unrecognised name is a client's arbitrary string, and echoing it would
+    // put unbounded caller-supplied text into the export.
+    const requested = asString((message.params as { name?: unknown } | undefined)?.name);
+    props.tool = requested !== undefined && knownTools.has(requested) ? requested : "unknown";
+  }
+
+  if (reply.error !== undefined) {
+    props.outcome = "rejected";
+  } else if ((reply.result as { isError?: unknown } | undefined)?.isError === true) {
+    props.outcome = "tool_error";
+  }
+
+  return props;
+}
+
+/** Cap on a client's self-reported name or version before it is exported. */
+const MAX_CLIENT_LABEL = 64;
+
+function clientLabel(value: unknown): string | undefined {
+  const text = asString(value);
+  return text === undefined ? undefined : text.slice(0, MAX_CLIENT_LABEL);
 }

--- a/src/middleware/analytics.ts
+++ b/src/middleware/analytics.ts
@@ -1,6 +1,7 @@
 import type { MiddlewareHandler } from "hono";
 import { routePath } from "hono/route";
-import { createPostHogClient } from "../analytics/posthog";
+import { surfaceForRoute } from "../analytics/events";
+import { trackerForRequest } from "../analytics/tracker";
 import type { Env } from "../types";
 import { createLogger } from "../utils/logger";
 
@@ -33,37 +34,16 @@ export const analyticsMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (
     agentId,
   });
 
-  // Honor the caller's opt-out (#257). Deliberately placed after the debug log
-  // above: that log stays in the operator's own Workers logs and never leaves
-  // the instance, whereas this gate governs export to a third party.
-  //
-  // Every path that authenticates a caller publishes the preference alongside
-  // the identity: authMiddleware for the API and UI, and git-http's own
-  // `authenticate` for the smart-HTTP surface it owns. Note the latter sets the
-  // preference WITHOUT a userId, so this must not be gated on attribution.
-  if (c.get("telemetryOptOut") === true) return;
-
-  const distinctId = userId ?? agentId ?? "server";
-  const client = createPostHogClient(c.env);
-  const capture = client.capture({
-    event: "api_request",
-    distinctId,
-    properties: {
-      method: c.req.method,
-      route,
-      status: c.res.status,
-      latency_ms: latency,
-      // Unattributed events would otherwise accrete on a shared "server"
-      // person profile; capture them personless instead.
-      ...(distinctId === "server" ? { $process_person_profile: false } : {}),
-    },
+  // The caller's opt-out (#257) is enforced inside the tracker, which cannot be
+  // built without resolving it. Deliberately *after* the debug log above: that
+  // log stays in the operator's own Workers logs and never leaves the instance,
+  // whereas the tracker governs export to a third party.
+  trackerForRequest(c).capture("api_request", {
+    method: c.req.method,
+    route,
+    status: c.res.status,
+    latency_ms: latency,
+    surface: surfaceForRoute(route),
+    actor_type: userId ? "user" : agentId ? "agent" : "anonymous",
   });
-  try {
-    const ctx = c.executionCtx;
-    if (ctx?.waitUntil) {
-      ctx.waitUntil(capture);
-    }
-  } catch {
-    capture.catch(() => undefined);
-  }
 };

--- a/src/queue/event-consumer.ts
+++ b/src/queue/event-consumer.ts
@@ -1,5 +1,4 @@
-import { createPostHogClient } from "../analytics/posthog";
-import { getAgent } from "../storage/agents";
+import { trackerForEventActor, trackerForSystem } from "../analytics/tracker";
 import {
   type EventRecord,
   getEvent,
@@ -9,7 +8,6 @@ import {
   markEventProcessed,
   setCompletedHandlers,
 } from "../storage/events";
-import { getUser } from "../storage/users";
 import type { Env, Message, MessageBatch } from "../types";
 import type { Logger } from "../utils/logger";
 import { createLogger } from "../utils/logger";
@@ -30,94 +28,36 @@ export interface EventHandler {
   handle(env: Env, event: EventRecord, logger: Logger): Promise<void>;
 }
 
-/**
- * Resolve the event author's telemetry preference (#257).
- *
- * Unlike the request path — where the flag rides the `users` row the auth
- * middleware already loaded — a queue consumer has no request and no auth
- * context, so it must look the actor up. That costs one read for a user-authored
- * event and two for an agent-authored one, against the 4+ D1 operations
- * `consumeOne` already performs per message.
- *
- * Fails CLOSED: an unresolved lookup suppresses the event. A privacy control
- * that exports whenever D1 hiccups is not a privacy control.
- *
- * Suppression is TERMINAL, not deferred. Returning normally lets `processEvent`
- * record "analytics" in `completed_handlers`, so a later retry of the same
- * message skips this handler rather than re-attempting the export. A transient
- * D1 error therefore drops one analytics event permanently. That is the
- * deliberate trade: analytics is best-effort, and retrying it would either
- * re-run the export for a user who may have opted out in the meantime or block
- * the webhook and issue-autoclose handlers that are not best-effort.
- */
-async function actorOptedOutOfTelemetry(
-  env: Env,
-  event: EventRecord,
-  logger: Logger,
-): Promise<boolean> {
-  // A system-authored event has no person behind it, so there is no preference
-  // to honor and nothing person-identifying to suppress.
-  if (event.actorType === "system" || !event.actorId) return false;
-
-  let ownerId = event.actorId;
-  if (event.actorType === "agent") {
-    // An agent acts under its owner's account, so the owner's choice governs it.
-    const agent = await getAgent(env.DB, event.actorId, logger);
-    if (!agent.success) {
-      logger.warn("Agent lookup failed for telemetry preference; suppressing event", {
-        eventId: event.id,
-        actorId: event.actorId,
-      });
-      return true;
-    }
-    ownerId = agent.data.ownerId;
-  }
-
-  const owner = await getUser(env.DB, ownerId, logger);
-  if (!owner.success) {
-    logger.warn("User lookup failed for telemetry preference; suppressing event", {
-      eventId: event.id,
-      ownerId,
-    });
-    return true;
-  }
-  return owner.data.telemetryOptOut === true;
-}
-
 const analyticsHandler: EventHandler = {
   name: "analytics",
   async handle(env, event, logger) {
-    // Suppression must not fail the message: analytics is best-effort, and
-    // throwing here would stop issue-autoclose and webhooks from ever running.
-    let optedOut: boolean;
+    // Resolving the actor's telemetry preference (#257) is the tracker's job,
+    // and it fails closed: an unresolvable lookup yields a tracker that sends
+    // nothing. A queue consumer has no request and no auth context, so unlike
+    // the request path it must read the preference from D1 — one lookup for a
+    // user-authored event, two for an agent-authored one, against the 4+ D1
+    // operations `consumeOne` already performs per message.
+    //
+    // Neither the lookup nor the send may fail the message: analytics is
+    // best-effort, and throwing here would stop issue-autoclose and webhooks
+    // from ever running.
+    //
+    // Suppression and delivery are alike TERMINAL, not deferred. Returning
+    // normally lets `processEvent` record "analytics" in `completed_handlers`,
+    // so a later retry of the same message skips this handler rather than
+    // re-attempting the export. A transient D1 error therefore drops one
+    // analytics event permanently. That is the deliberate trade: retrying
+    // would either re-run the export for a user who may have opted out in the
+    // meantime, or block the handlers that are not best-effort.
     try {
-      optedOut = await actorOptedOutOfTelemetry(env, event, logger);
+      const tracker = await trackerForEventActor(env, event, logger);
+      await tracker.captureDomainEvent(event);
     } catch (error) {
-      logger.warn("Telemetry preference lookup threw; suppressing event", {
+      logger.warn("Analytics handler threw; dropping event export", {
         eventId: event.id,
         error: error instanceof Error ? error.message : String(error),
       });
-      return;
     }
-    if (optedOut) return;
-
-    const posthog = createPostHogClient(env);
-    await posthog.capture({
-      event: `stratum.${event.type}`,
-      distinctId: event.actorId ?? "system",
-      properties: {
-        // The concrete project name is never sent (#257): it identifies private
-        // source as surely as a repo slug in a URL does, which the request path
-        // already redacts. The opaque id groups just as well — except on rows
-        // written before dual-write, which have no projectId at all and so
-        // group under nothing rather than under a name.
-        ...(event.projectId !== undefined ? { projectId: event.projectId } : {}),
-        actorType: event.actorType,
-        // Unattributed events would otherwise accrete on a shared "system"
-        // person profile, the same way the request path guards "server".
-        ...(event.actorId === undefined ? { $process_person_profile: false } : {}),
-      },
-    });
   },
 };
 
@@ -224,6 +164,18 @@ async function consumeOne(
     );
     if (attempts >= MAX_EVENT_ATTEMPTS) {
       await markEventFailed(env.DB, logger, eventId);
+      // An abandoned event is a durable notification that will never be
+      // delivered — a webhook subscriber silently missing a merge. It is the
+      // one queue outcome worth a metric, and it is reported personless
+      // against the instance rather than against whoever happened to trigger
+      // it: this describes the instance failing, not something a user did.
+      // Awaited, not scheduled: a queue consumer has no `waitUntil`, so an
+      // unawaited fetch can be cancelled when the handler returns.
+      await trackerForSystem(env).capture("background_job_completed", {
+        job: "event-consumer",
+        outcome: "abandoned",
+        attempts,
+      });
       msg.ack();
     } else {
       msg.retry();

--- a/src/queue/webhook-delivery.ts
+++ b/src/queue/webhook-delivery.ts
@@ -1,3 +1,5 @@
+import type { AnalyticsTracker } from "../analytics/tracker";
+import { trackerForSystem } from "../analytics/tracker";
 import type { EventRecord } from "../storage/events";
 import {
   type Webhook,
@@ -45,6 +47,7 @@ async function deliverToWebhook(
   webhook: Webhook,
   event: EventRecord,
   logger: Logger,
+  tracker: AnalyticsTracker,
 ): Promise<void> {
   const payload: WebhookPayload = {
     id: event.id,
@@ -86,6 +89,11 @@ async function deliverToWebhook(
       durationMs: Date.now() - startedAt,
       ...(response.ok ? {} : { error: `Receiver responded ${response.status}` }),
     });
+    // The delivery log answers "did MY webhook fire" for one project owner.
+    // This answers the operator's version — "is outbound delivery healthy on
+    // this instance" — which the per-project log cannot, because nobody reads
+    // every project's log. Carries no URL, no ids, and no receiver response.
+    await trackDelivery(tracker, response.ok);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logger.warn("Webhook delivery failed", {
@@ -101,7 +109,16 @@ async function deliverToWebhook(
       error: message.slice(0, MAX_ERROR_LENGTH),
       durationMs: Date.now() - startedAt,
     });
+    await trackDelivery(tracker, false);
   }
+}
+
+/** One personless delivery outcome. The receiver's identity never leaves the instance. */
+function trackDelivery(tracker: AnalyticsTracker, ok: boolean): Promise<void> {
+  return tracker.capture("background_job_completed", {
+    job: "webhook-delivery",
+    outcome: ok ? "succeeded" : "failed",
+  });
 }
 
 /**
@@ -142,5 +159,10 @@ export async function deliverEventToWebhooks(
   );
   if (matching.length === 0) return;
 
-  await Promise.all(matching.map((webhook) => deliverToWebhook(env.DB, webhook, event, logger)));
+  // One tracker for the whole fan-out: it holds no per-delivery state, and
+  // building it per webhook would re-read the environment for each receiver.
+  const tracker = trackerForSystem(env);
+  await Promise.all(
+    matching.map((webhook) => deliverToWebhook(env.DB, webhook, event, logger, tracker)),
+  );
 }

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { captureAuthCompleted } from "../analytics/auth";
 import { recordAudit } from "../storage/audit";
 import { createSession, deleteSession, getSession } from "../storage/sessions";
 import { getUserByEmail, getUserByGitHubId, upsertGitHubUser } from "../storage/users";
@@ -270,6 +271,13 @@ app.get("/github/callback", async (c) => {
       actorId: user.id,
       detail: { method: "github-oauth" },
     });
+    // `signin`, never `signup`: a first-time GitHub identity was diverted to
+    // the username step above and is counted there, once the account exists.
+    await captureAuthCompleted(c, sessionLogger, {
+      kind: "signin",
+      provider: "github",
+      userId: user.id,
+    });
   }
   if (!sessionResult.success) {
     sessionLogger.error("Failed to create session");
@@ -420,6 +428,13 @@ app.get("/google/callback", async (c) => {
     actorType: "user",
     actorId: userId,
     detail: { method: "google-oauth" },
+  });
+  // Reached only for an email that already has an account; a new Google
+  // identity is diverted to the username step and counted there.
+  await captureAuthCompleted(c, sessionLogger, {
+    kind: "signin",
+    provider: "google",
+    userId,
   });
 
   setCookie(c, "stratum_session", sessionResult.data.id, {

--- a/src/routes/email-auth.tsx
+++ b/src/routes/email-auth.tsx
@@ -1,6 +1,8 @@
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
+import { captureAuthCompleted } from "../analytics/auth";
+import type { AuthKind } from "../analytics/events";
 import { admitAndDeliverCodes, betaGateEnabled, validateInviteCode } from "../beta/gate";
 import { getMagicLinkEmail } from "../email/templates";
 import { enforceSameOrigin } from "../middleware/csrf";
@@ -664,7 +666,15 @@ app.post("/verify", async (c) => {
       }
 
       // Create session and redirect to welcome/onboarding
-      return await createSessionAndRedirect(c, userId, emailHash, rememberMe, logger, "/welcome");
+      return await createSessionAndRedirect(
+        c,
+        userId,
+        emailHash,
+        rememberMe,
+        logger,
+        "/welcome",
+        "signup",
+      );
     }
 
     if (intent === "login") {
@@ -702,6 +712,10 @@ async function createSessionAndRedirect(
   rememberMe: boolean,
   logger: ReturnType<typeof createLogger>,
   defaultRedirect = "/",
+  // What this link did to the account, for the acquisition funnel. Not
+  // inferable here: the signup branch reaches this function twice, once having
+  // created the account and once having found it already present.
+  kind: AuthKind = "signin",
 ): Promise<Response> {
   const sessionLogger = logger.child({ userId });
   const sessionResult = await createSession(c.env.DB, userId, sessionLogger, rememberMe);
@@ -712,6 +726,7 @@ async function createSessionAndRedirect(
       actorId: userId,
       detail: { method: "magic-link" },
     });
+    await captureAuthCompleted(c, sessionLogger, { kind, provider: "email", userId });
   }
 
   if (!sessionResult.success) {

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -34,6 +34,7 @@ import type { Logger } from "../utils/logger";
 import { buildAuthenticateChallenge } from "../utils/oauth-challenge";
 import { readTextWithLimit } from "../utils/request-body";
 import { requestLogger } from "../utils/request-logger";
+import { STRATUM_VERSION } from "../version";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -62,15 +63,11 @@ function recordOutcome(
 /**
  * Reported in the `initialize` handshake.
  *
- * Duplicated from `package.json` rather than imported: pulling JSON into the
- * Worker bundle would need `resolveJsonModule` and would ship the whole
- * manifest to the edge for one string. `tests/mcp-endpoint.test.ts` asserts the
- * two match, which is how this repo pins its other cross-file constants
- * (`tests/changelog.test.ts`, `tests/wrangler-migration-chain.test.ts`), so a
- * release bump that forgets this line fails CI rather than shipping a stale
- * version to every client's log.
+ * Re-exported from `src/version.ts`, which is also what stamps `$lib_version`
+ * on every analytics event — one constant, so the version a client is told and
+ * the version a metric is attributed to cannot disagree.
  */
-export const SERVER_VERSION = "0.2.0";
+export const SERVER_VERSION = STRATUM_VERSION;
 
 /**
  * Cap on a single JSON-RPC body.

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -15,9 +15,11 @@
  * be added, and the `GET` handler below is where the spec expects them.
  */
 import { Hono } from "hono";
+import type { AnalyticsTracker } from "../analytics/tracker";
+import { trackerForRequest } from "../analytics/tracker";
 import { StratumClient } from "../mcp/client";
 import { dispatchApiRequest } from "../mcp/dispatch";
-import { describeMcpOutcome } from "../mcp/outcome";
+import { describeMcpAnalytics, describeMcpOutcome } from "../mcp/outcome";
 import {
   JSON_RPC,
   LATEST_PROTOCOL_VERSION,
@@ -35,14 +37,26 @@ import { requestLogger } from "../utils/request-logger";
 
 const app = new Hono<{ Bindings: Env }>();
 
-/** One log line per exchange, at the level `describeMcpOutcome` picks. */
-function logOutcome(
+/**
+ * One log line and one analytics event per exchange.
+ *
+ * Both are derived here rather than at the two call sites below (single
+ * message, and each message of a batch) so a batched call is counted exactly
+ * like an unbatched one. `describeMcpAnalytics` returns null for exchanges
+ * that ran nothing, which are logged but not counted.
+ */
+function recordOutcome(
   logger: Logger,
+  tracker: AnalyticsTracker,
+  knownTools: ReadonlySet<string>,
   message: unknown,
   reply: Awaited<ReturnType<typeof handleMessage>>,
 ): void {
   const outcome = describeMcpOutcome(message, reply);
   logger[outcome.level](outcome.message, outcome.meta);
+
+  const analytics = describeMcpAnalytics(message, reply, knownTools);
+  if (analytics !== null) tracker.capture("mcp_request", analytics);
 }
 
 /**
@@ -179,6 +193,14 @@ app.post("/mcp", async (c) => {
     dispatchApiRequest(request, c.env, getExecutionCtx(c)),
   );
   const ctx = { tools: buildTools(client), serverVersion: SERVER_VERSION };
+  // The tool names this build actually defines, so an unrecognised name in a
+  // client's request is never echoed into the export. Derived from `ctx.tools`
+  // rather than from a second list, which would drift.
+  const knownTools = new Set(ctx.tools.map((t) => t.name));
+  // `api_request` already counts this POST; `mcp_request` is what makes the
+  // traffic legible — one HTTP request can carry a batch, and "which tool, for
+  // which client, with what outcome" is not recoverable from a route pattern.
+  const tracker = trackerForRequest(c);
 
   // A batch is a JSON array. Dropped from the 2025-06-18 revision but still
   // sent by clients on the two older ones we accept, so it is handled rather
@@ -212,7 +234,7 @@ app.post("/mcp", async (c) => {
     const replies = [];
     for (const message of parsed) {
       const reply = await handleMessage(message, ctx);
-      logOutcome(logger, message, reply);
+      recordOutcome(logger, tracker, knownTools, message, reply);
       if (reply !== null) replies.push(reply);
     }
     if (replies.length === 0) return new Response(null, { status: 202 });
@@ -220,7 +242,7 @@ app.post("/mcp", async (c) => {
   }
 
   const reply = await handleMessage(parsed, ctx);
-  logOutcome(logger, parsed, reply);
+  recordOutcome(logger, tracker, knownTools, parsed, reply);
   // A notification gets no body. 202 Accepted is what the spec prescribes, and
   // it is distinguishable from a 200 with an empty body, which some clients
   // treat as a truncated response.

--- a/src/routes/oauth-signup.tsx
+++ b/src/routes/oauth-signup.tsx
@@ -18,6 +18,8 @@
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { captureAuthCompleted } from "../analytics/auth";
+import type { AuthKind } from "../analytics/events";
 import { admitAndDeliverCodes, betaGateEnabled, validateInviteCode } from "../beta/gate";
 import { enforceSameOrigin } from "../middleware/csrf";
 import { recordAudit } from "../storage/audit";
@@ -170,6 +172,11 @@ async function issueSessionAndRedirect(
   record: PendingSignup,
   rememberMe: boolean,
   logger: Logger,
+  // Both callers land here, but they mean different things to the funnel: one
+  // arrives with an account that already existed, the other just created one.
+  // Inferring it from the record is not possible — by this point they look
+  // identical — so the caller states it.
+  kind: AuthKind,
 ): Promise<Response> {
   const sessionLogger = logger.child({ userId });
   const sessionResult = await createSession(c.env.DB, userId, sessionLogger, rememberMe);
@@ -183,6 +190,7 @@ async function issueSessionAndRedirect(
     actorId: userId,
     detail: { method: `${record.provider}-oauth` },
   });
+  await captureAuthCompleted(c, sessionLogger, { kind, provider: record.provider, userId });
   setCookie(c, "stratum_session", sessionResult.data.id, {
     httpOnly: true,
     secure: true,
@@ -378,7 +386,7 @@ app.post("/", async (c) => {
       if (!linked.success) logger.error("Failed to link GitHub account", linked.error);
     }
     await clearPendingSignup(c, token);
-    return issueSessionAndRedirect(c, existing.data.id, record, rememberMe, logger);
+    return issueSessionAndRedirect(c, existing.data.id, record, rememberMe, logger, "signin");
   }
 
   // Closed beta: the gate is enforced here rather than in the callback, which is
@@ -437,7 +445,7 @@ app.post("/", async (c) => {
   }
 
   await clearPendingSignup(c, token);
-  return issueSessionAndRedirect(c, userId, record, rememberMe, logger);
+  return issueSessionAndRedirect(c, userId, record, rememberMe, logger, "signup");
 });
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,13 @@ export interface Env {
   POSTHOG_API_KEY?: string;
   POSTHOG_HOST?: string;
   STRATUM_TELEMETRY_DISABLED?: string;
+  /**
+   * Which deployment this is ("production", "staging", a self-hoster's own
+   * label). Attached to every analytics event. Without it a staging deploy's
+   * traffic is indistinguishable from production's in the same PostHog
+   * project, and every funnel built on the data is quietly wrong.
+   */
+  STRATUM_ENVIRONMENT?: string;
   GITHUB_CLIENT_ID?: string;
   GITHUB_CLIENT_SECRET?: string;
   GOOGLE_CLIENT_ID?: string;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,11 @@
+/**
+ * The running server version.
+ *
+ * Duplicated from `package.json` rather than imported: pulling JSON into the
+ * Worker bundle would need `resolveJsonModule` and would ship the whole
+ * manifest to the edge for one string. `tests/mcp-endpoint.test.ts` asserts the
+ * two match, which is how this repo pins its other cross-file constants, so a
+ * release bump that forgets this line fails CI rather than shipping a stale
+ * version to every MCP client's log and every analytics event.
+ */
+export const STRATUM_VERSION = "0.2.0";

--- a/tests/analytics-auth.test.ts
+++ b/tests/analytics-auth.test.ts
@@ -127,4 +127,25 @@ describe("captureAuthCompleted", () => {
       runInRequest({ kind: "signin", provider: "github", userId: "user_1" }),
     ).resolves.toBeUndefined();
   });
+
+  // Without a person property a profile is an opaque id, and no cohort can ask
+  // "accounts that signed up with GitHub". `$set_once`, so a later sign-in
+  // through another provider cannot rewrite how someone actually arrived.
+  it("records the signup provider as a first-touch person property", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: { id: "user_1" } } as never);
+
+    await runInRequest({ kind: "signup", provider: "github", userId: "user_1" });
+
+    expect(captured[0]?.properties.$set_once).toEqual({ signup_provider: "github" });
+  });
+
+  it("does not rewrite the signup provider on a later sign-in", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: { id: "user_1" } } as never);
+
+    await runInRequest({ kind: "signin", provider: "google", userId: "user_1" });
+
+    expect(captured[0]?.properties.$set_once).toBeUndefined();
+  });
 });

--- a/tests/analytics-auth.test.ts
+++ b/tests/analytics-auth.test.ts
@@ -1,0 +1,130 @@
+import { Hono } from "hono";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { captureAuthCompleted } from "../src/analytics/auth";
+import type { Env } from "../src/types";
+import { createLogger } from "../src/utils/logger";
+
+vi.mock("../src/storage/users", () => ({ getUser: vi.fn() }));
+
+import { getUser } from "../src/storage/users";
+
+interface Captured {
+  event: string;
+  distinct_id: string;
+  properties: Record<string, string | number | boolean>;
+}
+
+function stubCapture(): Captured[] {
+  const captured: Captured[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init?: RequestInit) => {
+      captured.push(JSON.parse(init?.body as string) as Captured);
+      return new Response("ok");
+    }),
+  );
+  return captured;
+}
+
+const env = { POSTHOG_API_KEY: "phc_test", POSTHOG_HOST: "https://ph.example.com" } as Env;
+const logger = createLogger({ component: "test" });
+
+/**
+ * Runs `captureAuthCompleted` inside a real request, which is the only way to
+ * exercise the `waitUntil`-or-await branch it shares with the rest of this
+ * codebase's best-effort auth-path writes.
+ */
+async function runInRequest(
+  outcome: Parameters<typeof captureAuthCompleted>[2],
+  executionCtx?: ExecutionContext,
+): Promise<void> {
+  const app = new Hono<{ Bindings: Env }>();
+  app.get("/", async (c) => {
+    await captureAuthCompleted(c, logger, outcome);
+    return c.json({ ok: true });
+  });
+  await app.fetch(new Request("https://api.example.com/"), env, executionCtx);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("captureAuthCompleted", () => {
+  it("records a sign-up with its provider", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({
+      success: true,
+      data: { id: "user_1" },
+    } as never);
+
+    await runInRequest({ kind: "signup", provider: "github", userId: "user_1" });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.event).toBe("auth_completed");
+    expect(captured[0]?.distinct_id).toBe("user_1");
+    expect(captured[0]?.properties.kind).toBe("signup");
+    expect(captured[0]?.properties.provider).toBe("github");
+  });
+
+  it("records a sign-in distinctly from a sign-up", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: { id: "user_1" } } as never);
+
+    await runInRequest({ kind: "signin", provider: "email", userId: "user_1" });
+
+    expect(captured[0]?.properties.kind).toBe("signin");
+    expect(captured[0]?.properties.provider).toBe("email");
+  });
+
+  it("honours an existing account's opt-out", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({
+      success: true,
+      data: { id: "user_1", telemetryOptOut: true },
+    } as never);
+
+    await runInRequest({ kind: "signin", provider: "google", userId: "user_1" });
+
+    expect(captured).toHaveLength(0);
+  });
+
+  it("never carries an email address or a username", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({
+      success: true,
+      data: { id: "user_1", email: "person@acme.example", username: "acme-person" },
+    } as never);
+
+    await runInRequest({ kind: "signup", provider: "email", userId: "user_1" });
+
+    const body = JSON.stringify(captured[0]);
+    expect(body).not.toContain("acme");
+    expect(body).not.toContain("@");
+  });
+
+  it("schedules the send past the response when an execution context exists", async () => {
+    stubCapture();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: { id: "user_1" } } as never);
+    const waitUntil = vi.fn();
+
+    await runInRequest({ kind: "signup", provider: "github", userId: "user_1" }, {
+      waitUntil,
+      passThroughOnException: () => undefined,
+      props: {},
+    } as unknown as ExecutionContext);
+
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+  });
+
+  // Signing in must not be able to fail because telemetry did.
+  it("resolves when the preference lookup throws", async () => {
+    stubCapture();
+    vi.mocked(getUser).mockRejectedValue(new Error("D1 exploded"));
+
+    await expect(
+      runInRequest({ kind: "signin", provider: "github", userId: "user_1" }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/analytics-catalog.test.ts
+++ b/tests/analytics-catalog.test.ts
@@ -148,7 +148,9 @@ describe("domainEventProperties", () => {
   });
 
   it("contributes nothing for an event type with no whitelist entry", () => {
-    expect(domainEventProperties(makeEvent({ type: "sync.completed", payload: { commit: "a" } })));
+    expect(
+      domainEventProperties(makeEvent({ type: "sync.completed", payload: { commit: "a" } })),
+    ).toEqual({});
     expect(domainEventProperties(makeEvent({ type: "project.created", payload: {} }))).toEqual({});
   });
 

--- a/tests/analytics-catalog.test.ts
+++ b/tests/analytics-catalog.test.ts
@@ -1,0 +1,214 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+// Loaded via Vite's raw import (not node:fs) so this type-checks under the
+// Workers tsconfig, matching tests/wrangler-telemetry-config.test.ts.
+import FAQ from "../docs/user-guide/faq.md?raw";
+import {
+  ALL_EVENT_NAMES,
+  DOMAIN_EVENT_NAMES,
+  SURFACE_EVENT_NAMES,
+  domainEventName,
+  domainEventProperties,
+  importSourceProvider,
+  surfaceForRoute,
+} from "../src/analytics/events";
+import type { EventRecord } from "../src/storage/events";
+
+function makeEvent(over: Partial<EventRecord> = {}): EventRecord {
+  return {
+    id: "evt_1",
+    type: "change.created",
+    project: "acme/web",
+    projectId: "prj_abc",
+    actorType: "user",
+    actorId: "user_1",
+    payload: {},
+    status: "pending",
+    attempts: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    ...over,
+  };
+}
+
+describe("analytics catalog", () => {
+  it("has no duplicate event names", () => {
+    expect(new Set(ALL_EVENT_NAMES).size).toBe(ALL_EVENT_NAMES.length);
+  });
+
+  // The FAQ is the promise made to self-hosters about what leaves their
+  // instance. A new event name that nobody documented is exactly the drift
+  // this suite exists to catch — the code shipping more than the docs admit.
+  it("documents every surface event in the public FAQ", () => {
+    for (const name of SURFACE_EVENT_NAMES) {
+      expect(FAQ, `\`${name}\` is missing from docs/user-guide/faq.md`).toContain(`\`${name}\``);
+    }
+  });
+
+  it("documents the domain event family in the public FAQ", () => {
+    expect(FAQ).toContain("`stratum.<event type>`");
+  });
+
+  // Domain events whose payload contributes extra properties must say which,
+  // because "an opaque project id and the actor type" is no longer the whole
+  // answer for them.
+  it("documents every domain event that contributes extra properties", () => {
+    for (const type of [
+      "change.evaluated",
+      "change.reviewed",
+      "project.imported",
+      "issue.closed",
+    ]) {
+      const props = domainEventProperties(makeEvent({ type, payload: {} }));
+      // These types contribute properties for at least some payloads, so the
+      // FAQ must name them; the assertion below is what pins that.
+      expect(FAQ, `\`${domainEventName(type)}\` is missing from the FAQ`).toContain(
+        `\`${domainEventName(type)}\``,
+      );
+      expect(props).toBeDefined();
+    }
+    expect(FAQ).toContain("`stratum.deployment.*`");
+  });
+
+  it("names every outbox event type in DOMAIN_EVENT_NAMES", () => {
+    // The `DomainEventName` annotation on the constant makes the compiler
+    // enforce the reverse direction (no name here that is not an event type).
+    // This pins the count so a new StratumEvent member cannot be added to the
+    // union and silently left out of the runtime list.
+    expect(DOMAIN_EVENT_NAMES).toHaveLength(17);
+    for (const name of DOMAIN_EVENT_NAMES) expect(name.startsWith("stratum.")).toBe(true);
+  });
+});
+
+describe("domainEventProperties", () => {
+  it("exports the evaluation score and verdict — the reason the events are worth sending", () => {
+    const props = domainEventProperties(
+      makeEvent({ type: "change.evaluated", payload: { score: 0.82, passed: true } }),
+    );
+    expect(props).toEqual({ score: 0.82, passed: true });
+  });
+
+  it("exports a review verdict", () => {
+    const props = domainEventProperties(
+      makeEvent({ type: "change.reviewed", payload: { verdict: "request_changes" } }),
+    );
+    expect(props).toEqual({ verdict: "request_changes" });
+  });
+
+  it("drops a verdict that is not one of the known literals", () => {
+    const props = domainEventProperties(
+      makeEvent({ type: "change.reviewed", payload: { verdict: "acme-internal-policy" } }),
+    );
+    expect(props).toEqual({});
+  });
+
+  it("never exports a commit sha, workspace name, or issue title", () => {
+    const cases: EventRecord[] = [
+      makeEvent({ type: "change.merged", payload: { commit: "9f2c1ab", changeId: "ch_1" } }),
+      makeEvent({ type: "change.created", payload: { workspace: "secret-refactor" } }),
+      makeEvent({
+        type: "issue.opened",
+        payload: { title: "Prod outage at Acme", issueNumber: 7 },
+      }),
+    ];
+    for (const event of cases) {
+      expect(JSON.stringify(domainEventProperties(event))).not.toMatch(
+        /9f2c1ab|secret-refactor|Acme|ch_1/,
+      );
+    }
+  });
+
+  it("reports whether an issue closed through a linked change, not which one", () => {
+    const linked = domainEventProperties(
+      makeEvent({ type: "issue.closed", payload: { changeId: "ch_42", title: "Fix login" } }),
+    );
+    expect(linked).toEqual({ linked_change: true });
+
+    const manual = domainEventProperties(
+      makeEvent({ type: "issue.closed", payload: { title: "Fix login" } }),
+    );
+    expect(manual).toEqual({ linked_change: false });
+  });
+
+  it("reports the deploy target and whether a change drove it", () => {
+    const props = domainEventProperties(
+      makeEvent({
+        type: "deployment.failed",
+        payload: {
+          target: "vercel",
+          changeId: "ch_9",
+          commit: "abc123",
+          reason: "Build failed: /home/acme/app/src/secret.ts not found",
+        },
+      }),
+    );
+    expect(props).toEqual({ target: "vercel", linked_change: true });
+    // The failure reason is redacted against secrets by the runner, but it is
+    // still free text naming real paths. It must not leave the instance.
+    expect(JSON.stringify(props)).not.toContain("secret.ts");
+  });
+
+  it("contributes nothing for an event type with no whitelist entry", () => {
+    expect(domainEventProperties(makeEvent({ type: "sync.completed", payload: { commit: "a" } })));
+    expect(domainEventProperties(makeEvent({ type: "project.created", payload: {} }))).toEqual({});
+  });
+
+  it("ignores wrong-typed payload fields rather than exporting them", () => {
+    const props = domainEventProperties(
+      makeEvent({ type: "change.evaluated", payload: { score: "high", passed: "yes" } }),
+    );
+    expect(props).toEqual({});
+  });
+
+  it("drops a non-finite score", () => {
+    const props = domainEventProperties(
+      makeEvent({ type: "change.evaluated", payload: { score: Number.NaN, passed: false } }),
+    );
+    expect(props).toEqual({ passed: false });
+  });
+});
+
+describe("importSourceProvider", () => {
+  it("classifies the hosted providers", () => {
+    expect(importSourceProvider("https://github.com/acme/web.git")).toBe("github");
+    expect(importSourceProvider("https://gitlab.com/acme/web.git")).toBe("gitlab");
+    expect(importSourceProvider("https://bitbucket.org/acme/web.git")).toBe("bitbucket");
+  });
+
+  it("collapses a self-hosted host to `other` rather than reporting its name", () => {
+    // A self-hosted GitLab's hostname identifies the company running it.
+    expect(importSourceProvider("https://git.acme-internal.example/web.git")).toBe("other");
+  });
+
+  it("never returns anything derived from the URL", () => {
+    for (const url of ["not a url", "", "ssh://git@acme.example/web.git", null, 42]) {
+      expect(["github", "gitlab", "bitbucket", "other"]).toContain(importSourceProvider(url));
+    }
+  });
+});
+
+describe("surfaceForRoute", () => {
+  it("splits the product surfaces", () => {
+    expect(surfaceForRoute("/api/changes/:id")).toBe("api");
+    expect(surfaceForRoute("/api/admin/audit")).toBe("admin");
+    expect(surfaceForRoute("/auth/github/callback")).toBe("auth");
+    expect(surfaceForRoute("/mcp")).toBe("mcp");
+    expect(surfaceForRoute("/oauth/authorize")).toBe("auth");
+    expect(surfaceForRoute("/:namespace/:slug/changes")).toBe("ui");
+  });
+
+  it("recognises git smart-HTTP, which shares the UI's root prefix", () => {
+    expect(surfaceForRoute("/:namespace/:slug/info/refs")).toBe("git");
+    expect(surfaceForRoute("/:namespace/:slug/git-upload-pack")).toBe("git");
+    expect(surfaceForRoute("/:namespace/:slug/workspaces/:workspace/git-receive-pack")).toBe("git");
+  });
+
+  it("keeps non-product traffic out of the page-view story", () => {
+    expect(surfaceForRoute("*")).toBe("internal");
+    expect(surfaceForRoute("/health")).toBe("internal");
+    expect(surfaceForRoute("/csp-report")).toBe("internal");
+  });
+
+  it("does not let /api-adjacent literals fall into the api surface", () => {
+    expect(surfaceForRoute("/apifoo")).toBe("ui");
+  });
+});

--- a/tests/analytics-mcp.test.ts
+++ b/tests/analytics-mcp.test.ts
@@ -109,6 +109,31 @@ describe("describeMcpAnalytics", () => {
     expect(describeMcpAnalytics("not an object", null, TOOLS)).toBeNull();
   });
 
+  // A method name is caller-supplied free text: any authenticated client can
+  // POST an arbitrary string and get METHOD_NOT_FOUND back. Exporting it
+  // verbatim would put that text in the payload.
+  it("collapses an unrecognised method rather than exporting what the caller sent", () => {
+    const props = describeMcpAnalytics(
+      { jsonrpc: "2.0", id: 1, method: "acme/internal-secret-handshake" },
+      { jsonrpc: "2.0", id: 1, error: { code: -32601, message: "Method not found" } },
+      TOOLS,
+    );
+    expect(props?.mcp_method).toBe("unknown");
+    expect(props?.outcome).toBe("rejected");
+    expect(JSON.stringify(props)).not.toContain("acme");
+  });
+
+  it("keeps the real name for every method the server implements", () => {
+    for (const method of ["initialize", "ping", "tools/list", "tools/call"]) {
+      const props = describeMcpAnalytics(
+        { jsonrpc: "2.0", id: 1, method },
+        { jsonrpc: "2.0", id: 1, result: {} },
+        TOOLS,
+      );
+      expect(props?.mcp_method).toBe(method);
+    }
+  });
+
   it("reports a non-tool method without a tool property", () => {
     const props = describeMcpAnalytics(
       { jsonrpc: "2.0", id: 1, method: "tools/list" },

--- a/tests/analytics-mcp.test.ts
+++ b/tests/analytics-mcp.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { describeMcpAnalytics } from "../src/mcp/outcome";
+
+const TOOLS = new Set(["stratum_commit", "stratum_list_projects", "stratum_whoami"]);
+
+describe("describeMcpAnalytics", () => {
+  it("reports a successful tool call with the tool name", () => {
+    const props = describeMcpAnalytics(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "stratum_commit" } },
+      { jsonrpc: "2.0", id: 1, result: { content: [] } },
+      TOOLS,
+    );
+    expect(props).toEqual({
+      mcp_method: "tools/call",
+      outcome: "ok",
+      tool: "stratum_commit",
+    });
+  });
+
+  it("distinguishes a tool that ran and failed from one the protocol refused", () => {
+    const ranAndFailed = describeMcpAnalytics(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "stratum_commit" } },
+      { jsonrpc: "2.0", id: 1, result: { isError: true, content: [] } },
+      TOOLS,
+    );
+    expect(ranAndFailed?.outcome).toBe("tool_error");
+
+    const refused = describeMcpAnalytics(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "stratum_commit" } },
+      { jsonrpc: "2.0", id: 1, error: { code: -32602, message: "Invalid params" } },
+      TOOLS,
+    );
+    expect(refused?.outcome).toBe("rejected");
+  });
+
+  // A tool name arrives in the request body, so an arbitrary string can be put
+  // there. Echoing it would put unbounded caller-supplied text in the export.
+  it("reports an unrecognised tool name as `unknown` rather than echoing it", () => {
+    const props = describeMcpAnalytics(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "acme_internal_deploy_secret" },
+      },
+      { jsonrpc: "2.0", id: 1, error: { code: -32601, message: "Unknown tool" } },
+      TOOLS,
+    );
+    expect(props?.tool).toBe("unknown");
+    expect(JSON.stringify(props)).not.toContain("acme");
+  });
+
+  it("captures the client's self-description from the handshake", () => {
+    const props = describeMcpAnalytics(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-03-26", clientInfo: { name: "Claude", version: "1.2" } },
+      },
+      { jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-03-26" } },
+      TOOLS,
+    );
+    expect(props).toEqual({
+      mcp_method: "initialize",
+      outcome: "ok",
+      client_name: "Claude",
+      client_version: "1.2",
+      protocol_version: "2025-03-26",
+    });
+  });
+
+  it("caps a client name at 64 characters", () => {
+    const props = describeMcpAnalytics(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { clientInfo: { name: "x".repeat(500) } },
+      },
+      { jsonrpc: "2.0", id: 1, result: {} },
+      TOOLS,
+    );
+    expect(props?.client_name).toHaveLength(64);
+  });
+
+  it("omits client fields the handshake did not provide", () => {
+    const props = describeMcpAnalytics(
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      { jsonrpc: "2.0", id: 1, result: {} },
+      TOOLS,
+    );
+    expect(props).toEqual({ mcp_method: "initialize", outcome: "ok" });
+  });
+
+  // Counting these as tool calls would overstate MCP usage with traffic that
+  // never reached a tool.
+  it("counts nothing for a notification, which runs no tool", () => {
+    const props = describeMcpAnalytics(
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      null,
+      TOOLS,
+    );
+    expect(props).toBeNull();
+  });
+
+  it("counts nothing for a message that is not JSON-RPC", () => {
+    expect(describeMcpAnalytics({ hello: "world" }, null, TOOLS)).toBeNull();
+    expect(describeMcpAnalytics("not an object", null, TOOLS)).toBeNull();
+  });
+
+  it("reports a non-tool method without a tool property", () => {
+    const props = describeMcpAnalytics(
+      { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      { jsonrpc: "2.0", id: 1, result: { tools: [] } },
+      TOOLS,
+    );
+    expect(props).toEqual({ mcp_method: "tools/list", outcome: "ok" });
+  });
+});

--- a/tests/analytics-middleware.test.ts
+++ b/tests/analytics-middleware.test.ts
@@ -9,11 +9,14 @@ interface CapturedEvent {
   properties: Record<string, string | number | boolean>;
 }
 
-function makeApp(vars: { userId?: string; agentId?: string } = {}) {
+function makeApp(vars: { userId?: string; agentId?: string; agentOwnerId?: string } = {}) {
   const app = new Hono<{ Bindings: Env }>();
   app.use("*", async (c, next) => {
     if (vars.userId) c.set("userId", vars.userId);
     if (vars.agentId) c.set("agentId", vars.agentId);
+    // `authMiddleware` publishes the owner alongside the agent, because it has
+    // to load the owner anyway to read their telemetry preference.
+    if (vars.agentOwnerId) c.set("agentOwnerId", vars.agentOwnerId);
     await next();
   });
   app.use("*", analyticsMiddleware);
@@ -166,7 +169,22 @@ describe("analyticsMiddleware", () => {
     expect(captured[0]?.distinct_id).toBe("user-123");
   });
 
-  it("attributes events to the agent when no user is set", async () => {
+  // An agent is a credential, not a person. Attributing it to itself would mint
+  // a person profile per token, splitting one human's history across several.
+  it("attributes an agent's request to its owner, keeping the agent as a property", async () => {
+    const captured = stubCapture();
+    await makeApp({ agentId: "agent-42", agentOwnerId: "user-123" }).fetch(
+      new Request("https://api.example.com/api/changes"),
+      env,
+    );
+    await flushCapture();
+
+    expect(captured[0]?.distinct_id).toBe("user-123");
+    expect(captured[0]?.properties.agent_id).toBe("agent-42");
+    expect(captured[0]?.properties.actor_type).toBe("agent");
+  });
+
+  it("captures an agent personless when its owner cannot be resolved", async () => {
     const captured = stubCapture();
     await makeApp({ agentId: "agent-42" }).fetch(
       new Request("https://api.example.com/api/changes"),
@@ -174,7 +192,10 @@ describe("analyticsMiddleware", () => {
     );
     await flushCapture();
 
-    expect(captured[0]?.distinct_id).toBe("agent-42");
+    // No person to attribute to, so no profile is minted for the credential.
+    expect(captured[0]?.distinct_id).toBe("server");
+    expect(captured[0]?.properties.$process_person_profile).toBe(false);
+    expect(captured[0]?.properties.agent_id).toBe("agent-42");
   });
 
   it("captures unattributed events personless under the server id", async () => {
@@ -221,7 +242,7 @@ describe("analyticsMiddleware — segmentation properties", () => {
     expect(captured[0]?.properties.actor_type).toBe("user");
 
     const agentCaptured = stubCapture();
-    await makeApp({ agentId: "agent-42" }).fetch(
+    await makeApp({ agentId: "agent-42", agentOwnerId: "user-123" }).fetch(
       new Request("https://api.example.com/api/changes"),
       env,
     );

--- a/tests/analytics-middleware.test.ts
+++ b/tests/analytics-middleware.test.ts
@@ -186,3 +186,82 @@ describe("analyticsMiddleware", () => {
     expect(captured[0]?.properties.$process_person_profile).toBe(false);
   });
 });
+
+describe("analyticsMiddleware — segmentation properties", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("labels the surface that served the request", async () => {
+    const captured = stubCapture();
+    await makeApp().fetch(new Request("https://api.example.com/api/changes"), env);
+    await flushCapture();
+
+    expect(captured[0]?.properties.surface).toBe("api");
+  });
+
+  it("labels a UI page distinctly from the API", async () => {
+    const captured = stubCapture();
+    await makeApp().fetch(
+      new Request("https://api.example.com/@acme/secret-repo/blob/src/a.ts"),
+      env,
+    );
+    await flushCapture();
+
+    expect(captured[0]?.properties.surface).toBe("ui");
+  });
+
+  it("records how the caller was identified", async () => {
+    const captured = stubCapture();
+    await makeApp({ userId: "user-123" }).fetch(
+      new Request("https://api.example.com/api/changes"),
+      env,
+    );
+    await flushCapture();
+    expect(captured[0]?.properties.actor_type).toBe("user");
+
+    const agentCaptured = stubCapture();
+    await makeApp({ agentId: "agent-42" }).fetch(
+      new Request("https://api.example.com/api/changes"),
+      env,
+    );
+    await flushCapture();
+    expect(agentCaptured[0]?.properties.actor_type).toBe("agent");
+
+    const anonCaptured = stubCapture();
+    await makeApp().fetch(new Request("https://api.example.com/api/changes"), env);
+    await flushCapture();
+    expect(anonCaptured[0]?.properties.actor_type).toBe("anonymous");
+  });
+
+  it("stamps the operator's environment label", async () => {
+    const captured = stubCapture();
+    await makeApp().fetch(new Request("https://api.example.com/api/changes"), {
+      ...env,
+      STRATUM_ENVIRONMENT: "production",
+    } as Env);
+    await flushCapture();
+
+    expect(captured[0]?.properties.environment).toBe("production");
+  });
+
+  // The per-user opt-out now lives in the tracker rather than in this
+  // middleware. Pinned here because the middleware is where it used to live,
+  // and a refactor that loses it would otherwise fail no test in this file.
+  it("still honours the caller's opt-out", async () => {
+    const captured = stubCapture();
+    const app = new Hono<{ Bindings: Env }>();
+    app.use("*", async (c, next) => {
+      c.set("userId", "user-123");
+      c.set("telemetryOptOut", true);
+      await next();
+    });
+    app.use("*", analyticsMiddleware);
+    app.get("/api/changes", (c) => c.json({ ok: true }));
+
+    await app.fetch(new Request("https://api.example.com/api/changes"), env);
+    await flushCapture();
+
+    expect(captured).toHaveLength(0);
+  });
+});

--- a/tests/analytics-opt-out-queue.test.ts
+++ b/tests/analytics-opt-out-queue.test.ts
@@ -207,10 +207,10 @@ describe("telemetry opt-out — queue path", () => {
       };
       expect(JSON.stringify(properties)).not.toContain("acme/web");
       expect(properties.properties.project).toBeUndefined();
-      expect(properties.properties.projectId).toBe("prj_abc");
+      expect(properties.properties.project_id).toBe("prj_abc");
     });
 
-    it("omits projectId entirely on rows written before dual-write", async () => {
+    it("omits project_id entirely on rows written before dual-write", async () => {
       vi.mocked(getUser).mockResolvedValue({ success: true, data: liveUser });
 
       await processEvent(env, makeEvent({ projectId: undefined }), logger);
@@ -218,8 +218,8 @@ describe("telemetry opt-out — queue path", () => {
       const properties = mockCapture.mock.calls[0]?.[0] as {
         properties: Record<string, unknown>;
       };
-      expect("projectId" in properties.properties).toBe(false);
-      expect(properties.properties.actorType).toBe("user");
+      expect("project_id" in properties.properties).toBe(false);
+      expect(properties.properties.actor_type).toBe("user");
     });
   });
 });

--- a/tests/analytics-opt-out.test.ts
+++ b/tests/analytics-opt-out.test.ts
@@ -145,7 +145,11 @@ describe("telemetry opt-out — request path", () => {
     await flushCapture();
 
     expect(captured).toHaveLength(1);
-    expect(captured[0]?.distinct_id).toBe("agt_1");
+    // Attributed to the owner, not the agent: an agent token is a credential
+    // acting under a person's account, and minting a person profile per token
+    // would split that person's history and inflate the person count.
+    expect(captured[0]?.distinct_id).toBe("usr_1");
+    expect(captured[0]?.properties.agent_id).toBe("agt_1");
   });
 
   it("keeps capturing anonymous traffic personless — it carries no preference", async () => {

--- a/tests/analytics-tracker.test.ts
+++ b/tests/analytics-tracker.test.ts
@@ -1,10 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  AnalyticsTracker,
-  trackerForEventActor,
-  trackerForSystem,
-  trackerForUser,
-} from "../src/analytics/tracker";
+import { trackerForEventActor, trackerForSystem, trackerForUser } from "../src/analytics/tracker";
 import type { EventRecord } from "../src/storage/events";
 import type { Env } from "../src/types";
 import { createLogger } from "../src/utils/logger";
@@ -182,6 +177,20 @@ describe("trackerForEventActor", () => {
     expect(captured).toHaveLength(0);
   });
 
+  // `change-flow.ts` builds `{ type: "user" }` with the id omitted when it has
+  // none. Reclassifying that as system-authored would export a real person's
+  // activity with no preference consulted — the opt-out defeated by a missing
+  // field rather than by a decision.
+  it("suppresses a user-authored event whose actor id is missing", async () => {
+    const captured = stubCapture();
+    const event = makeEvent({ actorType: "user", actorId: undefined });
+
+    await (await trackerForEventActor(env, event, logger)).captureDomainEvent(event);
+
+    expect(captured).toHaveLength(0);
+    expect(getUser).not.toHaveBeenCalled();
+  });
+
   it("captures a system-authored event personless, with no lookup", async () => {
     const captured = stubCapture();
     const event = makeEvent({ actorType: "system", actorId: undefined });
@@ -228,24 +237,30 @@ describe("AnalyticsTracker — event shape", () => {
 
   it("hands the capture to waitUntil when the runtime offers one", async () => {
     stubCapture();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: optedInUser } as never);
     const waitUntil = vi.fn();
-    await AnalyticsTracker.create(
-      env,
-      { distinctId: "user_1", kind: "user", optedOut: false, attributed: true },
-      waitUntil,
-    ).capture("error_occurred", { route: "/api/changes", method: "GET", error_type: "TypeError" });
+
+    const tracker = await trackerForUser(env, "user_1", logger, waitUntil);
+    await tracker.capture("error_occurred", {
+      route: "/api/changes",
+      method: "GET",
+      error_type: "TypeError",
+    });
 
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 
-  it("does not schedule anything for a suppressed actor", async () => {
+  it("does not schedule anything for an opted-out actor", async () => {
     stubCapture();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: optedOutUser } as never);
     const waitUntil = vi.fn();
-    await AnalyticsTracker.create(
-      env,
-      { distinctId: "user_1", kind: "user", optedOut: true, attributed: true },
-      waitUntil,
-    ).capture("error_occurred", { route: "/api/changes", method: "GET", error_type: "TypeError" });
+
+    const tracker = await trackerForUser(env, "user_1", logger, waitUntil);
+    await tracker.capture("error_occurred", {
+      route: "/api/changes",
+      method: "GET",
+      error_type: "TypeError",
+    });
 
     expect(waitUntil).not.toHaveBeenCalled();
   });

--- a/tests/analytics-tracker.test.ts
+++ b/tests/analytics-tracker.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AnalyticsTracker,
+  trackerForEventActor,
+  trackerForSystem,
+  trackerForUser,
+} from "../src/analytics/tracker";
+import type { EventRecord } from "../src/storage/events";
+import type { Env } from "../src/types";
+import { createLogger } from "../src/utils/logger";
+
+vi.mock("../src/storage/users", () => ({ getUser: vi.fn() }));
+vi.mock("../src/storage/agents", () => ({ getAgent: vi.fn() }));
+
+import { getAgent } from "../src/storage/agents";
+import { getUser } from "../src/storage/users";
+
+interface Captured {
+  event: string;
+  distinct_id: string;
+  properties: Record<string, string | number | boolean>;
+}
+
+function stubCapture(): Captured[] {
+  const captured: Captured[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init?: RequestInit) => {
+      captured.push(JSON.parse(init?.body as string) as Captured);
+      return new Response("ok");
+    }),
+  );
+  return captured;
+}
+
+const env = { POSTHOG_API_KEY: "phc_test", POSTHOG_HOST: "https://ph.example.com" } as Env;
+const logger = createLogger({ component: "test" });
+
+const optedInUser = { id: "user_1", telemetryOptOut: false };
+const optedOutUser = { id: "user_1", telemetryOptOut: true };
+
+function makeEvent(over: Partial<EventRecord> = {}): EventRecord {
+  return {
+    id: "evt_1",
+    type: "change.merged",
+    project: "acme/web",
+    projectId: "prj_abc",
+    actorType: "user",
+    actorId: "user_1",
+    payload: {},
+    status: "pending",
+    attempts: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    ...over,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("AnalyticsTracker — the instance gate", () => {
+  it("sends nothing when the instance switch is set", async () => {
+    const captured = stubCapture();
+    await trackerForSystem({ ...env, STRATUM_TELEMETRY_DISABLED: "true" } as Env).capture(
+      "background_job_completed",
+      { job: "event-consumer", outcome: "failed" },
+    );
+    expect(captured).toHaveLength(0);
+  });
+
+  it("sends nothing when no API key is configured", async () => {
+    const captured = stubCapture();
+    await trackerForSystem({ POSTHOG_HOST: "https://ph.example.com" } as Env).capture(
+      "background_job_completed",
+      { job: "event-consumer", outcome: "failed" },
+    );
+    expect(captured).toHaveLength(0);
+  });
+});
+
+describe("AnalyticsTracker — the per-user gate", () => {
+  it("sends for a user who has not opted out", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: optedInUser } as never);
+
+    const tracker = await trackerForUser(env, "user_1", logger);
+    await tracker.capture("auth_completed", { kind: "signin", provider: "github" });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.distinct_id).toBe("user_1");
+    expect(captured[0]?.properties.kind).toBe("signin");
+  });
+
+  it("sends nothing for a user who opted out", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: optedOutUser } as never);
+
+    const tracker = await trackerForUser(env, "user_1", logger);
+    await tracker.capture("auth_completed", { kind: "signin", provider: "github" });
+
+    expect(captured).toHaveLength(0);
+  });
+
+  // A privacy control that exports whenever D1 hiccups is not a privacy control.
+  it("fails closed when the preference cannot be read", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({
+      success: false,
+      error: new Error("D1 unavailable"),
+    } as never);
+
+    const tracker = await trackerForUser(env, "user_1", logger);
+    await tracker.capture("auth_completed", { kind: "signup", provider: "email" });
+
+    expect(captured).toHaveLength(0);
+  });
+});
+
+describe("trackerForEventActor", () => {
+  it("honours the owner's choice for an agent-authored event", async () => {
+    const captured = stubCapture();
+    vi.mocked(getAgent).mockResolvedValue({
+      success: true,
+      data: { id: "agent_1", ownerId: "user_1" },
+    } as never);
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: optedOutUser } as never);
+
+    const tracker = await trackerForEventActor(
+      env,
+      makeEvent({ actorType: "agent", actorId: "agent_1" }),
+      logger,
+    );
+    await tracker.captureDomainEvent(makeEvent({ actorType: "agent", actorId: "agent_1" }));
+
+    expect(captured).toHaveLength(0);
+    // The owner was consulted, not the agent — routing through an agent must
+    // not re-enable telemetry the owner switched off.
+    expect(getUser).toHaveBeenCalledWith(env.DB, "user_1", logger);
+  });
+
+  it("attributes an agent event to the agent, not to its owner", async () => {
+    const captured = stubCapture();
+    vi.mocked(getAgent).mockResolvedValue({
+      success: true,
+      data: { id: "agent_1", ownerId: "user_1" },
+    } as never);
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: optedInUser } as never);
+
+    const event = makeEvent({ actorType: "agent", actorId: "agent_1" });
+    const tracker = await trackerForEventActor(env, event, logger);
+    await tracker.captureDomainEvent(event);
+
+    expect(captured[0]?.distinct_id).toBe("agent_1");
+    expect(captured[0]?.properties.actor_type).toBe("agent");
+  });
+
+  it("fails closed when the agent lookup fails", async () => {
+    const captured = stubCapture();
+    vi.mocked(getAgent).mockResolvedValue({ success: false, error: new Error("gone") } as never);
+
+    const event = makeEvent({ actorType: "agent", actorId: "agent_1" });
+    await (await trackerForEventActor(env, event, logger)).captureDomainEvent(event);
+
+    expect(captured).toHaveLength(0);
+  });
+
+  it("captures a system-authored event personless, with no lookup", async () => {
+    const captured = stubCapture();
+    const event = makeEvent({ actorType: "system", actorId: undefined });
+
+    await (await trackerForEventActor(env, event, logger)).captureDomainEvent(event);
+
+    expect(getUser).not.toHaveBeenCalled();
+    expect(captured[0]?.distinct_id).toBe("system");
+    expect(captured[0]?.properties.$process_person_profile).toBe(false);
+  });
+});
+
+describe("AnalyticsTracker — event shape", () => {
+  it("stamps the operator's environment label on every event", async () => {
+    const captured = stubCapture();
+    await trackerForSystem({ ...env, STRATUM_ENVIRONMENT: "staging" } as Env).capture(
+      "background_job_completed",
+      { job: "webhook-delivery", outcome: "succeeded" },
+    );
+    expect(captured[0]?.properties.environment).toBe("staging");
+  });
+
+  it("reports `unknown` rather than guessing when no label is set", async () => {
+    const captured = stubCapture();
+    await trackerForSystem(env).capture("background_job_completed", {
+      job: "webhook-delivery",
+      outcome: "succeeded",
+    });
+    expect(captured[0]?.properties.environment).toBe("unknown");
+  });
+
+  it("names a domain event `stratum.<type>` and sends the id, never the project name", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: optedInUser } as never);
+
+    const event = makeEvent({ type: "change.evaluated", payload: { score: 0.9, passed: true } });
+    await (await trackerForEventActor(env, event, logger)).captureDomainEvent(event);
+
+    expect(captured[0]?.event).toBe("stratum.change.evaluated");
+    expect(captured[0]?.properties.project_id).toBe("prj_abc");
+    expect(captured[0]?.properties.score).toBe(0.9);
+    expect(JSON.stringify(captured[0])).not.toContain("acme/web");
+  });
+
+  it("hands the capture to waitUntil when the runtime offers one", async () => {
+    stubCapture();
+    const waitUntil = vi.fn();
+    await AnalyticsTracker.create(
+      env,
+      { distinctId: "user_1", kind: "user", optedOut: false, attributed: true },
+      waitUntil,
+    ).capture("error_occurred", { route: "/api/changes", method: "GET", error_type: "TypeError" });
+
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not schedule anything for a suppressed actor", async () => {
+    stubCapture();
+    const waitUntil = vi.fn();
+    await AnalyticsTracker.create(
+      env,
+      { distinctId: "user_1", kind: "user", optedOut: true, attributed: true },
+      waitUntil,
+    ).capture("error_occurred", { route: "/api/changes", method: "GET", error_type: "TypeError" });
+
+    expect(waitUntil).not.toHaveBeenCalled();
+  });
+
+  // Telemetry must never be able to fail a request or a queue handler.
+  it("resolves rather than rejecting when the transport throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    await expect(
+      trackerForSystem(env).capture("background_job_completed", {
+        job: "event-consumer",
+        outcome: "abandoned",
+        attempts: 5,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/analytics-tracker.test.ts
+++ b/tests/analytics-tracker.test.ts
@@ -8,6 +8,7 @@ import {
 import type { EventRecord } from "../src/storage/events";
 import type { Env } from "../src/types";
 import { createLogger } from "../src/utils/logger";
+import { STRATUM_VERSION } from "../src/version";
 
 vi.mock("../src/storage/users", () => ({ getUser: vi.fn() }));
 vi.mock("../src/storage/agents", () => ({ getAgent: vi.fn() }));
@@ -140,7 +141,10 @@ describe("trackerForEventActor", () => {
     expect(getUser).toHaveBeenCalledWith(env.DB, "user_1", logger);
   });
 
-  it("attributes an agent event to the agent, not to its owner", async () => {
+  // An agent is a credential, not a person. Giving each one its own distinct id
+  // would mint a person profile per token, splitting one human's history across
+  // several profiles and making every user count and retention curve wrong.
+  it("attributes an agent event to its owner, keeping the agent as a property", async () => {
     const captured = stubCapture();
     vi.mocked(getAgent).mockResolvedValue({
       success: true,
@@ -152,8 +156,20 @@ describe("trackerForEventActor", () => {
     const tracker = await trackerForEventActor(env, event, logger);
     await tracker.captureDomainEvent(event);
 
-    expect(captured[0]?.distinct_id).toBe("agent_1");
+    expect(captured[0]?.distinct_id).toBe("user_1");
+    expect(captured[0]?.properties.agent_id).toBe("agent_1");
     expect(captured[0]?.properties.actor_type).toBe("agent");
+  });
+
+  it("does not tag a user-authored event with an agent id", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: optedInUser } as never);
+
+    const event = makeEvent({ actorType: "user", actorId: "user_1" });
+    await (await trackerForEventActor(env, event, logger)).captureDomainEvent(event);
+
+    expect(captured[0]?.distinct_id).toBe("user_1");
+    expect(captured[0]?.properties.agent_id).toBeUndefined();
   });
 
   it("fails closed when the agent lookup fails", async () => {
@@ -249,5 +265,74 @@ describe("AnalyticsTracker — event shape", () => {
         attempts: 5,
       }),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("AnalyticsTracker — ingestion correctness", () => {
+  // An outbox row is exported when a consumer reaches it. A retry, or the
+  // five-minute stale sweep, can delay that well past the minute the change was
+  // actually merged — so without an explicit timestamp the event lands in the
+  // wrong bucket and every time series skews toward whenever the queue drained.
+  it("dates a domain event from the outbox row, not from delivery time", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: optedInUser } as never);
+
+    const event = makeEvent({ createdAt: "2026-01-01T00:00:00Z" });
+    await (await trackerForEventActor(env, event, logger)).captureDomainEvent(event);
+
+    expect((captured[0] as unknown as { timestamp?: string }).timestamp).toBe(
+      "2026-01-01T00:00:00Z",
+    );
+  });
+
+  it("does not backdate a request-path event", async () => {
+    const captured = stubCapture();
+    await trackerForSystem(env).capture("background_job_completed", {
+      job: "webhook-delivery",
+      outcome: "succeeded",
+    });
+
+    expect((captured[0] as unknown as { timestamp?: string }).timestamp).toBeUndefined();
+  });
+
+  it("stamps the server version so a metric change can be tied to a release", async () => {
+    const captured = stubCapture();
+    await trackerForSystem(env).capture("background_job_completed", {
+      job: "event-consumer",
+      outcome: "failed",
+    });
+
+    expect(captured[0]?.properties.$lib).toBe("stratum-server");
+    expect(captured[0]?.properties.$lib_version).toBe(STRATUM_VERSION);
+  });
+
+  it("sends person properties as $set_once so first-touch values are never overwritten", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: optedInUser } as never);
+
+    const tracker = await trackerForUser(env, "user_1", logger);
+    await tracker.capture(
+      "auth_completed",
+      { kind: "signup", provider: "github" },
+      { signup_provider: "github" },
+    );
+
+    const body = captured[0] as unknown as { $set_once?: Record<string, unknown> };
+    expect(captured[0]?.properties.$set_once).toEqual({ signup_provider: "github" });
+    expect(body.$set_once).toBeUndefined();
+  });
+
+  it("never sets person properties for an opted-out person", async () => {
+    const captured = stubCapture();
+    vi.mocked(getUser).mockResolvedValue({ success: true, data: optedOutUser } as never);
+
+    const tracker = await trackerForUser(env, "user_1", logger);
+    await tracker.capture(
+      "auth_completed",
+      { kind: "signup", provider: "github" },
+      { signup_provider: "github" },
+    );
+
+    expect(captured).toHaveLength(0);
   });
 });

--- a/website/src/content/docs/guides/faq.md
+++ b/website/src/content/docs/guides/faq.md
@@ -216,23 +216,71 @@ top-level `[vars]`, so a top-level-only setting never reaches
 `wrangler deploy --env=production`. The instance switch always wins over an
 individual account's preference.
 
-Two kinds of event are sent, and only these:
+### What exactly is sent
 
-- **`api_request`**, one per request. Its properties are limited to the matched
-  route pattern (e.g. `/:namespace/:slug/files`), method, status, and latency —
-  never the concrete URL, so namespaces, repo slugs, change ids, and file paths
-  are not sent to PostHog. A request that never reached a registered route is
-  captured with `route: "*"`; a 404 is excluded entirely rather than captured as
-  `"*"`.
-- **`stratum.<event type>`**, one per repository activity (a change opening, a
-  merge). Its properties are limited to the event type, the actor type, and an
-  opaque project id — never the project's name.
+Every property on every event is either a **source-code literal** (a route
+pattern, an event type, a tool name) or a **bounded value** (a status code, a
+duration, a score, an enum). Names, paths, URLs, titles, refs, diffs, file
+contents, and request payloads are never sent. The one exception is noted
+against `mcp_request` below.
 
-Neither carries diffs, file contents, or request payloads.
+The list is exhaustive — `src/analytics/events.ts` is its single source of
+truth, and a test fails the build if this table and that file disagree.
+
+| Event | Sent when | Properties |
+|-------|-----------|------------|
+| `api_request` | Once per request that matched a route | `method`, `route`, `status`, `latency_ms`, `surface`, `actor_type` |
+| `mcp_request` | Once per JSON-RPC message handled at `/mcp` | `mcp_method`, `outcome`, `tool`, `client_name`, `client_version`, `protocol_version` |
+| `auth_completed` | Once per completed sign-up or sign-in | `kind` (`signup`/`signin`), `provider` (`github`/`google`/`email`) |
+| `error_occurred` | Once per unhandled exception | `route`, `method`, `error_type` |
+| `background_job_completed` | Once per background job reaching a terminal state | `job`, `outcome`, `attempts` |
+| `stratum.<event type>` | Once per repository activity (a change opening, a merge, a deploy) | `project_id`, `actor_type`, plus the per-type properties below |
+
+Every event additionally carries `environment` — the label the operator set in
+`STRATUM_ENVIRONMENT`, so staging traffic can be told apart from production.
+
+The per-type properties on `stratum.*` events are the whole reason they are
+worth collecting, and they are whitelisted per event type:
+
+| Event type | Extra properties |
+|------------|------------------|
+| `stratum.change.evaluated` | `score`, `passed` |
+| `stratum.change.reviewed` | `verdict` (`approve`/`request_changes`/`comment`) |
+| `stratum.project.imported` | `source_provider` (`github`/`gitlab`/`bitbucket`/`other`) |
+| `stratum.issue.closed` | `linked_change` (boolean) |
+| `stratum.deployment.*` | `target` (`cloudflare`/`vercel`), `linked_change` (boolean) |
+
+Everything else in an event's payload is dropped: workspace names, commit
+shas, issue titles, import URLs, and deployment failure text all stay on your
+instance. An event type not listed above contributes no extra properties at
+all.
+
+### The details worth knowing
+
+- **Route patterns, never URLs.** `api_request` reports
+  `/:namespace/:slug/files`, not the path that was actually requested, so
+  namespaces, repo slugs, change ids, and file paths are not sent. A request
+  that never reached a registered route is captured with `route: "*"`; a 404 is
+  excluded entirely rather than captured as `"*"`.
+- **`surface`** says which part of Stratum served the request — `api`, `ui`,
+  `git`, `mcp`, `auth`, `admin`, or `internal`. It is derived from the route
+  pattern, so it inherits the same guarantee.
+- **`mcp_request` carries the one free-text field.** `client_name` and
+  `client_version` are whatever the connecting software calls itself in the MCP
+  handshake, capped at 64 characters. They answer "which editors and agents
+  connect to Stratum". `tool` is reported only when it names a tool this build
+  defines; an unrecognised name is reported as `unknown` rather than echoed
+  back.
+- **`error_occurred` never carries the exception message.** Messages quote
+  their input. Only the error's type name (`TypeError`) is sent; the message
+  stays in your own Workers logs.
+- **Project ids, never project names.** A name identifies private source as
+  surely as a repo slug in a URL does. The opaque id groups events just as
+  well.
 
 Events also carry identity attribution: the `distinctId` is the acting user or
-agent id (or `server` for unattributed requests, which are marked personless) so
-usage can be counted per account.
+agent id (or `server` for unattributed requests, and `system` for events no
+person caused — both marked personless) so usage can be counted per account.
 
 ## Where are my invite codes?
 

--- a/website/src/content/docs/guides/faq.md
+++ b/website/src/content/docs/guides/faq.md
@@ -237,7 +237,15 @@ truth, and a test fails the build if this table and that file disagree.
 | `stratum.<event type>` | Once per repository activity (a change opening, a merge, a deploy) | `project_id`, `actor_type`, plus the per-type properties below |
 
 Every event additionally carries `environment` — the label the operator set in
-`STRATUM_ENVIRONMENT`, so staging traffic can be told apart from production.
+`STRATUM_ENVIRONMENT`, so staging traffic can be told apart from production —
+and `$lib_version`, the Stratum version that sent it, so a change in a metric
+can be tied to the release that caused it. An event caused by an agent also
+carries `agent_id`.
+
+One person property is ever set: `signup_provider`, recorded once when an
+account is created. It is what lets a question like "accounts that signed up
+with GitHub in August" be asked at all. Your email address, username, and
+display name are never sent.
 
 The per-type properties on `stratum.*` events are the whole reason they are
 worth collecting, and they are whitelisted per event type:
@@ -278,9 +286,18 @@ all.
   surely as a repo slug in a URL does. The opaque id groups events just as
   well.
 
-Events also carry identity attribution: the `distinctId` is the acting user or
-agent id (or `server` for unattributed requests, and `system` for events no
-person caused — both marked personless) so usage can be counted per account.
+Events also carry identity attribution: the `distinctId` is the acting user's
+id (or `server` for unattributed requests, and `system` for events no person
+caused — both marked personless) so usage can be counted per account.
+
+**An agent is attributed to the person who owns it**, not to itself. An agent
+token is a credential you minted, acting under your account — your opt-out
+already governs it, so your identity is what "who did this" means. The agent's
+own id rides along as `agent_id`, so the two stay distinguishable without an
+agent counting as a separate person.
+
+Domain events are dated from when the activity happened, not from when the
+queue got round to exporting them.
 
 ## Where are my invite codes?
 

--- a/website/src/content/docs/guides/faq.md
+++ b/website/src/content/docs/guides/faq.md
@@ -276,9 +276,10 @@ all.
 - **`mcp_request` carries the one free-text field.** `client_name` and
   `client_version` are whatever the connecting software calls itself in the MCP
   handshake, capped at 64 characters. They answer "which editors and agents
-  connect to Stratum". `tool` is reported only when it names a tool this build
-  defines; an unrecognised name is reported as `unknown` rather than echoed
-  back.
+  connect to Stratum". Everything else on the event is bounded: `tool` and
+  `mcp_method` are reported only when they name a tool or a JSON-RPC method
+  this build actually implements, and anything else — both are strings a client
+  can put anything in — is reported as `unknown` rather than echoed back.
 - **`error_occurred` never carries the exception message.** Messages quote
   their input. Only the error's type name (`TypeError`) is sent; the message
   stays in your own Workers logs.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -158,6 +158,10 @@ name = "EMAIL"
 
 [vars]
 POSTHOG_HOST = "https://app.posthog.com"
+# Labels this deployment on every analytics event, so staging traffic can be
+# told apart from production's in one PostHog project. Any string; events from
+# an instance that leaves it unset report `environment: "unknown"`.
+STRATUM_ENVIRONMENT = "development"
 # Enables the /dev-login session backdoor for local `wrangler dev` only. Named
 # envs do NOT inherit top-level vars, so staging/production (which re-declare
 # their own [vars]) leave this unset and the route stays inert there.
@@ -309,6 +313,10 @@ name = "EMAIL"
 
 [env.production.vars]
 POSTHOG_HOST = "https://app.posthog.com"
+# Segments this environment's analytics (see top-level [vars]). Declared per-env
+# because named envs don't inherit top-level vars — the same footgun as the
+# telemetry kill switch below.
+STRATUM_ENVIRONMENT = "production"
 # Telemetry kill switch. Must be declared here, not only at top level — named
 # envs don't inherit top-level vars, so a top-level-only setting never reaches
 # `wrangler deploy --env=production`.
@@ -456,6 +464,10 @@ name = "EMAIL"
 
 [env.staging.vars]
 POSTHOG_HOST = "https://app.posthog.com"
+# Segments this environment's analytics (see top-level [vars]). Declared per-env
+# because named envs don't inherit top-level vars — the same footgun as the
+# telemetry kill switch below.
+STRATUM_ENVIRONMENT = "staging"
 # Telemetry kill switch; must be declared per-env (see env.production.vars).
 # STRATUM_TELEMETRY_DISABLED = "true"
 # Local-only session backdoor; explicitly off on staging (see env.production.vars).


### PR DESCRIPTION
## Summary

Telemetry sent **two** events with almost no properties: `api_request` (route pattern, method, status, latency) and `stratum.<type>` (type, actor type, project id). It could count merges. It could not answer what fraction of changes pass evaluation, what reviewers decide, which deploy targets fail, which MCP tools agents actually call, or how anyone signed up.

Two problems, fixed in that order.

**1. A structural hole.** Export is governed by two gates, but only one — the instance switch — lived in the client. The per-user opt-out (#257) lived at each `capture()` call site, which is how the queue exporter originally shipped ignoring it entirely. `posthog.ts` carried a docblock warning about exactly this, but a comment cannot bind a call site that never reads it, and this PR adds several call sites.

`AnalyticsTracker` (`src/analytics/tracker.ts`) closes it structurally: no public constructor, and every factory must produce an `AnalyticsActor` whose preference is already resolved. A call site cannot reach `capture()` without having decided, and the lookup paths still fail closed. Behaviour at the existing call sites is unchanged.

**2. The data itself.** `src/analytics/events.ts` is the new catalog — one file that answers "what leaves my instance", with the privacy rule stated once: every property is a source-code literal or a bounded value.

### What is now captured

- **Domain events carry their payload** (whitelisted per type): evaluation `score`/`passed`, review `verdict`, deploy `target`, import `source_provider`, and whether an issue closed through a linked change. All of this was already computed and then discarded.
- **`mcp_request`** — one per JSON-RPC message at `/mcp`: method, tool, outcome, and the connecting client's name/version. The flagship agent surface previously emitted nothing.
- **`auth_completed`** — sign-up vs sign-in, by provider. One helper, called next to the `recordAudit` that already marks the same moment across five handlers in three files.
- **`error_occurred`** — an unhandled exception never reaches the analytics middleware's post-`next()` body, so a 500 born that way was invisible entirely.
- **`background_job_completed`** — abandoned outbox events and webhook delivery outcomes.
- **`api_request`** gains `surface` (api/ui/git/mcp/auth/admin/internal) and `actor_type`.
- **Every event** gains `environment`, from a new `STRATUM_ENVIRONMENT` var, so staging stops polluting production's numbers.

### Because this is open source

`docs/user-guide/faq.md` now lists every event and every property exhaustively, and `tests/analytics-catalog.test.ts` **fails the build** if that list and the code disagree. Free text is excluded by construction: exception messages, deployment failure reasons, and import URLs are dropped; MCP tool names are validated against the tools this build defines rather than echoed back; a self-hosted GitLab collapses to `other` rather than reporting a hostname that identifies the company running it.

## Related issues

Builds on the per-user opt-out from #257.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## How was this verified?

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`

56 new tests across four suites (`analytics-catalog`, `analytics-tracker`, `analytics-mcp`, `analytics-auth`) plus additions to `analytics-middleware`. `src/analytics` is at **99.4% statements**; `tracker.ts` and `posthog.ts` at 100%. Global coverage 73.7% statements / 80.7% branches, comfortably above the thresholds.

`cd website && npm run check:guides` reports all 12 mirrors in sync.

> **Note:** 43 tests fail in `tests/issues.test.ts` and `tests/issues-comment-body-limit.test.ts`. These are **pre-existing** — they fail identically on the base commit (`cb04046`) and are untouched by this PR.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] `CHANGELOG.md` updated (`## [Unreleased]`)
- [x] Public docs updated (`docs/user-guide/faq.md`, `docs/developer/deployment.md`, mirrors regenerated)
- [x] No secrets, tokens, or personal data committed
- [x] No client-side JavaScript added

## Reviewer attention

Three judgment calls worth a second opinion:

1. **Property rename.** `projectId` → `project_id` and `actorType` → `actor_type`, for consistency with `latency_ms` and every new property. This breaks any existing dashboard on those names; the CHANGELOG documents it with a `coalesce()` bridge. Easy to revert if there are dashboards in use.
2. **No CLI or agent telemetry.** `cli/` and `agent/` remain uninstrumented. Adding silent phone-home to a locally installed OSS binary is a different privacy decision from server-side telemetry — no opt-out UI, no account context at install time. Deliberately left as a maintainer call.
3. **`client_name` / `client_version` are the only free-text fields**, capped at 64 characters and documented as such in the FAQ. They are software self-identification, like a User-Agent, and "which editors connect" is worth knowing — but it is the one place the literals-only rule is relaxed.

## Follow-ups not in this PR

- PostHog **groups** for project/org, enabling native per-project adoption counts (`project_id` currently rides as a plain property).
- Per-evaluator breakdown on `change.evaluated`, which needs a new field on the outbox payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nJ5fwv3FwrbuTraoQBHP5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded analytics coverage for authentication, errors, background jobs, MCP requests, repository activity, and webhook delivery.
  - Added deployment environment labels, timestamps, version metadata, and consistent event properties.
  - Added privacy safeguards, including opt-out enforcement, bounded event data, owner attribution, and personless system metrics.

- **Documentation**
  - Expanded telemetry FAQs with the event catalog, supported properties, identity handling, and privacy limitations.
  - Documented environment configuration for staging and production.

- **Tests**
  - Added comprehensive coverage for analytics, privacy filtering, opt-outs, MCP reporting, and environment attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->