### PR TITLE
Make browser analytics actually send events, and say which control was clicked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,8 +148,17 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          POSTHOG_PUBLIC_KEY: ${{ vars.POSTHOG_PUBLIC_KEY }}
         run: |
-          npx wrangler deploy --env=staging
+          # The app's half of browser analytics. `POSTHOG_PUBLIC_KEY` is a
+          # `[vars]` entry that ships commented out, because a self-hoster who
+          # deployed this repo must not inherit our project token — so the
+          # value can only come from here, and until it did, the Worker served
+          # every page without the SDK while the docs site (deploy-docs.yml,
+          # which has passed it since day one) reported browser events. Empty
+          # when the repository variable is unset, which `webAnalyticsConfig`
+          # reads as off.
+          npx wrangler deploy --env=staging --var POSTHOG_PUBLIC_KEY:"$POSTHOG_PUBLIC_KEY"
           SUBDOMAIN=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
             "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/subdomain" \
             | jq -r '.result.subdomain')
@@ -239,8 +248,17 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          POSTHOG_PUBLIC_KEY: ${{ vars.POSTHOG_PUBLIC_KEY }}
         run: |
-          npx wrangler deploy --env=production
+          # The app's half of browser analytics. `POSTHOG_PUBLIC_KEY` is a
+          # `[vars]` entry that ships commented out, because a self-hoster who
+          # deployed this repo must not inherit our project token — so the
+          # value can only come from here, and until it did, the Worker served
+          # every page without the SDK while the docs site (deploy-docs.yml,
+          # which has passed it since day one) reported browser events. Empty
+          # when the repository variable is unset, which `webAnalyticsConfig`
+          # reads as off.
+          npx wrangler deploy --env=production --var POSTHOG_PUBLIC_KEY:"$POSTHOG_PUBLIC_KEY"
           SUBDOMAIN=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
             "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/subdomain" \
             | jq -r '.result.subdomain')

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -61,7 +61,17 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx wrangler deploy --env=production
+          POSTHOG_PUBLIC_KEY: ${{ vars.POSTHOG_PUBLIC_KEY }}
+        run: |
+          # The app's half of browser analytics. `POSTHOG_PUBLIC_KEY` is a
+          # `[vars]` entry that ships commented out, because a self-hoster who
+          # deployed this repo must not inherit our project token — so the
+          # value can only come from here, and until it did, the Worker served
+          # every page without the SDK while the docs site (deploy-docs.yml,
+          # which has passed it since day one) reported browser events. Empty
+          # when the repository variable is unset, which `webAnalyticsConfig`
+          # reads as off.
+          npx wrangler deploy --env=production --var POSTHOG_PUBLIC_KEY:"$POSTHOG_PUBLIC_KEY"
 
       - name: Smoke test
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,11 +59,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to route patterns, page titles and referrers are dropped, clicked-element
   text and attributes are masked, unrecognised properties are dropped rather
   than forwarded, Do Not Track and Global Privacy Control are respected, and
-  session replay is not shipped. The SDK is version-pinned and served from your
+  session replay is not shipped. No feature-flag request is made either: that
+  call is not a captured event, so the redaction cannot reach it, and PostHog
+  builds its body from stored properties that include the first URL of the
+  session. The SDK is version-pinned and served from your
   own origin through `/_ph/*`, which keeps it under your Content-Security-Policy
   and stops content blockers biasing the numbers. `docs/user-guide/faq.md`
   documents every browser event and every guarantee, and a test fails the build
   if that list and the code disagree.
+
+- **`ui_click` names the control that was clicked.** Masking element text and
+  attributes is what keeps repository and file names out of autocaptured
+  events, and it also leaves `$autocapture` able to say a button was clicked
+  but never which one. Navigation and the main actions now carry a `data-ph`
+  attribute — `nav-settings`, `project-tab-deployments` — whose value is a
+  literal in Stratum's own source; `ui_click` reports that value in `element`
+  and nothing else, and any value that is not a plain `[a-z][a-z0-9-]*` token
+  is dropped in the browser, so a name built from a repository or file name
+  cannot be reported even by mistake. It is the one browser event Stratum sends
+  itself rather than configuring PostHog to send.
 
 ### Fixed
 

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -299,6 +299,7 @@ below describe how we configure it rather than what we choose to emit:
 | `$identify` | A signed-in user is associated with their account |
 | `$set` | Person properties are recorded, as part of identifying |
 | `$create_alias` | A pre-sign-in anonymous session is linked to the account |
+| `ui_click` | An instrumented control is clicked. Carries one property, `element` |
 
 Every event additionally carries `environment` — the label the operator set in
 `STRATUM_ENVIRONMENT`, so staging traffic can be told apart from production —
@@ -355,6 +356,20 @@ this app's URLs and page titles are made of the things the promise forbids.
   a click on a repository link would send the repository name as link text and
   its path as an `href`. You therefore see that a file link was clicked, not
   which file.
+- **`ui_click` names the control, and only from a fixed vocabulary.** Because
+  of the masking above, `$autocapture` can say a button was clicked but never
+  which one, so navigation and the main actions carry a `data-ph` attribute
+  whose value is written literally in Stratum's own source — `nav-settings`,
+  `project-tab-deployments`. `ui_click` reports that value in `element` and
+  nothing else, and the browser drops any value that is not a plain
+  `[a-z][a-z0-9-]*` token, so a name assembled from a repository or file name
+  cannot be reported even by mistake. This is the only event on this page
+  Stratum sends itself rather than configuring PostHog to send.
+- **No feature flags are requested.** The SDK's flags call is not a captured
+  event, so the redaction above cannot reach it — and PostHog builds its body
+  from stored properties that include the first URL of the session. Stratum
+  reads no flags in the browser, so the call is switched off entirely rather
+  than trusted.
 - **No Core Web Vitals or dead-click tracking.** Both are implemented in code
   posthog-js downloads at runtime, and Stratum blocks runtime downloads so the
   only script your users receive is the pinned one served from your origin.

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -159,15 +159,20 @@ export const SURFACE_EVENT_NAMES: readonly SurfaceEventName[] = [
 ];
 
 /**
- * Events produced by PostHog's SDK in the browser, not by this codebase.
+ * Events sent from the browser, not by this codebase's server paths.
  *
  * They are listed here for one reason: `docs/user-guide/faq.md` tells
  * self-hosters the event list is exhaustive, and a test holds that claim to
- * account. Nothing in `src/` emits these — the SDK does, once
+ * account. Nothing in `src/` emits the `$`-prefixed ones — the SDK does, once
  * `POSTHOG_PUBLIC_KEY` is set — so the list has to be maintained by hand
  * against what `src/analytics/web-snippet.ts` enables. Turning on another SDK
  * capture feature means adding its event here, or the FAQ becomes a false
  * statement about what leaves the instance.
+ *
+ * `ui_click` is the exception: the bootstrap captures it itself, because
+ * autocapture with text and attribute masking on reports which TAG was clicked
+ * and never which control. It carries one property, `element`, read from a
+ * `data-ph` attribute written literally in this repo's JSX.
  */
 export const WEB_EVENT_NAMES: readonly string[] = [
   "$pageview",
@@ -180,6 +185,10 @@ export const WEB_EVENT_NAMES: readonly string[] = [
   // would break the anonymous-to-identified stitching identify() exists for.
   "$set",
   "$create_alias",
+  // First-party; see the docblock. Named for the surface rather than the
+  // action, matching `api_request` and `mcp_request`: the action is the
+  // `element` property, so a new instrumented control never needs a new event.
+  "ui_click",
 ];
 
 /** Every event name, for the docs-drift test and for operator reference. */

--- a/src/analytics/web-snippet.ts
+++ b/src/analytics/web-snippet.ts
@@ -16,6 +16,16 @@
  * dropped. A denylist would have been shorter and is what the first draft of
  * this work used, but it silently leaks whatever the next SDK release adds,
  * and it inverts the discipline `src/analytics/events.ts` is built on.
+ *
+ * ## The cost of that rule, and the one event that pays it back
+ *
+ * Masking element text and attributes is what keeps repo and file names out of
+ * autocaptured clicks, and it also leaves `$autocapture` reporting which TAG
+ * was clicked and never which control. So this file captures one event of its
+ * own, `ui_click`, carrying a `data-ph` value written as a literal in the JSX.
+ * It is the only place where the browser reports something this repository
+ * chose rather than something PostHog collected, which is why it is also the
+ * only place a pattern — not a rewrite — is what enforces the promise.
  */
 import type { WebAnalyticsConfig } from "./web";
 
@@ -69,11 +79,20 @@ export function bootstrapScript(config: WebAnalyticsConfig): string {
   function init() {
 
   // Mirrors WEB_EVENT_NAMES in ../analytics/events.ts, which is what the FAQ
-  // is tested against.
+  // is tested against. Every name but the last is PostHog's; \`ui_click\` is this
+  // file's own, and is captured at the bottom of \`loaded\`.
   var ALLOWED_EVENTS = {
     $pageview: 1, $pageleave: 1, $autocapture: 1, $rageclick: 1, $identify: 1,
-    $set: 1, $create_alias: 1,
+    $set: 1, $create_alias: 1, ui_click: 1,
   };
+
+  // The vocabulary \`ui_click\` may report: a lowercase kebab-case token, capped.
+  // The values come from \`data-ph\` attributes written as literals in this
+  // repository's JSX, so this pattern is not input validation — it is the
+  // structural version of that guarantee. A \`data-ph\` built by interpolating a
+  // repo slug or a filename cannot match it, so the leak that would otherwise
+  // be one template literal away is refused rather than shipped.
+  var UI_CLICK_NAME = /^[a-z][a-z0-9-]{0,39}$/;
 
   // The only path string this page may report: built from the route PATTERN the
   // server matched, so it contains no namespace, repo slug, change id, file
@@ -84,6 +103,15 @@ export function bootstrapScript(config: WebAnalyticsConfig): string {
   // Kept verbatim. Device, browser and session shape: non-identifying, and the
   // reason browser analytics is worth having at all.
   var KEEP = {
+    // Required for ingestion, and the reason this file shipped a bundle that
+    // sent nothing. posthog-js re-reads \`token\`, \`distinct_id\` and
+    // \`$cookieless_mode\` AFTER before_send returns, and drops any event that
+    // no longer carries all three. An allowlist that
+    // had never heard of them therefore rejected 100% of events — silently, at
+    // console.warn, on a surface nobody watches. Any future edit here that
+    // removes one of these turns browser analytics off entirely, which is why
+    // a test asserts them by name.
+    token: 1, distinct_id: 1, $cookieless_mode: 1,
     $browser: 1, $browser_version: 1, $browser_language: 1, $browser_language_prefix: 1,
     $os: 1, $os_version: 1, $device_type: 1, $timezone: 1, $timezone_offset: 1,
     $screen_height: 1, $screen_width: 1, $viewport_height: 1, $viewport_width: 1,
@@ -103,8 +131,9 @@ export function bootstrapScript(config: WebAnalyticsConfig): string {
     // The SDK sends the array form here (elementsChainAsString is false), so
     // dropping it costs nothing.
     $elements: 1, $event_type: 1, $ce_version: 1,
-    // Set by this bootstrap.
-    environment: 1,
+    // Set by this bootstrap: \`environment\` on every event, \`element\` on
+    // \`ui_click\` only. Both are source-code literals.
+    environment: 1, element: 1,
   };
 
   // Prefix-matched families whose members are named per-metric and cannot be
@@ -211,6 +240,22 @@ export function bootstrapScript(config: WebAnalyticsConfig): string {
     // session, and this ships to every self-hoster's users, not just ours.
     respect_dnt: true,
 
+    // No feature-flag call, and this is a privacy control rather than a
+    // performance one. \`before_send\` governs CAPTURED EVENTS; the flags request
+    // is not one, and posthog-js builds its body from persisted person
+    // properties — which include \`$initial_current_url\`, \`$initial_pathname\`
+    // and \`$initial_host\`. That body carried
+    // \`https://host/@alice/private-repo/tags?ref=main\` to PostHog on the first
+    // page load of every session, past every rewrite above, because the
+    // redaction never sees it. Nothing in this app reads a flag, so the
+    // request buys nothing to weigh against that.
+    //
+    // It also removes the SDK's remote-config fetch, which the proxy answers
+    // 204 (\`/array/<token>/config\` is not on its ingestion allowlist), and with
+    // it the last reason autocapture would have to wait for a network response
+    // before arming its listeners.
+    advanced_disable_flags: true,
+
     capture_pageview: true,
     capture_pageleave: true,
     autocapture: true,
@@ -259,6 +304,35 @@ export function bootstrapScript(config: WebAnalyticsConfig): string {
       // instanceProperties() does. Registered rather than passed per event so
       // autocaptured events carry it too.
       ph.register({ environment: cfg.environment });
+
+      // Which control was used, which $autocapture alone cannot answer here.
+      //
+      // mask_all_text and mask_all_element_attributes stay ON, so an
+      // autocaptured click reports \`button, nth_child: 2\` and nothing else —
+      // true to the promise and useless for "did anyone open Deploys". The
+      // missing half cannot come from relaxing either mask: every attribute
+      // this app renders is a candidate leak (\`href\` alone is
+      // /@alice/private-repo/tags), and posthog-js copies \`attr__href\` onto the
+      // element props whatever the mask says.
+      //
+      // So the identifier is supplied instead of extracted: a \`data-ph\`
+      // attribute whose value is written literally in the JSX. This reads one
+      // attribute, sends one property, and matches it against UI_CLICK_NAME
+      // first — the same discipline as \`enumProp\` in ../analytics/events.ts,
+      // where a field may only ever emit a value this repository contains.
+      //
+      // Capture phase, on document, registered once: a handler that calls
+      // stopPropagation cannot silence it, and delegation means a page can be
+      // instrumented by adding an attribute rather than by remembering to call
+      // anything.
+      document.addEventListener("click", function (event) {
+        var target = event && event.target;
+        var el = target && target.closest ? target.closest("[data-ph]") : null;
+        if (!el) return;
+        var name = el.getAttribute("data-ph");
+        if (typeof name !== "string" || !UI_CLICK_NAME.test(name)) return;
+        ph.capture("ui_click", { element: name });
+      }, true);
     },
   });
   }

--- a/src/ui/components/project-header.tsx
+++ b/src/ui/components/project-header.tsx
@@ -58,7 +58,7 @@ export const ProjectHeader: FC<ProjectHeaderProps> = ({ project, active, canWrit
         <div class="project-crumb">
           <span class="project-crumb-namespace">{project.namespace}</span>
           <span class="project-crumb-sep">/</span>
-          <a class="project-crumb-name" href={base}>
+          <a class="project-crumb-name" href={base} data-ph="project-crumb">
             {project.slug}
           </a>
           {project.visibility === "public" && <span class="badge badge-public">public</span>}
@@ -71,6 +71,11 @@ export const ProjectHeader: FC<ProjectHeaderProps> = ({ project, active, canWrit
             key={tab.key}
             href={tab.href}
             class={`project-tab ${active === tab.key ? "project-tab-active" : ""}`}
+            // The one interpolated `data-ph` in the app, and safe by
+            // construction: `tab.key` is the ProjectTab union, so every value
+            // it can produce is a literal a few lines above. Nothing here can
+            // become a project or file name.
+            data-ph={`project-tab-${tab.key}`}
             {...(active === tab.key ? { "aria-current": "page" } : {})}
           >
             {tab.label}

--- a/src/ui/layout.tsx
+++ b/src/ui/layout.tsx
@@ -43,8 +43,15 @@ export const Layout: FC<LayoutProps> = ({ title, user, refreshSeconds, active, c
         <link rel="stylesheet" href="/ui.css" />
       </head>
       <body>
+        {/*
+          `data-ph` is the click identifier browser analytics reports (see
+          src/analytics/web-snippet.ts). The value must be a literal written
+          here — never interpolated from a project, file or user name — and
+          only `[a-z][a-z0-9-]*` is accepted; anything else is dropped before
+          it leaves the browser rather than trusted.
+        */}
         <nav class="nav">
-          <a class="nav-brand" href="/">
+          <a class="nav-brand" href="/" data-ph="nav-home">
             stratum
           </a>
           {user && (
@@ -70,20 +77,30 @@ export const Layout: FC<LayoutProps> = ({ title, user, refreshSeconds, active, c
                 <span class="nav-user" title={`@${user.username}`}>
                   {user.displayName ?? user.username ?? user.email}
                 </span>
-                <a href="/new" class="nav-auth-link" aria-current={current("new")}>
+                <a
+                  href="/new"
+                  class="nav-auth-link"
+                  data-ph="nav-new-project"
+                  aria-current={current("new")}
+                >
                   new project
                 </a>
-                <a href="/settings" class="nav-auth-link" aria-current={current("settings")}>
+                <a
+                  href="/settings"
+                  class="nav-auth-link"
+                  data-ph="nav-settings"
+                  aria-current={current("settings")}
+                >
                   settings
                 </a>
                 <form method="post" action="/auth/logout" class="nav-logout-form">
-                  <button type="submit" class="nav-auth-link">
+                  <button type="submit" class="nav-auth-link" data-ph="nav-logout">
                     logout
                   </button>
                 </form>
               </>
             ) : (
-              <a href="/auth/login" class="nav-auth-link">
+              <a href="/auth/login" class="nav-auth-link" data-ph="nav-sign-in">
                 sign in
               </a>
             )}

--- a/tests/account-settings.test.tsx
+++ b/tests/account-settings.test.tsx
@@ -152,7 +152,10 @@ describe("GET /settings: account", () => {
 
   it("marks the settings link as the current page and drops the profile link", async () => {
     const html = await (await makeApp().fetch(get(), makeEnv())).text();
-    expect(html).toContain('href="/settings" class="nav-auth-link" aria-current="page"');
+    // Matched loosely across the attributes between them: pinning the exact
+    // rendered attribute string makes an unrelated addition to the link (the
+    // analytics `data-ph`, say) fail a test about the current-page marker.
+    expect(html).toMatch(/href="\/settings"[^>]*aria-current="page"/);
     expect(html).not.toContain('href="/profile"');
   });
 

--- a/tests/analytics-catalog.test.ts
+++ b/tests/analytics-catalog.test.ts
@@ -71,7 +71,12 @@ describe("analytics catalog", () => {
       }),
     )?.[1];
     expect(allowlist, "could not find ALLOWED_EVENTS in the emitted snippet").toBeTruthy();
-    const permitted = [...(allowlist as string).matchAll(/(\$[A-Za-z_]+):\s*1/g)].map((m) => m[1]);
+    // Not `\$`-anchored: `ui_click` is this repo's own browser event, and an
+    // allowlist entry the regex cannot see is an entry this test cannot hold to
+    // the FAQ.
+    const permitted = [...(allowlist as string).matchAll(/([$A-Za-z_][A-Za-z_]*):\s*1/g)].map(
+      (m) => m[1],
+    );
     expect(permitted.length).toBeGreaterThan(0);
     for (const name of permitted) {
       expect(

--- a/tests/analytics-deploy-config.test.ts
+++ b/tests/analytics-deploy-config.test.ts
@@ -1,0 +1,70 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+// Raw imports rather than node:fs, matching tests/wrangler-telemetry-config.test.ts.
+import ciWorkflow from "../.github/workflows/ci.yml?raw";
+import deployDocsWorkflow from "../.github/workflows/deploy-docs.yml?raw";
+import deployProductionWorkflow from "../.github/workflows/deploy-production.yml?raw";
+import prPreviewWorkflow from "../.github/workflows/pr-preview.yml?raw";
+import wranglerToml from "../wrangler.toml?raw";
+
+/**
+ * Browser analytics is off unless `POSTHOG_PUBLIC_KEY` reaches the Worker, and
+ * nothing in `src/` can tell the difference between "the operator chose not to
+ * enable it" and "the deploy forgot to pass it". Both produce pages with no
+ * SDK, no error, and no event — which is exactly how the application ran with
+ * zero browser events while the documentation site, whose workflow did pass the
+ * variable, reported them normally.
+ *
+ * The key cannot live in `wrangler.toml`: that file ships to self-hosters, and
+ * a token committed there would send THEIR users' events to OUR project. So the
+ * deploy workflow is the only place the value can come from, and this is what
+ * keeps it there.
+ */
+
+const KEY = "POSTHOG_PUBLIC_KEY";
+const FROM_REPOSITORY_VARIABLE = `${KEY}: \${{ vars.${KEY} }}`;
+
+/** Every line that actually runs `wrangler deploy`, not the ones discussing it. */
+function deployCommands(workflow: string): string[] {
+  return workflow
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => /^(run: )?npx wrangler deploy\b/.test(line));
+}
+
+describe("browser analytics deploy wiring", () => {
+  it.each([
+    ["ci.yml", ciWorkflow],
+    ["deploy-production.yml", deployProductionWorkflow],
+    ["deploy-docs.yml", deployDocsWorkflow],
+  ])("passes the project key on every deploy in %s", (_name, workflow) => {
+    const commands = deployCommands(workflow);
+    expect(commands.length).toBeGreaterThan(0);
+    for (const command of commands) {
+      expect(command, `\`${command}\` deploys without ${KEY}`).toContain(`--var ${KEY}:`);
+    }
+    // The flag is only half of it: without the step-level `env:` entry the
+    // shell expands `"$POSTHOG_PUBLIC_KEY"` to the empty string and the deploy
+    // succeeds with analytics off — the same silent failure, one layer down.
+    expect(workflow).toContain(FROM_REPOSITORY_VARIABLE);
+  });
+
+  it("leaves PR previews uninstrumented", () => {
+    // Previews run contributor branches on a real subdomain. Their traffic is
+    // not product usage, and `STRATUM_ENVIRONMENT = "preview"` in the generated
+    // config only labels it — this is what keeps there being nothing to label.
+    for (const command of deployCommands(prPreviewWorkflow)) {
+      expect(command).not.toContain(KEY);
+    }
+    expect(prPreviewWorkflow).not.toContain(FROM_REPOSITORY_VARIABLE);
+  });
+
+  it("keeps the key out of the config file self-hosters deploy", () => {
+    // An uncommented token here would be published in every page of every
+    // instance built from this repo, all of them reporting to us.
+    for (const line of wranglerToml.split("\n")) {
+      if (!line.includes(KEY)) continue;
+      expect(line.trimStart().startsWith("#"), `${KEY} is set in wrangler.toml`).toBe(true);
+    }
+  });
+});

--- a/tests/analytics-web-snippet.test.ts
+++ b/tests/analytics-web-snippet.test.ts
@@ -23,9 +23,19 @@ interface FakePostHog {
   identify: (id: string) => void;
   reset: () => void;
   register: (props: Record<string, unknown>) => void;
+  capture: (event: string, props?: Record<string, unknown>) => void;
   identified: string[];
   resets: number;
   registered: Record<string, unknown>[];
+  captured: Array<{ event: string; props?: Record<string, unknown> }>;
+}
+
+/** The smallest thing `closest("[data-ph]")` can be called on. */
+function fakeTarget(dataPh: string | null, matches = true): unknown {
+  const el = {
+    getAttribute: (name: string) => (name === "data-ph" ? dataPh : null),
+  };
+  return { closest: (selector: string) => (matches && selector === "[data-ph]" ? el : null) };
 }
 
 /**
@@ -37,6 +47,8 @@ function runBootstrap(config: WebAnalyticsConfig = CONFIG): {
   options: InitOptions;
   ph: FakePostHog;
   initCalledBeforeDomReady: boolean;
+  /** Fire the delegated listener the bootstrap registered on `document`. */
+  click: (target: unknown) => void;
 } {
   let options: InitOptions | undefined;
   const posthog = {
@@ -52,10 +64,12 @@ function runBootstrap(config: WebAnalyticsConfig = CONFIG): {
   // the listener fires. A bootstrap that calls init immediately would see
   // `posthog === undefined`, return, and send nothing forever.
   const listeners: Array<() => void> = [];
+  const clickHandlers: Array<(event: unknown) => void> = [];
   const doc = {
     readyState: "loading",
-    addEventListener: (event: string, handler: () => void) => {
-      if (event === "DOMContentLoaded") listeners.push(handler);
+    addEventListener: (event: string, handler: (event: unknown) => void) => {
+      if (event === "DOMContentLoaded") listeners.push(handler as () => void);
+      if (event === "click") clickHandlers.push(handler);
     },
   };
 
@@ -85,6 +99,7 @@ function runBootstrap(config: WebAnalyticsConfig = CONFIG): {
     identified: [],
     resets: 0,
     registered: [],
+    captured: [],
     identify(id) {
       this.identified.push(id);
     },
@@ -94,9 +109,22 @@ function runBootstrap(config: WebAnalyticsConfig = CONFIG): {
     register(props) {
       this.registered.push(props);
     },
+    capture(event, props) {
+      this.captured.push({ event, props });
+    },
   };
   options.loaded(ph);
-  return { options, ph, initCalledBeforeDomReady };
+  return {
+    options,
+    ph,
+    initCalledBeforeDomReady,
+    click(target) {
+      // The bootstrap registers on `document`; a page with no listener at all
+      // is the regression this indirection makes visible.
+      if (clickHandlers.length === 0) throw new Error("bootstrap registered no click listener");
+      for (const handler of clickHandlers) handler({ target });
+    },
+  };
 }
 
 /** Every property this app could plausibly leak, plus the safe ones that must survive. */
@@ -211,6 +239,23 @@ describe("bootstrap redaction", () => {
     }
   });
 
+  // The bug that made this whole feature a no-op: the allowlist deleted the
+  // three properties posthog-js re-reads AFTER before_send returns, so the SDK
+  // dropped every event for "had its 'token' property removed in a beforeSend
+  // function" — a console.warn on a surface nobody reads. Named individually
+  // because losing any one of them silently ends browser analytics.
+  it("keeps the properties posthog-js requires for ingestion", () => {
+    const { options } = runBootstrap();
+    const sent = options.before_send({
+      event: "$pageview",
+      properties: { token: "phc_abc123", distinct_id: "user_1", $cookieless_mode: false },
+    }) as Record<string, unknown>;
+    const kept = sent.properties as Record<string, unknown>;
+    expect(kept.token).toBe("phc_abc123");
+    expect(kept.distinct_id).toBe("user_1");
+    expect(kept.$cookieless_mode).toBe(false);
+  });
+
   it("survives a null or property-less event without throwing", () => {
     expect(options.before_send(null)).toBeNull();
     expect(() => options.before_send({ event: "$pageview" })).not.toThrow();
@@ -293,9 +338,70 @@ describe("autocapture element scrubbing", () => {
 
   it("still sends every event the FAQ does document", () => {
     const { options } = runBootstrap();
-    for (const name of ["$pageview", "$pageleave", "$autocapture", "$rageclick", "$identify"]) {
+    for (const name of [
+      "$pageview",
+      "$pageleave",
+      "$autocapture",
+      "$rageclick",
+      "$identify",
+      "ui_click",
+    ]) {
       expect(options.before_send({ event: name, properties: {} }), name).not.toBeNull();
     }
+  });
+});
+
+describe("ui_click", () => {
+  it("reports the data-ph identifier of the clicked control", () => {
+    // What $autocapture cannot answer with the masks on: it reports the tag and
+    // its position, never which control. `element` is the whole point.
+    const { ph, click } = runBootstrap();
+    click(fakeTarget("project-tab-deployments"));
+    expect(ph.captured).toEqual([
+      { event: "ui_click", props: { element: "project-tab-deployments" } },
+    ]);
+  });
+
+  it("walks up to the nearest instrumented ancestor", () => {
+    // Clicks land on the <span> inside a <button>. Without closest(), every
+    // control with a child element would report nothing.
+    const { ph, click } = runBootstrap();
+    click(fakeTarget("nav-logout"));
+    expect(ph.captured[0]?.props).toEqual({ element: "nav-logout" });
+  });
+
+  it("stays silent on a click that is not on an instrumented control", () => {
+    const { ph, click } = runBootstrap();
+    click(fakeTarget(null, false));
+    click({});
+    click(null);
+    expect(ph.captured).toEqual([]);
+  });
+
+  it("refuses a data-ph that is not a source-code literal", () => {
+    // The guarantee is structural, not conventional: a `data-ph` built by
+    // interpolating a repo slug, a filename or an email cannot match the
+    // vocabulary pattern, so it is dropped in the browser instead of becoming
+    // the leak every other rule in this file exists to prevent.
+    const { ph, click } = runBootstrap();
+    for (const value of [
+      "tab-@alice/private-repo",
+      "src/secret.ts",
+      "Create tag",
+      "alice@example.com",
+      "-leading-dash",
+      "a".repeat(41),
+      "",
+    ]) {
+      click(fakeTarget(value));
+    }
+    expect(ph.captured).toEqual([]);
+  });
+
+  it("sends nothing but the identifier", () => {
+    const { ph, click } = runBootstrap();
+    click(fakeTarget("nav-settings"));
+    expect(Object.keys(ph.captured[0]?.props ?? {})).toEqual(["element"]);
   });
 });
 
@@ -347,6 +453,14 @@ describe("SDK options", () => {
     expect(options.mask_all_text).toBe(true);
     expect(options.mask_all_element_attributes).toBe(true);
     expect(options.disable_capture_url_hashes).toBe(true);
+  });
+
+  it("makes no feature-flag request, which before_send cannot redact", () => {
+    // The flags request is not a captured event, so the redaction never sees
+    // it — and posthog-js builds its body from persisted person properties,
+    // which include $initial_current_url and $initial_pathname. It carried the
+    // concrete repo path to PostHog on the first page load of every session.
+    expect(options.advanced_disable_flags).toBe(true);
   });
 
   it("honours Do Not Track, the only opt-out an anonymous visitor has", () => {

--- a/website/src/content/docs/guides/faq.md
+++ b/website/src/content/docs/guides/faq.md
@@ -303,6 +303,7 @@ below describe how we configure it rather than what we choose to emit:
 | `$identify` | A signed-in user is associated with their account |
 | `$set` | Person properties are recorded, as part of identifying |
 | `$create_alias` | A pre-sign-in anonymous session is linked to the account |
+| `ui_click` | An instrumented control is clicked. Carries one property, `element` |
 
 Every event additionally carries `environment` — the label the operator set in
 `STRATUM_ENVIRONMENT`, so staging traffic can be told apart from production —
@@ -359,6 +360,20 @@ this app's URLs and page titles are made of the things the promise forbids.
   a click on a repository link would send the repository name as link text and
   its path as an `href`. You therefore see that a file link was clicked, not
   which file.
+- **`ui_click` names the control, and only from a fixed vocabulary.** Because
+  of the masking above, `$autocapture` can say a button was clicked but never
+  which one, so navigation and the main actions carry a `data-ph` attribute
+  whose value is written literally in Stratum's own source — `nav-settings`,
+  `project-tab-deployments`. `ui_click` reports that value in `element` and
+  nothing else, and the browser drops any value that is not a plain
+  `[a-z][a-z0-9-]*` token, so a name assembled from a repository or file name
+  cannot be reported even by mistake. This is the only event on this page
+  Stratum sends itself rather than configuring PostHog to send.
+- **No feature flags are requested.** The SDK's flags call is not a captured
+  event, so the redaction above cannot reach it — and PostHog builds its body
+  from stored properties that include the first URL of the session. Stratum
+  reads no flags in the browser, so the call is switched off entirely rather
+  than trusted.
 - **No Core Web Vitals or dead-click tracking.** Both are implemented in code
   posthog-js downloads at runtime, and Stratum blocks runtime downloads so the
   only script your users receive is the pinned one served from your origin.


### PR DESCRIPTION
## Summary

Browser analytics shipped in #367, and `app.usestratum.dev` has never sent a single client-side event since. Confirmed in PostHog before touching anything: every browser event in the last 7 days (`$pageview`, `$web_vitals`, `$pageleave`, `$autocapture`) carries `$host = usestratum.dev` — the documentation/marketing deployment. Zero from the application.

Three independent reasons, each silent. All three had to be fixed; any one of them alone still yields no data.

**1. No deploy passes `POSTHOG_PUBLIC_KEY`.** It cannot live in `wrangler.toml` — self-hosters deploy that file, and a token committed there would send *their* users' events to *our* project — so the deploy workflow is the only place the value can come from. `deploy-docs.yml` has passed it via `--var` from `vars.POSTHOG_PUBLIC_KEY` since day one, which is exactly why the docs site reports browser events and the app reports none. `ci.yml` (staging and production) and `deploy-production.yml` now pass it the same way, from the same repository variable. PR previews stay uninstrumented, deliberately.

**2. Even with a key, every event was dropped in the browser.** posthog-js re-reads `token`, `distinct_id` and `$cookieless_mode` *after* `before_send` returns and refuses any event missing one. The property allowlist had never heard of them, so it rejected 100% of captures — at `console.warn`, on a surface nobody watches. This is the failure mode `web-snippet.ts`'s own docblock was written to prevent, arriving from the opposite direction: the allowlist was too strict rather than too loose.

**3. The feature-flag request leaked what every rewrite in the snippet exists to prevent.** It is not a captured event, so `before_send` never sees it, and posthog-js builds its body from stored person properties. A decoded request body from the real SDK:

```json
{"person_properties":{"$initial_current_url":"https://app.usestratum.dev/@alice/private-repo/tags?ref=main",
"$initial_pathname":"/@alice/private-repo/tags","$initial_host":"app.usestratum.dev", ...}}
```

That went to PostHog on the first page load of every session, past every rewrite, because the redaction never sees it. Nothing in the app reads a flag, so `advanced_disable_flags: true` switches the call off rather than trusting it. It also removes the SDK's remote-config fetch (which the proxy answers 204, `/array/<token>/config` not being on the ingestion allowlist), so autocapture no longer waits on a network response before arming its listeners.

### Which control was clicked

Masking element text and attributes is what keeps repository and file names out of autocaptured clicks, and it also leaves `$autocapture` able to say a button was clicked but never which one. That cannot be fixed by relaxing either mask: every attribute this app renders is a candidate leak (`href` alone is `/@alice/private-repo/tags`), and posthog-js copies `attr__href` onto the element props whatever the mask says.

So the identifier is supplied rather than extracted. Navigation and the eight project tabs carry a `data-ph` attribute whose value is a literal in the JSX; a delegated capture-phase listener captures `ui_click` with that value in `element` and nothing else. Any value that is not a plain `[a-z][a-z0-9-]*` token is dropped in the browser, so a name assembled from a repository or file name cannot be reported even by mistake — the same discipline as `enumProp` in `src/analytics/events.ts`. That covers the login → project → branches → tags → deployments → settings flow end to end.

### Deliberately not included

- **Session replay.** It needs `array.full.js`, a `worker-src 'self' blob:` CSP change, and `/s/` on the proxy allowlist — and it records the DOM of pages rendering private source. `docs/user-guide/faq.md` already commits in writing to not shipping it, and that judgement still looks right.
- **`$dead_click` / `$web_vitals`.** Unreachable rather than unconfigured: posthog-js implements both in chunks it injects as `<script>` tags at runtime, which `disable_external_dependency_loading` blocks and the nonce-only `script-src` would block anyway. Setting `capture_dead_clicks: true` would produce nothing.

Server-side `api_request` and the `stratum.*` events are untouched.

## Related issues

Follows up #367.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Other:

## How was this verified?

Beyond the gates below, the emitted bootstrap was executed against the **real pinned SDK build** (`posthog-js@1.427.2/dist/array.js` — the exact bytes the proxy serves) in a DOM, with the network stubbed and request bodies gunzipped, so each claim above is observed rather than inferred from documentation:

- Before the fix: zero `/e/` requests, `console.warn` reading `Event '$pageview' had its 'token' property removed in a beforeSend function ... the event will be dropped`, plus a `/flags` request whose body carried the concrete repository path.
- After: `$identify`, `$pageview`, `$autocapture`, `ui_click`, all with `$current_url` rewritten to `https://app.usestratum.dev/:namespace/:slug/tags`, `element: "tag-create"`, and no `/flags` or `/array/.../config` request at all. Nothing in any payload matches the repository slug, file path, query string or title.

- [x] `npm run typecheck`
- [x] `npm test` — 3728 passed, 28 skipped
- [x] `npm run lint`

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass)
- [x] `CHANGELOG.md` updated (`## [Unreleased]`) — folded into the existing browser-analytics entry, which is unreleased
- [x] Public docs updated — `docs/user-guide/faq.md` gains the `ui_click` row, the vocabulary rule, and the no-feature-flags guarantee; mirrors regenerated with `npm run sync:guides`
- [x] No secrets, tokens, or personal data committed — the project token stays out of the repo and comes from the repository variable at deploy time, and a test pins that
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript — the only additions are `data-ph` attributes; the listener lives in the existing analytics bootstrap, which is the documented exception in `AGENTS.md`
- [x] I have read the [CLA](https://github.com/stratum-eng/stratum/blob/main/CLA.md) and agree to it for this contribution

### New coverage, one test per failure

Each of these fails against `main`'s behaviour:

- the three ingestion-required properties, asserted by name, since losing any one silently ends browser analytics
- `advanced_disable_flags`, with the reason it is a privacy control and not a performance one
- the `ui_click` vocabulary: ancestor lookup, silence on uninstrumented clicks, and refusal of interpolated values (`tab-@alice/private-repo`, `src/secret.ts`, an email, an over-long token)
- `tests/analytics-deploy-config.test.ts` — every workflow that deploys the app passes the key, previews do not, and `wrangler.toml` never sets it. This is the gap that let the app and the docs site drift apart unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cwvhkkyj5JQajWwRKHQYkq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cwvhkkyj5JQajWwRKHQYkq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privacy-conscious browser analytics for validated navigation and project-control clicks.
  * Click events include a controlled element identifier while masking text and other attributes.
  * Analytics now records the initial session URL and is served from the application origin.

* **Bug Fixes**
  * Corrected analytics configuration for staging and production deployments.

* **Documentation**
  * Updated telemetry FAQs and changelog with event details and privacy behavior.
  * Clarified that session replay and browser feature-flag requests are not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->