### PR TITLE
Rename npm packages to the @stratum-eng scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ generally: the next thing that wants to be an exception needs its own argument, 
 | Path | What it is |
 |------|------------|
 | `src/` | The Worker: routes, middleware, storage, queue consumers, evaluation engine, UI, and the remote MCP server (`src/mcp/`, served at `/mcp`) |
-| `cli/` | `@stratum/cli` — standalone publishable package |
-| `agent/` | `@stratum/agent` — reference agent, standalone publishable package |
+| `cli/` | `@stratum-eng/cli` — standalone publishable package |
+| `agent/` | `@stratum-eng/agent` — reference agent, standalone publishable package |
 | `tests/` | Vitest suites: unit (`tests/*.test.ts`), `tests/integration/`, `tests/smoke/` |
 | `migrations/` | D1 SQL migrations |
 | `docs/` | User, API, developer docs, ADRs (`docs/adr/`), and runbooks (`docs/runbooks/`) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 - **Stratum is no longer MIT-licensed.** The server, the web UI, `docs/`, and the
-  `website/` sources are now **AGPL-3.0-or-later**; the `@stratum/cli` and `@stratum/agent` packages are
+  `website/` sources are now **AGPL-3.0-or-later**; the `@stratum-eng/cli` and `@stratum-eng/agent` packages are
   **Apache-2.0**, chosen over MIT for its express patent grant. Everything
   released through v0.2.0 stays MIT and always will — anyone holding that code
   keeps their MIT rights in it, forks included. The new terms apply from this
@@ -296,7 +296,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   grant cannot reach `/api/admin/*` (even for the instance administrator, whom
   `resolveAdminAuth` would otherwise authorize on an `ADMIN_EMAIL` match), and
   cannot rotate the never-expiring legacy API key.
-- **CLI and MCP server guides.** Dedicated documentation for `@stratum/cli`
+- **CLI and MCP server guides.** Dedicated documentation for `@stratum-eng/cli`
   (`docs/user-guide/cli.md`) and the MCP server (`docs/user-guide/mcp.md`),
   published at `/guides/cli/` and `/guides/mcp/` — configuration, the full
   command/tool surface (including `project delete` and `account delete`, which
@@ -485,7 +485,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `127.0.0.1` do not stand in for each other.
 
 ### Removed
-- **The standalone `mcp/` package (`@stratum/mcp`).** It was a stdio process
+- **The standalone `mcp/` package (`@stratum-eng/mcp`).** It was a stdio process
   that wrapped the REST API over the network — 609 lines holding no state,
   touching no local git, and offering nothing the Worker could not do itself,
   in exchange for a clone-and-build install. The remote endpoint replaces it
@@ -760,7 +760,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   operations generated from the route code, replacing the 4-path stub.
 - Real user documentation: a full getting-started walkthrough and a 15-question
   FAQ (`docs/user-guide/`).
-- `@stratum/mcp` (`mcp/`): MCP server exposing the full eval-gated change flow —
+- `@stratum-eng/mcp` (`mcp/`): MCP server exposing the full eval-gated change flow —
   projects, workspaces, commits, changes, reviews, merges, and issues — so any
   MCP-capable agent or editor (Claude Code, Cursor, Zed, Copilot, custom agents)
   can work against Stratum without a bespoke integration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -485,7 +485,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `127.0.0.1` do not stand in for each other.
 
 ### Removed
-- **The standalone `mcp/` package (`@stratum-eng/mcp`).** It was a stdio process
+- **The standalone `mcp/` package (`@stratum/mcp`).** It was a stdio process
   that wrapped the REST API over the network — 609 lines holding no state,
   touching no local git, and offering nothing the Worker could not do itself,
   in exchange for a clone-and-build install. The remote endpoint replaces it
@@ -760,7 +760,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   operations generated from the route code, replacing the 4-path stub.
 - Real user documentation: a full getting-started walkthrough and a 15-question
   FAQ (`docs/user-guide/`).
-- `@stratum-eng/mcp` (`mcp/`): MCP server exposing the full eval-gated change flow —
+- `@stratum/mcp` (`mcp/`): MCP server exposing the full eval-gated change flow —
   projects, workspaces, commits, changes, reviews, merges, and issues — so any
   MCP-capable agent or editor (Claude Code, Cursor, Zed, Copilot, custom agents)
   can work against Stratum without a bespoke integration.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -11,8 +11,8 @@ authoritative account of which is which and why.
 | Path | License | SPDX |
 |---|---|---|
 | Everything not listed below — `src/`, `migrations/`, `scripts/`, `tests/`, `docs/`, `website/`, `wrangler.toml` | GNU Affero General Public License v3.0 or later | [`AGPL-3.0-or-later`](LICENSE) |
-| [`cli/`](cli) — the `@stratum/cli` package | Apache License 2.0 | [`Apache-2.0`](cli/LICENSE) |
-| [`agent/`](agent) — the `@stratum/agent` reference agent | Apache License 2.0 | [`Apache-2.0`](agent/LICENSE) |
+| [`cli/`](cli) — the `@stratum-eng/cli` package | Apache License 2.0 | [`Apache-2.0`](cli/LICENSE) |
+| [`agent/`](agent) — the `@stratum-eng/agent` reference agent | Apache License 2.0 | [`Apache-2.0`](agent/LICENSE) |
 | `website/public/.well-known/agent-skills/` — the published agent skill files | MIT License | `MIT` |
 
 The split follows the boundary that matters to a user: what you *run as a

--- a/README.md
+++ b/README.md
@@ -344,8 +344,8 @@ queue consumer and a stale-event sweep · workspace TTL sweep.
 **Interfaces**
 Server-rendered web UI · REST API (93 paths) · remote MCP server at `/mcp` with an
 OAuth 2.1 authorization server (dynamic client registration, PKCE, rotating refresh
-tokens) · `@stratum/cli` covering the change flow, issues, and activity ·
-`@stratum/agent` reference agent.
+tokens) · `@stratum-eng/cli` covering the change flow, issues, and activity ·
+`@stratum-eng/agent` reference agent.
 
 ## Known limitations
 
@@ -510,8 +510,8 @@ copyleft, what you run inside your own pipeline is not.
 
 | Path | License |
 |---|---|
-| [`cli/`](cli) — `@stratum/cli` | [Apache-2.0](cli/LICENSE) |
-| [`agent/`](agent) — `@stratum/agent` | [Apache-2.0](agent/LICENSE) |
+| [`cli/`](cli) — `@stratum-eng/cli` | [Apache-2.0](cli/LICENSE) |
+| [`agent/`](agent) — `@stratum-eng/agent` | [Apache-2.0](agent/LICENSE) |
 | `website/public/.well-known/agent-skills/` — the published agent skills | MIT |
 | everything else — the server, the web UI, `docs/`, `website/` | [AGPL-3.0-or-later](LICENSE) |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,7 +63,7 @@ under [Deployments](#deployments).
 
 ### Publish the client packages to npm
 
-- [ ] `@stratum/cli` and `@stratum/agent` both live in this repo at full API parity, but
+- [ ] `@stratum-eng/cli` and `@stratum-eng/agent` both live in this repo at full API parity, but
       neither is published, so consumers must build from source. Publishing needs a release
       workflow, provenance attestation, and a version policy across the two. (The MCP
       server no longer needs publishing at all — it is served by the Worker at `/mcp`.)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,7 @@ Please include:
 
 ## Scope
 
-In scope: the Worker (`src/`), the `@stratum/cli` and `@stratum/agent` packages, authentication and
+In scope: the Worker (`src/`), the `@stratum-eng/cli` and `@stratum-eng/agent` packages, authentication and
 token handling, the evaluation engine, and the merge/Git pipeline.
 
 Out of scope: vulnerabilities in third-party dependencies (report those upstream), denial-of-service

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,4 +1,4 @@
-# @stratum/agent
+# @stratum-eng/agent
 
 Reference agent for Stratum: proves the platform end-to-end for agent workflows.
 
@@ -7,7 +7,7 @@ export STRATUM_HOST=https://your-stratum-instance
 export STRATUM_API_KEY=stratum_user_…
 export ANTHROPIC_API_KEY=sk-ant-…
 
-npx @stratum/agent \
+npx @stratum-eng/agent \
   --repo @user/my-api \
   --objective "Fix the N+1 query in the users endpoint" \
   --model claude-sonnet-4-6

--- a/agent/package-lock.json
+++ b/agent/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@stratum/agent",
+  "name": "@stratum-eng/agent",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@stratum/agent",
+      "name": "@stratum-eng/agent",
       "version": "0.1.0",
       "license": "MIT",
       "bin": {

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stratum/agent",
+  "name": "@stratum-eng/agent",
   "version": "0.1.0",
   "description": "Reference agent for Stratum — fork, edit with an LLM, commit, open a Change",
   "license": "Apache-2.0",

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -2,7 +2,7 @@
 /**
  * Reference agent: proves the Stratum platform end-to-end for agent workflows.
  *
- *   npx @stratum/agent --repo @user/api --objective "Fix the N+1 query"
+ *   npx @stratum-eng/agent --repo @user/api --objective "Fix the N+1 query"
  *
  * Flow: create agent identity → fork workspace → read repo → ask Claude for
  * edits → commit with the agent token → open a Change (which runs evaluation).

--- a/changelog.d/npm-scope-stratum-eng.md
+++ b/changelog.d/npm-scope-stratum-eng.md
@@ -1,0 +1,8 @@
+### Changed
+- **The npm packages moved to the `@stratum-eng` scope.** `@stratum/cli` and
+  `@stratum/agent` are now `@stratum-eng/cli` and `@stratum-eng/agent` — the
+  `@stratum` scope on npm belongs to an unrelated owner. Install and `npx`
+  invocations change accordingly (`npx @stratum-eng/agent ...`); nothing else
+  about the packages, their binaries (`stratum`, `stratum-agent`), or their APIs
+  changes. Neither package was ever published under the old names, so there is
+  nothing to migrate off.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,4 +1,4 @@
-# @stratum/cli
+# @stratum-eng/cli
 
 CLI for Stratum — code hosting for the AI engineering era. Wraps the Stratum REST API.
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@stratum/cli",
+  "name": "@stratum-eng/cli",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@stratum/cli",
+      "name": "@stratum-eng/cli",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stratum/cli",
+  "name": "@stratum-eng/cli",
   "version": "0.2.0",
   "description": "CLI for Stratum \u2014 code hosting for the AI engineering era",
   "license": "Apache-2.0",

--- a/docs/CURRENT_CAPABILITIES.md
+++ b/docs/CURRENT_CAPABILITIES.md
@@ -137,7 +137,7 @@ environment (`wrangler.toml:75`), so it works out of the box.
 
 ## Tooling
 
-- `cli/` — @stratum/cli covering projects, workspaces, commits, changes incl.
+- `cli/` — @stratum-eng/cli covering projects, workspaces, commits, changes incl.
   review/merge, issues, activity and account. `stratum login` is a
   browser-based OAuth 2.1 + PKCE flow against a loopback redirect (RFC 8252),
   with `--read-only` for an `mcp:read` grant and `--key <token>` as the
@@ -145,7 +145,7 @@ environment (`wrangler.toml:75`), so it works out of the box.
   clears the local credential and revokes the grant on a best-effort basis
   (`cli/src/index.ts:148-171`). Deployments have no CLI command yet — use the
   API or the UI.
-- `agent/` — @stratum/agent reference agent: identity → fork → Claude edit plan
+- `agent/` — @stratum-eng/agent reference agent: identity → fork → Claude edit plan
   → commit → Change with evaluation.
 
 ## Known limitations / future work

--- a/docs/REMAINING_WORK.md
+++ b/docs/REMAINING_WORK.md
@@ -76,7 +76,7 @@ off the request path, are what this item still covers.
 Team write/admin grants are org-wide. Per-project grants allow finer-grained
 access control within an org.
 
-### Publish @stratum/cli and @stratum/agent to npm
+### Publish @stratum-eng/cli and @stratum-eng/agent to npm
 
 Both packages live in the repo at full API parity but are not yet published,
 so consumers must install from source.

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -1,6 +1,6 @@
 # The Stratum CLI
 
-`@stratum/cli` puts the change flow in the terminal: projects, workspaces,
+`@stratum-eng/cli` puts the change flow in the terminal: projects, workspaces,
 commits, evaluation-gated changes, reviews, and issues, each command a thin
 wrapper over the [REST API](../api/endpoints/README.md). It is built for humans
 and shell scripts; agents are usually better served by the

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -204,7 +204,7 @@ Artifacts namespaces.
 ## What license is Stratum under, and what does self-hosting oblige me to?
 
 Licensing is by directory: the server, web UI, `docs/`, and `website/` sources
-are **AGPL-3.0-or-later**; the `@stratum/cli` and `@stratum/agent` packages are
+are **AGPL-3.0-or-later**; the `@stratum-eng/cli` and `@stratum-eng/agent` packages are
 **Apache-2.0**; the published agent skills under
 `website/public/.well-known/agent-skills/` stay **MIT**, because they exist to be
 pasted into third-party agents. Releases through v0.2.0 were MIT and stay MIT.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -366,7 +366,7 @@ If a change was linked to an issue, the issue auto-closes on merge.
 
 ## 6. Connect your tools
 
-### CLI — `@stratum/cli`
+### CLI — `@stratum-eng/cli`
 
 The CLI wraps the full REST API: projects, workspaces, commits, changes
 (including review and merge), issues, and activity. It is not yet published to

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@stratum/website",
+  "name": "@stratum-eng/website",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@stratum/website",
+      "name": "@stratum-eng/website",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stratum/website",
+  "name": "@stratum-eng/website",
   "version": "0.1.0",
   "private": true,
   "license": "MIT",

--- a/website/scripts/mirror-docs.mjs
+++ b/website/scripts/mirror-docs.mjs
@@ -24,7 +24,7 @@ const GUIDES = [
   ["issues", "Open, triage, search, and link issues — and how a merged change closes them."],
   ["ci-integration", "Bring your own CI: run evaluations on your existing infrastructure and report verdicts back."],
   ["deployments", "Publish the merged tree to Cloudflare or Vercel after a change lands — the deploys: policy block, encrypted project secrets, the approval gate, limits, and what v1 does not do."],
-  ["cli", "Install and use @stratum/cli — projects, workspaces, commits, and the change flow from the terminal."],
+  ["cli", "Install and use @stratum-eng/cli — projects, workspaces, commits, and the change flow from the terminal."],
   ["mcp", "Connect any MCP-capable agent or editor to the evaluation-gated change flow over the hosted /mcp endpoint — OAuth 2.1, nothing to install."],
   ["troubleshooting", "Symptoms and fixes for auth, imports, evaluation, merges, and access."],
   ["faq", "Common questions about Stratum's merge gate, provenance, CI, limitations, and telemetry."],

--- a/website/src/content/docs/guides/cli.md
+++ b/website/src/content/docs/guides/cli.md
@@ -1,10 +1,10 @@
 ---
 title: "The Stratum CLI"
-description: "Install and use @stratum/cli — projects, workspaces, commits, and the change flow from the terminal."
+description: "Install and use @stratum-eng/cli — projects, workspaces, commits, and the change flow from the terminal."
 editUrl: "https://github.com/stratum-eng/stratum/edit/main/docs/user-guide/cli.md"
 ---
 
-`@stratum/cli` puts the change flow in the terminal: projects, workspaces,
+`@stratum-eng/cli` puts the change flow in the terminal: projects, workspaces,
 commits, evaluation-gated changes, reviews, and issues, each command a thin
 wrapper over the [REST API](/reference/endpoints/). It is built for humans
 and shell scripts; agents are usually better served by the

--- a/website/src/content/docs/guides/faq.md
+++ b/website/src/content/docs/guides/faq.md
@@ -208,7 +208,7 @@ Artifacts namespaces.
 ## What license is Stratum under, and what does self-hosting oblige me to?
 
 Licensing is by directory: the server, web UI, `docs/`, and `website/` sources
-are **AGPL-3.0-or-later**; the `@stratum/cli` and `@stratum/agent` packages are
+are **AGPL-3.0-or-later**; the `@stratum-eng/cli` and `@stratum-eng/agent` packages are
 **Apache-2.0**; the published agent skills under
 `website/public/.well-known/agent-skills/` stay **MIT**, because they exist to be
 pasted into third-party agents. Releases through v0.2.0 were MIT and stay MIT.

--- a/website/src/content/docs/guides/getting-started.md
+++ b/website/src/content/docs/guides/getting-started.md
@@ -370,7 +370,7 @@ If a change was linked to an issue, the issue auto-closes on merge.
 
 ## 6. Connect your tools
 
-### CLI — `@stratum/cli`
+### CLI — `@stratum-eng/cli`
 
 The CLI wraps the full REST API: projects, workspaces, commits, changes
 (including review and merge), issues, and activity. It is not yet published to


### PR DESCRIPTION
## Summary

The `@stratum` scope on npm is owned by an unrelated project, so the publishable packages move to the scope we secured, `@stratum-eng`.

- `cli/package.json` → `@stratum-eng/cli`, `agent/package.json` → `@stratum-eng/agent`, `website/package.json` → `@stratum-eng/website` (private, renamed for consistency). Each `package-lock.json` had both its top-level `name` and its `packages[""].name` updated, which is what `npm install` writes, so no lockfile drift.
- Prose and code references updated in `README.md`, `AGENTS.md`, `SECURITY.md`, `LICENSING.md`, `ROADMAP.md`, `CHANGELOG.md`, `docs/CURRENT_CAPABILITIES.md`, `docs/REMAINING_WORK.md`, `docs/user-guide/{cli,faq,getting-started}.md`, `cli/README.md`, `agent/README.md`, and the `npx @stratum-eng/agent` usage comment in `agent/src/index.ts`.
- The mirrored website guides plus the CLI guide description string in `website/scripts/mirror-docs.mjs` moved in lockstep — that string is compared against the mirrored front matter, so changing one without the other fails `check:guides`.
- Added `changelog.d/npm-scope-stratum-eng.md` under `### Changed`.

Two judgment calls worth a reviewer's attention:

1. **The removed `mcp/` package keeps its old name in the changelog.** My first commit renamed those two historical entries to `@stratum-eng/mcp` along with everything else; CodeRabbit caught that, and 9cd2ee1 reverts them. That manifest declared `@stratum/mcp` in every revision up to the commit that deleted it (`6019308`) and was never renamed, so the new-scope name refers to a package that has never existed and never will.
2. **References to `cli` and `agent` in released sections *are* renamed**, including the v0.2.0 entry at line 299. Rewriting released changelog sections is normally off-limits, but those packages still exist under the new scope, so a reader following an entry to npm needs the name that resolves today — where a retired name has no such reader to serve. If you would rather every released section stay verbatim as a matter of policy, say so and I'll revert line 299 too.

`changelog.d/npm-scope-stratum-eng.md` and those two `mcp` entries are now the only places the literal string `@stratum/` survives, both deliberately.

Out of scope but noticed nearby: `cli/package-lock.json` and `agent/package-lock.json` still record `"license": "MIT"` while their `package.json` files say `Apache-2.0` — pre-existing staleness from the relicensing commit, left alone here.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Other: npm package rename

## How was this verified?

All three gates were run locally on the branch head, plus the repo-specific consistency checks this change could break:

- [x] `npm run typecheck` — clean
- [x] `npm test` — 216 files passed, 3 skipped; 3768 tests passed, 28 skipped
- [x] `npm run lint` — 434 files checked, no fixes applied
- `npm run release:check` → "CHANGELOG.md and changelog.d/ are well-formed; latest release is 0.2.0" (re-run after the 9cd2ee1 changelog fix)
- `cd website && node scripts/mirror-docs.mjs --check` → "all 13 mirrors are in sync; 3 pages declared site-owned"
- `npm ci --dry-run` clean in `cli/`, `agent/`, and `website/` — that is the command that hard-errors when a manifest and its lockfile disagree on `name`, so it rules out lockfile drift from the rename (note the `CLI & Agent Packages` CI job runs `npm install`, which would not catch this)
- Repo-wide grep confirms no remaining `@stratum/` reference outside the two intentional cases above

The only non-Markdown, non-manifest change is a doc comment in `agent/src/index.ts`, so there is no runtime behavior to exercise beyond the suite above.

## Checklist

- [x] Tests added or updated for the change (coverage thresholds still pass) — no test changes needed; no runtime code changed
- [x] A `changelog.d/<slug>.md` fragment added if this is user-visible (not a direct `CHANGELOG.md` edit — see `changelog.d/README.md`)
- [x] Public docs updated if this changes user-facing config, API shape, or evaluator/policy behavior — canonical pages under `docs/user-guide/` edited, mirrors regenerated and verified with `check:guides`
- [x] No secrets, tokens, or personal data committed
- [x] The web UI change (if any) stays server-rendered with no client-side JavaScript — no web UI change
- [x] I have read the [CLA](https://github.com/stratum-eng/stratum/blob/main/CLA.md) and agree to it for this contribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NecXy7o61M2kucP6XSJ9xF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changed**
  - Renamed the published CLI and agent packages to `@stratum-eng/cli` and `@stratum-eng/agent`.
  - Renamed the website package to `@stratum-eng/website`.
  - Package names, binaries, and APIs remain unchanged.

- **Documentation**
  - Updated installation commands, usage examples, licensing information, guides, FAQs, changelogs, roadmap references, and publishing guidance to use the new package names.
  - New installations and `npx` commands should use the `@stratum-eng` scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
